### PR TITLE
Derive the Cloudflare account id instead of widening the deploy token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,44 @@ jobs:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: us-west-1
 
+      # SST's Cloudflare provider insists on an account id even though this
+      # deploy only writes DNS records into one known zone. It tries to
+      # discover one by listing accounts, which a Zone:DNS:Edit token cannot
+      # do — the deploy dies with "The Cloudflare Account ID was not able to
+      # be determined from this token".
+      #
+      # Broadening the token to Account:Read would fix it and is the wrong
+      # trade: a deploy credential that can enumerate the whole Cloudflare
+      # account, to learn one id that isn't secret. The zone endpoint already
+      # returns it, and reading the zone is within what a DNS-editing token
+      # is for. Set the CLOUDFLARE_ACCOUNT_ID repo variable to skip the
+      # lookup entirely.
+      - name: Resolve the Cloudflare account id
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          OVERRIDE: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -n "${OVERRIDE}" ]; then
+            echo "CLOUDFLARE_DEFAULT_ACCOUNT_ID=${OVERRIDE}" >> "$GITHUB_ENV"
+            echo "Using the CLOUDFLARE_ACCOUNT_ID repo variable."
+            exit 0
+          fi
+          response="$(curl -sS \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}")"
+          account="$(printf '%s' "$response" | jq -r '.result.account.id // empty')"
+          if [ -z "$account" ]; then
+            echo "::error::Could not read the account id from zone ${CLOUDFLARE_ZONE_ID}."
+            echo "The token needs Zone:Read on this zone as well as DNS:Edit — the" >&2
+            echo "'Edit zone DNS' template grants both. Alternatively set the" >&2
+            echo "CLOUDFLARE_ACCOUNT_ID repo variable (it is not a secret)." >&2
+            printf '%s' "$response" | jq -r '.errors // empty' >&2
+            exit 1
+          fi
+          echo "CLOUDFLARE_DEFAULT_ACCOUNT_ID=${account}" >> "$GITHUB_ENV"
+          echo "Resolved the Cloudflare account id from the zone."
+
       - name: Deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -89,6 +127,9 @@ jobs:
           First things to check:
           - Are CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID set as repo secrets?
             sst.config.ts refuses to deploy production without the zone id.
+          - Does the token carry Zone:Read as well as DNS:Edit? The account-id
+            lookup reads the zone; DNS:Edit on its own is not enough. Setting
+            the CLOUDFLARE_ACCOUNT_ID repo variable skips that lookup.
           - Did the ACM certificate finish DNS validation? The first production
             deploy blocks on it and can take several minutes.
           - The previous version is still being served — CloudFront only cuts

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -28,9 +28,17 @@
  * written DNS-only (grey cloud) — CloudFront is already the CDN, and proxying
  * through Cloudflare on top would double up TLS termination for nothing.
  *
- * Two env vars gate production and are read at deploy time, never committed:
- *   CLOUDFLARE_API_TOKEN   scoped to Zone:DNS:Edit on this zone only
+ * Env vars that gate production, read at deploy time and never committed:
+ *   CLOUDFLARE_API_TOKEN   scoped to this zone only. Needs Zone:Read as well
+ *                          as DNS:Edit — the "Edit zone DNS" template grants
+ *                          both, and the account lookup below needs the read.
  *   CLOUDFLARE_ZONE_ID     not secret, but kept alongside for symmetry
+ *   CLOUDFLARE_DEFAULT_ACCOUNT_ID
+ *                          SST demands an account id even for a DNS-only
+ *                          deploy, and a zone-scoped token can't list
+ *                          accounts to find one. deploy.yml reads it off the
+ *                          zone; set it by hand for a local `--stage
+ *                          production` run.
  */
 
 const DOMAIN = "schoolskills.app";


### PR DESCRIPTION
Refs #6

Third fault in the go-live chain. Like the first two it was invisible until a
real production deploy ran — the `dev` stage declares no Cloudflare provider at
all, which is what makes it deployable without credentials.

## The failure

```
✕ The Cloudflare Account ID was not able to be determined from this token.
```

SST's Cloudflare provider wants an account id even though this deploy only
writes DNS records into one already-known zone. It discovers one by listing
accounts, which a `Zone:DNS:Edit` token can't do.

## Why not just widen the token

Adding `Account:Read` would work, and it means a deploy credential that can
enumerate the whole Cloudflare account in exchange for one id that isn't even
secret. The zone endpoint already returns `result.account.id`, and reading the
zone you're about to edit is squarely inside what a DNS token is for.

So the workflow reads it off the zone and exports
`CLOUDFLARE_DEFAULT_ACCOUNT_ID` for the `sst deploy` step. No new secret, no
broader token, nothing manual.

## Escape hatches

Setting the `CLOUDFLARE_ACCOUNT_ID` **repo variable** skips the lookup — useful
if the token turns out to lack `Zone:Read`. The error message names both knobs,
because "account id not determined" tells you nothing about which one to turn,
and it also lands in the auto-filed deploy-failure issue.

## Validation

Prettier and type-check pass; step structure verified. The only real test is the
next production deploy — same as the two faults before it.