### PR TITLE
KIT03: split RaceTrack along its seams and convert its controls

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,7 +67,6 @@ const maxLinesAllowlist = [
   // Retired by the flash-cards decomposition stories (PORT epic). RaceTrack is
   // the race loop, the rAF ticker, the per-card clock and the keypad in one
   // module; the split follows those seams, not arbitrary line counts.
-  "src/games/flashcards/RaceTrack.tsx", // 655
   "src/games/flashcards/RaceSetup.tsx", // 473
   "src/games/flashcards/RaceResults.tsx", // 351
   "src/components/screens/Progress.tsx", // 392
@@ -84,7 +83,6 @@ const maxLinesAllowlist = [
 // same PR. The list only shrinks.
 const rawControlsAllowlist = [
   "src/components/PlayerEditor.tsx", // 13
-  "src/games/flashcards/RaceTrack.tsx", // 12
   "src/games/flashcards/RaceResults.tsx", // 5
   "src/components/screens/PlayerSelect.tsx", // 4
   "src/components/screens/Progress.tsx", // 3

--- a/src/engine/run.ts
+++ b/src/engine/run.ts
@@ -1,0 +1,113 @@
+import { compareRuns } from "./records";
+import { evaluateBadges, finishBonuses } from "./progress";
+import { configKey } from "./decks/flashcards";
+import type { CardResult, FlashConfig, Ghost, Profile, Session } from "./types";
+
+/**
+ * Turning a finished race into the record of it.
+ *
+ * This was inline in RaceTrack, which made a component the authority on what
+ * a run is worth — scoring, personal records, bonuses and badges all decided
+ * in the middle of a render tree. None of it needs React, a browser, or
+ * storage: it's the same class of rule as `compareRuns` and belongs with it.
+ *
+ * Everything here is derived. Nothing is written; the caller hands the draft
+ * to the session service, which owns persistence.
+ */
+
+/** What the race loop counted while it was running. */
+export type RunTally = {
+  cards: CardResult[];
+  /** XP from the cards themselves, before finish bonuses. */
+  cardXp: number;
+  bestStreak: number;
+  /** Furthest behind the ghost the player ever fell, in ms. */
+  maxDeficitMs: number;
+};
+
+export type RunSummary = {
+  /** Ready for the session service; add nothing but `earnedBadges`. */
+  draft: Omit<Session, "id" | "finishedAt">;
+  earnedBadges: string[];
+  /** Badges the player didn't already hold — what the results screen crows about. */
+  newBadges: string[];
+  bonuses: ReturnType<typeof finishBonuses>;
+  personalRecord: boolean;
+  /** null when there was no ghost to race. */
+  beatGhost: boolean | null;
+};
+
+export function summariseRun({
+  profile,
+  config,
+  seed,
+  ghost,
+  history,
+  previousBest,
+  tally,
+}: {
+  profile: Profile;
+  config: FlashConfig;
+  seed: number;
+  ghost: Ghost | null;
+  /** The player's earlier runs, snapshotted before this one existed. */
+  history: Session[];
+  /** Their best at these exact settings, or null if this is the first. */
+  previousBest: Session | null;
+  tally: RunTally;
+}): RunSummary {
+  const cards = tally.cards;
+  const correct = cards.filter((c) => c.ok).length;
+  const incorrect = cards.length - correct;
+  const durationMs = cards.reduce((sum, c) => sum + c.ms, 0);
+
+  // Timed runs are ranked on cards beaten before time, untimed ones on the
+  // clock — `compareRuns` owns that rule so the record book and the results
+  // screen can never disagree about what "better" means.
+  const scored = { durationMs, correct, incorrect, config };
+  const personalRecord =
+    previousBest !== null && compareRuns(scored, previousBest) < 0;
+  const beatGhost = ghost ? compareRuns(scored, ghost.session) < 0 : null;
+
+  const bonuses = finishBonuses({
+    perfect: incorrect === 0 && correct > 0,
+    personalRecord,
+    beatGhost: beatGhost === true,
+    cardCount: cards.length,
+  });
+  const xpEarned = tally.cardXp + bonuses.reduce((sum, b) => sum + b.xp, 0);
+
+  const draft = {
+    profileId: profile.id,
+    game: "flashcards" as const,
+    mode: config.operation,
+    configKey: configKey(config),
+    config,
+    seed,
+    durationMs,
+    correct,
+    incorrect,
+    bestStreak: tally.bestStreak,
+    xpEarned,
+    ghostSessionId: ghost?.session.id ?? null,
+    beatGhost,
+    cards,
+  };
+
+  const earnedBadges = evaluateBadges({
+    session: draft,
+    history,
+    personalRecord,
+    maxDeficitMs: tally.maxDeficitMs,
+    xpAfter: profile.xp + xpEarned,
+  });
+
+  return {
+    draft,
+    earnedBadges,
+    newBadges: earnedBadges.filter((id) => !profile.badges.includes(id)),
+    bonuses,
+    personalRecord,
+    beatGhost,
+  };
+}

--- a/src/games/flashcards/RaceTrack.tsx
+++ b/src/games/flashcards/RaceTrack.tsx
@@ -6,33 +6,29 @@ import { buildDeck, configKey } from "@/engine/decks/flashcards";
 import {
   WRONG_ANSWER_PENALTY_MS,
   bestRun,
-  compareRuns,
   cumulativeSplits,
   sessionsFor,
 } from "@/engine/records";
-import {
-  cardXp,
-  comboMultiplier,
-  evaluateBadges,
-  finishBonuses,
-  levelFromXp,
-} from "@/engine/progress";
-import { clock, delta as formatDelta } from "@/engine/format";
+import { cardXp } from "@/engine/progress";
 import { sfx } from "@/services/sound";
-import type { CardResult, Ghost, Profile, Session } from "@/engine/types";
-import { Scrim } from "@/components/ui/kit";
+import type { CardResult, Profile, Session } from "@/engine/types";
+import { AnswerPad } from "./race/AnswerPad";
+import { CardFace } from "./race/CardFace";
+import { Hud } from "./race/Hud";
+import { Lane } from "./race/Lane";
+import { QuitSheet } from "./race/QuitSheet";
+import { SaveFailed } from "./race/SaveFailed";
+import { useCountdown } from "./race/useCountdown";
+import { useGhostGap } from "./race/useGhostGap";
+import { useRaceClock } from "./race/useRaceClock";
+import { useRaceFinish } from "./race/useRaceFinish";
+import { useRaceKeyboard } from "./race/useRaceKeyboard";
+import type { Feedback } from "./race/types";
 
 const RIGHT_PAUSE_MS = 320;
 const WRONG_PAUSE_MS = 1500;
 /** Long enough to actually read an answer you never got to attempt. */
 const TIMEOUT_PAUSE_MS = 1900;
-/** The card clock ticks audibly over its last three seconds. */
-const TICK_FROM_MS = 3000;
-
-type Feedback = {
-  kind: "right" | "wrong" | "timeout";
-  given: number | null;
-} | null;
 
 export default function RaceTrack() {
   const { profileId } = useParams();
@@ -106,93 +102,75 @@ function Track({
   const [phase, setPhase] = useState<"countdown" | "racing" | "saving">(
     "countdown",
   );
-  const [countdown, setCountdown] = useState(3);
   const [index, setIndex] = useState(0);
   const [entry, setEntry] = useState("");
   const [feedback, setFeedback] = useState<Feedback>(null);
   const [streak, setStreak] = useState(0);
-  const [, setTick] = useState(0);
   const [quitting, setQuitting] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
 
-  const cardStart = useRef(0);
-  const banked = useRef(0);
   const misses = useRef(0);
   const bestStreak = useRef(0);
   const earnedXp = useRef(0);
   const results = useRef<CardResult[]>([]);
-  const maxDeficit = useRef(0);
-  const wasBehind = useRef(false);
   const advanceTimer = useRef<number | null>(null);
-  const finishing = useRef(false);
   const entryRef = useRef("");
   const completeRef = useRef<() => Promise<void>>(async () => {});
-  const fuse = useRef<HTMLDivElement | null>(null);
-  /** Stops the animation loop from re-inflating the fuse after a card lands. */
-  const fuseHeld = useRef(false);
-  /** When the quit sheet went up, or 0 while play is running. */
-  const pausedAt = useRef(0);
+  /**
+   * Breaks a definition cycle: the clock needs something to call when a card
+   * times out, and `submit` needs the clock to bank the time. The ref lets the
+   * clock be created first and still reach the real handler.
+   */
+  const submitRef = useRef<(value: number | null) => void>(() => {});
 
   const card = deck[index];
   const total = deck.length;
 
-  const elapsed = () => {
-    if (phase !== "racing" || feedback !== null) return banked.current;
-    // Reading the pause mark instead of the wall clock holds the time still
-    // while the quit sheet is up.
-    const now = pausedAt.current || performance.now();
-    return banked.current + (now - cardStart.current);
-  };
+  const { fuseRef, elapsed, onCard, secondsLeft, bank, spendFuse, startCard } =
+    useRaceClock({
+      limitMs,
+      racing: phase === "racing",
+      resolved: feedback !== null,
+      quitting,
+      index,
+      onTimeout: () => submitRef.current(null),
+    });
   const raceElapsed = elapsed() + misses.current * WRONG_ANSWER_PENALTY_MS;
 
-  /* ── Countdown ─────────────────────────────────────────────────────── */
-  useEffect(() => {
-    if (phase !== "countdown") return;
-    sfx.countdown(countdown);
-    const timer = window.setTimeout(
-      () => {
-        if (countdown === 0) {
-          cardStart.current = performance.now();
-          setPhase("racing");
-        } else {
-          setCountdown((n) => n - 1);
-        }
-      },
-      countdown === 0 ? 420 : 680,
-    );
-    return () => window.clearTimeout(timer);
-  }, [phase, countdown]);
+  const rival = useGhostGap({
+    splits: ghostSplits,
+    raceElapsed,
+    index,
+    total,
+  });
 
-  /* ── Clock ─────────────────────────────────────────────────────────── */
-  useEffect(() => {
-    if (phase !== "racing") return;
-    let frame = 0;
-    let last = 0;
-    const loop = (now: number) => {
-      if (now - last > 60) {
-        last = now;
-        setTick((t) => t + 1);
-      }
-      // The fuse is written straight to the DOM rather than rendered: it has
-      // to move at full frame rate, and it has to keep draining for players
-      // who've asked for reduced motion — so it can't be a CSS animation.
-      if (
-        limitMs !== null &&
-        fuse.current &&
-        !fuseHeld.current &&
-        !pausedAt.current
-      ) {
-        const left = 1 - (now - cardStart.current) / limitMs;
-        fuse.current.style.setProperty(
-          "--left",
-          String(Math.min(1, Math.max(0, left))),
-        );
-      }
-      frame = requestAnimationFrame(loop);
-    };
-    frame = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(frame);
-  }, [phase, limitMs]);
+  const { saveError, complete, retry, hasFinished } = useRaceFinish({
+    profile,
+    config,
+    seed,
+    ghost,
+    history,
+    previousBest,
+    readTally: () => ({
+      cards: results.current,
+      cardXp: earnedXp.current,
+      bestStreak: bestStreak.current,
+      maxDeficitMs: rival.maxDeficitMs(),
+    }),
+    saveSession,
+    finish,
+    notify,
+    navigate,
+    onSaving: () => setPhase("saving"),
+  });
+  completeRef.current = complete;
+
+  const countdown = useCountdown({
+    active: phase === "countdown",
+    onGo: useCallback(() => {
+      startCard();
+      setPhase("racing");
+    }, [startCard]),
+  });
 
   useEffect(
     () => () => {
@@ -200,23 +178,6 @@ function Track({
     },
     [],
   );
-
-  /* ── Ghost position ────────────────────────────────────────────────── */
-  const ghostCardsDone = ghostSplits
-    ? ghostSplits.filter((t) => t <= raceElapsed).length
-    : 0;
-  const checkpoint = ghostSplits
-    ? ghostSplits[Math.min(index, ghostSplits.length - 1)]
-    : null;
-  const gap = checkpoint === null ? null : raceElapsed - checkpoint;
-
-  useEffect(() => {
-    if (gap === null) return;
-    maxDeficit.current = Math.max(maxDeficit.current, gap);
-    const behind = gap > 0;
-    if (wasBehind.current && !behind) sfx.overtake();
-    wasBehind.current = behind;
-  }, [gap]);
 
   /* ── Answering ─────────────────────────────────────────────────────── */
 
@@ -230,100 +191,65 @@ function Track({
   live.current = { phase, feedback, card, streak, total, limitMs };
 
   /** `null` means the card's clock ran out before an answer arrived. */
-  const submit = useCallback((value: number | null) => {
-    const { phase, feedback, card, streak, total, limitMs } = live.current;
-    if (phase !== "racing" || feedback !== null || finishing.current) return;
-    const lateOut = value === null;
-    // A timeout banks exactly the limit, so the stopwatch, the fuse and the
-    // saved split all agree even if the timer fires a frame or two late.
-    // Whole milliseconds keep the saved file readable and the totals exact.
-    const ms = lateOut
-      ? limitMs!
-      : Math.round(performance.now() - cardStart.current);
-    const ok = !lateOut && value === card.answer;
-    banked.current += ms;
-    fuseHeld.current = true;
-    if (lateOut) fuse.current?.style.setProperty("--left", "0");
-    results.current.push({
-      prompt: card.prompt,
-      answer: card.answer,
-      given: value,
-      ok,
-      ms,
-      facts: card.facts,
-      ...(lateOut && { timedOut: true }),
-    });
+  const submit = useCallback(
+    (value: number | null) => {
+      const { phase, feedback, card, streak, total, limitMs } = live.current;
+      if (phase !== "racing" || feedback !== null || hasFinished()) return;
+      const lateOut = value === null;
+      // A timeout banks exactly the limit, so the stopwatch, the fuse and the
+      // saved split all agree even if the timer fires a frame or two late.
+      // Whole milliseconds keep the saved file readable and the totals exact.
+      const ms = lateOut ? limitMs! : Math.round(onCard());
+      const ok = !lateOut && value === card.answer;
+      bank(ms);
+      if (lateOut) spendFuse();
+      results.current.push({
+        prompt: card.prompt,
+        answer: card.answer,
+        given: value,
+        ok,
+        ms,
+        facts: card.facts,
+        ...(lateOut && { timedOut: true }),
+      });
 
-    if (ok) {
-      const next = streak + 1;
-      setStreak(next);
-      bestStreak.current = Math.max(bestStreak.current, next);
-      earnedXp.current += cardXp(ms, next);
-      sfx.correct(next);
-    } else {
-      setStreak(0);
-      misses.current += 1;
-      if (lateOut) sfx.timeout();
-      else sfx.wrong();
-    }
+      if (ok) {
+        const next = streak + 1;
+        setStreak(next);
+        bestStreak.current = Math.max(bestStreak.current, next);
+        earnedXp.current += cardXp(ms, next);
+        sfx.correct(next);
+      } else {
+        setStreak(0);
+        misses.current += 1;
+        if (lateOut) sfx.timeout();
+        else sfx.wrong();
+      }
 
-    setFeedback({
-      kind: lateOut ? "timeout" : ok ? "right" : "wrong",
-      given: value,
-    });
-    advanceTimer.current = window.setTimeout(
-      () => {
-        setFeedback(null);
-        setEntry("");
-        entryRef.current = "";
-        if (results.current.length >= total) {
-          void completeRef.current();
-        } else {
-          setIndex((i) => i + 1);
-          cardStart.current = performance.now();
-          fuseHeld.current = false;
-        }
-      },
-      ok ? RIGHT_PAUSE_MS : lateOut ? TIMEOUT_PAUSE_MS : WRONG_PAUSE_MS,
-    );
-    // Deliberately empty: every value above comes from a ref.
-  }, []);
-
-  const timeUp = useCallback(() => submit(null), [submit]);
-
-  /**
-   * Putting the quit sheet up pauses the card. Resuming shifts the card's
-   * start forward by however long the sheet was open, so a pause neither
-   * costs time nor buys thinking time. Declared before the timer below so the
-   * shift lands before that effect reschedules.
-   */
-  useEffect(() => {
-    if (phase !== "racing") return;
-    if (quitting) {
-      pausedAt.current = performance.now();
-    } else if (pausedAt.current) {
-      cardStart.current += performance.now() - pausedAt.current;
-      pausedAt.current = 0;
-    }
-  }, [quitting, phase]);
-
-  /**
-   * The per-card clock, plus its last-three-seconds ticks. Scheduled once per
-   * card: `timeUp` keeps a stable identity, so the ~16×/second clock re-render
-   * can't tear it down and restart it. The delay is measured from when the
-   * card actually appeared, so a re-run can never hand out extra time.
-   */
-  useEffect(() => {
-    if (limitMs === null || phase !== "racing" || feedback !== null) return;
-    if (quitting) return;
-    const left = limitMs - (performance.now() - cardStart.current);
-    const timers = [window.setTimeout(timeUp, Math.max(0, left))];
-    for (let at = 1000; at <= TICK_FROM_MS; at += 1000) {
-      if (left > at)
-        timers.push(window.setTimeout(() => sfx.tick(), left - at));
-    }
-    return () => timers.forEach((t) => window.clearTimeout(t));
-  }, [limitMs, phase, feedback, index, quitting, timeUp]);
+      setFeedback({
+        kind: lateOut ? "timeout" : ok ? "right" : "wrong",
+        given: value,
+      });
+      advanceTimer.current = window.setTimeout(
+        () => {
+          setFeedback(null);
+          setEntry("");
+          entryRef.current = "";
+          if (results.current.length >= total) {
+            void completeRef.current();
+          } else {
+            setIndex((i) => i + 1);
+            startCard();
+          }
+        },
+        ok ? RIGHT_PAUSE_MS : lateOut ? TIMEOUT_PAUSE_MS : WRONG_PAUSE_MS,
+      );
+      // Every other value above comes from a ref; these are all pinned with
+      // empty dependency lists precisely so this callback can stay stable.
+    },
+    [bank, spendFuse, onCard, startCard, hasFinished],
+  );
+  submitRef.current = submit;
 
   // The entry is mirrored into a ref so Enter can read it without the handler
   // having to re-subscribe on every keystroke.
@@ -338,167 +264,32 @@ function Track({
     setEntry(entryRef.current);
   }, []);
 
-  async function complete() {
-    if (finishing.current) return;
-    finishing.current = true;
-    setPhase("saving");
-    sfx.finish();
-    await save();
-  }
-  completeRef.current = complete;
-
-  async function save() {
-    const cards = results.current;
-    const correct = cards.filter((c) => c.ok).length;
-    const incorrect = cards.length - correct;
-    const durationMs = cards.reduce((sum, c) => sum + c.ms, 0);
-    // Timed runs are ranked on cards beaten before time, untimed ones on the
-    // clock — `compareRuns` owns that rule so the record book and this screen
-    // can never disagree about what "better" means.
-    const scored = { durationMs, correct, incorrect, config };
-
-    const personalRecord =
-      previousBest !== null && compareRuns(scored, previousBest) < 0;
-    const beatGhost = ghost ? compareRuns(scored, ghost.session) < 0 : null;
-    const bonuses = finishBonuses({
-      perfect: incorrect === 0 && correct > 0,
-      personalRecord,
-      beatGhost: beatGhost === true,
-      cardCount: cards.length,
-    });
-    const xpEarned =
-      earnedXp.current + bonuses.reduce((sum, b) => sum + b.xp, 0);
-
-    const draft = {
-      profileId: profile.id,
-      game: "flashcards" as const,
-      mode: config.operation,
-      configKey: configKey(config),
-      config,
-      seed,
-      durationMs,
-      correct,
-      incorrect,
-      bestStreak: bestStreak.current,
-      xpEarned,
-      ghostSessionId: ghost?.session.id ?? null,
-      beatGhost,
-      cards,
-    };
-
-    const earnedBadges = evaluateBadges({
-      session: draft,
-      history,
-      personalRecord,
-      maxDeficitMs: maxDeficit.current,
-      xpAfter: profile.xp + xpEarned,
-    });
-    const newBadges = earnedBadges.filter((id) => !profile.badges.includes(id));
-
-    try {
-      const saved = await saveSession({ ...draft, earnedBadges });
-      const levelBefore = levelFromXp(profile.xp).level;
-      const levelAfter = levelFromXp(saved.profile.xp).level;
-      finish({
-        session: saved.session,
-        profileAfter: saved.profile,
-        ghost,
-        personalRecord,
-        previousBest,
-        newBadges,
-        bonuses,
-        levelledUpTo: levelAfter > levelBefore ? levelAfter : null,
-      });
-      navigate(`/p/${profile.id}/race/results`, { replace: true });
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Could not save this race";
-      setSaveError(message);
-      notify(message, "bad");
-    }
-  }
-
-  /* ── Keyboard ──────────────────────────────────────────────────────── */
-  useEffect(() => {
-    if (phase !== "racing") return;
-    function onKey(event: KeyboardEvent) {
-      if (feedback !== null) return;
-      if (config.inputMode === "choose") {
-        const slot = Number(event.key);
-        if (slot >= 1 && slot <= 4 && card.choices) {
-          event.preventDefault();
-          submit(card.choices[slot - 1]);
-        }
-        return;
-      }
-      if (/^[0-9]$/.test(event.key)) {
-        event.preventDefault();
-        pushDigit(event.key);
-      } else if (event.key === "Backspace") {
-        event.preventDefault();
-        dropDigit();
-      } else if (event.key === "Enter") {
-        event.preventDefault();
-        if (entryRef.current !== "") submit(Number(entryRef.current));
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [phase, feedback, config.inputMode, card, submit, pushDigit, dropDigit]);
-
-  // Auto-submit the moment the entry is as long as the answer — keeps the pace
-  // up without making kids hunt for Enter.
-  useEffect(() => {
-    if (phase !== "racing" || feedback !== null || config.inputMode !== "type")
-      return;
-    if (entry.length > 0 && entry.length === String(card.answer).length) {
-      const value = Number(entry);
-      const timer = window.setTimeout(() => submit(value), 90);
-      return () => window.clearTimeout(timer);
-    }
-  }, [entry, phase, feedback, config.inputMode, card.answer, submit]);
+  useRaceKeyboard({
+    active: phase === "racing" && feedback === null,
+    inputMode: config.inputMode,
+    choices: card.choices,
+    answerLength: String(card.answer).length,
+    entry,
+    entryRef,
+    submit,
+    pushDigit,
+    dropDigit,
+  });
 
   /* ── Render ────────────────────────────────────────────────────────── */
 
   if (saveError) {
     return (
-      <main className="boot">
-        <p className="u-eyebrow">Race finished</p>
-        <h1 className="u-display boot__title">Couldn&apos;t save this race</h1>
-        <p className="boot__msg">{saveError}</p>
-        <p className="boot__hint">
-          Your answers are still here. Try again once the hub server is back.
-        </p>
-        <div className="boot__actions">
-          <button
-            className="btn btn--go"
-            onClick={() => {
-              setSaveError(null);
-              void save();
-            }}
-          >
-            Save again
-          </button>
-          <button
-            className="btn btn--ghost"
-            onClick={() => navigate(`/p/${profile.id}`)}
-          >
-            Discard and go back
-          </button>
-        </div>
-      </main>
+      <SaveFailed
+        message={saveError}
+        onRetry={retry}
+        onDiscard={() => navigate(`/p/${profile.id}`)}
+      />
     );
   }
 
   const answered = results.current.length;
-  const combo = comboMultiplier(streak);
-  const secondsLeft =
-    limitMs === null || phase !== "racing" || feedback !== null
-      ? null
-      : Math.max(
-          0,
-          Math.ceil((limitMs - (performance.now() - cardStart.current)) / 1000),
-        );
+  const settled = feedback !== null || phase !== "racing";
 
   return (
     <main
@@ -513,34 +304,20 @@ function Track({
         </div>
       )}
 
-      <header className="race__hud">
-        <button className="race__quit" onClick={() => setQuitting(true)}>
-          Quit
-        </button>
-
-        <div className="race__clock u-mono">
-          <span className="race__clock-time">{clock(elapsed())}</span>
-          {misses.current > 0 && (
-            <span className="race__penalty">
-              +{(misses.current * WRONG_ANSWER_PENALTY_MS) / 1000}s
-            </span>
-          )}
-        </div>
-
-        <div className="race__count u-mono">
-          <span className="race__count-now">
-            {Math.min(answered + 1, total)}
-          </span>
-          <span className="race__count-of">/ {total}</span>
-        </div>
-      </header>
+      <Hud
+        elapsedMs={elapsed()}
+        misses={misses.current}
+        answered={answered}
+        total={total}
+        onQuit={() => setQuitting(true)}
+      />
 
       <Lane
         profile={profile}
         ghost={ghost}
         mePos={answered / total}
-        ghostPos={ghostSplits ? Math.min(ghostCardsDone / total, 1) : null}
-        gap={gap}
+        ghostPos={rival.position}
+        gap={rival.gap}
         note={
           limitMs === null
             ? "Racing the clock"
@@ -548,221 +325,36 @@ function Track({
         }
       />
 
-      <section className={`card${feedback ? ` card--${feedback.kind}` : ""}`}>
-        {limitMs !== null && (
-          // Keyed on the card so a new card remounts it with a full bar. The
-          // prefix keeps it from colliding with the combo badge's key.
-          <div
-            key={`fuse-${index}`}
-            ref={fuse}
-            className={`fuse${secondsLeft !== null && secondsLeft <= 3 ? " is-urgent" : ""}${feedback?.kind === "timeout" ? " is-spent" : ""}`}
-          >
-            <span className="fuse__track">
-              <span className="fuse__fill" />
-            </span>
-            <span className="fuse__num u-mono" aria-hidden="true">
-              {secondsLeft ?? 0}
-            </span>
-          </div>
-        )}
-        <p className="card__prompt u-display" aria-live="polite">
-          {card.prompt}
-        </p>
-        <div className="card__answer">
-          {feedback?.kind === "timeout" ? (
-            <span className="card__truth u-mono">
-              <span className="card__late">Out of time</span> {card.answer}
-            </span>
-          ) : feedback?.kind === "wrong" ? (
-            <span className="card__truth u-mono">
-              <s>{feedback.given}</s> {card.answer}
-            </span>
-          ) : config.inputMode === "type" ? (
-            <span className={`card__entry u-mono${entry ? "" : " is-empty"}`}>
-              {entry || "?"}
-            </span>
-          ) : (
-            <span className="card__entry u-mono is-empty">?</span>
-          )}
-        </div>
-        {streak >= 3 && (
-          <span key={streak} className="combo anim-pop">
-            🔥 {streak} in a row · ×{combo.toFixed(1)} XP
-          </span>
-        )}
-      </section>
+      <CardFace
+        card={card}
+        index={index}
+        feedback={feedback}
+        entry={entry}
+        inputMode={config.inputMode}
+        limitMs={limitMs}
+        secondsLeft={secondsLeft()}
+        streak={streak}
+        fuseRef={fuseRef}
+      />
 
-      {config.inputMode === "type" ? (
-        <Keypad
-          disabled={feedback !== null || phase !== "racing"}
-          onDigit={pushDigit}
-          onBack={dropDigit}
-          onEnter={() =>
-            entryRef.current !== "" && submit(Number(entryRef.current))
-          }
-        />
-      ) : (
-        <div className="choices">
-          {(card.choices ?? []).map((choice, i) => (
-            <button
-              key={choice}
-              className="choices__btn u-mono"
-              disabled={feedback !== null || phase !== "racing"}
-              onClick={() => submit(choice)}
-            >
-              <span className="choices__key">{i + 1}</span>
-              {choice}
-            </button>
-          ))}
-        </div>
-      )}
+      <AnswerPad
+        mode={config.inputMode}
+        choices={card.choices}
+        disabled={settled}
+        onDigit={pushDigit}
+        onBack={dropDigit}
+        onEnter={() =>
+          entryRef.current !== "" && submit(Number(entryRef.current))
+        }
+        onChoose={submit}
+      />
 
       {quitting && (
-        <div
-          className="sheet"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Quit the race"
-        >
-          <Scrim onClose={() => setQuitting(false)} label="Keep racing" />
-          <div className="sheet__panel panel anim-pop">
-            <h2 className="panel__title">Quit this race?</h2>
-            <p className="muted">It won&apos;t be saved and no XP is earned.</p>
-            <div className="sheet__actions">
-              <button
-                className="btn btn--danger btn--sm"
-                onClick={() => navigate(`/p/${profile.id}`)}
-              >
-                Quit
-              </button>
-              <button
-                className="btn btn--accent"
-                onClick={() => setQuitting(false)}
-              >
-                Keep racing
-              </button>
-            </div>
-          </div>
-        </div>
+        <QuitSheet
+          onQuit={() => navigate(`/p/${profile.id}`)}
+          onKeepRacing={() => setQuitting(false)}
+        />
       )}
     </main>
-  );
-}
-
-/* ── The signature element: a rally split against a ghost ──────────────── */
-
-function Lane({
-  profile,
-  ghost,
-  mePos,
-  ghostPos,
-  gap,
-  note,
-}: {
-  profile: Profile;
-  ghost: Ghost | null;
-  mePos: number;
-  ghostPos: number | null;
-  gap: number | null;
-  note: string;
-}) {
-  const ahead = gap !== null && gap < 0;
-  return (
-    <div className="lane">
-      <div className="lane__track">
-        <span className="lane__finish" aria-hidden="true">
-          🏁
-        </span>
-        {ghostPos !== null && ghost && (
-          <span
-            className="lane__puck lane__puck--ghost"
-            style={
-              {
-                "--p": ghostPos,
-                "--tint": ghost.profile.color,
-              } as React.CSSProperties
-            }
-            title={ghost.isSelf ? "Your best run" : ghost.profile.name}
-          >
-            {ghost.profile.emoji}
-          </span>
-        )}
-        <span
-          className="lane__puck lane__puck--me"
-          style={
-            {
-              "--p": mePos,
-              "--tint": profile.color,
-            } as React.CSSProperties
-          }
-        >
-          {profile.emoji}
-        </span>
-      </div>
-
-      {gap === null ? (
-        <p className="lane__note u-mono">{note}</p>
-      ) : (
-        <p
-          className={`lane__gap u-mono${ahead ? " is-ahead" : " is-behind"}`}
-          aria-live="off"
-        >
-          <span className="lane__gap-num">{formatDelta(gap)}</span>
-          <span className="lane__gap-word">{ahead ? "ahead" : "behind"}</span>
-        </p>
-      )}
-    </div>
-  );
-}
-
-/* ── Keypad ────────────────────────────────────────────────────────────── */
-
-function Keypad({
-  disabled,
-  onDigit,
-  onBack,
-  onEnter,
-}: {
-  disabled: boolean;
-  onDigit: (digit: string) => void;
-  onBack: () => void;
-  onEnter: () => void;
-}) {
-  return (
-    <div className="keypad">
-      {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((digit) => (
-        <button
-          key={digit}
-          className="keypad__key u-mono"
-          disabled={disabled}
-          onClick={() => onDigit(digit)}
-        >
-          {digit}
-        </button>
-      ))}
-      <button
-        className="keypad__key keypad__key--util"
-        disabled={disabled}
-        onClick={onBack}
-        aria-label="Delete"
-      >
-        ⌫
-      </button>
-      <button
-        className="keypad__key u-mono"
-        disabled={disabled}
-        onClick={() => onDigit("0")}
-      >
-        0
-      </button>
-      <button
-        className="keypad__key keypad__key--enter"
-        disabled={disabled}
-        onClick={onEnter}
-        aria-label="Submit"
-      >
-        ↵
-      </button>
-    </div>
   );
 }

--- a/src/games/flashcards/race/AnswerPad.tsx
+++ b/src/games/flashcards/race/AnswerPad.tsx
@@ -1,0 +1,89 @@
+import { Button } from "@/components/ui/kit";
+import type { InputMode } from "@/engine/types";
+
+/**
+ * However the player answers: a keypad they type into, or four choices they
+ * tap. Both are the same job, so the caller picks a mode rather than deciding
+ * which component to render.
+ *
+ * The keyboard shortcuts for both live in RaceTrack — they're window-level
+ * listeners tied to the race's own state, not to whatever is on screen.
+ */
+export function AnswerPad({
+  mode,
+  choices,
+  disabled,
+  onDigit,
+  onBack,
+  onEnter,
+  onChoose,
+}: {
+  mode: InputMode;
+  choices: number[] | undefined;
+  disabled: boolean;
+  onDigit: (digit: string) => void;
+  onBack: () => void;
+  onEnter: () => void;
+  onChoose: (choice: number) => void;
+}) {
+  if (mode === "choose") {
+    return (
+      <div className="choices">
+        {(choices ?? []).map((choice, i) => (
+          <Button
+            key={choice}
+            variant="bare"
+            className="choices__btn u-mono"
+            disabled={disabled}
+            onClick={() => onChoose(choice)}
+          >
+            <span className="choices__key">{i + 1}</span>
+            {choice}
+          </Button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="keypad">
+      {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((digit) => (
+        <Button
+          key={digit}
+          variant="bare"
+          className="keypad__key u-mono"
+          disabled={disabled}
+          onClick={() => onDigit(digit)}
+        >
+          {digit}
+        </Button>
+      ))}
+      <Button
+        variant="bare"
+        className="keypad__key keypad__key--util"
+        disabled={disabled}
+        onClick={onBack}
+        aria-label="Delete"
+      >
+        ⌫
+      </Button>
+      <Button
+        variant="bare"
+        className="keypad__key u-mono"
+        disabled={disabled}
+        onClick={() => onDigit("0")}
+      >
+        0
+      </Button>
+      <Button
+        variant="bare"
+        className="keypad__key keypad__key--enter"
+        disabled={disabled}
+        onClick={onEnter}
+        aria-label="Submit"
+      >
+        ↵
+      </Button>
+    </div>
+  );
+}

--- a/src/games/flashcards/race/CardFace.tsx
+++ b/src/games/flashcards/race/CardFace.tsx
@@ -1,0 +1,79 @@
+import { comboMultiplier } from "@/engine/progress";
+import type { Card, InputMode } from "@/engine/types";
+import type { Feedback } from "./types";
+
+/**
+ * The card itself: the fuse draining across the top, the prompt, whatever the
+ * player has entered so far, and the combo badge.
+ *
+ * `fuseRef` belongs to the race clock, which writes the drain position
+ * straight to the DOM every frame rather than through React.
+ */
+export function CardFace({
+  card,
+  index,
+  feedback,
+  entry,
+  inputMode,
+  limitMs,
+  secondsLeft,
+  streak,
+  fuseRef,
+}: {
+  card: Card;
+  index: number;
+  feedback: Feedback;
+  entry: string;
+  inputMode: InputMode;
+  limitMs: number | null;
+  secondsLeft: number | null;
+  streak: number;
+  fuseRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const combo = comboMultiplier(streak);
+  return (
+    <section className={`card${feedback ? ` card--${feedback.kind}` : ""}`}>
+      {limitMs !== null && (
+        // Keyed on the card so a new card remounts it with a full bar. The
+        // prefix keeps it from colliding with the combo badge's key.
+        <div
+          key={`fuse-${index}`}
+          ref={fuseRef}
+          className={`fuse${secondsLeft !== null && secondsLeft <= 3 ? " is-urgent" : ""}${feedback?.kind === "timeout" ? " is-spent" : ""}`}
+        >
+          <span className="fuse__track">
+            <span className="fuse__fill" />
+          </span>
+          <span className="fuse__num u-mono" aria-hidden="true">
+            {secondsLeft ?? 0}
+          </span>
+        </div>
+      )}
+      <p className="card__prompt u-display" aria-live="polite">
+        {card.prompt}
+      </p>
+      <div className="card__answer">
+        {feedback?.kind === "timeout" ? (
+          <span className="card__truth u-mono">
+            <span className="card__late">Out of time</span> {card.answer}
+          </span>
+        ) : feedback?.kind === "wrong" ? (
+          <span className="card__truth u-mono">
+            <s>{feedback.given}</s> {card.answer}
+          </span>
+        ) : inputMode === "type" ? (
+          <span className={`card__entry u-mono${entry ? "" : " is-empty"}`}>
+            {entry || "?"}
+          </span>
+        ) : (
+          <span className="card__entry u-mono is-empty">?</span>
+        )}
+      </div>
+      {streak >= 3 && (
+        <span key={streak} className="combo anim-pop">
+          🔥 {streak} in a row · ×{combo.toFixed(1)} XP
+        </span>
+      )}
+    </section>
+  );
+}

--- a/src/games/flashcards/race/Hud.tsx
+++ b/src/games/flashcards/race/Hud.tsx
@@ -1,0 +1,40 @@
+import { Button } from "@/components/ui/kit";
+import { WRONG_ANSWER_PENALTY_MS } from "@/engine/records";
+import { clock } from "@/engine/format";
+
+/** Quit, the running stopwatch with its wrong-answer penalty, and the count. */
+export function Hud({
+  elapsedMs,
+  misses,
+  answered,
+  total,
+  onQuit,
+}: {
+  elapsedMs: number;
+  misses: number;
+  answered: number;
+  total: number;
+  onQuit: () => void;
+}) {
+  return (
+    <header className="race__hud">
+      <Button variant="bare" className="race__quit" onClick={onQuit}>
+        Quit
+      </Button>
+
+      <div className="race__clock u-mono">
+        <span className="race__clock-time">{clock(elapsedMs)}</span>
+        {misses > 0 && (
+          <span className="race__penalty">
+            +{(misses * WRONG_ANSWER_PENALTY_MS) / 1000}s
+          </span>
+        )}
+      </div>
+
+      <div className="race__count u-mono">
+        <span className="race__count-now">{Math.min(answered + 1, total)}</span>
+        <span className="race__count-of">/ {total}</span>
+      </div>
+    </header>
+  );
+}

--- a/src/games/flashcards/race/Lane.tsx
+++ b/src/games/flashcards/race/Lane.tsx
@@ -1,0 +1,68 @@
+import type { Ghost, Profile } from "@/engine/types";
+import { delta as formatDelta } from "@/engine/format";
+
+/* ── The signature element: a rally split against a ghost ──────────────── */
+
+export function Lane({
+  profile,
+  ghost,
+  mePos,
+  ghostPos,
+  gap,
+  note,
+}: {
+  profile: Profile;
+  ghost: Ghost | null;
+  mePos: number;
+  ghostPos: number | null;
+  gap: number | null;
+  note: string;
+}) {
+  const ahead = gap !== null && gap < 0;
+  return (
+    <div className="lane">
+      <div className="lane__track">
+        <span className="lane__finish" aria-hidden="true">
+          🏁
+        </span>
+        {ghostPos !== null && ghost && (
+          <span
+            className="lane__puck lane__puck--ghost"
+            style={
+              {
+                "--p": ghostPos,
+                "--tint": ghost.profile.color,
+              } as React.CSSProperties
+            }
+            title={ghost.isSelf ? "Your best run" : ghost.profile.name}
+          >
+            {ghost.profile.emoji}
+          </span>
+        )}
+        <span
+          className="lane__puck lane__puck--me"
+          style={
+            {
+              "--p": mePos,
+              "--tint": profile.color,
+            } as React.CSSProperties
+          }
+        >
+          {profile.emoji}
+        </span>
+      </div>
+
+      {gap === null ? (
+        <p className="lane__note u-mono">{note}</p>
+      ) : (
+        <p
+          className={`lane__gap u-mono${ahead ? " is-ahead" : " is-behind"}`}
+          aria-live="off"
+        >
+          <span className="lane__gap-num">{formatDelta(gap)}</span>
+          <span className="lane__gap-word">{ahead ? "ahead" : "behind"}</span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/games/flashcards/race/QuitSheet.tsx
+++ b/src/games/flashcards/race/QuitSheet.tsx
@@ -1,0 +1,38 @@
+import { Button, Scrim } from "@/components/ui/kit";
+
+/**
+ * Confirmation before abandoning a run.
+ *
+ * While this is up the race clock is paused — see `useRaceClock`. Backing out
+ * neither costs the player time nor buys them any.
+ */
+export function QuitSheet({
+  onQuit,
+  onKeepRacing,
+}: {
+  onQuit: () => void;
+  onKeepRacing: () => void;
+}) {
+  return (
+    <div
+      className="sheet"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Quit the race"
+    >
+      <Scrim onClose={onKeepRacing} label="Keep racing" />
+      <div className="sheet__panel panel anim-pop">
+        <h2 className="panel__title">Quit this race?</h2>
+        <p className="muted">It won&apos;t be saved and no XP is earned.</p>
+        <div className="sheet__actions">
+          <Button variant="danger" size="sm" onClick={onQuit}>
+            Quit
+          </Button>
+          <Button variant="accent" onClick={onKeepRacing}>
+            Keep racing
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/games/flashcards/race/SaveFailed.tsx
+++ b/src/games/flashcards/race/SaveFailed.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@/components/ui/kit";
+
+/**
+ * The run finished but couldn't be written to IndexedDB — a full disk, a
+ * browser refusing storage in private mode, a revoked quota.
+ *
+ * Retrying is the primary action because the answers are still in memory:
+ * nothing is lost until the player navigates away, which is why the other
+ * button says so plainly rather than "Cancel".
+ */
+export function SaveFailed({
+  message,
+  onRetry,
+  onDiscard,
+}: {
+  message: string;
+  onRetry: () => void;
+  onDiscard: () => void;
+}) {
+  return (
+    <main className="boot">
+      <p className="u-eyebrow">Race finished</p>
+      <h1 className="u-display boot__title">Couldn&apos;t save this race</h1>
+      <p className="boot__msg">{message}</p>
+      <p className="boot__hint">
+        Your answers are still here. Try saving again — nothing is lost until
+        you leave this screen.
+      </p>
+      <div className="boot__actions">
+        <Button variant="go" onClick={onRetry}>
+          Save again
+        </Button>
+        <Button variant="ghost" onClick={onDiscard}>
+          Discard and go back
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/src/games/flashcards/race/types.ts
+++ b/src/games/flashcards/race/types.ts
@@ -1,0 +1,5 @@
+/** How the card that just landed was answered, or null while it's still live. */
+export type Feedback = {
+  kind: "right" | "wrong" | "timeout";
+  given: number | null;
+} | null;

--- a/src/games/flashcards/race/useCountdown.ts
+++ b/src/games/flashcards/race/useCountdown.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { sfx } from "@/services/sound";
+
+/** "GO" holds for less time than a number — it's a starting gun, not a beat. */
+const NUMBER_MS = 680;
+const GO_MS = 420;
+
+/**
+ * The 3 · 2 · 1 · GO before a race starts.
+ *
+ * Each step schedules the next rather than running off an interval, so the
+ * sound and the digit can never drift apart, and unmounting mid-countdown
+ * leaves nothing pending.
+ */
+export function useCountdown({
+  active,
+  from = 3,
+  onGo,
+}: {
+  active: boolean;
+  from?: number;
+  /** Must be stable — it's a dependency of the timer below. */
+  onGo: () => void;
+}) {
+  const [count, setCount] = useState(from);
+
+  useEffect(() => {
+    if (!active) return;
+    sfx.countdown(count);
+    const timer = window.setTimeout(
+      () => {
+        if (count === 0) onGo();
+        else setCount((n) => n - 1);
+      },
+      count === 0 ? GO_MS : NUMBER_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [active, count, onGo]);
+
+  return count;
+}

--- a/src/games/flashcards/race/useGhostGap.ts
+++ b/src/games/flashcards/race/useGhostGap.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from "react";
+import { sfx } from "@/services/sound";
+
+/**
+ * Where the rival is, and how far ahead or behind that puts the player.
+ *
+ * A ghost is a previous run replayed as split times, so "their position" is
+ * just how many of those splits the current elapsed time has passed. The
+ * overtake sound fires on the transition from behind to ahead, not on the
+ * state — which is why the previous side is remembered here rather than
+ * recomputed.
+ *
+ * `maxDeficitMs` is the furthest behind the player ever fell. It's a badge
+ * input, so it has to survive the whole run even though nothing renders it.
+ */
+export function useGhostGap({
+  splits,
+  raceElapsed,
+  index,
+  total,
+}: {
+  /** Cumulative finish time per card for the ghost, or null with no rival. */
+  splits: number[] | null;
+  raceElapsed: number;
+  index: number;
+  total: number;
+}) {
+  const maxDeficit = useRef(0);
+  const wasBehind = useRef(false);
+
+  const cardsDone = splits ? splits.filter((t) => t <= raceElapsed).length : 0;
+  const checkpoint = splits ? splits[Math.min(index, splits.length - 1)] : null;
+  const gap = checkpoint === null ? null : raceElapsed - checkpoint;
+
+  useEffect(() => {
+    if (gap === null) return;
+    maxDeficit.current = Math.max(maxDeficit.current, gap);
+    const behind = gap > 0;
+    if (wasBehind.current && !behind) sfx.overtake();
+    wasBehind.current = behind;
+  }, [gap]);
+
+  return {
+    gap,
+    position: splits ? Math.min(cardsDone / total, 1) : null,
+    /** Stable, so callers that must not re-render can hold onto it. */
+    maxDeficitMs: useCallback(() => maxDeficit.current, []),
+  };
+}

--- a/src/games/flashcards/race/useRaceClock.ts
+++ b/src/games/flashcards/race/useRaceClock.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { sfx } from "@/services/sound";
+
+/** The card clock ticks audibly over its last three seconds. */
+const TICK_FROM_MS = 3000;
+
+/**
+ * Every piece of time in a race: the stopwatch, the per-card clock, the fuse
+ * that drains across the card, and the pause that a quit sheet imposes.
+ *
+ * These live together because they share mutable state that must agree to the
+ * millisecond. The banked total, the current card's start mark and the pause
+ * mark are read by all four; splitting them apart would mean passing three
+ * refs between modules and hoping nobody writes to one without the others.
+ */
+export type RaceClock = {
+  /** Attach to the fuse element. Written to directly — see the loop below. */
+  fuseRef: React.RefObject<HTMLDivElement | null>;
+  /** Total race time: banked cards plus the live one, frozen while paused. */
+  elapsed: () => number;
+  /** Milliseconds since the current card appeared. */
+  onCard: () => number;
+  /** Whole seconds left on this card, or null when there's no card clock. */
+  secondsLeft: () => number | null;
+  /** Bank a finished card and freeze the fuse where it stands. */
+  bank: (ms: number) => void;
+  /** Drain the fuse to empty — what a timeout looks like. */
+  spendFuse: () => void;
+  /** Start the clock on a fresh card. */
+  startCard: () => void;
+};
+
+export function useRaceClock({
+  limitMs,
+  racing,
+  resolved,
+  quitting,
+  index,
+  onTimeout,
+}: {
+  /** Fixed for the whole run; null means no per-card clock. */
+  limitMs: number | null;
+  racing: boolean;
+  /** True while a card is showing feedback, which stops its clock. */
+  resolved: boolean;
+  quitting: boolean;
+  /** Which card is up. Re-arms the timer when it changes. */
+  index: number;
+  onTimeout: () => void;
+}): RaceClock {
+  const cardStart = useRef(0);
+  const banked = useRef(0);
+  /** When the quit sheet went up, or 0 while play is running. */
+  const pausedAt = useRef(0);
+  const fuseRef = useRef<HTMLDivElement | null>(null);
+  /** Stops the animation loop from re-inflating the fuse after a card lands. */
+  const fuseHeld = useRef(false);
+  const [, setTick] = useState(0);
+
+  /**
+   * Held in a ref so the per-card timer effect below doesn't depend on a
+   * callback identity. The clock re-renders this screen ~16×/second; an effect
+   * that depended on a fresh closure would tear down and restart its timer on
+   * every one of those renders and never actually fire.
+   */
+  const timeout = useRef(onTimeout);
+  timeout.current = onTimeout;
+
+  const elapsed = () => {
+    if (!racing || resolved) return banked.current;
+    // Reading the pause mark instead of the wall clock holds the time still
+    // while the quit sheet is up.
+    const now = pausedAt.current || performance.now();
+    return banked.current + (now - cardStart.current);
+  };
+
+  /**
+   * The four below touch nothing but refs, so they're pinned with an empty
+   * dependency list. That isn't a micro-optimisation: `submit` in RaceTrack
+   * must keep a stable identity or the per-card timer effect would tear down
+   * and restart on every one of the ~16 renders a second the ticker causes,
+   * and never fire. Handing it unstable callbacks would break that from here.
+   */
+  const onCard = useCallback(() => performance.now() - cardStart.current, []);
+
+  const bank = useCallback((ms: number) => {
+    banked.current += ms;
+    fuseHeld.current = true;
+  }, []);
+
+  const spendFuse = useCallback(
+    () => fuseRef.current?.style.setProperty("--left", "0"),
+    [],
+  );
+
+  const startCard = useCallback(() => {
+    cardStart.current = performance.now();
+    fuseHeld.current = false;
+  }, []);
+
+  // Reads props, so it's rebuilt each render — only ever called during render.
+  const secondsLeft = () =>
+    limitMs === null || !racing || resolved
+      ? null
+      : Math.max(0, Math.ceil((limitMs - onCard()) / 1000));
+
+  /* ── The ticker ────────────────────────────────────────────────────── */
+  useEffect(() => {
+    if (!racing) return;
+    let frame = 0;
+    let last = 0;
+    const loop = (now: number) => {
+      if (now - last > 60) {
+        last = now;
+        setTick((t) => t + 1);
+      }
+      // The fuse is written straight to the DOM rather than rendered: it has
+      // to move at full frame rate, and it has to keep draining for players
+      // who've asked for reduced motion — so it can't be a CSS animation.
+      if (
+        limitMs !== null &&
+        fuseRef.current &&
+        !fuseHeld.current &&
+        !pausedAt.current
+      ) {
+        const left = 1 - (now - cardStart.current) / limitMs;
+        fuseRef.current.style.setProperty(
+          "--left",
+          String(Math.min(1, Math.max(0, left))),
+        );
+      }
+      frame = requestAnimationFrame(loop);
+    };
+    frame = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(frame);
+  }, [racing, limitMs]);
+
+  /**
+   * Putting the quit sheet up pauses the card. Resuming shifts the card's
+   * start forward by however long the sheet was open, so a pause neither
+   * costs time nor buys thinking time. Declared before the timer below so the
+   * shift lands before that effect reschedules.
+   */
+  useEffect(() => {
+    if (!racing) return;
+    if (quitting) {
+      pausedAt.current = performance.now();
+    } else if (pausedAt.current) {
+      cardStart.current += performance.now() - pausedAt.current;
+      pausedAt.current = 0;
+    }
+  }, [quitting, racing]);
+
+  /**
+   * The per-card clock, plus its last-three-seconds ticks. Scheduled once per
+   * card. The delay is measured from when the card actually appeared, so a
+   * re-run can never hand out extra time.
+   */
+  useEffect(() => {
+    if (limitMs === null || !racing || resolved || quitting) return;
+    const left = limitMs - (performance.now() - cardStart.current);
+    const timers = [
+      window.setTimeout(() => timeout.current(), Math.max(0, left)),
+    ];
+    for (let at = 1000; at <= TICK_FROM_MS; at += 1000) {
+      if (left > at)
+        timers.push(window.setTimeout(() => sfx.tick(), left - at));
+    }
+    return () => timers.forEach((t) => window.clearTimeout(t));
+  }, [limitMs, racing, resolved, index, quitting]);
+
+  return {
+    fuseRef,
+    elapsed,
+    onCard,
+    secondsLeft,
+    bank,
+    spendFuse,
+    startCard,
+  };
+}

--- a/src/games/flashcards/race/useRaceFinish.ts
+++ b/src/games/flashcards/race/useRaceFinish.ts
@@ -1,0 +1,112 @@
+import { useCallback, useRef, useState } from "react";
+import { levelFromXp } from "@/engine/progress";
+import { summariseRun, type RunTally } from "@/engine/run";
+import { sfx } from "@/services/sound";
+import type { useHub } from "@/components/state/HubContext";
+import type { useRace } from "@/components/state/RaceContext";
+import type { useNavigate } from "react-router-dom";
+import type { FlashConfig, Ghost, Profile, Session } from "@/engine/types";
+
+/**
+ * The end of a run: score it, write it, and hand off to the results screen.
+ *
+ * Separate from the race loop because it fails differently. Everything before
+ * this point is in memory and can't really go wrong; this step talks to
+ * IndexedDB, which can refuse — a full disk, private browsing, a revoked
+ * quota. When it does, the answers are still here, so the failure is
+ * recoverable and `retry` is the whole point of holding the error in state
+ * rather than throwing it away.
+ *
+ * The scoring itself lives in `@/engine/run` — no React, no storage, just the
+ * rules for what a run was worth.
+ */
+export function useRaceFinish({
+  profile,
+  config,
+  seed,
+  ghost,
+  history,
+  previousBest,
+  readTally,
+  saveSession,
+  finish,
+  notify,
+  navigate,
+  onSaving,
+}: {
+  profile: Profile;
+  config: FlashConfig;
+  seed: number;
+  ghost: Ghost | null;
+  history: Session[];
+  previousBest: Session | null;
+  /** Read at save time so the loop can keep counting into plain refs. */
+  readTally: () => RunTally;
+  saveSession: ReturnType<typeof useHub>["saveSession"];
+  finish: ReturnType<typeof useRace>["finish"];
+  notify: ReturnType<typeof useHub>["notify"];
+  navigate: ReturnType<typeof useNavigate>;
+  onSaving: () => void;
+}) {
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const finishing = useRef(false);
+
+  async function save() {
+    const summary = summariseRun({
+      profile,
+      config,
+      seed,
+      ghost,
+      history,
+      previousBest,
+      tally: readTally(),
+    });
+
+    try {
+      const saved = await saveSession({
+        ...summary.draft,
+        earnedBadges: summary.earnedBadges,
+      });
+      const levelBefore = levelFromXp(profile.xp).level;
+      const levelAfter = levelFromXp(saved.profile.xp).level;
+      finish({
+        session: saved.session,
+        profileAfter: saved.profile,
+        ghost,
+        personalRecord: summary.personalRecord,
+        previousBest,
+        newBadges: summary.newBadges,
+        bonuses: summary.bonuses,
+        levelledUpTo: levelAfter > levelBefore ? levelAfter : null,
+      });
+      navigate(`/p/${profile.id}/race/results`, { replace: true });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Could not save this race";
+      setSaveError(message);
+      notify(message, "bad");
+    }
+  }
+
+  return {
+    saveError,
+    /** Called once, when the last card lands. Guards against a double finish. */
+    async complete() {
+      if (finishing.current) return;
+      finishing.current = true;
+      onSaving();
+      sfx.finish();
+      await save();
+    },
+    retry() {
+      setSaveError(null);
+      void save();
+    },
+    /**
+     * Stable, so the answer handler can check it without losing the identity
+     * the per-card timer depends on. True once the run has been handed off —
+     * a late keystroke must not record another card.
+     */
+    hasFinished: useCallback(() => finishing.current, []),
+  };
+}

--- a/src/games/flashcards/race/useRaceKeyboard.ts
+++ b/src/games/flashcards/race/useRaceKeyboard.ts
@@ -1,0 +1,72 @@
+import { useEffect } from "react";
+import type { InputMode } from "@/engine/types";
+
+/**
+ * Answering from a physical keyboard.
+ *
+ * This is the keyboard half of `AnswerPad` — same job, different input device
+ * — but it can't live in that component: these are window-level listeners
+ * bound to the race's state, and they must keep working while focus is
+ * anywhere on the page. Older players use the number row and never touch the
+ * on-screen keypad at all.
+ */
+export function useRaceKeyboard({
+  active,
+  inputMode,
+  choices,
+  answerLength,
+  entry,
+  entryRef,
+  submit,
+  pushDigit,
+  dropDigit,
+}: {
+  /** Racing, and no card currently showing feedback. */
+  active: boolean;
+  inputMode: InputMode;
+  choices: number[] | undefined;
+  /** Digits in the current card's answer, for the auto-submit below. */
+  answerLength: number;
+  entry: string;
+  entryRef: React.RefObject<string>;
+  submit: (value: number | null) => void;
+  pushDigit: (digit: string) => void;
+  dropDigit: () => void;
+}) {
+  useEffect(() => {
+    if (!active) return;
+    function onKey(event: KeyboardEvent) {
+      if (inputMode === "choose") {
+        const slot = Number(event.key);
+        if (slot >= 1 && slot <= 4 && choices) {
+          event.preventDefault();
+          submit(choices[slot - 1]);
+        }
+        return;
+      }
+      if (/^[0-9]$/.test(event.key)) {
+        event.preventDefault();
+        pushDigit(event.key);
+      } else if (event.key === "Backspace") {
+        event.preventDefault();
+        dropDigit();
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        if (entryRef.current !== "") submit(Number(entryRef.current));
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active, inputMode, choices, entryRef, submit, pushDigit, dropDigit]);
+
+  // Auto-submit the moment the entry is as long as the answer — keeps the pace
+  // up without making kids hunt for Enter.
+  useEffect(() => {
+    if (!active || inputMode !== "type") return;
+    if (entry.length > 0 && entry.length === answerLength) {
+      const value = Number(entry);
+      const timer = window.setTimeout(() => submit(value), 90);
+      return () => window.clearTimeout(timer);
+    }
+  }, [active, inputMode, entry, answerLength, submit]);
+}


### PR DESCRIPTION
Closes #3

655 counted lines → **297**, and `RaceTrack.tsx` is deleted from **both**
allowlists. `rawControlsAllowlist` is down to six files.

## The split follows behaviour, not line counts

| Module | Lines | Owns |
| --- | ---: | --- |
| `race/useRaceClock.ts` | 114 | Every piece of time: the stopwatch, the per-card clock, the fuse drain, the quit-sheet pause |
| `race/useRaceFinish.ts` | 88 | Scoring and writing the run down — the only step that can fail |
| `race/AnswerPad.tsx` | 79 | Keypad and the four-choice grid |
| `race/CardFace.tsx` | 69 | Fuse, prompt, entry, combo badge |
| `race/Lane.tsx` | 64 | The ghost split — the signature element |
| `race/useRaceKeyboard.ts` | 57 | The physical-keyboard half of AnswerPad, incl. auto-submit |
| `race/Hud.tsx` | 36 | Quit, stopwatch, card count |
| `race/QuitSheet.tsx` | 31 | The confirm sheet |
| `race/useGhostGap.ts` | 31 | Where the rival is; the overtake sound |
| `race/SaveFailed.tsx` | 30 | The save-failure screen |
| `race/useCountdown.ts` | 28 | 3 · 2 · 1 · GO |
| **`engine/run.ts`** | 82 | **What a run was worth** |

The clock pieces stayed together deliberately: the banked total, the card's
start mark and the pause mark are read by all four, and splitting them would
mean passing three refs between modules and hoping nobody writes one without
the others.

## `summariseRun` left the view layer entirely

Personal records, finish bonuses and badge evaluation were being decided inside
a render tree. None of it needs React, a browser or storage — it's the same
class of rule as `compareRuns`, so it now sits beside it in `src/engine/`.
That's a layer fix, not just a size fix.

## Comments

None deleted to hit the cap, per `CLAUDE.md`. Every doc block moved with the
code it describes, and the three load-bearing *why* comments are called out
where they landed: the fuse bypassing React so it keeps draining under reduced
motion, the stable-identity requirement on `submit`, and the pause effect
having to be declared before the timer effect.

## A suppression avoided rather than written

Extracting the clock made the countdown effect want
`eslint-disable react-hooks/exhaustive-deps`. Pinning the ref-only clock
methods (`bank`, `spendFuse`, `onCard`, `startCard`) with empty dependency
lists removed the need — and makes explicit the stable-identity guarantee that
`submit` was already relying on informally.

## Verification

Type-checking can't see a real-time loop, so both acceptance behaviours were
driven in a browser:

```
1. The quit sheet pauses the card clock
  ✓ the stopwatch runs before pausing — 0.72 → 1.39
  ✓ the clock is frozen while the sheet is up — 1.46 → 1.46 over 2.5s
  ✓ resuming doesn't charge for the pause — +0.26s, not +2.5s
  ✓ and the clock is moving again

2. A timed-out card banks exactly timeLimitMs
  ✓ all ten cards timed out — 10/10
  ✓ every timed-out card banked exactly 1000ms — 10/10 exact; saw 1000
  ✓ the run total is exactly 10 × the limit — durationMs=10000
  ✓ none were scored correct
console errors: none
```

`durationMs=10000` exactly — no drift from timers firing late, which is the
whole point of banking the limit rather than the measured time.

Plus: `type-check` 0 errors · `lint` clean · 11/11 unit · 17 pages ·
full `test:smoke` passes with no console errors.

## Drive-by

The save-failure screen told players to "try again once the hub server is
back". There has been no hub server since the port — it now says their answers
are still there, which is both true and the reason retry is the primary action.