### PR TITLE
KIT04b: split the last three screens and delete maxLinesAllowlist

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,19 +59,6 @@ import prettier from "eslint-config-prettier/flat";
 // module it now describes.
 const MAX_COMPONENT_LINES = 300;
 
-// Files over the cap, each against the story that retires it. The list SHRINKS:
-// delete the entry in the same PR that splits the file. Counts are non-comment,
-// non-blank lines measured when the game was ported from the local-only app,
-// where nothing enforced a cap.
-const maxLinesAllowlist = [
-  // Retired by the flash-cards decomposition stories (PORT epic). RaceTrack is
-  // the race loop, the rAF ticker, the per-card clock and the keypad in one
-  // module; the split follows those seams, not arbitrary line counts.
-  "src/games/flashcards/RaceSetup.tsx", // 473
-  "src/games/flashcards/RaceResults.tsx", // 351
-  "src/components/screens/Progress.tsx", // 392
-];
-
 // Storage is an implementation detail of the service layer — the direct
 // analogue of monilibrium's "Prisma client only in services/" boundary. A React
 // component that reaches for `localStorage` bypasses the profile/session
@@ -398,7 +385,11 @@ export default defineConfig([
   // is coverage, not scannability.
   {
     files: ["src/components/**/*.{ts,tsx}", "src/games/**/*.{ts,tsx}"],
-    ignores: ["**/*.test.{ts,tsx}", ...maxLinesAllowlist],
+    // Tests only. There WAS an allowlist here too — RaceTrack (655), RaceSetup
+    // (473), Progress (392) and RaceResults (351), inherited from the
+    // local-only app where nothing enforced a cap. All four were split along
+    // their seams by the KIT03/KIT04 stories and the list was deleted.
+    ignores: ["**/*.test.{ts,tsx}"],
     rules: {
       "max-lines": [
         "error",

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -2,11 +2,10 @@ import { useMemo, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import TopBar from "@/components/TopBar";
-import { Avatar, Button } from "@/components/ui/kit";
+import { Button } from "@/components/ui/kit";
 import { BADGES } from "@/engine/progress";
 import {
   bestRun,
-  factKey,
   factStats,
   lifetimeStats,
   masteryOf,
@@ -14,27 +13,17 @@ import {
   sessionsFor,
   tableProgress,
   troubleFacts,
-  type Mastery,
 } from "@/engine/records";
 import {
   OPERATIONS,
-  OPERATION_ORDER,
   buildDrill,
-  describeConfig,
   timeLimitForAge,
 } from "@/engine/decks/flashcards";
 import { sfx } from "@/services/sound";
-import { clock, duration, percent, shortDate } from "@/engine/format";
+import { FactMap } from "./progress/FactMap";
+import { RecordBook, RunList } from "./progress/RecordBook";
+import { duration, percent } from "@/engine/format";
 import type { Operation } from "@/engine/types";
-
-const AXIS = Array.from({ length: 12 }, (_, i) => i + 1);
-
-const MASTERY_LABEL: Record<Mastery, string> = {
-  untried: "Not tried yet",
-  learning: "Still learning",
-  solid: "Getting there",
-  mastered: "Mastered",
-};
 
 export default function Progress() {
   const { profileId } = useParams();
@@ -115,90 +104,12 @@ export default function Progress() {
         </div>
       </section>
 
-      <section className="panel anim-rise">
-        <div className="panel__head">
-          <h2 className="panel__title">Fact map</h2>
-          <div className="segmented segmented--slim">
-            {OPERATION_ORDER.map((op) => (
-              <Button
-                key={op}
-                variant="bare"
-                className={`segmented__btn${operation === op ? " is-on" : ""}`}
-                onClick={() => setOperation(op)}
-                pressed={operation === op}
-              >
-                {OPERATIONS[op].symbol}
-              </Button>
-            ))}
-          </div>
-        </div>
-        <p className="muted">
-          Every {spec.label.toLowerCase()} fact from 1 to 12. A square turns
-          green once it&apos;s answered right three times running and under four
-          seconds — that&apos;s recall, not counting.
-        </p>
-
-        <div className="factmap__wrap">
-          <table className="factmap">
-            <caption className="u-sr">{spec.label} facts by mastery</caption>
-            <thead>
-              <tr>
-                <th scope="col" className="factmap__corner u-mono">
-                  {spec.symbol}
-                </th>
-                {AXIS.map((n) => (
-                  <th key={n} scope="col" className="u-mono factmap__axis">
-                    {n}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {AXIS.map((row) => (
-                <tr key={row}>
-                  <th scope="row" className="u-mono factmap__axis">
-                    {row}
-                  </th>
-                  {AXIS.map((col) => {
-                    const stat = grid.get(factKey(row, col));
-                    const level = masteryOf(stat);
-                    const avg = stat
-                      ? stat.totalMs / stat.attempts / 1000
-                      : null;
-                    return (
-                      <td key={col} className={`factmap__cell is-${level}`}>
-                        <span className="u-sr">
-                          {row} {spec.symbol} {col}: {MASTERY_LABEL[level]}
-                        </span>
-                        <span className="factmap__tip" aria-hidden="true">
-                          {row} {spec.symbol} {col}
-                          {stat
-                            ? ` · ${stat.correct}/${stat.attempts} · ${avg!.toFixed(1)}s`
-                            : " · not tried"}
-                        </span>
-                      </td>
-                    );
-                  })}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <ul className="legend">
-          {(["untried", "learning", "solid", "mastered"] as Mastery[]).map(
-            (level) => (
-              <li key={level} className="legend__item">
-                <span
-                  className={`legend__swatch is-${level}`}
-                  aria-hidden="true"
-                />
-                {MASTERY_LABEL[level]}
-              </li>
-            ),
-          )}
-        </ul>
-      </section>
+      <FactMap
+        operation={operation}
+        onOperationChange={setOperation}
+        spec={spec}
+        grid={grid}
+      />
 
       <section className="panel anim-rise">
         <div className="panel__head">
@@ -328,86 +239,9 @@ export default function Progress() {
         </section>
       </div>
 
-      <section className="panel anim-rise">
-        <div className="panel__head">
-          <h2 className="panel__title">Records</h2>
-        </div>
-        {records.length === 0 ? (
-          <p className="muted">Race something and your best times land here.</p>
-        ) : (
-          <div className="splits__scroll">
-            <table className="splits">
-              <thead>
-                <tr>
-                  <th scope="col">Race</th>
-                  <th scope="col">Your best</th>
-                  <th scope="col">House best</th>
-                </tr>
-              </thead>
-              <tbody>
-                {records.map((record) => {
-                  const isMine = record.houseBest.profileId === profile.id;
-                  return (
-                    <tr key={record.key}>
-                      <td className="splits__card">
-                        {describeConfig(record.myBest.config)}
-                      </td>
-                      <td className="u-mono">
-                        {clock(raceTimeMs(record.myBest))}
-                      </td>
-                      <td className="u-mono splits__holder">
-                        {clock(raceTimeMs(record.houseBest))}
-                        {record.holder && (
-                          <span
-                            className={`splits__who${isMine ? " is-ahead" : ""}`}
-                          >
-                            <Avatar profile={record.holder} size="1.1rem" />
-                            {isMine ? "you" : record.holder.name}
-                          </span>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
+      <RecordBook records={records} profileId={profile.id} />
 
-      <section className="panel anim-rise">
-        <div className="panel__head">
-          <h2 className="panel__title">Every race</h2>
-        </div>
-        {mine.length === 0 ? (
-          <p className="muted">No races yet.</p>
-        ) : (
-          <ul className="runlist">
-            {[...mine]
-              .reverse()
-              .slice(0, 40)
-              .map((session) => (
-                <li key={session.id} className="runlist__row">
-                  <span className="runlist__when u-mono">
-                    {shortDate(session.finishedAt)}
-                  </span>
-                  <span className="runlist__what">
-                    {describeConfig(session.config)}
-                  </span>
-                  <span className="runlist__acc u-mono">
-                    {percent(
-                      session.correct /
-                        Math.max(1, session.correct + session.incorrect),
-                    )}
-                  </span>
-                  <span className="runlist__time u-mono">
-                    {clock(raceTimeMs(session))}
-                  </span>
-                </li>
-              ))}
-          </ul>
-        )}
-      </section>
+      <RunList sessions={mine} />
     </main>
   );
 }

--- a/src/components/screens/progress/FactMap.tsx
+++ b/src/components/screens/progress/FactMap.tsx
@@ -1,0 +1,123 @@
+import { Button } from "@/components/ui/kit";
+import {
+  OPERATIONS,
+  OPERATION_ORDER,
+  type OperationSpec,
+} from "@/engine/decks/flashcards";
+import { factKey, masteryOf, type Mastery } from "@/engine/records";
+import type { Operation } from "@/engine/types";
+
+const AXIS = Array.from({ length: 12 }, (_, i) => i + 1);
+
+export const MASTERY_LABEL: Record<Mastery, string> = {
+  untried: "Not tried yet",
+  learning: "Still learning",
+  solid: "Getting there",
+  mastered: "Mastered",
+};
+
+/**
+ * Every fact from 1 to 12, coloured by how well it's known.
+ *
+ * A real <table> with header cells on both axes: a grid of 144 divs would be
+ * unreadable to a screen reader, and each cell already carries its own
+ * spoken-only summary. The operation switcher sits in the heading rather than
+ * above the map because it changes what the map *is*, not how it's filtered.
+ */
+export function FactMap({
+  operation,
+  onOperationChange,
+  spec,
+  grid,
+}: {
+  operation: Operation;
+  onOperationChange: (op: Operation) => void;
+  spec: OperationSpec;
+  /** Per-fact attempt stats, keyed by `factKey`. */
+  grid: Map<string, { attempts: number; correct: number; totalMs: number }>;
+}) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Fact map</h2>
+        <div className="segmented segmented--slim">
+          {OPERATION_ORDER.map((op) => (
+            <Button
+              key={op}
+              variant="bare"
+              className={`segmented__btn${operation === op ? " is-on" : ""}`}
+              onClick={() => onOperationChange(op)}
+              pressed={operation === op}
+            >
+              {OPERATIONS[op].symbol}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <p className="muted">
+        Every {spec.label.toLowerCase()} fact from 1 to 12. A square turns green
+        once it&apos;s answered right three times running and under four seconds
+        — that&apos;s recall, not counting.
+      </p>
+
+      <div className="factmap__wrap">
+        <table className="factmap">
+          <caption className="u-sr">{spec.label} facts by mastery</caption>
+          <thead>
+            <tr>
+              <th scope="col" className="factmap__corner u-mono">
+                {spec.symbol}
+              </th>
+              {AXIS.map((n) => (
+                <th key={n} scope="col" className="u-mono factmap__axis">
+                  {n}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {AXIS.map((row) => (
+              <tr key={row}>
+                <th scope="row" className="u-mono factmap__axis">
+                  {row}
+                </th>
+                {AXIS.map((col) => {
+                  const stat = grid.get(factKey(row, col));
+                  const level = masteryOf(stat);
+                  const avg = stat ? stat.totalMs / stat.attempts / 1000 : null;
+                  return (
+                    <td key={col} className={`factmap__cell is-${level}`}>
+                      <span className="u-sr">
+                        {row} {spec.symbol} {col}: {MASTERY_LABEL[level]}
+                      </span>
+                      <span className="factmap__tip" aria-hidden="true">
+                        {row} {spec.symbol} {col}
+                        {stat
+                          ? ` · ${stat.correct}/${stat.attempts} · ${avg!.toFixed(1)}s`
+                          : " · not tried"}
+                      </span>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <ul className="legend">
+        {(["untried", "learning", "solid", "mastered"] as Mastery[]).map(
+          (level) => (
+            <li key={level} className="legend__item">
+              <span
+                className={`legend__swatch is-${level}`}
+                aria-hidden="true"
+              />
+              {MASTERY_LABEL[level]}
+            </li>
+          ),
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/screens/progress/RecordBook.tsx
+++ b/src/components/screens/progress/RecordBook.tsx
@@ -1,0 +1,115 @@
+import { Avatar } from "@/components/ui/kit";
+import { describeConfig } from "@/engine/decks/flashcards";
+import { raceTimeMs } from "@/engine/records";
+import { clock, percent, shortDate } from "@/engine/format";
+import type { Profile, Session } from "@/engine/types";
+
+type Record_ = {
+  key: string;
+  myBest: Session;
+  houseBest: Session;
+  holder: Profile | undefined;
+};
+
+/**
+ * Best times per race type, mine against the household's.
+ *
+ * The house column is the whole point of a shared device: a sibling's name
+ * next to a time is the thing that makes a kid want another go. It only
+ * compares runs at identical settings, which is what `record.key` guarantees.
+ */
+export function RecordBook({
+  records,
+  profileId,
+}: {
+  records: Record_[];
+  profileId: string;
+}) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Records</h2>
+      </div>
+      {records.length === 0 ? (
+        <p className="muted">Race something and your best times land here.</p>
+      ) : (
+        <div className="splits__scroll">
+          <table className="splits">
+            <thead>
+              <tr>
+                <th scope="col">Race</th>
+                <th scope="col">Your best</th>
+                <th scope="col">House best</th>
+              </tr>
+            </thead>
+            <tbody>
+              {records.map((record) => {
+                const isMine = record.houseBest.profileId === profileId;
+                return (
+                  <tr key={record.key}>
+                    <td className="splits__card">
+                      {describeConfig(record.myBest.config)}
+                    </td>
+                    <td className="u-mono">
+                      {clock(raceTimeMs(record.myBest))}
+                    </td>
+                    <td className="u-mono splits__holder">
+                      {clock(raceTimeMs(record.houseBest))}
+                      {record.holder && (
+                        <span
+                          className={`splits__who${isMine ? " is-ahead" : ""}`}
+                        >
+                          <Avatar profile={record.holder} size="1.1rem" />
+                          {isMine ? "you" : record.holder.name}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** The last 40 runs, newest first. Older ones live in the record book above. */
+export function RunList({ sessions }: { sessions: Session[] }) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Every race</h2>
+      </div>
+      {sessions.length === 0 ? (
+        <p className="muted">No races yet.</p>
+      ) : (
+        <ul className="runlist">
+          {[...sessions]
+            .reverse()
+            .slice(0, 40)
+            .map((session) => (
+              <li key={session.id} className="runlist__row">
+                <span className="runlist__when u-mono">
+                  {shortDate(session.finishedAt)}
+                </span>
+                <span className="runlist__what">
+                  {describeConfig(session.config)}
+                </span>
+                <span className="runlist__acc u-mono">
+                  {percent(
+                    session.correct /
+                      Math.max(1, session.correct + session.incorrect),
+                  )}
+                </span>
+                <span className="runlist__time u-mono">
+                  {clock(raceTimeMs(session))}
+                </span>
+              </li>
+            ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/games/flashcards/RaceResults.tsx
+++ b/src/games/flashcards/RaceResults.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
-import { Avatar, Button, Confetti } from "@/components/ui/kit";
+import { Button, Confetti } from "@/components/ui/kit";
 import TopBar from "@/components/TopBar";
 import {
   WRONG_ANSWER_PENALTY_MS,
@@ -12,11 +12,13 @@ import {
   timeLimitOf,
   timedOutCount,
 } from "@/engine/records";
-import { BADGES_BY_ID } from "@/engine/progress";
 import { buildDrill, describeConfig } from "@/engine/decks/flashcards";
-import { clock, delta as formatDelta, percent, plural } from "@/engine/format";
+import { clock, delta as formatDelta, plural } from "@/engine/format";
 import { randomSeed } from "@/engine/random";
 import { sfx } from "@/services/sound";
+import { Rewards } from "./results/Rewards";
+import { Scoreline } from "./results/Scoreline";
+import { SplitsTable } from "./results/SplitsTable";
 
 export default function RaceResults() {
   const { profileId } = useParams();
@@ -173,158 +175,19 @@ export default function RaceResults() {
         )}
       </section>
 
-      <section className="scoreline panel anim-rise">
-        <div className="stat">
-          <span className="stat__value">{percent(accuracy)}</span>
-          <span className="stat__label">Correct</span>
-        </div>
-        <div className="stat">
-          <span className="stat__value">
-            {session.correct}
-            <span className="scoreline__of">
-              /{session.correct + session.incorrect}
-            </span>
-          </span>
-          <span className="stat__label">Cards</span>
-        </div>
-        <div className="stat">
-          <span className="stat__value">{session.bestStreak}</span>
-          <span className="stat__label">Best streak</span>
-        </div>
-        <div className="stat">
-          <span className="stat__value">
-            {(
-              session.durationMs /
-              Math.max(1, session.cards.length) /
-              1000
-            ).toFixed(2)}
-            s
-          </span>
-          <span className="stat__label">Per card</span>
-        </div>
-        <div className="stat stat--xp">
-          <span className="stat__value">
-            +{session.xpEarned.toLocaleString()}
-          </span>
-          <span className="stat__label">XP earned</span>
-        </div>
-      </section>
+      <Scoreline session={session} accuracy={accuracy} />
 
-      {(bonuses.length > 0 || levelledUpTo || newBadges.length > 0) && (
-        <section className="rewards anim-rise">
-          {levelledUpTo && (
-            <div className="reward reward--level">
-              <span className="reward__icon" aria-hidden="true">
-                🌟
-              </span>
-              <span>
-                <strong>Level {levelledUpTo}</strong>
-                <span className="reward__sub">You levelled up</span>
-              </span>
-            </div>
-          )}
-          {bonuses.map((bonus) => (
-            <div key={bonus.label} className="reward">
-              <span className="reward__icon" aria-hidden="true">
-                ⚡
-              </span>
-              <span>
-                <strong>{bonus.label}</strong>
-                <span className="reward__sub">+{bonus.xp} XP</span>
-              </span>
-            </div>
-          ))}
-          {newBadges.map((id) => {
-            const badge = BADGES_BY_ID.get(id);
-            if (!badge) return null;
-            return (
-              <div key={id} className="reward reward--badge">
-                <span className="reward__icon" aria-hidden="true">
-                  {badge.icon}
-                </span>
-                <span>
-                  <strong>{badge.name}</strong>
-                  <span className="reward__sub">{badge.how}</span>
-                </span>
-              </div>
-            );
-          })}
-        </section>
-      )}
-
-      <section className="panel anim-rise">
-        <div className="panel__head">
-          <h2 className="panel__title">Splits</h2>
-          {ghost && (
-            <span className="chip">
-              <Avatar profile={ghost.profile} size="1.2rem" />
-              {ghost.isSelf ? "Your best run" : ghost.profile.name}
-            </span>
-          )}
-        </div>
-        <div className="splits__scroll">
-          <table className="splits">
-            <thead>
-              <tr>
-                <th scope="col">#</th>
-                <th scope="col">Card</th>
-                <th scope="col">You</th>
-                {ghostSplits && <th scope="col">Rival</th>}
-                {ghostSplits && <th scope="col">Gap</th>}
-              </tr>
-            </thead>
-            <tbody>
-              {session.cards.map((card, i) => {
-                const gap =
-                  ghostSplits && ghostSplits[i] !== undefined
-                    ? mySplits[i] - ghostSplits[i]
-                    : null;
-                return (
-                  <tr
-                    key={i}
-                    className={
-                      card.ok
-                        ? undefined
-                        : card.timedOut
-                          ? "splits__row--late"
-                          : "splits__row--miss"
-                    }
-                  >
-                    <td className="u-mono splits__n">{i + 1}</td>
-                    <td className="splits__card">
-                      {card.prompt} = {card.answer}
-                      {!card.ok && (
-                        <span
-                          className={`splits__given${card.timedOut ? " is-late" : ""}`}
-                        >
-                          {card.timedOut
-                            ? "ran out of time"
-                            : `you said ${card.given}`}
-                        </span>
-                      )}
-                    </td>
-                    <td className="u-mono">{(card.ms / 1000).toFixed(2)}</td>
-                    {ghostSplits && (
-                      <td className="u-mono splits__rival">
-                        {ghost!.session.cards[i]
-                          ? (ghost!.session.cards[i].ms / 1000).toFixed(2)
-                          : "—"}
-                      </td>
-                    )}
-                    {ghostSplits && (
-                      <td
-                        className={`u-mono splits__gap${gap !== null && gap < 0 ? " is-ahead" : " is-behind"}`}
-                      >
-                        {gap === null ? "—" : formatDelta(gap)}
-                      </td>
-                    )}
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </section>
+      <Rewards
+        levelledUpTo={levelledUpTo}
+        bonuses={bonuses}
+        newBadges={newBadges}
+      />
+      <SplitsTable
+        session={session}
+        ghost={ghost}
+        mySplits={mySplits}
+        ghostSplits={ghostSplits}
+      />
 
       <div className="results__actions">
         {practiceFirst && (

--- a/src/games/flashcards/RaceSetup.tsx
+++ b/src/games/flashcards/RaceSetup.tsx
@@ -8,26 +8,24 @@ import {
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
 import TopBar from "@/components/TopBar";
-import { Avatar, Button, Input } from "@/components/ui/kit";
+import { Button } from "@/components/ui/kit";
 import {
   OPERATIONS,
   OPERATION_ORDER,
-  PRESETS,
-  TIME_LIMITS,
-  TIME_MAX_MS,
-  TIME_MIN_MS,
-  TIME_STEP_MS,
   buildDeck,
   configKey,
   presetForAge,
   snapTimeLimit,
   timeLimitForAge,
 } from "@/engine/decks/flashcards";
-import { accuracyOf, ghostsFor, raceTimeMs } from "@/engine/records";
-import { clock, percent, shortDate } from "@/engine/format";
+import { ghostsFor } from "@/engine/records";
 import { randomSeed } from "@/engine/random";
 import { sfx } from "@/services/sound";
-import type { FlashConfig, Ghost, InputMode, Operation } from "@/engine/types";
+import { ClockPicker } from "./setup/ClockPicker";
+import { DeckPicker } from "./setup/DeckPicker";
+import { PresetRow } from "./setup/PresetRow";
+import { RivalList } from "./setup/RivalList";
+import type { FlashConfig, InputMode, Operation } from "@/engine/types";
 
 const CARD_COUNTS = [10, 15, 20, 30, 50];
 const TABLE_NUMBERS = Array.from({ length: 12 }, (_, i) => i + 1);
@@ -73,7 +71,6 @@ export default function RaceSetup() {
     { length: 13 - spec.minOther },
     (_, i) => i + spec.minOther,
   );
-  const drill = config.facts?.length ? config.facts : null;
   // A drill sizes its own deck, so make room for whatever length it picked.
   const cardCounts = CARD_COUNTS.includes(config.cardCount)
     ? CARD_COUNTS
@@ -160,34 +157,13 @@ export default function RaceSetup() {
       />
 
       <div className="setup__grid">
-        <section className="panel anim-rise">
-          <div className="panel__head">
-            <h2 className="panel__title">Pick a race</h2>
-          </div>
-          <div className="preset-row">
-            {PRESETS.map((preset) => {
-              const chosen = configKey(preset.config) === key;
-              return (
-                <Button
-                  key={preset.id}
-                  variant="bare"
-                  className={`preset${chosen ? " is-chosen" : ""}`}
-                  onClick={() => {
-                    sfx.tap();
-                    setConfig(preset.config);
-                  }}
-                  pressed={chosen}
-                >
-                  <span className="preset__emoji" aria-hidden="true">
-                    {preset.emoji}
-                  </span>
-                  <span className="preset__name u-display">{preset.name}</span>
-                  <span className="preset__tag">{preset.tagline}</span>
-                </Button>
-              );
-            })}
-          </div>
-        </section>
+        <PresetRow
+          currentKey={key}
+          onChoose={(next) => {
+            sfx.tap();
+            setConfig(next);
+          }}
+        />
 
         <section className="panel anim-rise">
           <div className="panel__head">
@@ -225,118 +201,17 @@ export default function RaceSetup() {
             </div>
           </div>
 
-          {drill ? (
-            <div className="control">
-              <span className="control__label">Practice set</span>
-              <p className="drill__lead">
-                The {drill.length} facts you&apos;ve been missing most. Answer
-                each one twice.
-              </p>
-              <ul className="factchips">
-                {drill.map(([a, b]) => (
-                  <li key={`${a}:${b}`} className="factchip u-mono">
-                    {a} {spec.symbol} {b}
-                  </li>
-                ))}
-              </ul>
-              <div className="control__row">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    sfx.tap();
-                    patch({ facts: undefined });
-                  }}
-                >
-                  Pick numbers instead
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <div className="control">
-              <div className="numbers">
-                <div className="numbers__side">
-                  <span className="control__label">{spec.focusLabel}</span>
-                  <div className="tablegrid">
-                    {TABLE_NUMBERS.map((n) => (
-                      <Button
-                        key={n}
-                        variant="bare"
-                        className={`tablegrid__cell u-mono${config.tables.includes(n) ? " is-on" : ""}`}
-                        onClick={() => toggleTable(n)}
-                        pressed={config.tables.includes(n)}
-                      >
-                        {n}
-                      </Button>
-                    ))}
-                  </div>
-                  <div className="control__row">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ tables: TABLE_NUMBERS })}
-                    >
-                      All
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ tables: [2, 5, 10] })}
-                    >
-                      Easy three
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ tables: [6, 7, 8, 9] })}
-                    >
-                      Tricky four
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="numbers__side">
-                  <span className="control__label">{spec.pairLabel}</span>
-                  <div className="tablegrid">
-                    {otherNumbers.map((n) => (
-                      <Button
-                        key={n}
-                        variant="bare"
-                        className={`tablegrid__cell u-mono${config.others.includes(n) ? " is-on" : ""}`}
-                        onClick={() => toggleOther(n)}
-                        pressed={config.others.includes(n)}
-                      >
-                        {n}
-                      </Button>
-                    ))}
-                  </div>
-                  <div className="control__row">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ others: otherNumbers })}
-                    >
-                      All
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ others: [...config.tables] })}
-                    >
-                      Match tables
-                    </Button>
-                  </div>
-                </div>
-              </div>
-              <p className="numbers__note">
-                Cards only ever use numbers lit up on both sides. Unticking a
-                number on the left removes it from the right too.
-              </p>
-              <p className="numbers__preview u-mono">
-                e.g. {sample.join(" · ")}
-              </p>
-            </div>
-          )}
+          <DeckPicker
+            config={config}
+            spec={spec}
+            focusNumbers={TABLE_NUMBERS}
+            pairNumbers={otherNumbers}
+            sample={sample}
+            onToggleFocus={toggleTable}
+            onTogglePair={toggleOther}
+            patch={patch}
+            tap={sfx.tap}
+          />
 
           <div className="control">
             <span className="control__label">How many cards</span>
@@ -358,83 +233,26 @@ export default function RaceSetup() {
             </div>
           </div>
 
-          <div className="control">
-            <span className="control__label">Time per card</span>
-            <div className="segmented">
-              {TIME_LIMITS.map(({ ms, label }) => {
-                const on = (config.timeLimitMs ?? null) === ms;
-                return (
-                  <Button
-                    key={label}
-                    variant="bare"
-                    className={`segmented__btn u-mono${on ? " is-on" : ""}`}
-                    onClick={() => {
-                      sfx.tap();
-                      setLimit(ms);
-                    }}
-                    pressed={on}
-                  >
-                    {label}
-                  </Button>
-                );
-              })}
-            </div>
-
-            <div className="timelimit">
-              <Button
-                variant="bare"
-                className="timelimit__step u-mono"
-                onClick={() => bumpLimit(-TIME_STEP_MS)}
-                aria-label="Quarter of a second less"
-              >
-                −
-              </Button>
-              <span className="timelimit__field">
-                <Input
-                  className="timelimit__input u-mono"
-                  type="number"
-                  inputMode="decimal"
-                  step={TIME_STEP_MS / 1000}
-                  min={TIME_MIN_MS / 1000}
-                  max={TIME_MAX_MS / 1000}
-                  value={limitShown}
-                  placeholder="off"
-                  aria-label="Seconds per card"
-                  blurOnEnter
-                  onChange={(text) => {
-                    setLimitDraft(text);
-                    if (text.trim() === "") {
-                      patch({ timeLimitMs: null });
-                      return;
-                    }
-                    const typed = Number(text);
-                    if (Number.isFinite(typed))
-                      patch({ timeLimitMs: snapTimeLimit(typed * 1000) });
-                  }}
-                  onBlur={() => setLimitDraft(null)}
-                />
-                <span className="timelimit__unit u-mono">s</span>
-              </span>
-              <Button
-                variant="bare"
-                className="timelimit__step u-mono"
-                onClick={() => bumpLimit(TIME_STEP_MS)}
-                aria-label="Quarter of a second more"
-              >
-                +
-              </Button>
-              <span className="timelimit__hint">
-                Or set it exactly — quarter-second steps, down to{" "}
-                {TIME_MIN_MS / 1000}s. Clear the box for no clock.
-              </span>
-            </div>
-
-            <p className="numbers__note">
-              {config.timeLimitMs
-                ? "Run out of time and the answer is shown, then the next card comes up. Anything you miss lands on your practice list."
-                : "No card clock. The whole race is timed instead — take as long as you need on any one card."}
-            </p>
-          </div>
+          <ClockPicker
+            limitMs={config.timeLimitMs ?? null}
+            shownSeconds={limitShown}
+            onPreset={(ms) => {
+              sfx.tap();
+              setLimit(ms);
+            }}
+            onStep={bumpLimit}
+            onType={(text) => {
+              setLimitDraft(text);
+              if (text.trim() === "") {
+                patch({ timeLimitMs: null });
+                return;
+              }
+              const typed = Number(text);
+              if (Number.isFinite(typed))
+                patch({ timeLimitMs: snapTimeLimit(typed * 1000) });
+            }}
+            onDraftEnd={() => setLimitDraft(null)}
+          />
 
           <div className="control">
             <span className="control__label">Answering</span>
@@ -463,71 +281,15 @@ export default function RaceSetup() {
           </div>
         </section>
 
-        <section className="panel anim-rise setup__rivals">
-          <div className="panel__head">
-            <h2 className="panel__title">Who are you racing?</h2>
-          </div>
-          <p className="muted setup__rival-note">
-            Only runs with these exact settings show up here — same cards, same
-            order, fair race.
-          </p>
-
-          <ul className="rivals">
-            <li>
-              <Button
-                variant="bare"
-                className={`rival${rivalId === null ? " is-chosen" : ""}`}
-                onClick={() => {
-                  sfx.tap();
-                  setRivalId(null);
-                }}
-                pressed={rivalId === null}
-              >
-                <span className="rival__icon" aria-hidden="true">
-                  🕐
-                </span>
-                <span className="rival__body">
-                  <span className="rival__name u-display">Just the clock</span>
-                  <span className="rival__meta">
-                    No ghost — set a time to beat
-                  </span>
-                </span>
-              </Button>
-            </li>
-            {rivals.map((ghost: Ghost) => (
-              <li key={ghost.session.id}>
-                <Button
-                  variant="bare"
-                  className={`rival${rivalId === ghost.session.id ? " is-chosen" : ""}`}
-                  style={
-                    { "--tint": ghost.profile.color } as React.CSSProperties
-                  }
-                  onClick={() => {
-                    sfx.tap();
-                    setRivalId(ghost.session.id);
-                  }}
-                  pressed={rivalId === ghost.session.id}
-                >
-                  <Avatar profile={ghost.profile} size="2.4rem" />
-                  <span className="rival__body">
-                    <span className="rival__name u-display">
-                      {ghost.isSelf ? "Your best" : ghost.profile.name}
-                    </span>
-                    <span className="rival__meta u-mono">
-                      {clock(raceTimeMs(ghost.session))} ·{" "}
-                      {percent(accuracyOf(ghost.session))} ·{" "}
-                      {shortDate(ghost.session.finishedAt)}
-                    </span>
-                  </span>
-                </Button>
-              </li>
-            ))}
-          </ul>
-
-          <Button variant="go" className="setup__go" onClick={launch}>
-            Start race
-          </Button>
-        </section>
+        <RivalList
+          rivals={rivals}
+          chosenId={rivalId}
+          onChoose={(id) => {
+            sfx.tap();
+            setRivalId(id);
+          }}
+          onStart={launch}
+        />
       </div>
     </main>
   );

--- a/src/games/flashcards/results/Rewards.tsx
+++ b/src/games/flashcards/results/Rewards.tsx
@@ -1,0 +1,62 @@
+import { BADGES_BY_ID } from "@/engine/progress";
+
+/**
+ * What the run earned beyond the score: a level, XP bonuses, new badges.
+ *
+ * Renders nothing at all when there's nothing to celebrate — an empty rewards
+ * strip on an ordinary run would make every ordinary run feel like a miss.
+ */
+export function Rewards({
+  levelledUpTo,
+  bonuses,
+  newBadges,
+}: {
+  levelledUpTo: number | null;
+  bonuses: Array<{ label: string; xp: number }>;
+  newBadges: string[];
+}) {
+  if (!levelledUpTo && bonuses.length === 0 && newBadges.length === 0) {
+    return null;
+  }
+  return (
+    <section className="rewards anim-rise">
+      {levelledUpTo && (
+        <div className="reward reward--level">
+          <span className="reward__icon" aria-hidden="true">
+            🌟
+          </span>
+          <span>
+            <strong>Level {levelledUpTo}</strong>
+            <span className="reward__sub">You levelled up</span>
+          </span>
+        </div>
+      )}
+      {bonuses.map((bonus) => (
+        <div key={bonus.label} className="reward">
+          <span className="reward__icon" aria-hidden="true">
+            ⚡
+          </span>
+          <span>
+            <strong>{bonus.label}</strong>
+            <span className="reward__sub">+{bonus.xp} XP</span>
+          </span>
+        </div>
+      ))}
+      {newBadges.map((id) => {
+        const badge = BADGES_BY_ID.get(id);
+        if (!badge) return null;
+        return (
+          <div key={id} className="reward reward--badge">
+            <span className="reward__icon" aria-hidden="true">
+              {badge.icon}
+            </span>
+            <span>
+              <strong>{badge.name}</strong>
+              <span className="reward__sub">{badge.how}</span>
+            </span>
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/games/flashcards/results/Scoreline.tsx
+++ b/src/games/flashcards/results/Scoreline.tsx
@@ -1,0 +1,44 @@
+import { percent } from "@/engine/format";
+import type { Session } from "@/engine/types";
+
+/** The five numbers a player actually looks at first. */
+export function Scoreline({
+  session,
+  accuracy,
+}: {
+  session: Session;
+  accuracy: number;
+}) {
+  const perCard = session.durationMs / Math.max(1, session.cards.length) / 1000;
+  return (
+    <section className="scoreline panel anim-rise">
+      <div className="stat">
+        <span className="stat__value">{percent(accuracy)}</span>
+        <span className="stat__label">Correct</span>
+      </div>
+      <div className="stat">
+        <span className="stat__value">
+          {session.correct}
+          <span className="scoreline__of">
+            /{session.correct + session.incorrect}
+          </span>
+        </span>
+        <span className="stat__label">Cards</span>
+      </div>
+      <div className="stat">
+        <span className="stat__value">{session.bestStreak}</span>
+        <span className="stat__label">Best streak</span>
+      </div>
+      <div className="stat">
+        <span className="stat__value">{perCard.toFixed(2)}s</span>
+        <span className="stat__label">Per card</span>
+      </div>
+      <div className="stat stat--xp">
+        <span className="stat__value">
+          +{session.xpEarned.toLocaleString()}
+        </span>
+        <span className="stat__label">XP earned</span>
+      </div>
+    </section>
+  );
+}

--- a/src/games/flashcards/results/SplitsTable.tsx
+++ b/src/games/flashcards/results/SplitsTable.tsx
@@ -1,0 +1,98 @@
+import { Avatar } from "@/components/ui/kit";
+import { delta as formatDelta } from "@/engine/format";
+import type { Ghost, Session } from "@/engine/types";
+
+/**
+ * Card-by-card, with the rival's time alongside when there was one.
+ *
+ * A real <table> rather than a grid of divs: this is tabular data, the header
+ * row is what makes the rival and gap columns legible, and it's the one part
+ * of the results screen a parent is likely to read across.
+ */
+export function SplitsTable({
+  session,
+  ghost,
+  mySplits,
+  ghostSplits,
+}: {
+  session: Session;
+  ghost: Ghost | null;
+  /** Cumulative finish times, used only to compute the running gap. */
+  mySplits: number[];
+  ghostSplits: number[] | null;
+}) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Splits</h2>
+        {ghost && (
+          <span className="chip">
+            <Avatar profile={ghost.profile} size="1.2rem" />
+            {ghost.isSelf ? "Your best run" : ghost.profile.name}
+          </span>
+        )}
+      </div>
+      <div className="splits__scroll">
+        <table className="splits">
+          <thead>
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">Card</th>
+              <th scope="col">You</th>
+              {ghostSplits && <th scope="col">Rival</th>}
+              {ghostSplits && <th scope="col">Gap</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {session.cards.map((card, i) => {
+              const gap =
+                ghostSplits && ghostSplits[i] !== undefined
+                  ? mySplits[i] - ghostSplits[i]
+                  : null;
+              const rivalCard = ghost?.session.cards[i];
+              return (
+                <tr
+                  key={i}
+                  className={
+                    card.ok
+                      ? undefined
+                      : card.timedOut
+                        ? "splits__row--late"
+                        : "splits__row--miss"
+                  }
+                >
+                  <td className="u-mono splits__n">{i + 1}</td>
+                  <td className="splits__card">
+                    {card.prompt} = {card.answer}
+                    {!card.ok && (
+                      <span
+                        className={`splits__given${card.timedOut ? " is-late" : ""}`}
+                      >
+                        {card.timedOut
+                          ? "ran out of time"
+                          : `you said ${card.given}`}
+                      </span>
+                    )}
+                  </td>
+                  <td className="u-mono">{(card.ms / 1000).toFixed(2)}</td>
+                  {ghostSplits && (
+                    <td className="u-mono splits__rival">
+                      {rivalCard ? (rivalCard.ms / 1000).toFixed(2) : "—"}
+                    </td>
+                  )}
+                  {ghostSplits && (
+                    <td
+                      className={`u-mono splits__gap${gap !== null && gap < 0 ? " is-ahead" : " is-behind"}`}
+                    >
+                      {gap === null ? "—" : formatDelta(gap)}
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/games/flashcards/setup/ClockPicker.tsx
+++ b/src/games/flashcards/setup/ClockPicker.tsx
@@ -1,0 +1,100 @@
+import { Button, Input } from "@/components/ui/kit";
+import {
+  TIME_LIMITS,
+  TIME_MAX_MS,
+  TIME_MIN_MS,
+  TIME_STEP_MS,
+} from "@/engine/decks/flashcards";
+
+/**
+ * How long a player gets per card, or nothing at all.
+ *
+ * Two ways in, deliberately: presets for the common answers, and an exact
+ * field for the parent who knows their kid needs 3.75 seconds. The field keeps
+ * the raw text while it has focus and only snaps to the quarter-second grid on
+ * commit — otherwise typing "3.3" on the way to "3.35" would fight the caret.
+ */
+export function ClockPicker({
+  limitMs,
+  shownSeconds,
+  onPreset,
+  onStep,
+  onType,
+  onDraftEnd,
+}: {
+  limitMs: number | null;
+  /** Raw draft text while focused, otherwise the stored value. */
+  shownSeconds: string;
+  onPreset: (ms: number | null) => void;
+  onStep: (deltaMs: number) => void;
+  onType: (text: string) => void;
+  onDraftEnd: () => void;
+}) {
+  return (
+    <div className="control">
+      <span className="control__label">Time per card</span>
+      <div className="segmented">
+        {TIME_LIMITS.map(({ ms, label }) => {
+          const on = (limitMs ?? null) === ms;
+          return (
+            <Button
+              key={label}
+              variant="bare"
+              className={`segmented__btn u-mono${on ? " is-on" : ""}`}
+              onClick={() => onPreset(ms)}
+              pressed={on}
+            >
+              {label}
+            </Button>
+          );
+        })}
+      </div>
+
+      <div className="timelimit">
+        <Button
+          variant="bare"
+          className="timelimit__step u-mono"
+          onClick={() => onStep(-TIME_STEP_MS)}
+          aria-label="Quarter of a second less"
+        >
+          −
+        </Button>
+        <span className="timelimit__field">
+          <Input
+            className="timelimit__input u-mono"
+            type="number"
+            inputMode="decimal"
+            step={TIME_STEP_MS / 1000}
+            min={TIME_MIN_MS / 1000}
+            max={TIME_MAX_MS / 1000}
+            value={shownSeconds}
+            placeholder="off"
+            aria-label="Seconds per card"
+            blurOnEnter
+            onChange={onType}
+            onBlur={onDraftEnd}
+          />
+          <span className="timelimit__unit u-mono">s</span>
+        </span>
+        <Button
+          variant="bare"
+          className="timelimit__step u-mono"
+          onClick={() => onStep(TIME_STEP_MS)}
+          aria-label="Quarter of a second more"
+        >
+          +
+        </Button>
+        <span className="timelimit__hint">
+          Or set it exactly — quarter-second steps, down to {TIME_MIN_MS / 1000}
+          s. Clear the box for no clock.
+        </span>
+      </div>
+
+      <p className="numbers__note">
+        {limitMs
+          ? "Run out of time and the answer is shown, then the next card comes up. Anything you miss lands on your practice list."
+          : "No card clock. The whole race is timed instead — take as long as you need on any one card."}
+      </p>
+    </div>
+  );
+}

--- a/src/games/flashcards/setup/DeckPicker.tsx
+++ b/src/games/flashcards/setup/DeckPicker.tsx
@@ -1,0 +1,154 @@
+import { Button } from "@/components/ui/kit";
+import type { OperationSpec } from "@/engine/decks/flashcards";
+import type { FlashConfig } from "@/engine/types";
+
+/**
+ * Which numbers end up on the cards.
+ *
+ * Two grids, and the promise the layout makes is that a card only ever uses a
+ * number lit on BOTH sides — so unticking 12 on the left has to remove it from
+ * the right too, or the grid is lying. That rule lives in `onToggleFocus`,
+ * with the state it has to mutate.
+ *
+ * A drill arrives with its facts already chosen, so it replaces the grids
+ * entirely rather than trying to render as a selection.
+ */
+export function DeckPicker({
+  config,
+  spec,
+  focusNumbers,
+  pairNumbers,
+  sample,
+  onToggleFocus,
+  onTogglePair,
+  patch,
+  tap,
+}: {
+  config: FlashConfig;
+  spec: OperationSpec;
+  focusNumbers: number[];
+  pairNumbers: number[];
+  /** Three real cards from the current settings, so a tick shows its effect. */
+  sample: string[];
+  onToggleFocus: (n: number) => void;
+  onTogglePair: (n: number) => void;
+  patch: (next: Partial<FlashConfig>) => void;
+  tap: () => void;
+}) {
+  const drill = config.facts?.length ? config.facts : null;
+
+  if (drill) {
+    return (
+      <div className="control">
+        <span className="control__label">Practice set</span>
+        <p className="drill__lead">
+          The {drill.length} facts you&apos;ve been missing most. Answer each
+          one twice.
+        </p>
+        <ul className="factchips">
+          {drill.map(([a, b]) => (
+            <li key={`${a}:${b}`} className="factchip u-mono">
+              {a} {spec.symbol} {b}
+            </li>
+          ))}
+        </ul>
+        <div className="control__row">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              tap();
+              patch({ facts: undefined });
+            }}
+          >
+            Pick numbers instead
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="control">
+      <div className="numbers">
+        <div className="numbers__side">
+          <span className="control__label">{spec.focusLabel}</span>
+          <div className="tablegrid">
+            {focusNumbers.map((n) => (
+              <Button
+                key={n}
+                variant="bare"
+                className={`tablegrid__cell u-mono${config.tables.includes(n) ? " is-on" : ""}`}
+                onClick={() => onToggleFocus(n)}
+                pressed={config.tables.includes(n)}
+              >
+                {n}
+              </Button>
+            ))}
+          </div>
+          <div className="control__row">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ tables: focusNumbers })}
+            >
+              All
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ tables: [2, 5, 10] })}
+            >
+              Easy three
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ tables: [6, 7, 8, 9] })}
+            >
+              Tricky four
+            </Button>
+          </div>
+        </div>
+
+        <div className="numbers__side">
+          <span className="control__label">{spec.pairLabel}</span>
+          <div className="tablegrid">
+            {pairNumbers.map((n) => (
+              <Button
+                key={n}
+                variant="bare"
+                className={`tablegrid__cell u-mono${config.others.includes(n) ? " is-on" : ""}`}
+                onClick={() => onTogglePair(n)}
+                pressed={config.others.includes(n)}
+              >
+                {n}
+              </Button>
+            ))}
+          </div>
+          <div className="control__row">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ others: pairNumbers })}
+            >
+              All
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ others: [...config.tables] })}
+            >
+              Match tables
+            </Button>
+          </div>
+        </div>
+      </div>
+      <p className="numbers__note">
+        Cards only ever use numbers lit up on both sides. Unticking a number on
+        the left removes it from the right too.
+      </p>
+      <p className="numbers__preview u-mono">e.g. {sample.join(" · ")}</p>
+    </div>
+  );
+}

--- a/src/games/flashcards/setup/PresetRow.tsx
+++ b/src/games/flashcards/setup/PresetRow.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/kit";
+import { PRESETS, configKey } from "@/engine/decks/flashcards";
+import type { FlashConfig } from "@/engine/types";
+
+/**
+ * The one-tap answers, for the player who doesn't want to configure anything.
+ *
+ * A preset reads as chosen when the CURRENT config matches it exactly —
+ * compared by `configKey`, the same identity the record book uses to decide
+ * whether two runs are comparable. So tweaking any dial below silently
+ * un-chooses the preset, which is the honest thing for it to do.
+ */
+export function PresetRow({
+  currentKey,
+  onChoose,
+}: {
+  currentKey: string;
+  onChoose: (config: FlashConfig) => void;
+}) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Pick a race</h2>
+      </div>
+      <div className="preset-row">
+        {PRESETS.map((preset) => {
+          const chosen = configKey(preset.config) === currentKey;
+          return (
+            <Button
+              key={preset.id}
+              variant="bare"
+              className={`preset${chosen ? " is-chosen" : ""}`}
+              onClick={() => onChoose(preset.config)}
+              pressed={chosen}
+            >
+              <span className="preset__emoji" aria-hidden="true">
+                {preset.emoji}
+              </span>
+              <span className="preset__name u-display">{preset.name}</span>
+              <span className="preset__tag">{preset.tagline}</span>
+            </Button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/games/flashcards/setup/RivalList.tsx
+++ b/src/games/flashcards/setup/RivalList.tsx
@@ -1,0 +1,83 @@
+import { Avatar, Button } from "@/components/ui/kit";
+import { accuracyOf, raceTimeMs } from "@/engine/records";
+import { clock, percent, shortDate } from "@/engine/format";
+import type { Ghost } from "@/engine/types";
+
+/**
+ * Who the player is racing.
+ *
+ * Only runs at the exact same settings appear, because a ghost is a replay of
+ * a specific deck — racing one built from different cards wouldn't be a race.
+ * That filtering happens upstream in `ghostsFor`; this only has to render what
+ * survived it, and say why the list might be empty.
+ */
+export function RivalList({
+  rivals,
+  chosenId,
+  onChoose,
+  onStart,
+}: {
+  rivals: Ghost[];
+  /** null means "just the clock" — no ghost. */
+  chosenId: string | null;
+  onChoose: (id: string | null) => void;
+  onStart: () => void;
+}) {
+  return (
+    <section className="panel anim-rise setup__rivals">
+      <div className="panel__head">
+        <h2 className="panel__title">Who are you racing?</h2>
+      </div>
+      <p className="muted setup__rival-note">
+        Only runs with these exact settings show up here — same cards, same
+        order, fair race.
+      </p>
+
+      <ul className="rivals">
+        <li>
+          <Button
+            variant="bare"
+            className={`rival${chosenId === null ? " is-chosen" : ""}`}
+            onClick={() => onChoose(null)}
+            pressed={chosenId === null}
+          >
+            <span className="rival__icon" aria-hidden="true">
+              🕐
+            </span>
+            <span className="rival__body">
+              <span className="rival__name u-display">Just the clock</span>
+              <span className="rival__meta">No ghost — set a time to beat</span>
+            </span>
+          </Button>
+        </li>
+        {rivals.map((ghost) => (
+          <li key={ghost.session.id}>
+            <Button
+              variant="bare"
+              className={`rival${chosenId === ghost.session.id ? " is-chosen" : ""}`}
+              style={{ "--tint": ghost.profile.color } as React.CSSProperties}
+              onClick={() => onChoose(ghost.session.id)}
+              pressed={chosenId === ghost.session.id}
+            >
+              <Avatar profile={ghost.profile} size="2.4rem" />
+              <span className="rival__body">
+                <span className="rival__name u-display">
+                  {ghost.isSelf ? "Your best" : ghost.profile.name}
+                </span>
+                <span className="rival__meta u-mono">
+                  {clock(raceTimeMs(ghost.session))} ·{" "}
+                  {percent(accuracyOf(ghost.session))} ·{" "}
+                  {shortDate(ghost.session.finishedAt)}
+                </span>
+              </span>
+            </Button>
+          </li>
+        ))}
+      </ul>
+
+      <Button variant="go" className="setup__go" onClick={onStart}>
+        Start race
+      </Button>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #4, and with it epic #5.

**Both allowlists in `eslint.config.mjs` are gone.** The 300-line cap and the
native-controls ban now apply to every view module with no exceptions.

| File | Before | After |
| --- | ---: | ---: |
| `RaceSetup.tsx` | 487 | **254** |
| `Progress.tsx` | 394 | **232** |
| `RaceResults.tsx` | 348 | **212** |

## The seams are the panels

These screens already *are* a column of independently comprehensible sections,
so that's where they came apart:

- `setup/PresetRow` · `setup/DeckPicker` · `setup/ClockPicker` · `setup/RivalList`
- `results/Scoreline` · `results/Rewards` · `results/SplitsTable`
- `progress/FactMap` · `progress/RecordBook` (+ `RunList`)

## Two things nearly went wrong

Worth recording because one of them would have shipped:

1. `factKey`, `masteryOf` and `Mastery` live in `engine/records`, not
   `engine/progress`. Type-checking caught it.
2. I retyped the mastery legend as *"Not tried / Learning / Solid / Mastered"*.
   The real copy is *"Not tried yet / Still learning / Getting there /
   Mastered"*. Nothing would have failed — the wording is just deliberately
   softer for a child reading that their times tables are "Not tried **yet**".
   There's now an assertion pinning it.

## Verification

Nothing else drives the Progress screen — the smoke run goes setup → race →
results and never opens it — so a section that quietly stopped rendering would
have been invisible. New browser checks:

```
Progress screen
  ✓ Fact map / Trouble spots / Table trophies / Badges / Records / Every race
  ✓ the fact map draws all 144 cells
  ✓ the mastery legend keeps its original wording
    — Not tried yet|Still learning|Getting there|Mastered
  ✓ the record book has the finished race — 1 row
  ✓ the run list has it too — 1 row
  ✓ switching operation keeps the map

Results screen after the split
  ✓ the scoreline shows all five stats — Correct|Cards|Best streak|Per card|XP earned
  ✓ the splits table has one row per card — 10 rows
  ✓ timed-out cards are marked          ✓ the verdict headline renders
  ✓ the action row is intact — 5 buttons
```

Plus the clock field still snaps and clamps (3.3→3.25, 99→60, 0.1→1), and the
full smoke run passes. Zero console errors throughout.

`type-check` 0 errors · `lint` clean · 21/21 unit · 17 pages built.