### PR TITLE
KIT04a: convert the last 28 controls and delete the raw-controls allowlist

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,24 +72,6 @@ const maxLinesAllowlist = [
   "src/components/screens/Progress.tsx", // 392
 ];
 
-// Files that still hand-roll native controls, inherited wholesale from the
-// local-only app where no kit boundary existed. 55 call sites across 8 files;
-// converting them blind during the port would have been a large untested
-// rewrite of every interactive surface at once, so the debt is recorded here
-// instead of hidden.
-//
-// Retired by the kit-conversion stories: each file's controls move to <Button>,
-// <Input>, <Select> and <Field> primitives, and its entry is deleted in the
-// same PR. The list only shrinks.
-const rawControlsAllowlist = [
-  "src/components/PlayerEditor.tsx", // 13
-  "src/games/flashcards/RaceResults.tsx", // 5
-  "src/components/screens/PlayerSelect.tsx", // 4
-  "src/components/screens/Progress.tsx", // 3
-  "src/components/screens/PlayerHub.tsx", // 2
-  "src/components/TopBar.tsx", // 1
-];
-
 // Storage is an implementation detail of the service layer — the direct
 // analogue of monilibrium's "Prisma client only in services/" boundary. A React
 // component that reaches for `localStorage` bypasses the profile/session
@@ -384,7 +366,12 @@ export default defineConfig([
   // tone — and hit targets are not cosmetic here, the youngest player is five.
   {
     files: ["**/*.tsx"],
-    ignores: ["src/components/ui/**", ...rawControlsAllowlist],
+    // No exceptions. There WAS an allowlist here — 55 hand-rolled controls
+    // across 8 files, inherited from the local-only app where no kit existed.
+    // It was drained to zero by the KIT01–KIT04 stories and then deleted, so
+    // adding a file back means editing this rule rather than appending to a
+    // list, which is the point.
+    ignores: ["src/components/ui/**"],
     rules: {
       "no-restricted-syntax": [
         "error",
@@ -392,7 +379,7 @@ export default defineConfig([
           selector:
             "JSXOpeningElement[name.name=/^(button|input|select|textarea|label)$/]",
           message:
-            "Don't hand-roll native controls outside src/components/ui/. Use the kit: <button>→<Button>, <input>→<Input>/<NumberPad>, <select>→<Select>, <label>→<Field>. If the kit is missing a primitive, add it there.",
+            "Don't hand-roll native controls outside src/components/ui/. Use the kit: <button>→<Button>, <input>→<Input>, <select>→<Select>, <label>/<fieldset>→<Field>/<FieldSet>. If the kit is missing a primitive, add it there.",
         },
       ],
     },

--- a/eslint.config.test.mjs
+++ b/eslint.config.test.mjs
@@ -80,6 +80,28 @@ describe("view layer (src/components/, src/games/, src/pages/)", () => {
     expect(fired).toContain(SYNTAX);
   });
 
+  // The test above uses a made-up path, so it passed for the whole time an
+  // allowlist exempted eight real files from the same rule. These are those
+  // files. If an allowlist ever comes back, this is what fails.
+  it.each([
+    "src/components/PlayerEditor.tsx",
+    "src/components/TopBar.tsx",
+    "src/components/BackupPanel.tsx",
+    "src/components/screens/PlayerHub.tsx",
+    "src/components/screens/PlayerSelect.tsx",
+    "src/components/screens/Progress.tsx",
+    "src/games/flashcards/App.tsx",
+    "src/games/flashcards/RaceSetup.tsx",
+    "src/games/flashcards/RaceTrack.tsx",
+    "src/games/flashcards/RaceResults.tsx",
+  ])("rejects native controls at %s, which used to be exempt", async (path) => {
+    const fired = await rulesFiredFor(
+      path,
+      `export const X = () => <button type="button">go</button>;\n`,
+    );
+    expect(fired).toContain(SYNTAX);
+  });
+
   it('rejects role="button" on a non-button', async () => {
     const fired = await rulesFiredFor(
       "src/components/Hub.tsx",

--- a/src/components/PlayerEditor.tsx
+++ b/src/components/PlayerEditor.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useHub } from "@/components/state/HubContext";
 import { sfx } from "@/services/sound";
 import type { Profile } from "@/engine/types";
-import { Scrim } from "@/components/ui/kit";
+import { Button, Field, FieldSet, Input, Scrim } from "@/components/ui/kit";
 
 export const AVATARS = [
   "🦊",
@@ -135,132 +135,123 @@ export default function PlayerEditor({ profile, onClose, onDeleted }: Props) {
           <h2 className="panel__title">
             {isNew ? "New player" : "Edit player"}
           </h2>
-          <button
-            type="button"
-            className="btn btn--ghost btn--sm"
-            onClick={onClose}
-          >
+          <Button variant="ghost" size="sm" onClick={onClose}>
             Close
-          </button>
+          </Button>
         </div>
 
-        <label className="field">
-          <span className="field__label">Name</span>
-          <input
+        <Field label="Name">
+          <Input
             ref={nameField}
-            className="field__input"
             value={name}
             maxLength={24}
-            onChange={(e) => setName(e.target.value)}
+            onChange={setName}
             placeholder="Type a name"
             autoComplete="off"
           />
-        </label>
+        </Field>
 
-        <fieldset className="field">
-          <legend className="field__label">Avatar</legend>
+        <FieldSet legend="Avatar">
           <div className="picker picker--emoji">
             {AVATARS.map((option) => (
-              <button
+              <Button
                 key={option}
-                type="button"
+                variant="bare"
                 className={`picker__cell${option === emoji ? " is-chosen" : ""}`}
                 onClick={() => {
                   setEmoji(option);
                   sfx.tap();
                 }}
-                aria-pressed={option === emoji}
+                pressed={option === emoji}
                 aria-label={`Avatar ${option}`}
               >
                 {option}
-              </button>
+              </Button>
             ))}
           </div>
-        </fieldset>
+        </FieldSet>
 
-        <fieldset className="field">
-          <legend className="field__label">Colour</legend>
+        <FieldSet legend="Colour">
           <div className="picker picker--color">
             {COLORS.map((option) => (
-              <button
+              <Button
                 key={option}
-                type="button"
+                variant="bare"
                 className={`swatch${option === color ? " is-chosen" : ""}`}
                 style={{ background: option }}
                 onClick={() => {
                   setColor(option);
                   sfx.tap();
                 }}
-                aria-pressed={option === color}
+                pressed={option === color}
                 aria-label={`Colour ${option}`}
               />
             ))}
           </div>
-        </fieldset>
+        </FieldSet>
 
-        <fieldset className="field">
-          <legend className="field__label">Age</legend>
+        <FieldSet
+          legend="Age"
+          hint="Sets the default difficulty and how big everything looks."
+        >
           <div className="stepper">
-            <button
-              type="button"
+            <Button
+              variant="bare"
               className="stepper__btn"
               onClick={() => setAge((a) => Math.max(3, a - 1))}
               aria-label="Younger"
             >
               −
-            </button>
+            </Button>
             <span className="stepper__value u-mono">{age}</span>
-            <button
-              type="button"
+            <Button
+              variant="bare"
               className="stepper__btn"
               onClick={() => setAge((a) => Math.min(18, a + 1))}
               aria-label="Older"
             >
               +
-            </button>
+            </Button>
           </div>
-          <p className="field__hint">
-            Sets the default difficulty and how big everything looks.
-          </p>
-        </fieldset>
+        </FieldSet>
 
         <div className="sheet__actions">
           {!isNew &&
             (confirmingDelete ? (
               <div className="sheet__confirm">
                 <span>Remove {profile.name} and all their races?</span>
-                <button
-                  type="button"
-                  className="btn btn--danger btn--sm"
+                <Button
+                  variant="danger"
+                  size="sm"
                   onClick={() => void remove()}
                   disabled={saving}
                 >
                   Remove
-                </button>
-                <button
-                  type="button"
-                  className="btn btn--ghost btn--sm"
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setConfirmingDelete(false)}
                 >
                   Keep
-                </button>
+                </Button>
               </div>
             ) : (
-              <button
-                type="button"
-                className="btn btn--danger btn--sm"
+              <Button
+                variant="danger"
+                size="sm"
                 onClick={() => setConfirmingDelete(true)}
               >
                 Remove player
-              </button>
+              </Button>
             ))}
-          <button
+          <Button
             type="submit"
-            className="btn btn--accent"
+            variant="accent"
             disabled={!name.trim() || saving}
           >
             {isNew ? "Add player" : "Save"}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Avatar } from "@/components/ui/kit";
+import { Avatar, Button } from "@/components/ui/kit";
 import { levelFromXp } from "@/engine/progress";
 import { useHub } from "@/components/state/HubContext";
 import { setSoundEnabled } from "@/services/sound";
@@ -61,15 +61,16 @@ export default function TopBar({
 
       <div className="topbar__actions">
         {children}
-        <button
+        <Button
+          variant="bare"
           className="topbar__icon"
           onClick={() => void toggleSound()}
-          aria-pressed={soundOn}
+          pressed={soundOn}
           title={soundOn ? "Turn sound off" : "Turn sound on"}
         >
           <span aria-hidden="true">{soundOn ? "🔊" : "🔇"}</span>
           <span className="u-sr">Sound {soundOn ? "on" : "off"}</span>
-        </button>
+        </Button>
       </div>
     </header>
   );

--- a/src/components/screens/PlayerHub.tsx
+++ b/src/components/screens/PlayerHub.tsx
@@ -1,7 +1,7 @@
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import TopBar from "@/components/TopBar";
-import { Stat } from "@/components/ui/kit";
+import { Button, Stat } from "@/components/ui/kit";
 import {
   bestRun,
   lifetimeStats,
@@ -62,17 +62,19 @@ export default function PlayerHub() {
             Race a deck of multiplication cards against the clock — or against a
             ghost of your best run, or one of your siblings&apos;.
           </p>
-          <button
-            className="btn btn--go hub__cta"
+          <Button
+            variant="go"
+            className="hub__cta"
             onClick={() => {
               sfx.select();
               navigate(`/p/${profile.id}/race`);
             }}
           >
             Set up a race →
-          </button>
+          </Button>
           {trouble.length >= 3 && (
-            <button
+            <Button
+              variant="bare"
               className="hub__drill"
               onClick={() => {
                 sfx.select();
@@ -91,7 +93,7 @@ export default function PlayerHub() {
               }}
             >
               or practise {plural(trouble.length, "fact")} you keep missing →
-            </button>
+            </Button>
           )}
         </div>
 

--- a/src/components/screens/PlayerSelect.tsx
+++ b/src/components/screens/PlayerSelect.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useHub } from "@/components/state/HubContext";
-import { Avatar, LevelRing } from "@/components/ui/kit";
+import { Avatar, Button, LevelRing } from "@/components/ui/kit";
 import PlayerEditor from "@/components/PlayerEditor";
 import BackupPanel from "@/components/BackupPanel";
 import { lifetimeStats, sessionsFor } from "@/engine/records";
@@ -49,9 +49,9 @@ export default function PlayerSelect() {
             Every player gets their own times, records and badges. Nothing
             leaves this device.
           </p>
-          <button className="btn btn--go" onClick={() => setEditing(null)}>
+          <Button variant="go" onClick={() => setEditing(null)}>
             Add a player
-          </button>
+          </Button>
         </div>
       ) : (
         <ul className="select__grid">
@@ -73,12 +73,13 @@ export default function PlayerSelect() {
                     } as React.CSSProperties
                   }
                 >
-                  <button
+                  <Button
+                    variant="bare"
                     className="driver__enter"
                     onClick={() => enter(profile)}
                   >
                     <span className="u-sr">Play as {profile.name}</span>
-                  </button>
+                  </Button>
                   <div className="driver__top">
                     <Avatar profile={profile} size="4.25rem" />
                     <LevelRing
@@ -104,12 +105,13 @@ export default function PlayerSelect() {
                       </dd>
                     </div>
                   </dl>
-                  <button
+                  <Button
+                    variant="bare"
                     className="driver__edit"
                     onClick={() => setEditing(profile)}
                   >
                     Edit<span className="u-sr"> {profile.name}</span>
-                  </button>
+                  </Button>
                 </div>
               </li>
             );
@@ -118,7 +120,8 @@ export default function PlayerSelect() {
             className="anim-rise"
             style={{ animationDelay: `${profiles.length * 70}ms` }}
           >
-            <button
+            <Button
+              variant="bare"
               className="driver driver--add"
               onClick={() => setEditing(null)}
             >
@@ -126,7 +129,7 @@ export default function PlayerSelect() {
                 +
               </span>
               <span className="driver__name u-display">Add player</span>
-            </button>
+            </Button>
           </li>
         </ul>
       )}

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import TopBar from "@/components/TopBar";
-import { Avatar } from "@/components/ui/kit";
+import { Avatar, Button } from "@/components/ui/kit";
 import { BADGES } from "@/engine/progress";
 import {
   bestRun,
@@ -120,14 +120,15 @@ export default function Progress() {
           <h2 className="panel__title">Fact map</h2>
           <div className="segmented segmented--slim">
             {OPERATION_ORDER.map((op) => (
-              <button
+              <Button
                 key={op}
+                variant="bare"
                 className={`segmented__btn${operation === op ? " is-on" : ""}`}
                 onClick={() => setOperation(op)}
-                aria-pressed={operation === op}
+                pressed={operation === op}
               >
                 {OPERATIONS[op].symbol}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -203,8 +204,9 @@ export default function Progress() {
         <div className="panel__head">
           <h2 className="panel__title">Trouble spots</h2>
           {trouble.length > 0 && (
-            <button
-              className="btn btn--accent btn--sm"
+            <Button
+              variant="accent"
+              size="sm"
               onClick={() => {
                 sfx.select();
                 navigate(`/p/${profile.id}/race`, {
@@ -222,7 +224,7 @@ export default function Progress() {
               }}
             >
               Drill these
-            </button>
+            </Button>
           )}
         </div>
         {trouble.length === 0 ? (

--- a/src/games/flashcards/RaceResults.tsx
+++ b/src/games/flashcards/RaceResults.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
-import { Avatar, Confetti } from "@/components/ui/kit";
+import { Avatar, Button, Confetti } from "@/components/ui/kit";
 import TopBar from "@/components/TopBar";
 import {
   WRONG_ANSWER_PENALTY_MS,
@@ -328,42 +328,39 @@ export default function RaceResults() {
 
       <div className="results__actions">
         {practiceFirst && (
-          <button className="btn btn--go" onClick={practise}>
+          <Button variant="go" onClick={practise}>
             Practise {plural(missedFacts.length, "fact")}
-          </button>
+          </Button>
         )}
-        <button
-          className={`btn ${practiceFirst ? "btn--accent" : "btn--go"}`}
+        <Button
+          variant={practiceFirst ? "accent" : "go"}
           onClick={() => raceAgain(ghost)}
         >
           Race again
-        </button>
+        </Button>
         {!ghost && (
-          <button
-            className="btn btn--accent"
-            onClick={() => raceAgain(selfGhost)}
-          >
+          <Button variant="accent" onClick={() => raceAgain(selfGhost)}>
             Race this ghost
-          </button>
+          </Button>
         )}
-        <button
-          className="btn btn--ghost"
+        <Button
+          variant="ghost"
           onClick={() => {
             clear();
             navigate(`/p/${profile.id}/race`);
           }}
         >
           Change settings
-        </button>
-        <button
-          className="btn btn--ghost"
+        </Button>
+        <Button
+          variant="ghost"
           onClick={() => {
             clear();
             navigate(`/p/${profile.id}`);
           }}
         >
           Back to hub
-        </button>
+        </Button>
       </div>
     </main>
   );


### PR DESCRIPTION
Refs #4 — the control half. The three remaining oversized files
(`RaceSetup` 487, `Progress` 394, `RaceResults` 348) and `maxLinesAllowlist`
follow in a second PR, as the issue permits.

## The debt is paid

TopBar (1), PlayerHub (2), Progress (3), PlayerSelect (4), RaceResults (5),
PlayerEditor (13). With KIT01–KIT03 that's all **55** call sites inherited from
the local-only app.

`rawControlsAllowlist` is **deleted**, not emptied — along with the `ignores`
spread that consumed it. Adding an exception now means editing the rule, which
is a different kind of decision from appending to a list.

## PlayerEditor is the one with teeth

Thirteen controls, and the app's only `<form>`. Every avatar and colour swatch
is a button inside it. The old markup spelled `type="button"` out at each of
those sites; `<Button>`'s default is now the only thing stopping a tap on 🦊
from submitting the form and creating a half-configured player. So it's checked
rather than assumed.

Its three `<fieldset>`/`<legend>` groups became `<FieldSet>` and the name row
`<Field>` — the hand-rolled label markup goes away with them.

## A test that was passing for the wrong reason

`rejects hand-rolled native controls` lints a snippet at
`src/components/Hub.tsx` — a path that has never existed. So it passed happily
for the entire time an allowlist exempted eight **real** files from that same
rule. Added a case per formerly-exempt path.

Mutation-checked, because a guard I can't see fail is not a guard:

```
ignores: ["src/components/ui/**", "src/components/TopBar.tsx"]
→ × rejects native controls at src/components/TopBar.tsx, which used to be exempt
   Tests  1 failed | 20 passed (21)
```

## Browser verification

A control that quietly stops working type-checks perfectly, so:

```
1. The pickers must not submit the form
  ✓ the name field is focused on open
  ✓ the sheet is still open after tapping a picker
  ✓ the avatar reads as selected      ✓ the colour reads as selected
2. The age stepper
  ✓ + increments — 8 → 9              ✓ − decrements
  ✓ the hint still renders inside the fieldset
3. Submitting still works
  ✓ the player saved with the chosen avatar and colour — Editor:🐝:#ff4d6d
4. Editing and removing
  ✓ the confirm step appears          ✓ Keep backs out
  ✓ the player is gone — 0 left
console errors: none
```

Plus `type-check` 0 errors · `lint` clean · **21/21** unit · 17 pages ·
`test:smoke` passes with no console errors.

## Drive-by

The ban's message told people to use `<NumberPad>`, a primitive that has never
existed. It now names the real ones, including `<FieldSet>`.