### PR TITLE
Release: production deploy fixes + kit primitives

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,8 +91,6 @@ const rawControlsAllowlist = [
   "src/components/screens/Progress.tsx", // 3
   "src/components/screens/PlayerHub.tsx", // 2
   "src/components/TopBar.tsx", // 1
-  "src/games/flashcards/App.tsx", // 1
-  "src/components/BackupPanel.tsx", // 1
 ];
 
 // Storage is an implementation detail of the service layer — the direct

--- a/scripts/setup-github-oidc.sh
+++ b/scripts/setup-github-oidc.sh
@@ -14,6 +14,16 @@
 #      triggered it was the post-merge run on main. Omitting it fails the
 #      first release deploy with AssumeRoleWithWebIdentity denied — a mistake
 #      already paid for once in monilibrium_2.
+#
+#      ⚠️ Debugging a denied assume-role: the error GitHub prints ("Not
+#      authorized to perform sts:AssumeRoleWithWebIdentity") never says which
+#      claim failed, and the token isn't in the log. CloudTrail has it —
+#      the denied event records the exact subject as the principal id:
+#        aws cloudtrail lookup-events --profile schoolskills --region us-west-1 \
+#          --lookup-attributes AttributeKey=EventName,AttributeValue=AssumeRoleWithWebIdentity \
+#          --max-results 1 --query 'Events[].CloudTrailEvent' --output text | jq .userIdentity
+#      That is how the immutable-subject mismatch below was found, after the
+#      first two production deploys failed identically.
 #   3. A least-privilege deploy policy, attached to the role.
 #   4. The `AWS_DEPLOY_ROLE_ARN` repo VARIABLE (not a secret — role ARNs
 #      aren't sensitive) that deploy.yml reads.
@@ -31,6 +41,17 @@ set -euo pipefail
 export AWS_PROFILE="${AWS_PROFILE:-schoolskills}"
 
 REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+# GitHub now issues IMMUTABLE OIDC subjects: the numeric owner and repository
+# ids are interpolated into the sub, so the claim reads
+#   repo:owner@34669268/name@1332338472:ref:refs/heads/main
+# rather than the documented `repo:owner/name:ref:...`. The ids are what make
+# it immutable — renaming the repo or the account can't be used to inherit
+# another repo's trust. Both forms are trusted below so the role keeps working
+# whichever one GitHub presents; `sub` is matched with StringEquals against
+# exact strings, never a wildcard.
+REPO_ID="$(gh repo view --json id --jq .databaseId 2>/dev/null || gh api "repos/${REPO}" --jq .id)"
+OWNER_ID="$(gh api "repos/${REPO}" --jq .owner.id)"
+REPO_IMMUTABLE="${REPO%%/*}@${OWNER_ID}/${REPO##*/}@${REPO_ID}"
 ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 ROLE_NAME="github-actions-schoolskills-deploy"
 POLICY_NAME="github-actions-schoolskills-deploy"
@@ -78,6 +99,8 @@ TRUST_POLICY="$(
         "StringEquals": {
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
           "token.actions.githubusercontent.com:sub": [
+            "repo:${REPO_IMMUTABLE}:ref:refs/heads/main",
+            "repo:${REPO_IMMUTABLE}:ref:refs/heads/develop",
             "repo:${REPO}:ref:refs/heads/main",
             "repo:${REPO}:ref:refs/heads/develop"
           ]

--- a/src/components/BackupPanel.tsx
+++ b/src/components/BackupPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { useHub } from "@/components/state/HubContext";
-import { FilePicker } from "@/components/ui/kit";
+import { Button, FilePicker } from "@/components/ui/kit";
 import { exportAll, importAll, type Backup } from "@/services/hub";
 import { sfx } from "@/services/sound";
 
@@ -65,13 +65,14 @@ export default function BackupPanel() {
 
   return (
     <div className="backup">
-      <button
-        className="btn btn--ghost btn--sm"
+      <Button
+        variant="ghost"
+        size="sm"
         onClick={() => void download()}
         disabled={busy || profiles.length === 0}
       >
         ⬇ Back up progress
-      </button>
+      </Button>
       <FilePicker onFile={(file) => void restore(file)}>
         ⬆ Restore from a backup
       </FilePicker>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,68 @@
+import type { ButtonHTMLAttributes } from "react";
+
+/**
+ * The one button in the app.
+ *
+ * Two families of button exist in this codebase and both go through here:
+ *
+ * - **Pill buttons** — the `.btn` scale, selected with `variant` and `size`.
+ * - **Skinned buttons** — `preset`, `segmented__btn`, `tablegrid__cell`,
+ *   `rival`, `picker__cell`, `swatch`, `keypad__key`, `stepper__btn`,
+ *   `topbar__icon`. Each carries its own complete CSS, so `variant="bare"`
+ *   adds no classes at all and the caller's `className` is used verbatim.
+ *
+ * `bare` is what makes the kit boundary enforceable rather than aspirational.
+ * Without it a skinned control has no primitive to reach for, and the only way
+ * past the lint rule is a suppression — which is how kits die.
+ */
+export type ButtonVariant =
+  "solid" | "go" | "accent" | "ghost" | "danger" | "bare";
+
+export type ButtonSize = "md" | "sm";
+
+const VARIANT_CLASS: Record<Exclude<ButtonVariant, "bare">, string> = {
+  solid: "",
+  go: "btn--go",
+  accent: "btn--accent",
+  ghost: "btn--ghost",
+  danger: "btn--danger",
+};
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  /**
+   * Sets `aria-pressed`. The matching `is-on` / `is-chosen` class stays with
+   * the caller: each skin names its selected state differently, and the kit
+   * has no business knowing which.
+   */
+  pressed?: boolean;
+}
+
+export function Button({
+  variant = "solid",
+  size = "md",
+  pressed,
+  className,
+  // Defaulting to "button" rather than inheriting the platform default. A
+  // bare <button> inside a <form> submits it — which is a real hazard here,
+  // since the player editor is a form full of avatar and colour pickers.
+  type = "button",
+  ...rest
+}: ButtonProps) {
+  const classes =
+    variant === "bare"
+      ? className
+      : [
+          "btn",
+          VARIANT_CLASS[variant],
+          size === "sm" ? "btn--sm" : "",
+          className,
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+  return (
+    <button type={type} className={classes} aria-pressed={pressed} {...rest} />
+  );
+}

--- a/src/components/ui/Field.tsx
+++ b/src/components/ui/Field.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+/**
+ * A labelled form row: label, control, optional hint, optional inline error.
+ *
+ * `Field` wraps its control in a `<label>`, so the association is structural —
+ * no `htmlFor`/`id` pair to keep in sync, and nothing to forget. That only
+ * works for a single control, which is why `FieldSet` below exists for groups.
+ */
+export function Field({
+  label,
+  hint,
+  error,
+  children,
+}: {
+  label: string;
+  hint?: ReactNode;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="field">
+      <span className="field__label">{label}</span>
+      {children}
+      {/* Spans, not paragraphs: a <label> may only contain phrasing content.
+          `.field` is a grid, so they stack the same either way. */}
+      {hint ? <span className="field__hint">{hint}</span> : null}
+      {error ? (
+        <span className="field__error" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </label>
+  );
+}
+
+/**
+ * The same row for a *group* of controls — an avatar picker, a colour picker,
+ * a stepper. A `<label>` can only point at one control, so a group needs
+ * `<fieldset>`/`<legend>` to be announced as one named thing.
+ */
+export function FieldSet({
+  legend,
+  hint,
+  children,
+}: {
+  legend: string;
+  hint?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <fieldset className="field">
+      <legend className="field__label">{legend}</legend>
+      {children}
+      {hint ? <p className="field__hint">{hint}</p> : null}
+    </fieldset>
+  );
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,51 @@
+import type { InputHTMLAttributes, Ref } from "react";
+
+/**
+ * Text and numeric entry.
+ *
+ * `onChange` hands over the string rather than the event — every call site
+ * only ever wanted `event.target.value`, and matching `Toggle`'s
+ * `onChange(next)` shape keeps the kit consistent with itself. Everything else
+ * a native input understands (`type`, `step`, `min`, `max`, `inputMode`,
+ * `maxLength`, `autoComplete`, `onBlur`, `ref`) passes straight through.
+ *
+ * Numeric fields deliberately keep the raw string. The race clock accepts
+ * quarter-second steps and snaps what you type (3.3 → 3.25); parsing here
+ * would strip the intermediate text a player types on the way to a number.
+ */
+export interface InputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "onChange" | "value" | "size"
+> {
+  value: string | number;
+  onChange: (value: string) => void;
+  /**
+   * Commit on Enter by dropping focus. Numeric fields that snap their value on
+   * blur need this, or a typed value sits uncommitted until the player thinks
+   * to click elsewhere.
+   */
+  blurOnEnter?: boolean;
+  ref?: Ref<HTMLInputElement>;
+}
+
+export function Input({
+  value,
+  onChange,
+  blurOnEnter = false,
+  className = "field__input",
+  onKeyDown,
+  ...rest
+}: InputProps) {
+  return (
+    <input
+      className={className}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={(event) => {
+        if (blurOnEnter && event.key === "Enter") event.currentTarget.blur();
+        onKeyDown?.(event);
+      }}
+      {...rest}
+    />
+  );
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,54 @@
+import type { SelectHTMLAttributes } from "react";
+
+/**
+ * A styled single-choice dropdown.
+ *
+ * No screen uses one today — every choice in the app is currently a segmented
+ * row or a grid of tappable cells, which suits a five-year-old better than a
+ * dropdown does. It exists because the native-control ban already tells you
+ * `<select>` → `<Select>`, and a rule that names a primitive which doesn't
+ * exist leaves a suppression as the only way forward. Reach for a segmented
+ * row first; this is for the long lists where that stops working.
+ *
+ * The wrapper span carries the chevron. `appearance: none` removes the
+ * platform arrow, and drawing our own with a border triangle keeps it on
+ * `currentColor`'s side of the theme rather than baking a colour into an SVG.
+ */
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectProps extends Omit<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  "onChange" | "value" | "children"
+> {
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+}
+
+export function Select({
+  value,
+  onChange,
+  options,
+  className = "field__input field__select",
+  ...rest
+}: SelectProps) {
+  return (
+    <span className="field__selectwrap">
+      <select
+        className={className}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        {...rest}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </span>
+  );
+}

--- a/src/components/ui/kit.tsx
+++ b/src/components/ui/kit.tsx
@@ -1,6 +1,22 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import type { Profile } from "@/engine/types";
 
+/**
+ * `@/components/ui/kit` is the kit's single import path — every feature file
+ * already imports from here, so the form primitives are re-exported rather
+ * than given their own paths. They live in their own modules because each one
+ * carries a real doc block and this file has a 300-line cap to respect.
+ */
+export {
+  Button,
+  type ButtonProps,
+  type ButtonSize,
+  type ButtonVariant,
+} from "./Button";
+export { Input, type InputProps } from "./Input";
+export { Field, FieldSet } from "./Field";
+export { Select, type SelectOption, type SelectProps } from "./Select";
+
 export function Avatar({
   profile,
   size = "3.5rem",

--- a/src/games/flashcards/App.tsx
+++ b/src/games/flashcards/App.tsx
@@ -3,6 +3,7 @@ import { HashRouter, Navigate, Route, Routes } from "react-router-dom";
 import { ToastRail } from "@/components/ToastRail";
 import { HubProvider, useHub } from "@/components/state/HubContext";
 import { RaceProvider } from "@/components/state/RaceContext";
+import { Button } from "@/components/ui/kit";
 import PlayerSelect from "@/components/screens/PlayerSelect";
 import PlayerHub from "@/components/screens/PlayerHub";
 import Progress from "@/components/screens/Progress";
@@ -59,9 +60,9 @@ function Shell() {
           can do that. Progress is only ever saved on this device, so there's
           nothing to recover from elsewhere.
         </p>
-        <button className="btn btn--go" onClick={() => void reload()}>
+        <Button variant="go" onClick={() => void reload()}>
           Try again
-        </button>
+        </Button>
       </div>
     );
   }

--- a/src/styles/screens.css
+++ b/src/styles/screens.css
@@ -319,6 +319,37 @@
   width: auto;
 }
 
+.field__error {
+  font-size: var(--step--2);
+  color: var(--flare);
+}
+
+/* The chevron for <Select>. `.field__input` sets `background` as a shorthand,
+   which resets background-image — so the arrow is drawn as a rotated border
+   on the wrapper instead, where it also follows the theme colour. */
+.field__selectwrap {
+  position: relative;
+  display: block;
+}
+
+.field__selectwrap::after {
+  content: "";
+  position: absolute;
+  right: 1.1em;
+  top: 50%;
+  width: 0.45em;
+  height: 0.45em;
+  border-right: 2px solid var(--chalk-dim);
+  border-bottom: 2px solid var(--chalk-dim);
+  transform: translateY(-70%) rotate(45deg);
+  pointer-events: none;
+}
+
+.field__select {
+  appearance: none;
+  padding-right: 2.6em;
+}
+
 .picker--emoji {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(2.6rem, 1fr));

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -45,7 +45,18 @@ export default $config({
       protect: input?.stage === "production",
       home: "aws",
       providers: {
-        aws: { region: "us-west-1", profile: "schoolskills" },
+        aws: {
+          region: "us-west-1",
+          // A named profile locally, nothing in CI.
+          //
+          // On a developer machine credentials come from `aws sso login
+          // --profile schoolskills`. On a GitHub runner they arrive as
+          // AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN from the OIDC role
+          // assumption, and there is no shared config file at all — naming a
+          // profile there fails the deploy outright with "failed to get shared
+          // config profile, schoolskills", after OIDC has already succeeded.
+          profile: process.env.CI ? undefined : "schoolskills",
+        },
         // Only production declares the Cloudflare provider. Declaring it
         // unconditionally makes Pulumi initialise and AUTHENTICATE it on every
         // stage, so a domain-less dev deploy fails with "Invalid access token"


### PR DESCRIPTION
Second attempt at the first production deploy. The first merge to `main` was
correct code that couldn't deploy — two independent infrastructure faults,
neither observable until a real deploy ran.

## What this release adds over the last one

- **OIDC trust policy** now matches GitHub's immutable subject format
  (`repo:owner@id/name@id:ref:...`). The live IAM role is already updated;
  `scripts/setup-github-oidc.sh` is brought back in sync so re-running it
  doesn't undo the fix.
- **`sst.config.ts`** no longer names a local SSO profile when running in CI.
- **Kit primitives** — `Button`, `Input`, `Select`, `Field`, `FieldSet`.

See #21 for the full diagnosis, including the CloudTrail lookup that surfaced
the real OIDC subject.

## Expected on merge

`sst deploy --stage production` claims `schoolskills.app`, writes the app CNAME
and the ACM validation records via Cloudflare, then the smoke checks run against
the live domain. First deploy blocks on certificate validation and distribution
rollout — allow 20-40 minutes.

**Merge commit, not squash.**