### PR TITLE
KIT01: the form primitives the kit boundary has been promising

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,8 +91,6 @@ const rawControlsAllowlist = [
   "src/components/screens/Progress.tsx", // 3
   "src/components/screens/PlayerHub.tsx", // 2
   "src/components/TopBar.tsx", // 1
-  "src/games/flashcards/App.tsx", // 1
-  "src/components/BackupPanel.tsx", // 1
 ];
 
 // Storage is an implementation detail of the service layer — the direct

--- a/src/components/BackupPanel.tsx
+++ b/src/components/BackupPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { useHub } from "@/components/state/HubContext";
-import { FilePicker } from "@/components/ui/kit";
+import { Button, FilePicker } from "@/components/ui/kit";
 import { exportAll, importAll, type Backup } from "@/services/hub";
 import { sfx } from "@/services/sound";
 
@@ -65,13 +65,14 @@ export default function BackupPanel() {
 
   return (
     <div className="backup">
-      <button
-        className="btn btn--ghost btn--sm"
+      <Button
+        variant="ghost"
+        size="sm"
         onClick={() => void download()}
         disabled={busy || profiles.length === 0}
       >
         ⬇ Back up progress
-      </button>
+      </Button>
       <FilePicker onFile={(file) => void restore(file)}>
         ⬆ Restore from a backup
       </FilePicker>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,68 @@
+import type { ButtonHTMLAttributes } from "react";
+
+/**
+ * The one button in the app.
+ *
+ * Two families of button exist in this codebase and both go through here:
+ *
+ * - **Pill buttons** — the `.btn` scale, selected with `variant` and `size`.
+ * - **Skinned buttons** — `preset`, `segmented__btn`, `tablegrid__cell`,
+ *   `rival`, `picker__cell`, `swatch`, `keypad__key`, `stepper__btn`,
+ *   `topbar__icon`. Each carries its own complete CSS, so `variant="bare"`
+ *   adds no classes at all and the caller's `className` is used verbatim.
+ *
+ * `bare` is what makes the kit boundary enforceable rather than aspirational.
+ * Without it a skinned control has no primitive to reach for, and the only way
+ * past the lint rule is a suppression — which is how kits die.
+ */
+export type ButtonVariant =
+  "solid" | "go" | "accent" | "ghost" | "danger" | "bare";
+
+export type ButtonSize = "md" | "sm";
+
+const VARIANT_CLASS: Record<Exclude<ButtonVariant, "bare">, string> = {
+  solid: "",
+  go: "btn--go",
+  accent: "btn--accent",
+  ghost: "btn--ghost",
+  danger: "btn--danger",
+};
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  /**
+   * Sets `aria-pressed`. The matching `is-on` / `is-chosen` class stays with
+   * the caller: each skin names its selected state differently, and the kit
+   * has no business knowing which.
+   */
+  pressed?: boolean;
+}
+
+export function Button({
+  variant = "solid",
+  size = "md",
+  pressed,
+  className,
+  // Defaulting to "button" rather than inheriting the platform default. A
+  // bare <button> inside a <form> submits it — which is a real hazard here,
+  // since the player editor is a form full of avatar and colour pickers.
+  type = "button",
+  ...rest
+}: ButtonProps) {
+  const classes =
+    variant === "bare"
+      ? className
+      : [
+          "btn",
+          VARIANT_CLASS[variant],
+          size === "sm" ? "btn--sm" : "",
+          className,
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+  return (
+    <button type={type} className={classes} aria-pressed={pressed} {...rest} />
+  );
+}

--- a/src/components/ui/Field.tsx
+++ b/src/components/ui/Field.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+/**
+ * A labelled form row: label, control, optional hint, optional inline error.
+ *
+ * `Field` wraps its control in a `<label>`, so the association is structural —
+ * no `htmlFor`/`id` pair to keep in sync, and nothing to forget. That only
+ * works for a single control, which is why `FieldSet` below exists for groups.
+ */
+export function Field({
+  label,
+  hint,
+  error,
+  children,
+}: {
+  label: string;
+  hint?: ReactNode;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="field">
+      <span className="field__label">{label}</span>
+      {children}
+      {/* Spans, not paragraphs: a <label> may only contain phrasing content.
+          `.field` is a grid, so they stack the same either way. */}
+      {hint ? <span className="field__hint">{hint}</span> : null}
+      {error ? (
+        <span className="field__error" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </label>
+  );
+}
+
+/**
+ * The same row for a *group* of controls — an avatar picker, a colour picker,
+ * a stepper. A `<label>` can only point at one control, so a group needs
+ * `<fieldset>`/`<legend>` to be announced as one named thing.
+ */
+export function FieldSet({
+  legend,
+  hint,
+  children,
+}: {
+  legend: string;
+  hint?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <fieldset className="field">
+      <legend className="field__label">{legend}</legend>
+      {children}
+      {hint ? <p className="field__hint">{hint}</p> : null}
+    </fieldset>
+  );
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,51 @@
+import type { InputHTMLAttributes, Ref } from "react";
+
+/**
+ * Text and numeric entry.
+ *
+ * `onChange` hands over the string rather than the event — every call site
+ * only ever wanted `event.target.value`, and matching `Toggle`'s
+ * `onChange(next)` shape keeps the kit consistent with itself. Everything else
+ * a native input understands (`type`, `step`, `min`, `max`, `inputMode`,
+ * `maxLength`, `autoComplete`, `onBlur`, `ref`) passes straight through.
+ *
+ * Numeric fields deliberately keep the raw string. The race clock accepts
+ * quarter-second steps and snaps what you type (3.3 → 3.25); parsing here
+ * would strip the intermediate text a player types on the way to a number.
+ */
+export interface InputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "onChange" | "value" | "size"
+> {
+  value: string | number;
+  onChange: (value: string) => void;
+  /**
+   * Commit on Enter by dropping focus. Numeric fields that snap their value on
+   * blur need this, or a typed value sits uncommitted until the player thinks
+   * to click elsewhere.
+   */
+  blurOnEnter?: boolean;
+  ref?: Ref<HTMLInputElement>;
+}
+
+export function Input({
+  value,
+  onChange,
+  blurOnEnter = false,
+  className = "field__input",
+  onKeyDown,
+  ...rest
+}: InputProps) {
+  return (
+    <input
+      className={className}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={(event) => {
+        if (blurOnEnter && event.key === "Enter") event.currentTarget.blur();
+        onKeyDown?.(event);
+      }}
+      {...rest}
+    />
+  );
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,54 @@
+import type { SelectHTMLAttributes } from "react";
+
+/**
+ * A styled single-choice dropdown.
+ *
+ * No screen uses one today — every choice in the app is currently a segmented
+ * row or a grid of tappable cells, which suits a five-year-old better than a
+ * dropdown does. It exists because the native-control ban already tells you
+ * `<select>` → `<Select>`, and a rule that names a primitive which doesn't
+ * exist leaves a suppression as the only way forward. Reach for a segmented
+ * row first; this is for the long lists where that stops working.
+ *
+ * The wrapper span carries the chevron. `appearance: none` removes the
+ * platform arrow, and drawing our own with a border triangle keeps it on
+ * `currentColor`'s side of the theme rather than baking a colour into an SVG.
+ */
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps extends Omit<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  "onChange" | "value" | "children"
+> {
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+}
+
+export function Select({
+  value,
+  onChange,
+  options,
+  className = "field__input field__select",
+  ...rest
+}: SelectProps) {
+  return (
+    <span className="field__selectwrap">
+      <select
+        className={className}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        {...rest}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </span>
+  );
+}

--- a/src/components/ui/kit.tsx
+++ b/src/components/ui/kit.tsx
@@ -1,6 +1,22 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import type { Profile } from "@/engine/types";
 
+/**
+ * `@/components/ui/kit` is the kit's single import path — every feature file
+ * already imports from here, so the form primitives are re-exported rather
+ * than given their own paths. They live in their own modules because each one
+ * carries a real doc block and this file has a 300-line cap to respect.
+ */
+export {
+  Button,
+  type ButtonProps,
+  type ButtonSize,
+  type ButtonVariant,
+} from "./Button";
+export { Input, type InputProps } from "./Input";
+export { Field, FieldSet } from "./Field";
+export { Select, type SelectOption, type SelectProps } from "./Select";
+
 export function Avatar({
   profile,
   size = "3.5rem",

--- a/src/games/flashcards/App.tsx
+++ b/src/games/flashcards/App.tsx
@@ -3,6 +3,7 @@ import { HashRouter, Navigate, Route, Routes } from "react-router-dom";
 import { ToastRail } from "@/components/ToastRail";
 import { HubProvider, useHub } from "@/components/state/HubContext";
 import { RaceProvider } from "@/components/state/RaceContext";
+import { Button } from "@/components/ui/kit";
 import PlayerSelect from "@/components/screens/PlayerSelect";
 import PlayerHub from "@/components/screens/PlayerHub";
 import Progress from "@/components/screens/Progress";
@@ -59,9 +60,9 @@ function Shell() {
           can do that. Progress is only ever saved on this device, so there's
           nothing to recover from elsewhere.
         </p>
-        <button className="btn btn--go" onClick={() => void reload()}>
+        <Button variant="go" onClick={() => void reload()}>
           Try again
-        </button>
+        </Button>
       </div>
     );
   }

--- a/src/styles/screens.css
+++ b/src/styles/screens.css
@@ -319,6 +319,37 @@
   width: auto;
 }
 
+.field__error {
+  font-size: var(--step--2);
+  color: var(--flare);
+}
+
+/* The chevron for <Select>. `.field__input` sets `background` as a shorthand,
+   which resets background-image — so the arrow is drawn as a rotated border
+   on the wrapper instead, where it also follows the theme colour. */
+.field__selectwrap {
+  position: relative;
+  display: block;
+}
+
+.field__selectwrap::after {
+  content: "";
+  position: absolute;
+  right: 1.1em;
+  top: 50%;
+  width: 0.45em;
+  height: 0.45em;
+  border-right: 2px solid var(--chalk-dim);
+  border-bottom: 2px solid var(--chalk-dim);
+  transform: translateY(-70%) rotate(45deg);
+  pointer-events: none;
+}
+
+.field__select {
+  appearance: none;
+  padding-right: 2.6em;
+}
+
 .picker--emoji {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(2.6rem, 1fr));


### PR DESCRIPTION
Closes #1

## What

Adds `Button`, `Input`, `Select`, `Field` and `FieldSet` to `src/components/ui/`.
They live in their own modules and are re-exported from `kit.tsx`, which stays
the single import path every feature file already uses.

## Why `bare`

`Button` has to cover two families, not one:

| Family | Example classes | How |
| --- | --- | --- |
| Pill buttons | `btn btn--go`, `btn--ghost btn--sm` | `variant` + `size` |
| Bespoke skins | `preset`, `segmented__btn`, `tablegrid__cell`, `rival`, `picker__cell`, `swatch`, `keypad__key`, `stepper__btn`, `topbar__icon` | `variant="bare"` + the caller's own `className` |

Roughly two thirds of the 55 controls awaiting conversion are the second kind.
Without `bare` they'd have no primitive to reach for, and each conversion story
would need its own `eslint-disable` — the kit boundary would be enforced only
where it was already easy.

`pressed` sets `aria-pressed` but does **not** own the selected-state class:
some skins say `is-on`, others `is-chosen`.

## Visual parity

Class output is identical by construction — `variant="go"` renders exactly
`btn btn--go`, `variant="ghost" size="sm"` renders `btn btn--ghost btn--sm`.
`bare` adds nothing. New CSS is additive only: `.field__error`,
`.field__selectwrap`, `.field__select`.

One behaviour change, and it's a fix: `type="button"` is now the default. A bare
`<button>` inside `PlayerEditor`'s `<form>` submits it.

## Scope note

The issue puts call-site conversion out of scope, but `App.tsx` and
`BackupPanel.tsx` (one control each) are converted here anyway. They're an epic
gap — stories #2, #3 and #4 name RaceSetup, RaceTrack, RaceResults, Progress,
PlayerSelect, PlayerHub, PlayerEditor and TopBar, so nothing would ever have
retired those two entries and `rawControlsAllowlist` could never reach empty.
Converting them also means the primitives ship with real call sites rather than
untested.

## About `Select`

No screen uses a dropdown today — every choice is a segmented row or a grid of
tappable cells, which suits a five-year-old better. It's here because the lint
message already names it, so its absence is what would force a suppression. The
doc block says to reach for a segmented row first.

## Validation

- `npm run type-check` — 0 errors, 0 warnings (pre-existing `FormEvent`
  deprecation hint in `PlayerEditor.tsx:79` unchanged)
- `npm run lint` — clean, no new suppressions
- `npm run test:unit` — 11/11
- `npm run build` — 17 pages, static
- `npm run test:smoke` — all checks pass, zero console errors