### PR TITLE
Fix the two things blocking the production deploy

### DIFF
--- a/scripts/setup-github-oidc.sh
+++ b/scripts/setup-github-oidc.sh
@@ -14,6 +14,16 @@
 #      triggered it was the post-merge run on main. Omitting it fails the
 #      first release deploy with AssumeRoleWithWebIdentity denied — a mistake
 #      already paid for once in monilibrium_2.
+#
+#      ⚠️ Debugging a denied assume-role: the error GitHub prints ("Not
+#      authorized to perform sts:AssumeRoleWithWebIdentity") never says which
+#      claim failed, and the token isn't in the log. CloudTrail has it —
+#      the denied event records the exact subject as the principal id:
+#        aws cloudtrail lookup-events --profile schoolskills --region us-west-1 \
+#          --lookup-attributes AttributeKey=EventName,AttributeValue=AssumeRoleWithWebIdentity \
+#          --max-results 1 --query 'Events[].CloudTrailEvent' --output text | jq .userIdentity
+#      That is how the immutable-subject mismatch below was found, after the
+#      first two production deploys failed identically.
 #   3. A least-privilege deploy policy, attached to the role.
 #   4. The `AWS_DEPLOY_ROLE_ARN` repo VARIABLE (not a secret — role ARNs
 #      aren't sensitive) that deploy.yml reads.
@@ -31,6 +41,17 @@ set -euo pipefail
 export AWS_PROFILE="${AWS_PROFILE:-schoolskills}"
 
 REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+# GitHub now issues IMMUTABLE OIDC subjects: the numeric owner and repository
+# ids are interpolated into the sub, so the claim reads
+#   repo:owner@34669268/name@1332338472:ref:refs/heads/main
+# rather than the documented `repo:owner/name:ref:...`. The ids are what make
+# it immutable — renaming the repo or the account can't be used to inherit
+# another repo's trust. Both forms are trusted below so the role keeps working
+# whichever one GitHub presents; `sub` is matched with StringEquals against
+# exact strings, never a wildcard.
+REPO_ID="$(gh repo view --json id --jq .databaseId 2>/dev/null || gh api "repos/${REPO}" --jq .id)"
+OWNER_ID="$(gh api "repos/${REPO}" --jq .owner.id)"
+REPO_IMMUTABLE="${REPO%%/*}@${OWNER_ID}/${REPO##*/}@${REPO_ID}"
 ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 ROLE_NAME="github-actions-schoolskills-deploy"
 POLICY_NAME="github-actions-schoolskills-deploy"
@@ -78,6 +99,8 @@ TRUST_POLICY="$(
         "StringEquals": {
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
           "token.actions.githubusercontent.com:sub": [
+            "repo:${REPO_IMMUTABLE}:ref:refs/heads/main",
+            "repo:${REPO_IMMUTABLE}:ref:refs/heads/develop",
             "repo:${REPO}:ref:refs/heads/main",
             "repo:${REPO}:ref:refs/heads/develop"
           ]

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -45,7 +45,18 @@ export default $config({
       protect: input?.stage === "production",
       home: "aws",
       providers: {
-        aws: { region: "us-west-1", profile: "schoolskills" },
+        aws: {
+          region: "us-west-1",
+          // A named profile locally, nothing in CI.
+          //
+          // On a developer machine credentials come from `aws sso login
+          // --profile schoolskills`. On a GitHub runner they arrive as
+          // AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN from the OIDC role
+          // assumption, and there is no shared config file at all — naming a
+          // profile there fails the deploy outright with "failed to get shared
+          // config profile, schoolskills", after OIDC has already succeeded.
+          profile: process.env.CI ? undefined : "schoolskills",
+        },
         // Only production declares the Cloudflare provider. Declaring it
         // unconditionally makes Pulumi initialise and AUTHENTICATE it on every
         // stage, so a domain-less dev deploy fails with "Invalid access token"


### PR DESCRIPTION
Refs #6

The pipeline was green everywhere except the one place that matters. Two
independent faults, stacked — the second was unreachable until the first was
fixed.

## 1. GitHub issues immutable OIDC subjects

The trust policy matched the documented shape:

```
repo:jordanmbush/schoolskills:ref:refs/heads/main
```

The token actually presents:

```
repo:jordanmbush@34669268/schoolskills@1332338472:ref:refs/heads/main
```

The numeric owner and repository ids are what make the subject *immutable* —
renaming a repo or an account can no longer inherit another repo's trust. No
`sub` matched, so every deploy died at assume-role.

**This is hard to diagnose from GitHub.** The action retries a dozen times and
reports only `Not authorized to perform sts:AssumeRoleWithWebIdentity`; it never
says which claim failed, and the token isn't in the log. CloudTrail records the
exact subject as the principal id on the denied event. That lookup is now
documented in the script header, because the next person will hit this too.

Both forms are trusted so the role survives GitHub presenting either. Still
`StringEquals` on exact strings — a wildcard in the owner segment
(`jordanmbush*`) would also match `jordanmbush-anything/...`.

The live role has already been updated; this brings the script that generates
it back in sync.

## 2. `sst.config.ts` named a local SSO profile in CI

`profile: "schoolskills"` is correct on a developer machine and wrong on a
runner, where credentials arrive as `AWS_ACCESS_KEY_ID`/`SECRET`/`SESSION_TOKEN`
from the role assumption and there's no shared config file at all. It failed
with `failed to get shared config profile, schoolskills` **after** OIDC had
succeeded — so fault 1 had to be fixed before this one could even surface.

Now gated on `CI`, which GitHub Actions sets.

## Validation

`bash -n` on the script, `type-check`, `lint`, `format:check` all pass. The real
proof is the next production deploy, which is the only place either fault was
ever observable.