### PR TITLE
Release: the kit epic — both lint allowlists retired

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,19 +59,6 @@ import prettier from "eslint-config-prettier/flat";
 // module it now describes.
 const MAX_COMPONENT_LINES = 300;
 
-// Files over the cap, each against the story that retires it. The list SHRINKS:
-// delete the entry in the same PR that splits the file. Counts are non-comment,
-// non-blank lines measured when the game was ported from the local-only app,
-// where nothing enforced a cap.
-const maxLinesAllowlist = [
-  // Retired by the flash-cards decomposition stories (PORT epic). RaceTrack is
-  // the race loop, the rAF ticker, the per-card clock and the keypad in one
-  // module; the split follows those seams, not arbitrary line counts.
-  "src/games/flashcards/RaceSetup.tsx", // 473
-  "src/games/flashcards/RaceResults.tsx", // 351
-  "src/components/screens/Progress.tsx", // 392
-];
-
 // Storage is an implementation detail of the service layer — the direct
 // analogue of monilibrium's "Prisma client only in services/" boundary. A React
 // component that reaches for `localStorage` bypasses the profile/session
@@ -398,7 +385,11 @@ export default defineConfig([
   // is coverage, not scannability.
   {
     files: ["src/components/**/*.{ts,tsx}", "src/games/**/*.{ts,tsx}"],
-    ignores: ["**/*.test.{ts,tsx}", ...maxLinesAllowlist],
+    // Tests only. There WAS an allowlist here too — RaceTrack (655), RaceSetup
+    // (473), Progress (392) and RaceResults (351), inherited from the
+    // local-only app where nothing enforced a cap. All four were split along
+    // their seams by the KIT03/KIT04 stories and the list was deleted.
+    ignores: ["**/*.test.{ts,tsx}"],
     rules: {
       "max-lines": [
         "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,7 +67,6 @@ const maxLinesAllowlist = [
   // Retired by the flash-cards decomposition stories (PORT epic). RaceTrack is
   // the race loop, the rAF ticker, the per-card clock and the keypad in one
   // module; the split follows those seams, not arbitrary line counts.
-  "src/games/flashcards/RaceTrack.tsx", // 655
   "src/games/flashcards/RaceSetup.tsx", // 473
   "src/games/flashcards/RaceResults.tsx", // 351
   "src/components/screens/Progress.tsx", // 392
@@ -84,7 +83,6 @@ const maxLinesAllowlist = [
 // same PR. The list only shrinks.
 const rawControlsAllowlist = [
   "src/components/PlayerEditor.tsx", // 13
-  "src/games/flashcards/RaceTrack.tsx", // 12
   "src/games/flashcards/RaceResults.tsx", // 5
   "src/components/screens/PlayerSelect.tsx", // 4
   "src/components/screens/Progress.tsx", // 3

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,24 +72,6 @@ const maxLinesAllowlist = [
   "src/components/screens/Progress.tsx", // 392
 ];
 
-// Files that still hand-roll native controls, inherited wholesale from the
-// local-only app where no kit boundary existed. 55 call sites across 8 files;
-// converting them blind during the port would have been a large untested
-// rewrite of every interactive surface at once, so the debt is recorded here
-// instead of hidden.
-//
-// Retired by the kit-conversion stories: each file's controls move to <Button>,
-// <Input>, <Select> and <Field> primitives, and its entry is deleted in the
-// same PR. The list only shrinks.
-const rawControlsAllowlist = [
-  "src/components/PlayerEditor.tsx", // 13
-  "src/games/flashcards/RaceResults.tsx", // 5
-  "src/components/screens/PlayerSelect.tsx", // 4
-  "src/components/screens/Progress.tsx", // 3
-  "src/components/screens/PlayerHub.tsx", // 2
-  "src/components/TopBar.tsx", // 1
-];
-
 // Storage is an implementation detail of the service layer — the direct
 // analogue of monilibrium's "Prisma client only in services/" boundary. A React
 // component that reaches for `localStorage` bypasses the profile/session
@@ -384,7 +366,12 @@ export default defineConfig([
   // tone — and hit targets are not cosmetic here, the youngest player is five.
   {
     files: ["**/*.tsx"],
-    ignores: ["src/components/ui/**", ...rawControlsAllowlist],
+    // No exceptions. There WAS an allowlist here — 55 hand-rolled controls
+    // across 8 files, inherited from the local-only app where no kit existed.
+    // It was drained to zero by the KIT01–KIT04 stories and then deleted, so
+    // adding a file back means editing this rule rather than appending to a
+    // list, which is the point.
+    ignores: ["src/components/ui/**"],
     rules: {
       "no-restricted-syntax": [
         "error",
@@ -392,7 +379,7 @@ export default defineConfig([
           selector:
             "JSXOpeningElement[name.name=/^(button|input|select|textarea|label)$/]",
           message:
-            "Don't hand-roll native controls outside src/components/ui/. Use the kit: <button>→<Button>, <input>→<Input>/<NumberPad>, <select>→<Select>, <label>→<Field>. If the kit is missing a primitive, add it there.",
+            "Don't hand-roll native controls outside src/components/ui/. Use the kit: <button>→<Button>, <input>→<Input>, <select>→<Select>, <label>/<fieldset>→<Field>/<FieldSet>. If the kit is missing a primitive, add it there.",
         },
       ],
     },

--- a/eslint.config.test.mjs
+++ b/eslint.config.test.mjs
@@ -80,6 +80,28 @@ describe("view layer (src/components/, src/games/, src/pages/)", () => {
     expect(fired).toContain(SYNTAX);
   });
 
+  // The test above uses a made-up path, so it passed for the whole time an
+  // allowlist exempted eight real files from the same rule. These are those
+  // files. If an allowlist ever comes back, this is what fails.
+  it.each([
+    "src/components/PlayerEditor.tsx",
+    "src/components/TopBar.tsx",
+    "src/components/BackupPanel.tsx",
+    "src/components/screens/PlayerHub.tsx",
+    "src/components/screens/PlayerSelect.tsx",
+    "src/components/screens/Progress.tsx",
+    "src/games/flashcards/App.tsx",
+    "src/games/flashcards/RaceSetup.tsx",
+    "src/games/flashcards/RaceTrack.tsx",
+    "src/games/flashcards/RaceResults.tsx",
+  ])("rejects native controls at %s, which used to be exempt", async (path) => {
+    const fired = await rulesFiredFor(
+      path,
+      `export const X = () => <button type="button">go</button>;\n`,
+    );
+    expect(fired).toContain(SYNTAX);
+  });
+
   it('rejects role="button" on a non-button', async () => {
     const fired = await rulesFiredFor(
       "src/components/Hub.tsx",

--- a/src/components/PlayerEditor.tsx
+++ b/src/components/PlayerEditor.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useHub } from "@/components/state/HubContext";
 import { sfx } from "@/services/sound";
 import type { Profile } from "@/engine/types";
-import { Scrim } from "@/components/ui/kit";
+import { Button, Field, FieldSet, Input, Scrim } from "@/components/ui/kit";
 
 export const AVATARS = [
   "🦊",
@@ -135,132 +135,123 @@ export default function PlayerEditor({ profile, onClose, onDeleted }: Props) {
           <h2 className="panel__title">
             {isNew ? "New player" : "Edit player"}
           </h2>
-          <button
-            type="button"
-            className="btn btn--ghost btn--sm"
-            onClick={onClose}
-          >
+          <Button variant="ghost" size="sm" onClick={onClose}>
             Close
-          </button>
+          </Button>
         </div>
 
-        <label className="field">
-          <span className="field__label">Name</span>
-          <input
+        <Field label="Name">
+          <Input
             ref={nameField}
-            className="field__input"
             value={name}
             maxLength={24}
-            onChange={(e) => setName(e.target.value)}
+            onChange={setName}
             placeholder="Type a name"
             autoComplete="off"
           />
-        </label>
+        </Field>
 
-        <fieldset className="field">
-          <legend className="field__label">Avatar</legend>
+        <FieldSet legend="Avatar">
           <div className="picker picker--emoji">
             {AVATARS.map((option) => (
-              <button
+              <Button
                 key={option}
-                type="button"
+                variant="bare"
                 className={`picker__cell${option === emoji ? " is-chosen" : ""}`}
                 onClick={() => {
                   setEmoji(option);
                   sfx.tap();
                 }}
-                aria-pressed={option === emoji}
+                pressed={option === emoji}
                 aria-label={`Avatar ${option}`}
               >
                 {option}
-              </button>
+              </Button>
             ))}
           </div>
-        </fieldset>
+        </FieldSet>
 
-        <fieldset className="field">
-          <legend className="field__label">Colour</legend>
+        <FieldSet legend="Colour">
           <div className="picker picker--color">
             {COLORS.map((option) => (
-              <button
+              <Button
                 key={option}
-                type="button"
+                variant="bare"
                 className={`swatch${option === color ? " is-chosen" : ""}`}
                 style={{ background: option }}
                 onClick={() => {
                   setColor(option);
                   sfx.tap();
                 }}
-                aria-pressed={option === color}
+                pressed={option === color}
                 aria-label={`Colour ${option}`}
               />
             ))}
           </div>
-        </fieldset>
+        </FieldSet>
 
-        <fieldset className="field">
-          <legend className="field__label">Age</legend>
+        <FieldSet
+          legend="Age"
+          hint="Sets the default difficulty and how big everything looks."
+        >
           <div className="stepper">
-            <button
-              type="button"
+            <Button
+              variant="bare"
               className="stepper__btn"
               onClick={() => setAge((a) => Math.max(3, a - 1))}
               aria-label="Younger"
             >
               −
-            </button>
+            </Button>
             <span className="stepper__value u-mono">{age}</span>
-            <button
-              type="button"
+            <Button
+              variant="bare"
               className="stepper__btn"
               onClick={() => setAge((a) => Math.min(18, a + 1))}
               aria-label="Older"
             >
               +
-            </button>
+            </Button>
           </div>
-          <p className="field__hint">
-            Sets the default difficulty and how big everything looks.
-          </p>
-        </fieldset>
+        </FieldSet>
 
         <div className="sheet__actions">
           {!isNew &&
             (confirmingDelete ? (
               <div className="sheet__confirm">
                 <span>Remove {profile.name} and all their races?</span>
-                <button
-                  type="button"
-                  className="btn btn--danger btn--sm"
+                <Button
+                  variant="danger"
+                  size="sm"
                   onClick={() => void remove()}
                   disabled={saving}
                 >
                   Remove
-                </button>
-                <button
-                  type="button"
-                  className="btn btn--ghost btn--sm"
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setConfirmingDelete(false)}
                 >
                   Keep
-                </button>
+                </Button>
               </div>
             ) : (
-              <button
-                type="button"
-                className="btn btn--danger btn--sm"
+              <Button
+                variant="danger"
+                size="sm"
                 onClick={() => setConfirmingDelete(true)}
               >
                 Remove player
-              </button>
+              </Button>
             ))}
-          <button
+          <Button
             type="submit"
-            className="btn btn--accent"
+            variant="accent"
             disabled={!name.trim() || saving}
           >
             {isNew ? "Add player" : "Save"}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Avatar } from "@/components/ui/kit";
+import { Avatar, Button } from "@/components/ui/kit";
 import { levelFromXp } from "@/engine/progress";
 import { useHub } from "@/components/state/HubContext";
 import { setSoundEnabled } from "@/services/sound";
@@ -61,15 +61,16 @@ export default function TopBar({
 
       <div className="topbar__actions">
         {children}
-        <button
+        <Button
+          variant="bare"
           className="topbar__icon"
           onClick={() => void toggleSound()}
-          aria-pressed={soundOn}
+          pressed={soundOn}
           title={soundOn ? "Turn sound off" : "Turn sound on"}
         >
           <span aria-hidden="true">{soundOn ? "🔊" : "🔇"}</span>
           <span className="u-sr">Sound {soundOn ? "on" : "off"}</span>
-        </button>
+        </Button>
       </div>
     </header>
   );

--- a/src/components/screens/PlayerHub.tsx
+++ b/src/components/screens/PlayerHub.tsx
@@ -1,7 +1,7 @@
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import TopBar from "@/components/TopBar";
-import { Stat } from "@/components/ui/kit";
+import { Button, Stat } from "@/components/ui/kit";
 import {
   bestRun,
   lifetimeStats,
@@ -62,17 +62,19 @@ export default function PlayerHub() {
             Race a deck of multiplication cards against the clock — or against a
             ghost of your best run, or one of your siblings&apos;.
           </p>
-          <button
-            className="btn btn--go hub__cta"
+          <Button
+            variant="go"
+            className="hub__cta"
             onClick={() => {
               sfx.select();
               navigate(`/p/${profile.id}/race`);
             }}
           >
             Set up a race →
-          </button>
+          </Button>
           {trouble.length >= 3 && (
-            <button
+            <Button
+              variant="bare"
               className="hub__drill"
               onClick={() => {
                 sfx.select();
@@ -91,7 +93,7 @@ export default function PlayerHub() {
               }}
             >
               or practise {plural(trouble.length, "fact")} you keep missing →
-            </button>
+            </Button>
           )}
         </div>
 

--- a/src/components/screens/PlayerSelect.tsx
+++ b/src/components/screens/PlayerSelect.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useHub } from "@/components/state/HubContext";
-import { Avatar, LevelRing } from "@/components/ui/kit";
+import { Avatar, Button, LevelRing } from "@/components/ui/kit";
 import PlayerEditor from "@/components/PlayerEditor";
 import BackupPanel from "@/components/BackupPanel";
 import { lifetimeStats, sessionsFor } from "@/engine/records";
@@ -49,9 +49,9 @@ export default function PlayerSelect() {
             Every player gets their own times, records and badges. Nothing
             leaves this device.
           </p>
-          <button className="btn btn--go" onClick={() => setEditing(null)}>
+          <Button variant="go" onClick={() => setEditing(null)}>
             Add a player
-          </button>
+          </Button>
         </div>
       ) : (
         <ul className="select__grid">
@@ -73,12 +73,13 @@ export default function PlayerSelect() {
                     } as React.CSSProperties
                   }
                 >
-                  <button
+                  <Button
+                    variant="bare"
                     className="driver__enter"
                     onClick={() => enter(profile)}
                   >
                     <span className="u-sr">Play as {profile.name}</span>
-                  </button>
+                  </Button>
                   <div className="driver__top">
                     <Avatar profile={profile} size="4.25rem" />
                     <LevelRing
@@ -104,12 +105,13 @@ export default function PlayerSelect() {
                       </dd>
                     </div>
                   </dl>
-                  <button
+                  <Button
+                    variant="bare"
                     className="driver__edit"
                     onClick={() => setEditing(profile)}
                   >
                     Edit<span className="u-sr"> {profile.name}</span>
-                  </button>
+                  </Button>
                 </div>
               </li>
             );
@@ -118,7 +120,8 @@ export default function PlayerSelect() {
             className="anim-rise"
             style={{ animationDelay: `${profiles.length * 70}ms` }}
           >
-            <button
+            <Button
+              variant="bare"
               className="driver driver--add"
               onClick={() => setEditing(null)}
             >
@@ -126,7 +129,7 @@ export default function PlayerSelect() {
                 +
               </span>
               <span className="driver__name u-display">Add player</span>
-            </button>
+            </Button>
           </li>
         </ul>
       )}

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import TopBar from "@/components/TopBar";
-import { Avatar } from "@/components/ui/kit";
+import { Avatar, Button } from "@/components/ui/kit";
 import { BADGES } from "@/engine/progress";
 import {
   bestRun,
@@ -120,14 +120,15 @@ export default function Progress() {
           <h2 className="panel__title">Fact map</h2>
           <div className="segmented segmented--slim">
             {OPERATION_ORDER.map((op) => (
-              <button
+              <Button
                 key={op}
+                variant="bare"
                 className={`segmented__btn${operation === op ? " is-on" : ""}`}
                 onClick={() => setOperation(op)}
-                aria-pressed={operation === op}
+                pressed={operation === op}
               >
                 {OPERATIONS[op].symbol}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -203,8 +204,9 @@ export default function Progress() {
         <div className="panel__head">
           <h2 className="panel__title">Trouble spots</h2>
           {trouble.length > 0 && (
-            <button
-              className="btn btn--accent btn--sm"
+            <Button
+              variant="accent"
+              size="sm"
               onClick={() => {
                 sfx.select();
                 navigate(`/p/${profile.id}/race`, {
@@ -222,7 +224,7 @@ export default function Progress() {
               }}
             >
               Drill these
-            </button>
+            </Button>
           )}
         </div>
         {trouble.length === 0 ? (

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -2,11 +2,10 @@ import { useMemo, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import TopBar from "@/components/TopBar";
-import { Avatar, Button } from "@/components/ui/kit";
+import { Button } from "@/components/ui/kit";
 import { BADGES } from "@/engine/progress";
 import {
   bestRun,
-  factKey,
   factStats,
   lifetimeStats,
   masteryOf,
@@ -14,27 +13,17 @@ import {
   sessionsFor,
   tableProgress,
   troubleFacts,
-  type Mastery,
 } from "@/engine/records";
 import {
   OPERATIONS,
-  OPERATION_ORDER,
   buildDrill,
-  describeConfig,
   timeLimitForAge,
 } from "@/engine/decks/flashcards";
 import { sfx } from "@/services/sound";
-import { clock, duration, percent, shortDate } from "@/engine/format";
+import { FactMap } from "./progress/FactMap";
+import { RecordBook, RunList } from "./progress/RecordBook";
+import { duration, percent } from "@/engine/format";
 import type { Operation } from "@/engine/types";
-
-const AXIS = Array.from({ length: 12 }, (_, i) => i + 1);
-
-const MASTERY_LABEL: Record<Mastery, string> = {
-  untried: "Not tried yet",
-  learning: "Still learning",
-  solid: "Getting there",
-  mastered: "Mastered",
-};
 
 export default function Progress() {
   const { profileId } = useParams();
@@ -115,90 +104,12 @@ export default function Progress() {
         </div>
       </section>
 
-      <section className="panel anim-rise">
-        <div className="panel__head">
-          <h2 className="panel__title">Fact map</h2>
-          <div className="segmented segmented--slim">
-            {OPERATION_ORDER.map((op) => (
-              <Button
-                key={op}
-                variant="bare"
-                className={`segmented__btn${operation === op ? " is-on" : ""}`}
-                onClick={() => setOperation(op)}
-                pressed={operation === op}
-              >
-                {OPERATIONS[op].symbol}
-              </Button>
-            ))}
-          </div>
-        </div>
-        <p className="muted">
-          Every {spec.label.toLowerCase()} fact from 1 to 12. A square turns
-          green once it&apos;s answered right three times running and under four
-          seconds — that&apos;s recall, not counting.
-        </p>
-
-        <div className="factmap__wrap">
-          <table className="factmap">
-            <caption className="u-sr">{spec.label} facts by mastery</caption>
-            <thead>
-              <tr>
-                <th scope="col" className="factmap__corner u-mono">
-                  {spec.symbol}
-                </th>
-                {AXIS.map((n) => (
-                  <th key={n} scope="col" className="u-mono factmap__axis">
-                    {n}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {AXIS.map((row) => (
-                <tr key={row}>
-                  <th scope="row" className="u-mono factmap__axis">
-                    {row}
-                  </th>
-                  {AXIS.map((col) => {
-                    const stat = grid.get(factKey(row, col));
-                    const level = masteryOf(stat);
-                    const avg = stat
-                      ? stat.totalMs / stat.attempts / 1000
-                      : null;
-                    return (
-                      <td key={col} className={`factmap__cell is-${level}`}>
-                        <span className="u-sr">
-                          {row} {spec.symbol} {col}: {MASTERY_LABEL[level]}
-                        </span>
-                        <span className="factmap__tip" aria-hidden="true">
-                          {row} {spec.symbol} {col}
-                          {stat
-                            ? ` · ${stat.correct}/${stat.attempts} · ${avg!.toFixed(1)}s`
-                            : " · not tried"}
-                        </span>
-                      </td>
-                    );
-                  })}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <ul className="legend">
-          {(["untried", "learning", "solid", "mastered"] as Mastery[]).map(
-            (level) => (
-              <li key={level} className="legend__item">
-                <span
-                  className={`legend__swatch is-${level}`}
-                  aria-hidden="true"
-                />
-                {MASTERY_LABEL[level]}
-              </li>
-            ),
-          )}
-        </ul>
-      </section>
+      <FactMap
+        operation={operation}
+        onOperationChange={setOperation}
+        spec={spec}
+        grid={grid}
+      />
 
       <section className="panel anim-rise">
         <div className="panel__head">
@@ -328,86 +239,9 @@ export default function Progress() {
         </section>
       </div>
 
-      <section className="panel anim-rise">
-        <div className="panel__head">
-          <h2 className="panel__title">Records</h2>
-        </div>
-        {records.length === 0 ? (
-          <p className="muted">Race something and your best times land here.</p>
-        ) : (
-          <div className="splits__scroll">
-            <table className="splits">
-              <thead>
-                <tr>
-                  <th scope="col">Race</th>
-                  <th scope="col">Your best</th>
-                  <th scope="col">House best</th>
-                </tr>
-              </thead>
-              <tbody>
-                {records.map((record) => {
-                  const isMine = record.houseBest.profileId === profile.id;
-                  return (
-                    <tr key={record.key}>
-                      <td className="splits__card">
-                        {describeConfig(record.myBest.config)}
-                      </td>
-                      <td className="u-mono">
-                        {clock(raceTimeMs(record.myBest))}
-                      </td>
-                      <td className="u-mono splits__holder">
-                        {clock(raceTimeMs(record.houseBest))}
-                        {record.holder && (
-                          <span
-                            className={`splits__who${isMine ? " is-ahead" : ""}`}
-                          >
-                            <Avatar profile={record.holder} size="1.1rem" />
-                            {isMine ? "you" : record.holder.name}
-                          </span>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
+      <RecordBook records={records} profileId={profile.id} />
 
-      <section className="panel anim-rise">
-        <div className="panel__head">
-          <h2 className="panel__title">Every race</h2>
-        </div>
-        {mine.length === 0 ? (
-          <p className="muted">No races yet.</p>
-        ) : (
-          <ul className="runlist">
-            {[...mine]
-              .reverse()
-              .slice(0, 40)
-              .map((session) => (
-                <li key={session.id} className="runlist__row">
-                  <span className="runlist__when u-mono">
-                    {shortDate(session.finishedAt)}
-                  </span>
-                  <span className="runlist__what">
-                    {describeConfig(session.config)}
-                  </span>
-                  <span className="runlist__acc u-mono">
-                    {percent(
-                      session.correct /
-                        Math.max(1, session.correct + session.incorrect),
-                    )}
-                  </span>
-                  <span className="runlist__time u-mono">
-                    {clock(raceTimeMs(session))}
-                  </span>
-                </li>
-              ))}
-          </ul>
-        )}
-      </section>
+      <RunList sessions={mine} />
     </main>
   );
 }

--- a/src/components/screens/progress/FactMap.tsx
+++ b/src/components/screens/progress/FactMap.tsx
@@ -1,0 +1,123 @@
+import { Button } from "@/components/ui/kit";
+import {
+  OPERATIONS,
+  OPERATION_ORDER,
+  type OperationSpec,
+} from "@/engine/decks/flashcards";
+import { factKey, masteryOf, type Mastery } from "@/engine/records";
+import type { Operation } from "@/engine/types";
+
+const AXIS = Array.from({ length: 12 }, (_, i) => i + 1);
+
+export const MASTERY_LABEL: Record<Mastery, string> = {
+  untried: "Not tried yet",
+  learning: "Still learning",
+  solid: "Getting there",
+  mastered: "Mastered",
+};
+
+/**
+ * Every fact from 1 to 12, coloured by how well it's known.
+ *
+ * A real <table> with header cells on both axes: a grid of 144 divs would be
+ * unreadable to a screen reader, and each cell already carries its own
+ * spoken-only summary. The operation switcher sits in the heading rather than
+ * above the map because it changes what the map *is*, not how it's filtered.
+ */
+export function FactMap({
+  operation,
+  onOperationChange,
+  spec,
+  grid,
+}: {
+  operation: Operation;
+  onOperationChange: (op: Operation) => void;
+  spec: OperationSpec;
+  /** Per-fact attempt stats, keyed by `factKey`. */
+  grid: Map<string, { attempts: number; correct: number; totalMs: number }>;
+}) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Fact map</h2>
+        <div className="segmented segmented--slim">
+          {OPERATION_ORDER.map((op) => (
+            <Button
+              key={op}
+              variant="bare"
+              className={`segmented__btn${operation === op ? " is-on" : ""}`}
+              onClick={() => onOperationChange(op)}
+              pressed={operation === op}
+            >
+              {OPERATIONS[op].symbol}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <p className="muted">
+        Every {spec.label.toLowerCase()} fact from 1 to 12. A square turns green
+        once it&apos;s answered right three times running and under four seconds
+        — that&apos;s recall, not counting.
+      </p>
+
+      <div className="factmap__wrap">
+        <table className="factmap">
+          <caption className="u-sr">{spec.label} facts by mastery</caption>
+          <thead>
+            <tr>
+              <th scope="col" className="factmap__corner u-mono">
+                {spec.symbol}
+              </th>
+              {AXIS.map((n) => (
+                <th key={n} scope="col" className="u-mono factmap__axis">
+                  {n}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {AXIS.map((row) => (
+              <tr key={row}>
+                <th scope="row" className="u-mono factmap__axis">
+                  {row}
+                </th>
+                {AXIS.map((col) => {
+                  const stat = grid.get(factKey(row, col));
+                  const level = masteryOf(stat);
+                  const avg = stat ? stat.totalMs / stat.attempts / 1000 : null;
+                  return (
+                    <td key={col} className={`factmap__cell is-${level}`}>
+                      <span className="u-sr">
+                        {row} {spec.symbol} {col}: {MASTERY_LABEL[level]}
+                      </span>
+                      <span className="factmap__tip" aria-hidden="true">
+                        {row} {spec.symbol} {col}
+                        {stat
+                          ? ` · ${stat.correct}/${stat.attempts} · ${avg!.toFixed(1)}s`
+                          : " · not tried"}
+                      </span>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <ul className="legend">
+        {(["untried", "learning", "solid", "mastered"] as Mastery[]).map(
+          (level) => (
+            <li key={level} className="legend__item">
+              <span
+                className={`legend__swatch is-${level}`}
+                aria-hidden="true"
+              />
+              {MASTERY_LABEL[level]}
+            </li>
+          ),
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/screens/progress/RecordBook.tsx
+++ b/src/components/screens/progress/RecordBook.tsx
@@ -1,0 +1,115 @@
+import { Avatar } from "@/components/ui/kit";
+import { describeConfig } from "@/engine/decks/flashcards";
+import { raceTimeMs } from "@/engine/records";
+import { clock, percent, shortDate } from "@/engine/format";
+import type { Profile, Session } from "@/engine/types";
+
+type Record_ = {
+  key: string;
+  myBest: Session;
+  houseBest: Session;
+  holder: Profile | undefined;
+};
+
+/**
+ * Best times per race type, mine against the household's.
+ *
+ * The house column is the whole point of a shared device: a sibling's name
+ * next to a time is the thing that makes a kid want another go. It only
+ * compares runs at identical settings, which is what `record.key` guarantees.
+ */
+export function RecordBook({
+  records,
+  profileId,
+}: {
+  records: Record_[];
+  profileId: string;
+}) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Records</h2>
+      </div>
+      {records.length === 0 ? (
+        <p className="muted">Race something and your best times land here.</p>
+      ) : (
+        <div className="splits__scroll">
+          <table className="splits">
+            <thead>
+              <tr>
+                <th scope="col">Race</th>
+                <th scope="col">Your best</th>
+                <th scope="col">House best</th>
+              </tr>
+            </thead>
+            <tbody>
+              {records.map((record) => {
+                const isMine = record.houseBest.profileId === profileId;
+                return (
+                  <tr key={record.key}>
+                    <td className="splits__card">
+                      {describeConfig(record.myBest.config)}
+                    </td>
+                    <td className="u-mono">
+                      {clock(raceTimeMs(record.myBest))}
+                    </td>
+                    <td className="u-mono splits__holder">
+                      {clock(raceTimeMs(record.houseBest))}
+                      {record.holder && (
+                        <span
+                          className={`splits__who${isMine ? " is-ahead" : ""}`}
+                        >
+                          <Avatar profile={record.holder} size="1.1rem" />
+                          {isMine ? "you" : record.holder.name}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** The last 40 runs, newest first. Older ones live in the record book above. */
+export function RunList({ sessions }: { sessions: Session[] }) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Every race</h2>
+      </div>
+      {sessions.length === 0 ? (
+        <p className="muted">No races yet.</p>
+      ) : (
+        <ul className="runlist">
+          {[...sessions]
+            .reverse()
+            .slice(0, 40)
+            .map((session) => (
+              <li key={session.id} className="runlist__row">
+                <span className="runlist__when u-mono">
+                  {shortDate(session.finishedAt)}
+                </span>
+                <span className="runlist__what">
+                  {describeConfig(session.config)}
+                </span>
+                <span className="runlist__acc u-mono">
+                  {percent(
+                    session.correct /
+                      Math.max(1, session.correct + session.incorrect),
+                  )}
+                </span>
+                <span className="runlist__time u-mono">
+                  {clock(raceTimeMs(session))}
+                </span>
+              </li>
+            ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/engine/run.ts
+++ b/src/engine/run.ts
@@ -1,0 +1,113 @@
+import { compareRuns } from "./records";
+import { evaluateBadges, finishBonuses } from "./progress";
+import { configKey } from "./decks/flashcards";
+import type { CardResult, FlashConfig, Ghost, Profile, Session } from "./types";
+
+/**
+ * Turning a finished race into the record of it.
+ *
+ * This was inline in RaceTrack, which made a component the authority on what
+ * a run is worth — scoring, personal records, bonuses and badges all decided
+ * in the middle of a render tree. None of it needs React, a browser, or
+ * storage: it's the same class of rule as `compareRuns` and belongs with it.
+ *
+ * Everything here is derived. Nothing is written; the caller hands the draft
+ * to the session service, which owns persistence.
+ */
+
+/** What the race loop counted while it was running. */
+export type RunTally = {
+  cards: CardResult[];
+  /** XP from the cards themselves, before finish bonuses. */
+  cardXp: number;
+  bestStreak: number;
+  /** Furthest behind the ghost the player ever fell, in ms. */
+  maxDeficitMs: number;
+};
+
+export type RunSummary = {
+  /** Ready for the session service; add nothing but `earnedBadges`. */
+  draft: Omit<Session, "id" | "finishedAt">;
+  earnedBadges: string[];
+  /** Badges the player didn't already hold — what the results screen crows about. */
+  newBadges: string[];
+  bonuses: ReturnType<typeof finishBonuses>;
+  personalRecord: boolean;
+  /** null when there was no ghost to race. */
+  beatGhost: boolean | null;
+};
+
+export function summariseRun({
+  profile,
+  config,
+  seed,
+  ghost,
+  history,
+  previousBest,
+  tally,
+}: {
+  profile: Profile;
+  config: FlashConfig;
+  seed: number;
+  ghost: Ghost | null;
+  /** The player's earlier runs, snapshotted before this one existed. */
+  history: Session[];
+  /** Their best at these exact settings, or null if this is the first. */
+  previousBest: Session | null;
+  tally: RunTally;
+}): RunSummary {
+  const cards = tally.cards;
+  const correct = cards.filter((c) => c.ok).length;
+  const incorrect = cards.length - correct;
+  const durationMs = cards.reduce((sum, c) => sum + c.ms, 0);
+
+  // Timed runs are ranked on cards beaten before time, untimed ones on the
+  // clock — `compareRuns` owns that rule so the record book and the results
+  // screen can never disagree about what "better" means.
+  const scored = { durationMs, correct, incorrect, config };
+  const personalRecord =
+    previousBest !== null && compareRuns(scored, previousBest) < 0;
+  const beatGhost = ghost ? compareRuns(scored, ghost.session) < 0 : null;
+
+  const bonuses = finishBonuses({
+    perfect: incorrect === 0 && correct > 0,
+    personalRecord,
+    beatGhost: beatGhost === true,
+    cardCount: cards.length,
+  });
+  const xpEarned = tally.cardXp + bonuses.reduce((sum, b) => sum + b.xp, 0);
+
+  const draft = {
+    profileId: profile.id,
+    game: "flashcards" as const,
+    mode: config.operation,
+    configKey: configKey(config),
+    config,
+    seed,
+    durationMs,
+    correct,
+    incorrect,
+    bestStreak: tally.bestStreak,
+    xpEarned,
+    ghostSessionId: ghost?.session.id ?? null,
+    beatGhost,
+    cards,
+  };
+
+  const earnedBadges = evaluateBadges({
+    session: draft,
+    history,
+    personalRecord,
+    maxDeficitMs: tally.maxDeficitMs,
+    xpAfter: profile.xp + xpEarned,
+  });
+
+  return {
+    draft,
+    earnedBadges,
+    newBadges: earnedBadges.filter((id) => !profile.badges.includes(id)),
+    bonuses,
+    personalRecord,
+    beatGhost,
+  };
+}

--- a/src/games/flashcards/RaceResults.tsx
+++ b/src/games/flashcards/RaceResults.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
-import { Avatar, Button, Confetti } from "@/components/ui/kit";
+import { Button, Confetti } from "@/components/ui/kit";
 import TopBar from "@/components/TopBar";
 import {
   WRONG_ANSWER_PENALTY_MS,
@@ -12,11 +12,13 @@ import {
   timeLimitOf,
   timedOutCount,
 } from "@/engine/records";
-import { BADGES_BY_ID } from "@/engine/progress";
 import { buildDrill, describeConfig } from "@/engine/decks/flashcards";
-import { clock, delta as formatDelta, percent, plural } from "@/engine/format";
+import { clock, delta as formatDelta, plural } from "@/engine/format";
 import { randomSeed } from "@/engine/random";
 import { sfx } from "@/services/sound";
+import { Rewards } from "./results/Rewards";
+import { Scoreline } from "./results/Scoreline";
+import { SplitsTable } from "./results/SplitsTable";
 
 export default function RaceResults() {
   const { profileId } = useParams();
@@ -173,158 +175,19 @@ export default function RaceResults() {
         )}
       </section>
 
-      <section className="scoreline panel anim-rise">
-        <div className="stat">
-          <span className="stat__value">{percent(accuracy)}</span>
-          <span className="stat__label">Correct</span>
-        </div>
-        <div className="stat">
-          <span className="stat__value">
-            {session.correct}
-            <span className="scoreline__of">
-              /{session.correct + session.incorrect}
-            </span>
-          </span>
-          <span className="stat__label">Cards</span>
-        </div>
-        <div className="stat">
-          <span className="stat__value">{session.bestStreak}</span>
-          <span className="stat__label">Best streak</span>
-        </div>
-        <div className="stat">
-          <span className="stat__value">
-            {(
-              session.durationMs /
-              Math.max(1, session.cards.length) /
-              1000
-            ).toFixed(2)}
-            s
-          </span>
-          <span className="stat__label">Per card</span>
-        </div>
-        <div className="stat stat--xp">
-          <span className="stat__value">
-            +{session.xpEarned.toLocaleString()}
-          </span>
-          <span className="stat__label">XP earned</span>
-        </div>
-      </section>
+      <Scoreline session={session} accuracy={accuracy} />
 
-      {(bonuses.length > 0 || levelledUpTo || newBadges.length > 0) && (
-        <section className="rewards anim-rise">
-          {levelledUpTo && (
-            <div className="reward reward--level">
-              <span className="reward__icon" aria-hidden="true">
-                🌟
-              </span>
-              <span>
-                <strong>Level {levelledUpTo}</strong>
-                <span className="reward__sub">You levelled up</span>
-              </span>
-            </div>
-          )}
-          {bonuses.map((bonus) => (
-            <div key={bonus.label} className="reward">
-              <span className="reward__icon" aria-hidden="true">
-                ⚡
-              </span>
-              <span>
-                <strong>{bonus.label}</strong>
-                <span className="reward__sub">+{bonus.xp} XP</span>
-              </span>
-            </div>
-          ))}
-          {newBadges.map((id) => {
-            const badge = BADGES_BY_ID.get(id);
-            if (!badge) return null;
-            return (
-              <div key={id} className="reward reward--badge">
-                <span className="reward__icon" aria-hidden="true">
-                  {badge.icon}
-                </span>
-                <span>
-                  <strong>{badge.name}</strong>
-                  <span className="reward__sub">{badge.how}</span>
-                </span>
-              </div>
-            );
-          })}
-        </section>
-      )}
-
-      <section className="panel anim-rise">
-        <div className="panel__head">
-          <h2 className="panel__title">Splits</h2>
-          {ghost && (
-            <span className="chip">
-              <Avatar profile={ghost.profile} size="1.2rem" />
-              {ghost.isSelf ? "Your best run" : ghost.profile.name}
-            </span>
-          )}
-        </div>
-        <div className="splits__scroll">
-          <table className="splits">
-            <thead>
-              <tr>
-                <th scope="col">#</th>
-                <th scope="col">Card</th>
-                <th scope="col">You</th>
-                {ghostSplits && <th scope="col">Rival</th>}
-                {ghostSplits && <th scope="col">Gap</th>}
-              </tr>
-            </thead>
-            <tbody>
-              {session.cards.map((card, i) => {
-                const gap =
-                  ghostSplits && ghostSplits[i] !== undefined
-                    ? mySplits[i] - ghostSplits[i]
-                    : null;
-                return (
-                  <tr
-                    key={i}
-                    className={
-                      card.ok
-                        ? undefined
-                        : card.timedOut
-                          ? "splits__row--late"
-                          : "splits__row--miss"
-                    }
-                  >
-                    <td className="u-mono splits__n">{i + 1}</td>
-                    <td className="splits__card">
-                      {card.prompt} = {card.answer}
-                      {!card.ok && (
-                        <span
-                          className={`splits__given${card.timedOut ? " is-late" : ""}`}
-                        >
-                          {card.timedOut
-                            ? "ran out of time"
-                            : `you said ${card.given}`}
-                        </span>
-                      )}
-                    </td>
-                    <td className="u-mono">{(card.ms / 1000).toFixed(2)}</td>
-                    {ghostSplits && (
-                      <td className="u-mono splits__rival">
-                        {ghost!.session.cards[i]
-                          ? (ghost!.session.cards[i].ms / 1000).toFixed(2)
-                          : "—"}
-                      </td>
-                    )}
-                    {ghostSplits && (
-                      <td
-                        className={`u-mono splits__gap${gap !== null && gap < 0 ? " is-ahead" : " is-behind"}`}
-                      >
-                        {gap === null ? "—" : formatDelta(gap)}
-                      </td>
-                    )}
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </section>
+      <Rewards
+        levelledUpTo={levelledUpTo}
+        bonuses={bonuses}
+        newBadges={newBadges}
+      />
+      <SplitsTable
+        session={session}
+        ghost={ghost}
+        mySplits={mySplits}
+        ghostSplits={ghostSplits}
+      />
 
       <div className="results__actions">
         {practiceFirst && (

--- a/src/games/flashcards/RaceResults.tsx
+++ b/src/games/flashcards/RaceResults.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
-import { Avatar, Confetti } from "@/components/ui/kit";
+import { Avatar, Button, Confetti } from "@/components/ui/kit";
 import TopBar from "@/components/TopBar";
 import {
   WRONG_ANSWER_PENALTY_MS,
@@ -328,42 +328,39 @@ export default function RaceResults() {
 
       <div className="results__actions">
         {practiceFirst && (
-          <button className="btn btn--go" onClick={practise}>
+          <Button variant="go" onClick={practise}>
             Practise {plural(missedFacts.length, "fact")}
-          </button>
+          </Button>
         )}
-        <button
-          className={`btn ${practiceFirst ? "btn--accent" : "btn--go"}`}
+        <Button
+          variant={practiceFirst ? "accent" : "go"}
           onClick={() => raceAgain(ghost)}
         >
           Race again
-        </button>
+        </Button>
         {!ghost && (
-          <button
-            className="btn btn--accent"
-            onClick={() => raceAgain(selfGhost)}
-          >
+          <Button variant="accent" onClick={() => raceAgain(selfGhost)}>
             Race this ghost
-          </button>
+          </Button>
         )}
-        <button
-          className="btn btn--ghost"
+        <Button
+          variant="ghost"
           onClick={() => {
             clear();
             navigate(`/p/${profile.id}/race`);
           }}
         >
           Change settings
-        </button>
-        <button
-          className="btn btn--ghost"
+        </Button>
+        <Button
+          variant="ghost"
           onClick={() => {
             clear();
             navigate(`/p/${profile.id}`);
           }}
         >
           Back to hub
-        </button>
+        </Button>
       </div>
     </main>
   );

--- a/src/games/flashcards/RaceSetup.tsx
+++ b/src/games/flashcards/RaceSetup.tsx
@@ -8,26 +8,24 @@ import {
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
 import TopBar from "@/components/TopBar";
-import { Avatar, Button, Input } from "@/components/ui/kit";
+import { Button } from "@/components/ui/kit";
 import {
   OPERATIONS,
   OPERATION_ORDER,
-  PRESETS,
-  TIME_LIMITS,
-  TIME_MAX_MS,
-  TIME_MIN_MS,
-  TIME_STEP_MS,
   buildDeck,
   configKey,
   presetForAge,
   snapTimeLimit,
   timeLimitForAge,
 } from "@/engine/decks/flashcards";
-import { accuracyOf, ghostsFor, raceTimeMs } from "@/engine/records";
-import { clock, percent, shortDate } from "@/engine/format";
+import { ghostsFor } from "@/engine/records";
 import { randomSeed } from "@/engine/random";
 import { sfx } from "@/services/sound";
-import type { FlashConfig, Ghost, InputMode, Operation } from "@/engine/types";
+import { ClockPicker } from "./setup/ClockPicker";
+import { DeckPicker } from "./setup/DeckPicker";
+import { PresetRow } from "./setup/PresetRow";
+import { RivalList } from "./setup/RivalList";
+import type { FlashConfig, InputMode, Operation } from "@/engine/types";
 
 const CARD_COUNTS = [10, 15, 20, 30, 50];
 const TABLE_NUMBERS = Array.from({ length: 12 }, (_, i) => i + 1);
@@ -73,7 +71,6 @@ export default function RaceSetup() {
     { length: 13 - spec.minOther },
     (_, i) => i + spec.minOther,
   );
-  const drill = config.facts?.length ? config.facts : null;
   // A drill sizes its own deck, so make room for whatever length it picked.
   const cardCounts = CARD_COUNTS.includes(config.cardCount)
     ? CARD_COUNTS
@@ -160,34 +157,13 @@ export default function RaceSetup() {
       />
 
       <div className="setup__grid">
-        <section className="panel anim-rise">
-          <div className="panel__head">
-            <h2 className="panel__title">Pick a race</h2>
-          </div>
-          <div className="preset-row">
-            {PRESETS.map((preset) => {
-              const chosen = configKey(preset.config) === key;
-              return (
-                <Button
-                  key={preset.id}
-                  variant="bare"
-                  className={`preset${chosen ? " is-chosen" : ""}`}
-                  onClick={() => {
-                    sfx.tap();
-                    setConfig(preset.config);
-                  }}
-                  pressed={chosen}
-                >
-                  <span className="preset__emoji" aria-hidden="true">
-                    {preset.emoji}
-                  </span>
-                  <span className="preset__name u-display">{preset.name}</span>
-                  <span className="preset__tag">{preset.tagline}</span>
-                </Button>
-              );
-            })}
-          </div>
-        </section>
+        <PresetRow
+          currentKey={key}
+          onChoose={(next) => {
+            sfx.tap();
+            setConfig(next);
+          }}
+        />
 
         <section className="panel anim-rise">
           <div className="panel__head">
@@ -225,118 +201,17 @@ export default function RaceSetup() {
             </div>
           </div>
 
-          {drill ? (
-            <div className="control">
-              <span className="control__label">Practice set</span>
-              <p className="drill__lead">
-                The {drill.length} facts you&apos;ve been missing most. Answer
-                each one twice.
-              </p>
-              <ul className="factchips">
-                {drill.map(([a, b]) => (
-                  <li key={`${a}:${b}`} className="factchip u-mono">
-                    {a} {spec.symbol} {b}
-                  </li>
-                ))}
-              </ul>
-              <div className="control__row">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    sfx.tap();
-                    patch({ facts: undefined });
-                  }}
-                >
-                  Pick numbers instead
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <div className="control">
-              <div className="numbers">
-                <div className="numbers__side">
-                  <span className="control__label">{spec.focusLabel}</span>
-                  <div className="tablegrid">
-                    {TABLE_NUMBERS.map((n) => (
-                      <Button
-                        key={n}
-                        variant="bare"
-                        className={`tablegrid__cell u-mono${config.tables.includes(n) ? " is-on" : ""}`}
-                        onClick={() => toggleTable(n)}
-                        pressed={config.tables.includes(n)}
-                      >
-                        {n}
-                      </Button>
-                    ))}
-                  </div>
-                  <div className="control__row">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ tables: TABLE_NUMBERS })}
-                    >
-                      All
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ tables: [2, 5, 10] })}
-                    >
-                      Easy three
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ tables: [6, 7, 8, 9] })}
-                    >
-                      Tricky four
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="numbers__side">
-                  <span className="control__label">{spec.pairLabel}</span>
-                  <div className="tablegrid">
-                    {otherNumbers.map((n) => (
-                      <Button
-                        key={n}
-                        variant="bare"
-                        className={`tablegrid__cell u-mono${config.others.includes(n) ? " is-on" : ""}`}
-                        onClick={() => toggleOther(n)}
-                        pressed={config.others.includes(n)}
-                      >
-                        {n}
-                      </Button>
-                    ))}
-                  </div>
-                  <div className="control__row">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ others: otherNumbers })}
-                    >
-                      All
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => patch({ others: [...config.tables] })}
-                    >
-                      Match tables
-                    </Button>
-                  </div>
-                </div>
-              </div>
-              <p className="numbers__note">
-                Cards only ever use numbers lit up on both sides. Unticking a
-                number on the left removes it from the right too.
-              </p>
-              <p className="numbers__preview u-mono">
-                e.g. {sample.join(" · ")}
-              </p>
-            </div>
-          )}
+          <DeckPicker
+            config={config}
+            spec={spec}
+            focusNumbers={TABLE_NUMBERS}
+            pairNumbers={otherNumbers}
+            sample={sample}
+            onToggleFocus={toggleTable}
+            onTogglePair={toggleOther}
+            patch={patch}
+            tap={sfx.tap}
+          />
 
           <div className="control">
             <span className="control__label">How many cards</span>
@@ -358,83 +233,26 @@ export default function RaceSetup() {
             </div>
           </div>
 
-          <div className="control">
-            <span className="control__label">Time per card</span>
-            <div className="segmented">
-              {TIME_LIMITS.map(({ ms, label }) => {
-                const on = (config.timeLimitMs ?? null) === ms;
-                return (
-                  <Button
-                    key={label}
-                    variant="bare"
-                    className={`segmented__btn u-mono${on ? " is-on" : ""}`}
-                    onClick={() => {
-                      sfx.tap();
-                      setLimit(ms);
-                    }}
-                    pressed={on}
-                  >
-                    {label}
-                  </Button>
-                );
-              })}
-            </div>
-
-            <div className="timelimit">
-              <Button
-                variant="bare"
-                className="timelimit__step u-mono"
-                onClick={() => bumpLimit(-TIME_STEP_MS)}
-                aria-label="Quarter of a second less"
-              >
-                −
-              </Button>
-              <span className="timelimit__field">
-                <Input
-                  className="timelimit__input u-mono"
-                  type="number"
-                  inputMode="decimal"
-                  step={TIME_STEP_MS / 1000}
-                  min={TIME_MIN_MS / 1000}
-                  max={TIME_MAX_MS / 1000}
-                  value={limitShown}
-                  placeholder="off"
-                  aria-label="Seconds per card"
-                  blurOnEnter
-                  onChange={(text) => {
-                    setLimitDraft(text);
-                    if (text.trim() === "") {
-                      patch({ timeLimitMs: null });
-                      return;
-                    }
-                    const typed = Number(text);
-                    if (Number.isFinite(typed))
-                      patch({ timeLimitMs: snapTimeLimit(typed * 1000) });
-                  }}
-                  onBlur={() => setLimitDraft(null)}
-                />
-                <span className="timelimit__unit u-mono">s</span>
-              </span>
-              <Button
-                variant="bare"
-                className="timelimit__step u-mono"
-                onClick={() => bumpLimit(TIME_STEP_MS)}
-                aria-label="Quarter of a second more"
-              >
-                +
-              </Button>
-              <span className="timelimit__hint">
-                Or set it exactly — quarter-second steps, down to{" "}
-                {TIME_MIN_MS / 1000}s. Clear the box for no clock.
-              </span>
-            </div>
-
-            <p className="numbers__note">
-              {config.timeLimitMs
-                ? "Run out of time and the answer is shown, then the next card comes up. Anything you miss lands on your practice list."
-                : "No card clock. The whole race is timed instead — take as long as you need on any one card."}
-            </p>
-          </div>
+          <ClockPicker
+            limitMs={config.timeLimitMs ?? null}
+            shownSeconds={limitShown}
+            onPreset={(ms) => {
+              sfx.tap();
+              setLimit(ms);
+            }}
+            onStep={bumpLimit}
+            onType={(text) => {
+              setLimitDraft(text);
+              if (text.trim() === "") {
+                patch({ timeLimitMs: null });
+                return;
+              }
+              const typed = Number(text);
+              if (Number.isFinite(typed))
+                patch({ timeLimitMs: snapTimeLimit(typed * 1000) });
+            }}
+            onDraftEnd={() => setLimitDraft(null)}
+          />
 
           <div className="control">
             <span className="control__label">Answering</span>
@@ -463,71 +281,15 @@ export default function RaceSetup() {
           </div>
         </section>
 
-        <section className="panel anim-rise setup__rivals">
-          <div className="panel__head">
-            <h2 className="panel__title">Who are you racing?</h2>
-          </div>
-          <p className="muted setup__rival-note">
-            Only runs with these exact settings show up here — same cards, same
-            order, fair race.
-          </p>
-
-          <ul className="rivals">
-            <li>
-              <Button
-                variant="bare"
-                className={`rival${rivalId === null ? " is-chosen" : ""}`}
-                onClick={() => {
-                  sfx.tap();
-                  setRivalId(null);
-                }}
-                pressed={rivalId === null}
-              >
-                <span className="rival__icon" aria-hidden="true">
-                  🕐
-                </span>
-                <span className="rival__body">
-                  <span className="rival__name u-display">Just the clock</span>
-                  <span className="rival__meta">
-                    No ghost — set a time to beat
-                  </span>
-                </span>
-              </Button>
-            </li>
-            {rivals.map((ghost: Ghost) => (
-              <li key={ghost.session.id}>
-                <Button
-                  variant="bare"
-                  className={`rival${rivalId === ghost.session.id ? " is-chosen" : ""}`}
-                  style={
-                    { "--tint": ghost.profile.color } as React.CSSProperties
-                  }
-                  onClick={() => {
-                    sfx.tap();
-                    setRivalId(ghost.session.id);
-                  }}
-                  pressed={rivalId === ghost.session.id}
-                >
-                  <Avatar profile={ghost.profile} size="2.4rem" />
-                  <span className="rival__body">
-                    <span className="rival__name u-display">
-                      {ghost.isSelf ? "Your best" : ghost.profile.name}
-                    </span>
-                    <span className="rival__meta u-mono">
-                      {clock(raceTimeMs(ghost.session))} ·{" "}
-                      {percent(accuracyOf(ghost.session))} ·{" "}
-                      {shortDate(ghost.session.finishedAt)}
-                    </span>
-                  </span>
-                </Button>
-              </li>
-            ))}
-          </ul>
-
-          <Button variant="go" className="setup__go" onClick={launch}>
-            Start race
-          </Button>
-        </section>
+        <RivalList
+          rivals={rivals}
+          chosenId={rivalId}
+          onChoose={(id) => {
+            sfx.tap();
+            setRivalId(id);
+          }}
+          onStart={launch}
+        />
       </div>
     </main>
   );

--- a/src/games/flashcards/RaceTrack.tsx
+++ b/src/games/flashcards/RaceTrack.tsx
@@ -6,33 +6,29 @@ import { buildDeck, configKey } from "@/engine/decks/flashcards";
 import {
   WRONG_ANSWER_PENALTY_MS,
   bestRun,
-  compareRuns,
   cumulativeSplits,
   sessionsFor,
 } from "@/engine/records";
-import {
-  cardXp,
-  comboMultiplier,
-  evaluateBadges,
-  finishBonuses,
-  levelFromXp,
-} from "@/engine/progress";
-import { clock, delta as formatDelta } from "@/engine/format";
+import { cardXp } from "@/engine/progress";
 import { sfx } from "@/services/sound";
-import type { CardResult, Ghost, Profile, Session } from "@/engine/types";
-import { Scrim } from "@/components/ui/kit";
+import type { CardResult, Profile, Session } from "@/engine/types";
+import { AnswerPad } from "./race/AnswerPad";
+import { CardFace } from "./race/CardFace";
+import { Hud } from "./race/Hud";
+import { Lane } from "./race/Lane";
+import { QuitSheet } from "./race/QuitSheet";
+import { SaveFailed } from "./race/SaveFailed";
+import { useCountdown } from "./race/useCountdown";
+import { useGhostGap } from "./race/useGhostGap";
+import { useRaceClock } from "./race/useRaceClock";
+import { useRaceFinish } from "./race/useRaceFinish";
+import { useRaceKeyboard } from "./race/useRaceKeyboard";
+import type { Feedback } from "./race/types";
 
 const RIGHT_PAUSE_MS = 320;
 const WRONG_PAUSE_MS = 1500;
 /** Long enough to actually read an answer you never got to attempt. */
 const TIMEOUT_PAUSE_MS = 1900;
-/** The card clock ticks audibly over its last three seconds. */
-const TICK_FROM_MS = 3000;
-
-type Feedback = {
-  kind: "right" | "wrong" | "timeout";
-  given: number | null;
-} | null;
 
 export default function RaceTrack() {
   const { profileId } = useParams();
@@ -106,93 +102,75 @@ function Track({
   const [phase, setPhase] = useState<"countdown" | "racing" | "saving">(
     "countdown",
   );
-  const [countdown, setCountdown] = useState(3);
   const [index, setIndex] = useState(0);
   const [entry, setEntry] = useState("");
   const [feedback, setFeedback] = useState<Feedback>(null);
   const [streak, setStreak] = useState(0);
-  const [, setTick] = useState(0);
   const [quitting, setQuitting] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
 
-  const cardStart = useRef(0);
-  const banked = useRef(0);
   const misses = useRef(0);
   const bestStreak = useRef(0);
   const earnedXp = useRef(0);
   const results = useRef<CardResult[]>([]);
-  const maxDeficit = useRef(0);
-  const wasBehind = useRef(false);
   const advanceTimer = useRef<number | null>(null);
-  const finishing = useRef(false);
   const entryRef = useRef("");
   const completeRef = useRef<() => Promise<void>>(async () => {});
-  const fuse = useRef<HTMLDivElement | null>(null);
-  /** Stops the animation loop from re-inflating the fuse after a card lands. */
-  const fuseHeld = useRef(false);
-  /** When the quit sheet went up, or 0 while play is running. */
-  const pausedAt = useRef(0);
+  /**
+   * Breaks a definition cycle: the clock needs something to call when a card
+   * times out, and `submit` needs the clock to bank the time. The ref lets the
+   * clock be created first and still reach the real handler.
+   */
+  const submitRef = useRef<(value: number | null) => void>(() => {});
 
   const card = deck[index];
   const total = deck.length;
 
-  const elapsed = () => {
-    if (phase !== "racing" || feedback !== null) return banked.current;
-    // Reading the pause mark instead of the wall clock holds the time still
-    // while the quit sheet is up.
-    const now = pausedAt.current || performance.now();
-    return banked.current + (now - cardStart.current);
-  };
+  const { fuseRef, elapsed, onCard, secondsLeft, bank, spendFuse, startCard } =
+    useRaceClock({
+      limitMs,
+      racing: phase === "racing",
+      resolved: feedback !== null,
+      quitting,
+      index,
+      onTimeout: () => submitRef.current(null),
+    });
   const raceElapsed = elapsed() + misses.current * WRONG_ANSWER_PENALTY_MS;
 
-  /* ── Countdown ─────────────────────────────────────────────────────── */
-  useEffect(() => {
-    if (phase !== "countdown") return;
-    sfx.countdown(countdown);
-    const timer = window.setTimeout(
-      () => {
-        if (countdown === 0) {
-          cardStart.current = performance.now();
-          setPhase("racing");
-        } else {
-          setCountdown((n) => n - 1);
-        }
-      },
-      countdown === 0 ? 420 : 680,
-    );
-    return () => window.clearTimeout(timer);
-  }, [phase, countdown]);
+  const rival = useGhostGap({
+    splits: ghostSplits,
+    raceElapsed,
+    index,
+    total,
+  });
 
-  /* ── Clock ─────────────────────────────────────────────────────────── */
-  useEffect(() => {
-    if (phase !== "racing") return;
-    let frame = 0;
-    let last = 0;
-    const loop = (now: number) => {
-      if (now - last > 60) {
-        last = now;
-        setTick((t) => t + 1);
-      }
-      // The fuse is written straight to the DOM rather than rendered: it has
-      // to move at full frame rate, and it has to keep draining for players
-      // who've asked for reduced motion — so it can't be a CSS animation.
-      if (
-        limitMs !== null &&
-        fuse.current &&
-        !fuseHeld.current &&
-        !pausedAt.current
-      ) {
-        const left = 1 - (now - cardStart.current) / limitMs;
-        fuse.current.style.setProperty(
-          "--left",
-          String(Math.min(1, Math.max(0, left))),
-        );
-      }
-      frame = requestAnimationFrame(loop);
-    };
-    frame = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(frame);
-  }, [phase, limitMs]);
+  const { saveError, complete, retry, hasFinished } = useRaceFinish({
+    profile,
+    config,
+    seed,
+    ghost,
+    history,
+    previousBest,
+    readTally: () => ({
+      cards: results.current,
+      cardXp: earnedXp.current,
+      bestStreak: bestStreak.current,
+      maxDeficitMs: rival.maxDeficitMs(),
+    }),
+    saveSession,
+    finish,
+    notify,
+    navigate,
+    onSaving: () => setPhase("saving"),
+  });
+  completeRef.current = complete;
+
+  const countdown = useCountdown({
+    active: phase === "countdown",
+    onGo: useCallback(() => {
+      startCard();
+      setPhase("racing");
+    }, [startCard]),
+  });
 
   useEffect(
     () => () => {
@@ -200,23 +178,6 @@ function Track({
     },
     [],
   );
-
-  /* ── Ghost position ────────────────────────────────────────────────── */
-  const ghostCardsDone = ghostSplits
-    ? ghostSplits.filter((t) => t <= raceElapsed).length
-    : 0;
-  const checkpoint = ghostSplits
-    ? ghostSplits[Math.min(index, ghostSplits.length - 1)]
-    : null;
-  const gap = checkpoint === null ? null : raceElapsed - checkpoint;
-
-  useEffect(() => {
-    if (gap === null) return;
-    maxDeficit.current = Math.max(maxDeficit.current, gap);
-    const behind = gap > 0;
-    if (wasBehind.current && !behind) sfx.overtake();
-    wasBehind.current = behind;
-  }, [gap]);
 
   /* ── Answering ─────────────────────────────────────────────────────── */
 
@@ -230,100 +191,65 @@ function Track({
   live.current = { phase, feedback, card, streak, total, limitMs };
 
   /** `null` means the card's clock ran out before an answer arrived. */
-  const submit = useCallback((value: number | null) => {
-    const { phase, feedback, card, streak, total, limitMs } = live.current;
-    if (phase !== "racing" || feedback !== null || finishing.current) return;
-    const lateOut = value === null;
-    // A timeout banks exactly the limit, so the stopwatch, the fuse and the
-    // saved split all agree even if the timer fires a frame or two late.
-    // Whole milliseconds keep the saved file readable and the totals exact.
-    const ms = lateOut
-      ? limitMs!
-      : Math.round(performance.now() - cardStart.current);
-    const ok = !lateOut && value === card.answer;
-    banked.current += ms;
-    fuseHeld.current = true;
-    if (lateOut) fuse.current?.style.setProperty("--left", "0");
-    results.current.push({
-      prompt: card.prompt,
-      answer: card.answer,
-      given: value,
-      ok,
-      ms,
-      facts: card.facts,
-      ...(lateOut && { timedOut: true }),
-    });
+  const submit = useCallback(
+    (value: number | null) => {
+      const { phase, feedback, card, streak, total, limitMs } = live.current;
+      if (phase !== "racing" || feedback !== null || hasFinished()) return;
+      const lateOut = value === null;
+      // A timeout banks exactly the limit, so the stopwatch, the fuse and the
+      // saved split all agree even if the timer fires a frame or two late.
+      // Whole milliseconds keep the saved file readable and the totals exact.
+      const ms = lateOut ? limitMs! : Math.round(onCard());
+      const ok = !lateOut && value === card.answer;
+      bank(ms);
+      if (lateOut) spendFuse();
+      results.current.push({
+        prompt: card.prompt,
+        answer: card.answer,
+        given: value,
+        ok,
+        ms,
+        facts: card.facts,
+        ...(lateOut && { timedOut: true }),
+      });
 
-    if (ok) {
-      const next = streak + 1;
-      setStreak(next);
-      bestStreak.current = Math.max(bestStreak.current, next);
-      earnedXp.current += cardXp(ms, next);
-      sfx.correct(next);
-    } else {
-      setStreak(0);
-      misses.current += 1;
-      if (lateOut) sfx.timeout();
-      else sfx.wrong();
-    }
+      if (ok) {
+        const next = streak + 1;
+        setStreak(next);
+        bestStreak.current = Math.max(bestStreak.current, next);
+        earnedXp.current += cardXp(ms, next);
+        sfx.correct(next);
+      } else {
+        setStreak(0);
+        misses.current += 1;
+        if (lateOut) sfx.timeout();
+        else sfx.wrong();
+      }
 
-    setFeedback({
-      kind: lateOut ? "timeout" : ok ? "right" : "wrong",
-      given: value,
-    });
-    advanceTimer.current = window.setTimeout(
-      () => {
-        setFeedback(null);
-        setEntry("");
-        entryRef.current = "";
-        if (results.current.length >= total) {
-          void completeRef.current();
-        } else {
-          setIndex((i) => i + 1);
-          cardStart.current = performance.now();
-          fuseHeld.current = false;
-        }
-      },
-      ok ? RIGHT_PAUSE_MS : lateOut ? TIMEOUT_PAUSE_MS : WRONG_PAUSE_MS,
-    );
-    // Deliberately empty: every value above comes from a ref.
-  }, []);
-
-  const timeUp = useCallback(() => submit(null), [submit]);
-
-  /**
-   * Putting the quit sheet up pauses the card. Resuming shifts the card's
-   * start forward by however long the sheet was open, so a pause neither
-   * costs time nor buys thinking time. Declared before the timer below so the
-   * shift lands before that effect reschedules.
-   */
-  useEffect(() => {
-    if (phase !== "racing") return;
-    if (quitting) {
-      pausedAt.current = performance.now();
-    } else if (pausedAt.current) {
-      cardStart.current += performance.now() - pausedAt.current;
-      pausedAt.current = 0;
-    }
-  }, [quitting, phase]);
-
-  /**
-   * The per-card clock, plus its last-three-seconds ticks. Scheduled once per
-   * card: `timeUp` keeps a stable identity, so the ~16×/second clock re-render
-   * can't tear it down and restart it. The delay is measured from when the
-   * card actually appeared, so a re-run can never hand out extra time.
-   */
-  useEffect(() => {
-    if (limitMs === null || phase !== "racing" || feedback !== null) return;
-    if (quitting) return;
-    const left = limitMs - (performance.now() - cardStart.current);
-    const timers = [window.setTimeout(timeUp, Math.max(0, left))];
-    for (let at = 1000; at <= TICK_FROM_MS; at += 1000) {
-      if (left > at)
-        timers.push(window.setTimeout(() => sfx.tick(), left - at));
-    }
-    return () => timers.forEach((t) => window.clearTimeout(t));
-  }, [limitMs, phase, feedback, index, quitting, timeUp]);
+      setFeedback({
+        kind: lateOut ? "timeout" : ok ? "right" : "wrong",
+        given: value,
+      });
+      advanceTimer.current = window.setTimeout(
+        () => {
+          setFeedback(null);
+          setEntry("");
+          entryRef.current = "";
+          if (results.current.length >= total) {
+            void completeRef.current();
+          } else {
+            setIndex((i) => i + 1);
+            startCard();
+          }
+        },
+        ok ? RIGHT_PAUSE_MS : lateOut ? TIMEOUT_PAUSE_MS : WRONG_PAUSE_MS,
+      );
+      // Every other value above comes from a ref; these are all pinned with
+      // empty dependency lists precisely so this callback can stay stable.
+    },
+    [bank, spendFuse, onCard, startCard, hasFinished],
+  );
+  submitRef.current = submit;
 
   // The entry is mirrored into a ref so Enter can read it without the handler
   // having to re-subscribe on every keystroke.
@@ -338,167 +264,32 @@ function Track({
     setEntry(entryRef.current);
   }, []);
 
-  async function complete() {
-    if (finishing.current) return;
-    finishing.current = true;
-    setPhase("saving");
-    sfx.finish();
-    await save();
-  }
-  completeRef.current = complete;
-
-  async function save() {
-    const cards = results.current;
-    const correct = cards.filter((c) => c.ok).length;
-    const incorrect = cards.length - correct;
-    const durationMs = cards.reduce((sum, c) => sum + c.ms, 0);
-    // Timed runs are ranked on cards beaten before time, untimed ones on the
-    // clock — `compareRuns` owns that rule so the record book and this screen
-    // can never disagree about what "better" means.
-    const scored = { durationMs, correct, incorrect, config };
-
-    const personalRecord =
-      previousBest !== null && compareRuns(scored, previousBest) < 0;
-    const beatGhost = ghost ? compareRuns(scored, ghost.session) < 0 : null;
-    const bonuses = finishBonuses({
-      perfect: incorrect === 0 && correct > 0,
-      personalRecord,
-      beatGhost: beatGhost === true,
-      cardCount: cards.length,
-    });
-    const xpEarned =
-      earnedXp.current + bonuses.reduce((sum, b) => sum + b.xp, 0);
-
-    const draft = {
-      profileId: profile.id,
-      game: "flashcards" as const,
-      mode: config.operation,
-      configKey: configKey(config),
-      config,
-      seed,
-      durationMs,
-      correct,
-      incorrect,
-      bestStreak: bestStreak.current,
-      xpEarned,
-      ghostSessionId: ghost?.session.id ?? null,
-      beatGhost,
-      cards,
-    };
-
-    const earnedBadges = evaluateBadges({
-      session: draft,
-      history,
-      personalRecord,
-      maxDeficitMs: maxDeficit.current,
-      xpAfter: profile.xp + xpEarned,
-    });
-    const newBadges = earnedBadges.filter((id) => !profile.badges.includes(id));
-
-    try {
-      const saved = await saveSession({ ...draft, earnedBadges });
-      const levelBefore = levelFromXp(profile.xp).level;
-      const levelAfter = levelFromXp(saved.profile.xp).level;
-      finish({
-        session: saved.session,
-        profileAfter: saved.profile,
-        ghost,
-        personalRecord,
-        previousBest,
-        newBadges,
-        bonuses,
-        levelledUpTo: levelAfter > levelBefore ? levelAfter : null,
-      });
-      navigate(`/p/${profile.id}/race/results`, { replace: true });
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Could not save this race";
-      setSaveError(message);
-      notify(message, "bad");
-    }
-  }
-
-  /* ── Keyboard ──────────────────────────────────────────────────────── */
-  useEffect(() => {
-    if (phase !== "racing") return;
-    function onKey(event: KeyboardEvent) {
-      if (feedback !== null) return;
-      if (config.inputMode === "choose") {
-        const slot = Number(event.key);
-        if (slot >= 1 && slot <= 4 && card.choices) {
-          event.preventDefault();
-          submit(card.choices[slot - 1]);
-        }
-        return;
-      }
-      if (/^[0-9]$/.test(event.key)) {
-        event.preventDefault();
-        pushDigit(event.key);
-      } else if (event.key === "Backspace") {
-        event.preventDefault();
-        dropDigit();
-      } else if (event.key === "Enter") {
-        event.preventDefault();
-        if (entryRef.current !== "") submit(Number(entryRef.current));
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [phase, feedback, config.inputMode, card, submit, pushDigit, dropDigit]);
-
-  // Auto-submit the moment the entry is as long as the answer — keeps the pace
-  // up without making kids hunt for Enter.
-  useEffect(() => {
-    if (phase !== "racing" || feedback !== null || config.inputMode !== "type")
-      return;
-    if (entry.length > 0 && entry.length === String(card.answer).length) {
-      const value = Number(entry);
-      const timer = window.setTimeout(() => submit(value), 90);
-      return () => window.clearTimeout(timer);
-    }
-  }, [entry, phase, feedback, config.inputMode, card.answer, submit]);
+  useRaceKeyboard({
+    active: phase === "racing" && feedback === null,
+    inputMode: config.inputMode,
+    choices: card.choices,
+    answerLength: String(card.answer).length,
+    entry,
+    entryRef,
+    submit,
+    pushDigit,
+    dropDigit,
+  });
 
   /* ── Render ────────────────────────────────────────────────────────── */
 
   if (saveError) {
     return (
-      <main className="boot">
-        <p className="u-eyebrow">Race finished</p>
-        <h1 className="u-display boot__title">Couldn&apos;t save this race</h1>
-        <p className="boot__msg">{saveError}</p>
-        <p className="boot__hint">
-          Your answers are still here. Try again once the hub server is back.
-        </p>
-        <div className="boot__actions">
-          <button
-            className="btn btn--go"
-            onClick={() => {
-              setSaveError(null);
-              void save();
-            }}
-          >
-            Save again
-          </button>
-          <button
-            className="btn btn--ghost"
-            onClick={() => navigate(`/p/${profile.id}`)}
-          >
-            Discard and go back
-          </button>
-        </div>
-      </main>
+      <SaveFailed
+        message={saveError}
+        onRetry={retry}
+        onDiscard={() => navigate(`/p/${profile.id}`)}
+      />
     );
   }
 
   const answered = results.current.length;
-  const combo = comboMultiplier(streak);
-  const secondsLeft =
-    limitMs === null || phase !== "racing" || feedback !== null
-      ? null
-      : Math.max(
-          0,
-          Math.ceil((limitMs - (performance.now() - cardStart.current)) / 1000),
-        );
+  const settled = feedback !== null || phase !== "racing";
 
   return (
     <main
@@ -513,34 +304,20 @@ function Track({
         </div>
       )}
 
-      <header className="race__hud">
-        <button className="race__quit" onClick={() => setQuitting(true)}>
-          Quit
-        </button>
-
-        <div className="race__clock u-mono">
-          <span className="race__clock-time">{clock(elapsed())}</span>
-          {misses.current > 0 && (
-            <span className="race__penalty">
-              +{(misses.current * WRONG_ANSWER_PENALTY_MS) / 1000}s
-            </span>
-          )}
-        </div>
-
-        <div className="race__count u-mono">
-          <span className="race__count-now">
-            {Math.min(answered + 1, total)}
-          </span>
-          <span className="race__count-of">/ {total}</span>
-        </div>
-      </header>
+      <Hud
+        elapsedMs={elapsed()}
+        misses={misses.current}
+        answered={answered}
+        total={total}
+        onQuit={() => setQuitting(true)}
+      />
 
       <Lane
         profile={profile}
         ghost={ghost}
         mePos={answered / total}
-        ghostPos={ghostSplits ? Math.min(ghostCardsDone / total, 1) : null}
-        gap={gap}
+        ghostPos={rival.position}
+        gap={rival.gap}
         note={
           limitMs === null
             ? "Racing the clock"
@@ -548,221 +325,36 @@ function Track({
         }
       />
 
-      <section className={`card${feedback ? ` card--${feedback.kind}` : ""}`}>
-        {limitMs !== null && (
-          // Keyed on the card so a new card remounts it with a full bar. The
-          // prefix keeps it from colliding with the combo badge's key.
-          <div
-            key={`fuse-${index}`}
-            ref={fuse}
-            className={`fuse${secondsLeft !== null && secondsLeft <= 3 ? " is-urgent" : ""}${feedback?.kind === "timeout" ? " is-spent" : ""}`}
-          >
-            <span className="fuse__track">
-              <span className="fuse__fill" />
-            </span>
-            <span className="fuse__num u-mono" aria-hidden="true">
-              {secondsLeft ?? 0}
-            </span>
-          </div>
-        )}
-        <p className="card__prompt u-display" aria-live="polite">
-          {card.prompt}
-        </p>
-        <div className="card__answer">
-          {feedback?.kind === "timeout" ? (
-            <span className="card__truth u-mono">
-              <span className="card__late">Out of time</span> {card.answer}
-            </span>
-          ) : feedback?.kind === "wrong" ? (
-            <span className="card__truth u-mono">
-              <s>{feedback.given}</s> {card.answer}
-            </span>
-          ) : config.inputMode === "type" ? (
-            <span className={`card__entry u-mono${entry ? "" : " is-empty"}`}>
-              {entry || "?"}
-            </span>
-          ) : (
-            <span className="card__entry u-mono is-empty">?</span>
-          )}
-        </div>
-        {streak >= 3 && (
-          <span key={streak} className="combo anim-pop">
-            🔥 {streak} in a row · ×{combo.toFixed(1)} XP
-          </span>
-        )}
-      </section>
+      <CardFace
+        card={card}
+        index={index}
+        feedback={feedback}
+        entry={entry}
+        inputMode={config.inputMode}
+        limitMs={limitMs}
+        secondsLeft={secondsLeft()}
+        streak={streak}
+        fuseRef={fuseRef}
+      />
 
-      {config.inputMode === "type" ? (
-        <Keypad
-          disabled={feedback !== null || phase !== "racing"}
-          onDigit={pushDigit}
-          onBack={dropDigit}
-          onEnter={() =>
-            entryRef.current !== "" && submit(Number(entryRef.current))
-          }
-        />
-      ) : (
-        <div className="choices">
-          {(card.choices ?? []).map((choice, i) => (
-            <button
-              key={choice}
-              className="choices__btn u-mono"
-              disabled={feedback !== null || phase !== "racing"}
-              onClick={() => submit(choice)}
-            >
-              <span className="choices__key">{i + 1}</span>
-              {choice}
-            </button>
-          ))}
-        </div>
-      )}
+      <AnswerPad
+        mode={config.inputMode}
+        choices={card.choices}
+        disabled={settled}
+        onDigit={pushDigit}
+        onBack={dropDigit}
+        onEnter={() =>
+          entryRef.current !== "" && submit(Number(entryRef.current))
+        }
+        onChoose={submit}
+      />
 
       {quitting && (
-        <div
-          className="sheet"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Quit the race"
-        >
-          <Scrim onClose={() => setQuitting(false)} label="Keep racing" />
-          <div className="sheet__panel panel anim-pop">
-            <h2 className="panel__title">Quit this race?</h2>
-            <p className="muted">It won&apos;t be saved and no XP is earned.</p>
-            <div className="sheet__actions">
-              <button
-                className="btn btn--danger btn--sm"
-                onClick={() => navigate(`/p/${profile.id}`)}
-              >
-                Quit
-              </button>
-              <button
-                className="btn btn--accent"
-                onClick={() => setQuitting(false)}
-              >
-                Keep racing
-              </button>
-            </div>
-          </div>
-        </div>
+        <QuitSheet
+          onQuit={() => navigate(`/p/${profile.id}`)}
+          onKeepRacing={() => setQuitting(false)}
+        />
       )}
     </main>
-  );
-}
-
-/* ── The signature element: a rally split against a ghost ──────────────── */
-
-function Lane({
-  profile,
-  ghost,
-  mePos,
-  ghostPos,
-  gap,
-  note,
-}: {
-  profile: Profile;
-  ghost: Ghost | null;
-  mePos: number;
-  ghostPos: number | null;
-  gap: number | null;
-  note: string;
-}) {
-  const ahead = gap !== null && gap < 0;
-  return (
-    <div className="lane">
-      <div className="lane__track">
-        <span className="lane__finish" aria-hidden="true">
-          🏁
-        </span>
-        {ghostPos !== null && ghost && (
-          <span
-            className="lane__puck lane__puck--ghost"
-            style={
-              {
-                "--p": ghostPos,
-                "--tint": ghost.profile.color,
-              } as React.CSSProperties
-            }
-            title={ghost.isSelf ? "Your best run" : ghost.profile.name}
-          >
-            {ghost.profile.emoji}
-          </span>
-        )}
-        <span
-          className="lane__puck lane__puck--me"
-          style={
-            {
-              "--p": mePos,
-              "--tint": profile.color,
-            } as React.CSSProperties
-          }
-        >
-          {profile.emoji}
-        </span>
-      </div>
-
-      {gap === null ? (
-        <p className="lane__note u-mono">{note}</p>
-      ) : (
-        <p
-          className={`lane__gap u-mono${ahead ? " is-ahead" : " is-behind"}`}
-          aria-live="off"
-        >
-          <span className="lane__gap-num">{formatDelta(gap)}</span>
-          <span className="lane__gap-word">{ahead ? "ahead" : "behind"}</span>
-        </p>
-      )}
-    </div>
-  );
-}
-
-/* ── Keypad ────────────────────────────────────────────────────────────── */
-
-function Keypad({
-  disabled,
-  onDigit,
-  onBack,
-  onEnter,
-}: {
-  disabled: boolean;
-  onDigit: (digit: string) => void;
-  onBack: () => void;
-  onEnter: () => void;
-}) {
-  return (
-    <div className="keypad">
-      {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((digit) => (
-        <button
-          key={digit}
-          className="keypad__key u-mono"
-          disabled={disabled}
-          onClick={() => onDigit(digit)}
-        >
-          {digit}
-        </button>
-      ))}
-      <button
-        className="keypad__key keypad__key--util"
-        disabled={disabled}
-        onClick={onBack}
-        aria-label="Delete"
-      >
-        ⌫
-      </button>
-      <button
-        className="keypad__key u-mono"
-        disabled={disabled}
-        onClick={() => onDigit("0")}
-      >
-        0
-      </button>
-      <button
-        className="keypad__key keypad__key--enter"
-        disabled={disabled}
-        onClick={onEnter}
-        aria-label="Submit"
-      >
-        ↵
-      </button>
-    </div>
   );
 }

--- a/src/games/flashcards/race/AnswerPad.tsx
+++ b/src/games/flashcards/race/AnswerPad.tsx
@@ -1,0 +1,89 @@
+import { Button } from "@/components/ui/kit";
+import type { InputMode } from "@/engine/types";
+
+/**
+ * However the player answers: a keypad they type into, or four choices they
+ * tap. Both are the same job, so the caller picks a mode rather than deciding
+ * which component to render.
+ *
+ * The keyboard shortcuts for both live in RaceTrack — they're window-level
+ * listeners tied to the race's own state, not to whatever is on screen.
+ */
+export function AnswerPad({
+  mode,
+  choices,
+  disabled,
+  onDigit,
+  onBack,
+  onEnter,
+  onChoose,
+}: {
+  mode: InputMode;
+  choices: number[] | undefined;
+  disabled: boolean;
+  onDigit: (digit: string) => void;
+  onBack: () => void;
+  onEnter: () => void;
+  onChoose: (choice: number) => void;
+}) {
+  if (mode === "choose") {
+    return (
+      <div className="choices">
+        {(choices ?? []).map((choice, i) => (
+          <Button
+            key={choice}
+            variant="bare"
+            className="choices__btn u-mono"
+            disabled={disabled}
+            onClick={() => onChoose(choice)}
+          >
+            <span className="choices__key">{i + 1}</span>
+            {choice}
+          </Button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="keypad">
+      {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((digit) => (
+        <Button
+          key={digit}
+          variant="bare"
+          className="keypad__key u-mono"
+          disabled={disabled}
+          onClick={() => onDigit(digit)}
+        >
+          {digit}
+        </Button>
+      ))}
+      <Button
+        variant="bare"
+        className="keypad__key keypad__key--util"
+        disabled={disabled}
+        onClick={onBack}
+        aria-label="Delete"
+      >
+        ⌫
+      </Button>
+      <Button
+        variant="bare"
+        className="keypad__key u-mono"
+        disabled={disabled}
+        onClick={() => onDigit("0")}
+      >
+        0
+      </Button>
+      <Button
+        variant="bare"
+        className="keypad__key keypad__key--enter"
+        disabled={disabled}
+        onClick={onEnter}
+        aria-label="Submit"
+      >
+        ↵
+      </Button>
+    </div>
+  );
+}

--- a/src/games/flashcards/race/CardFace.tsx
+++ b/src/games/flashcards/race/CardFace.tsx
@@ -1,0 +1,79 @@
+import { comboMultiplier } from "@/engine/progress";
+import type { Card, InputMode } from "@/engine/types";
+import type { Feedback } from "./types";
+
+/**
+ * The card itself: the fuse draining across the top, the prompt, whatever the
+ * player has entered so far, and the combo badge.
+ *
+ * `fuseRef` belongs to the race clock, which writes the drain position
+ * straight to the DOM every frame rather than through React.
+ */
+export function CardFace({
+  card,
+  index,
+  feedback,
+  entry,
+  inputMode,
+  limitMs,
+  secondsLeft,
+  streak,
+  fuseRef,
+}: {
+  card: Card;
+  index: number;
+  feedback: Feedback;
+  entry: string;
+  inputMode: InputMode;
+  limitMs: number | null;
+  secondsLeft: number | null;
+  streak: number;
+  fuseRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const combo = comboMultiplier(streak);
+  return (
+    <section className={`card${feedback ? ` card--${feedback.kind}` : ""}`}>
+      {limitMs !== null && (
+        // Keyed on the card so a new card remounts it with a full bar. The
+        // prefix keeps it from colliding with the combo badge's key.
+        <div
+          key={`fuse-${index}`}
+          ref={fuseRef}
+          className={`fuse${secondsLeft !== null && secondsLeft <= 3 ? " is-urgent" : ""}${feedback?.kind === "timeout" ? " is-spent" : ""}`}
+        >
+          <span className="fuse__track">
+            <span className="fuse__fill" />
+          </span>
+          <span className="fuse__num u-mono" aria-hidden="true">
+            {secondsLeft ?? 0}
+          </span>
+        </div>
+      )}
+      <p className="card__prompt u-display" aria-live="polite">
+        {card.prompt}
+      </p>
+      <div className="card__answer">
+        {feedback?.kind === "timeout" ? (
+          <span className="card__truth u-mono">
+            <span className="card__late">Out of time</span> {card.answer}
+          </span>
+        ) : feedback?.kind === "wrong" ? (
+          <span className="card__truth u-mono">
+            <s>{feedback.given}</s> {card.answer}
+          </span>
+        ) : inputMode === "type" ? (
+          <span className={`card__entry u-mono${entry ? "" : " is-empty"}`}>
+            {entry || "?"}
+          </span>
+        ) : (
+          <span className="card__entry u-mono is-empty">?</span>
+        )}
+      </div>
+      {streak >= 3 && (
+        <span key={streak} className="combo anim-pop">
+          🔥 {streak} in a row · ×{combo.toFixed(1)} XP
+        </span>
+      )}
+    </section>
+  );
+}

--- a/src/games/flashcards/race/Hud.tsx
+++ b/src/games/flashcards/race/Hud.tsx
@@ -1,0 +1,40 @@
+import { Button } from "@/components/ui/kit";
+import { WRONG_ANSWER_PENALTY_MS } from "@/engine/records";
+import { clock } from "@/engine/format";
+
+/** Quit, the running stopwatch with its wrong-answer penalty, and the count. */
+export function Hud({
+  elapsedMs,
+  misses,
+  answered,
+  total,
+  onQuit,
+}: {
+  elapsedMs: number;
+  misses: number;
+  answered: number;
+  total: number;
+  onQuit: () => void;
+}) {
+  return (
+    <header className="race__hud">
+      <Button variant="bare" className="race__quit" onClick={onQuit}>
+        Quit
+      </Button>
+
+      <div className="race__clock u-mono">
+        <span className="race__clock-time">{clock(elapsedMs)}</span>
+        {misses > 0 && (
+          <span className="race__penalty">
+            +{(misses * WRONG_ANSWER_PENALTY_MS) / 1000}s
+          </span>
+        )}
+      </div>
+
+      <div className="race__count u-mono">
+        <span className="race__count-now">{Math.min(answered + 1, total)}</span>
+        <span className="race__count-of">/ {total}</span>
+      </div>
+    </header>
+  );
+}

--- a/src/games/flashcards/race/Lane.tsx
+++ b/src/games/flashcards/race/Lane.tsx
@@ -1,0 +1,68 @@
+import type { Ghost, Profile } from "@/engine/types";
+import { delta as formatDelta } from "@/engine/format";
+
+/* ── The signature element: a rally split against a ghost ──────────────── */
+
+export function Lane({
+  profile,
+  ghost,
+  mePos,
+  ghostPos,
+  gap,
+  note,
+}: {
+  profile: Profile;
+  ghost: Ghost | null;
+  mePos: number;
+  ghostPos: number | null;
+  gap: number | null;
+  note: string;
+}) {
+  const ahead = gap !== null && gap < 0;
+  return (
+    <div className="lane">
+      <div className="lane__track">
+        <span className="lane__finish" aria-hidden="true">
+          🏁
+        </span>
+        {ghostPos !== null && ghost && (
+          <span
+            className="lane__puck lane__puck--ghost"
+            style={
+              {
+                "--p": ghostPos,
+                "--tint": ghost.profile.color,
+              } as React.CSSProperties
+            }
+            title={ghost.isSelf ? "Your best run" : ghost.profile.name}
+          >
+            {ghost.profile.emoji}
+          </span>
+        )}
+        <span
+          className="lane__puck lane__puck--me"
+          style={
+            {
+              "--p": mePos,
+              "--tint": profile.color,
+            } as React.CSSProperties
+          }
+        >
+          {profile.emoji}
+        </span>
+      </div>
+
+      {gap === null ? (
+        <p className="lane__note u-mono">{note}</p>
+      ) : (
+        <p
+          className={`lane__gap u-mono${ahead ? " is-ahead" : " is-behind"}`}
+          aria-live="off"
+        >
+          <span className="lane__gap-num">{formatDelta(gap)}</span>
+          <span className="lane__gap-word">{ahead ? "ahead" : "behind"}</span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/games/flashcards/race/QuitSheet.tsx
+++ b/src/games/flashcards/race/QuitSheet.tsx
@@ -1,0 +1,38 @@
+import { Button, Scrim } from "@/components/ui/kit";
+
+/**
+ * Confirmation before abandoning a run.
+ *
+ * While this is up the race clock is paused — see `useRaceClock`. Backing out
+ * neither costs the player time nor buys them any.
+ */
+export function QuitSheet({
+  onQuit,
+  onKeepRacing,
+}: {
+  onQuit: () => void;
+  onKeepRacing: () => void;
+}) {
+  return (
+    <div
+      className="sheet"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Quit the race"
+    >
+      <Scrim onClose={onKeepRacing} label="Keep racing" />
+      <div className="sheet__panel panel anim-pop">
+        <h2 className="panel__title">Quit this race?</h2>
+        <p className="muted">It won&apos;t be saved and no XP is earned.</p>
+        <div className="sheet__actions">
+          <Button variant="danger" size="sm" onClick={onQuit}>
+            Quit
+          </Button>
+          <Button variant="accent" onClick={onKeepRacing}>
+            Keep racing
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/games/flashcards/race/SaveFailed.tsx
+++ b/src/games/flashcards/race/SaveFailed.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@/components/ui/kit";
+
+/**
+ * The run finished but couldn't be written to IndexedDB — a full disk, a
+ * browser refusing storage in private mode, a revoked quota.
+ *
+ * Retrying is the primary action because the answers are still in memory:
+ * nothing is lost until the player navigates away, which is why the other
+ * button says so plainly rather than "Cancel".
+ */
+export function SaveFailed({
+  message,
+  onRetry,
+  onDiscard,
+}: {
+  message: string;
+  onRetry: () => void;
+  onDiscard: () => void;
+}) {
+  return (
+    <main className="boot">
+      <p className="u-eyebrow">Race finished</p>
+      <h1 className="u-display boot__title">Couldn&apos;t save this race</h1>
+      <p className="boot__msg">{message}</p>
+      <p className="boot__hint">
+        Your answers are still here. Try saving again — nothing is lost until
+        you leave this screen.
+      </p>
+      <div className="boot__actions">
+        <Button variant="go" onClick={onRetry}>
+          Save again
+        </Button>
+        <Button variant="ghost" onClick={onDiscard}>
+          Discard and go back
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/src/games/flashcards/race/types.ts
+++ b/src/games/flashcards/race/types.ts
@@ -1,0 +1,5 @@
+/** How the card that just landed was answered, or null while it's still live. */
+export type Feedback = {
+  kind: "right" | "wrong" | "timeout";
+  given: number | null;
+} | null;

--- a/src/games/flashcards/race/useCountdown.ts
+++ b/src/games/flashcards/race/useCountdown.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { sfx } from "@/services/sound";
+
+/** "GO" holds for less time than a number — it's a starting gun, not a beat. */
+const NUMBER_MS = 680;
+const GO_MS = 420;
+
+/**
+ * The 3 · 2 · 1 · GO before a race starts.
+ *
+ * Each step schedules the next rather than running off an interval, so the
+ * sound and the digit can never drift apart, and unmounting mid-countdown
+ * leaves nothing pending.
+ */
+export function useCountdown({
+  active,
+  from = 3,
+  onGo,
+}: {
+  active: boolean;
+  from?: number;
+  /** Must be stable — it's a dependency of the timer below. */
+  onGo: () => void;
+}) {
+  const [count, setCount] = useState(from);
+
+  useEffect(() => {
+    if (!active) return;
+    sfx.countdown(count);
+    const timer = window.setTimeout(
+      () => {
+        if (count === 0) onGo();
+        else setCount((n) => n - 1);
+      },
+      count === 0 ? GO_MS : NUMBER_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [active, count, onGo]);
+
+  return count;
+}

--- a/src/games/flashcards/race/useGhostGap.ts
+++ b/src/games/flashcards/race/useGhostGap.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from "react";
+import { sfx } from "@/services/sound";
+
+/**
+ * Where the rival is, and how far ahead or behind that puts the player.
+ *
+ * A ghost is a previous run replayed as split times, so "their position" is
+ * just how many of those splits the current elapsed time has passed. The
+ * overtake sound fires on the transition from behind to ahead, not on the
+ * state — which is why the previous side is remembered here rather than
+ * recomputed.
+ *
+ * `maxDeficitMs` is the furthest behind the player ever fell. It's a badge
+ * input, so it has to survive the whole run even though nothing renders it.
+ */
+export function useGhostGap({
+  splits,
+  raceElapsed,
+  index,
+  total,
+}: {
+  /** Cumulative finish time per card for the ghost, or null with no rival. */
+  splits: number[] | null;
+  raceElapsed: number;
+  index: number;
+  total: number;
+}) {
+  const maxDeficit = useRef(0);
+  const wasBehind = useRef(false);
+
+  const cardsDone = splits ? splits.filter((t) => t <= raceElapsed).length : 0;
+  const checkpoint = splits ? splits[Math.min(index, splits.length - 1)] : null;
+  const gap = checkpoint === null ? null : raceElapsed - checkpoint;
+
+  useEffect(() => {
+    if (gap === null) return;
+    maxDeficit.current = Math.max(maxDeficit.current, gap);
+    const behind = gap > 0;
+    if (wasBehind.current && !behind) sfx.overtake();
+    wasBehind.current = behind;
+  }, [gap]);
+
+  return {
+    gap,
+    position: splits ? Math.min(cardsDone / total, 1) : null,
+    /** Stable, so callers that must not re-render can hold onto it. */
+    maxDeficitMs: useCallback(() => maxDeficit.current, []),
+  };
+}

--- a/src/games/flashcards/race/useRaceClock.ts
+++ b/src/games/flashcards/race/useRaceClock.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { sfx } from "@/services/sound";
+
+/** The card clock ticks audibly over its last three seconds. */
+const TICK_FROM_MS = 3000;
+
+/**
+ * Every piece of time in a race: the stopwatch, the per-card clock, the fuse
+ * that drains across the card, and the pause that a quit sheet imposes.
+ *
+ * These live together because they share mutable state that must agree to the
+ * millisecond. The banked total, the current card's start mark and the pause
+ * mark are read by all four; splitting them apart would mean passing three
+ * refs between modules and hoping nobody writes to one without the others.
+ */
+export type RaceClock = {
+  /** Attach to the fuse element. Written to directly — see the loop below. */
+  fuseRef: React.RefObject<HTMLDivElement | null>;
+  /** Total race time: banked cards plus the live one, frozen while paused. */
+  elapsed: () => number;
+  /** Milliseconds since the current card appeared. */
+  onCard: () => number;
+  /** Whole seconds left on this card, or null when there's no card clock. */
+  secondsLeft: () => number | null;
+  /** Bank a finished card and freeze the fuse where it stands. */
+  bank: (ms: number) => void;
+  /** Drain the fuse to empty — what a timeout looks like. */
+  spendFuse: () => void;
+  /** Start the clock on a fresh card. */
+  startCard: () => void;
+};
+
+export function useRaceClock({
+  limitMs,
+  racing,
+  resolved,
+  quitting,
+  index,
+  onTimeout,
+}: {
+  /** Fixed for the whole run; null means no per-card clock. */
+  limitMs: number | null;
+  racing: boolean;
+  /** True while a card is showing feedback, which stops its clock. */
+  resolved: boolean;
+  quitting: boolean;
+  /** Which card is up. Re-arms the timer when it changes. */
+  index: number;
+  onTimeout: () => void;
+}): RaceClock {
+  const cardStart = useRef(0);
+  const banked = useRef(0);
+  /** When the quit sheet went up, or 0 while play is running. */
+  const pausedAt = useRef(0);
+  const fuseRef = useRef<HTMLDivElement | null>(null);
+  /** Stops the animation loop from re-inflating the fuse after a card lands. */
+  const fuseHeld = useRef(false);
+  const [, setTick] = useState(0);
+
+  /**
+   * Held in a ref so the per-card timer effect below doesn't depend on a
+   * callback identity. The clock re-renders this screen ~16×/second; an effect
+   * that depended on a fresh closure would tear down and restart its timer on
+   * every one of those renders and never actually fire.
+   */
+  const timeout = useRef(onTimeout);
+  timeout.current = onTimeout;
+
+  const elapsed = () => {
+    if (!racing || resolved) return banked.current;
+    // Reading the pause mark instead of the wall clock holds the time still
+    // while the quit sheet is up.
+    const now = pausedAt.current || performance.now();
+    return banked.current + (now - cardStart.current);
+  };
+
+  /**
+   * The four below touch nothing but refs, so they're pinned with an empty
+   * dependency list. That isn't a micro-optimisation: `submit` in RaceTrack
+   * must keep a stable identity or the per-card timer effect would tear down
+   * and restart on every one of the ~16 renders a second the ticker causes,
+   * and never fire. Handing it unstable callbacks would break that from here.
+   */
+  const onCard = useCallback(() => performance.now() - cardStart.current, []);
+
+  const bank = useCallback((ms: number) => {
+    banked.current += ms;
+    fuseHeld.current = true;
+  }, []);
+
+  const spendFuse = useCallback(
+    () => fuseRef.current?.style.setProperty("--left", "0"),
+    [],
+  );
+
+  const startCard = useCallback(() => {
+    cardStart.current = performance.now();
+    fuseHeld.current = false;
+  }, []);
+
+  // Reads props, so it's rebuilt each render — only ever called during render.
+  const secondsLeft = () =>
+    limitMs === null || !racing || resolved
+      ? null
+      : Math.max(0, Math.ceil((limitMs - onCard()) / 1000));
+
+  /* ── The ticker ────────────────────────────────────────────────────── */
+  useEffect(() => {
+    if (!racing) return;
+    let frame = 0;
+    let last = 0;
+    const loop = (now: number) => {
+      if (now - last > 60) {
+        last = now;
+        setTick((t) => t + 1);
+      }
+      // The fuse is written straight to the DOM rather than rendered: it has
+      // to move at full frame rate, and it has to keep draining for players
+      // who've asked for reduced motion — so it can't be a CSS animation.
+      if (
+        limitMs !== null &&
+        fuseRef.current &&
+        !fuseHeld.current &&
+        !pausedAt.current
+      ) {
+        const left = 1 - (now - cardStart.current) / limitMs;
+        fuseRef.current.style.setProperty(
+          "--left",
+          String(Math.min(1, Math.max(0, left))),
+        );
+      }
+      frame = requestAnimationFrame(loop);
+    };
+    frame = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(frame);
+  }, [racing, limitMs]);
+
+  /**
+   * Putting the quit sheet up pauses the card. Resuming shifts the card's
+   * start forward by however long the sheet was open, so a pause neither
+   * costs time nor buys thinking time. Declared before the timer below so the
+   * shift lands before that effect reschedules.
+   */
+  useEffect(() => {
+    if (!racing) return;
+    if (quitting) {
+      pausedAt.current = performance.now();
+    } else if (pausedAt.current) {
+      cardStart.current += performance.now() - pausedAt.current;
+      pausedAt.current = 0;
+    }
+  }, [quitting, racing]);
+
+  /**
+   * The per-card clock, plus its last-three-seconds ticks. Scheduled once per
+   * card. The delay is measured from when the card actually appeared, so a
+   * re-run can never hand out extra time.
+   */
+  useEffect(() => {
+    if (limitMs === null || !racing || resolved || quitting) return;
+    const left = limitMs - (performance.now() - cardStart.current);
+    const timers = [
+      window.setTimeout(() => timeout.current(), Math.max(0, left)),
+    ];
+    for (let at = 1000; at <= TICK_FROM_MS; at += 1000) {
+      if (left > at)
+        timers.push(window.setTimeout(() => sfx.tick(), left - at));
+    }
+    return () => timers.forEach((t) => window.clearTimeout(t));
+  }, [limitMs, racing, resolved, index, quitting]);
+
+  return {
+    fuseRef,
+    elapsed,
+    onCard,
+    secondsLeft,
+    bank,
+    spendFuse,
+    startCard,
+  };
+}

--- a/src/games/flashcards/race/useRaceFinish.ts
+++ b/src/games/flashcards/race/useRaceFinish.ts
@@ -1,0 +1,112 @@
+import { useCallback, useRef, useState } from "react";
+import { levelFromXp } from "@/engine/progress";
+import { summariseRun, type RunTally } from "@/engine/run";
+import { sfx } from "@/services/sound";
+import type { useHub } from "@/components/state/HubContext";
+import type { useRace } from "@/components/state/RaceContext";
+import type { useNavigate } from "react-router-dom";
+import type { FlashConfig, Ghost, Profile, Session } from "@/engine/types";
+
+/**
+ * The end of a run: score it, write it, and hand off to the results screen.
+ *
+ * Separate from the race loop because it fails differently. Everything before
+ * this point is in memory and can't really go wrong; this step talks to
+ * IndexedDB, which can refuse — a full disk, private browsing, a revoked
+ * quota. When it does, the answers are still here, so the failure is
+ * recoverable and `retry` is the whole point of holding the error in state
+ * rather than throwing it away.
+ *
+ * The scoring itself lives in `@/engine/run` — no React, no storage, just the
+ * rules for what a run was worth.
+ */
+export function useRaceFinish({
+  profile,
+  config,
+  seed,
+  ghost,
+  history,
+  previousBest,
+  readTally,
+  saveSession,
+  finish,
+  notify,
+  navigate,
+  onSaving,
+}: {
+  profile: Profile;
+  config: FlashConfig;
+  seed: number;
+  ghost: Ghost | null;
+  history: Session[];
+  previousBest: Session | null;
+  /** Read at save time so the loop can keep counting into plain refs. */
+  readTally: () => RunTally;
+  saveSession: ReturnType<typeof useHub>["saveSession"];
+  finish: ReturnType<typeof useRace>["finish"];
+  notify: ReturnType<typeof useHub>["notify"];
+  navigate: ReturnType<typeof useNavigate>;
+  onSaving: () => void;
+}) {
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const finishing = useRef(false);
+
+  async function save() {
+    const summary = summariseRun({
+      profile,
+      config,
+      seed,
+      ghost,
+      history,
+      previousBest,
+      tally: readTally(),
+    });
+
+    try {
+      const saved = await saveSession({
+        ...summary.draft,
+        earnedBadges: summary.earnedBadges,
+      });
+      const levelBefore = levelFromXp(profile.xp).level;
+      const levelAfter = levelFromXp(saved.profile.xp).level;
+      finish({
+        session: saved.session,
+        profileAfter: saved.profile,
+        ghost,
+        personalRecord: summary.personalRecord,
+        previousBest,
+        newBadges: summary.newBadges,
+        bonuses: summary.bonuses,
+        levelledUpTo: levelAfter > levelBefore ? levelAfter : null,
+      });
+      navigate(`/p/${profile.id}/race/results`, { replace: true });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Could not save this race";
+      setSaveError(message);
+      notify(message, "bad");
+    }
+  }
+
+  return {
+    saveError,
+    /** Called once, when the last card lands. Guards against a double finish. */
+    async complete() {
+      if (finishing.current) return;
+      finishing.current = true;
+      onSaving();
+      sfx.finish();
+      await save();
+    },
+    retry() {
+      setSaveError(null);
+      void save();
+    },
+    /**
+     * Stable, so the answer handler can check it without losing the identity
+     * the per-card timer depends on. True once the run has been handed off —
+     * a late keystroke must not record another card.
+     */
+    hasFinished: useCallback(() => finishing.current, []),
+  };
+}

--- a/src/games/flashcards/race/useRaceKeyboard.ts
+++ b/src/games/flashcards/race/useRaceKeyboard.ts
@@ -1,0 +1,72 @@
+import { useEffect } from "react";
+import type { InputMode } from "@/engine/types";
+
+/**
+ * Answering from a physical keyboard.
+ *
+ * This is the keyboard half of `AnswerPad` — same job, different input device
+ * — but it can't live in that component: these are window-level listeners
+ * bound to the race's state, and they must keep working while focus is
+ * anywhere on the page. Older players use the number row and never touch the
+ * on-screen keypad at all.
+ */
+export function useRaceKeyboard({
+  active,
+  inputMode,
+  choices,
+  answerLength,
+  entry,
+  entryRef,
+  submit,
+  pushDigit,
+  dropDigit,
+}: {
+  /** Racing, and no card currently showing feedback. */
+  active: boolean;
+  inputMode: InputMode;
+  choices: number[] | undefined;
+  /** Digits in the current card's answer, for the auto-submit below. */
+  answerLength: number;
+  entry: string;
+  entryRef: React.RefObject<string>;
+  submit: (value: number | null) => void;
+  pushDigit: (digit: string) => void;
+  dropDigit: () => void;
+}) {
+  useEffect(() => {
+    if (!active) return;
+    function onKey(event: KeyboardEvent) {
+      if (inputMode === "choose") {
+        const slot = Number(event.key);
+        if (slot >= 1 && slot <= 4 && choices) {
+          event.preventDefault();
+          submit(choices[slot - 1]);
+        }
+        return;
+      }
+      if (/^[0-9]$/.test(event.key)) {
+        event.preventDefault();
+        pushDigit(event.key);
+      } else if (event.key === "Backspace") {
+        event.preventDefault();
+        dropDigit();
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        if (entryRef.current !== "") submit(Number(entryRef.current));
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active, inputMode, choices, entryRef, submit, pushDigit, dropDigit]);
+
+  // Auto-submit the moment the entry is as long as the answer — keeps the pace
+  // up without making kids hunt for Enter.
+  useEffect(() => {
+    if (!active || inputMode !== "type") return;
+    if (entry.length > 0 && entry.length === answerLength) {
+      const value = Number(entry);
+      const timer = window.setTimeout(() => submit(value), 90);
+      return () => window.clearTimeout(timer);
+    }
+  }, [active, inputMode, entry, answerLength, submit]);
+}

--- a/src/games/flashcards/results/Rewards.tsx
+++ b/src/games/flashcards/results/Rewards.tsx
@@ -1,0 +1,62 @@
+import { BADGES_BY_ID } from "@/engine/progress";
+
+/**
+ * What the run earned beyond the score: a level, XP bonuses, new badges.
+ *
+ * Renders nothing at all when there's nothing to celebrate — an empty rewards
+ * strip on an ordinary run would make every ordinary run feel like a miss.
+ */
+export function Rewards({
+  levelledUpTo,
+  bonuses,
+  newBadges,
+}: {
+  levelledUpTo: number | null;
+  bonuses: Array<{ label: string; xp: number }>;
+  newBadges: string[];
+}) {
+  if (!levelledUpTo && bonuses.length === 0 && newBadges.length === 0) {
+    return null;
+  }
+  return (
+    <section className="rewards anim-rise">
+      {levelledUpTo && (
+        <div className="reward reward--level">
+          <span className="reward__icon" aria-hidden="true">
+            🌟
+          </span>
+          <span>
+            <strong>Level {levelledUpTo}</strong>
+            <span className="reward__sub">You levelled up</span>
+          </span>
+        </div>
+      )}
+      {bonuses.map((bonus) => (
+        <div key={bonus.label} className="reward">
+          <span className="reward__icon" aria-hidden="true">
+            ⚡
+          </span>
+          <span>
+            <strong>{bonus.label}</strong>
+            <span className="reward__sub">+{bonus.xp} XP</span>
+          </span>
+        </div>
+      ))}
+      {newBadges.map((id) => {
+        const badge = BADGES_BY_ID.get(id);
+        if (!badge) return null;
+        return (
+          <div key={id} className="reward reward--badge">
+            <span className="reward__icon" aria-hidden="true">
+              {badge.icon}
+            </span>
+            <span>
+              <strong>{badge.name}</strong>
+              <span className="reward__sub">{badge.how}</span>
+            </span>
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/games/flashcards/results/Scoreline.tsx
+++ b/src/games/flashcards/results/Scoreline.tsx
@@ -1,0 +1,44 @@
+import { percent } from "@/engine/format";
+import type { Session } from "@/engine/types";
+
+/** The five numbers a player actually looks at first. */
+export function Scoreline({
+  session,
+  accuracy,
+}: {
+  session: Session;
+  accuracy: number;
+}) {
+  const perCard = session.durationMs / Math.max(1, session.cards.length) / 1000;
+  return (
+    <section className="scoreline panel anim-rise">
+      <div className="stat">
+        <span className="stat__value">{percent(accuracy)}</span>
+        <span className="stat__label">Correct</span>
+      </div>
+      <div className="stat">
+        <span className="stat__value">
+          {session.correct}
+          <span className="scoreline__of">
+            /{session.correct + session.incorrect}
+          </span>
+        </span>
+        <span className="stat__label">Cards</span>
+      </div>
+      <div className="stat">
+        <span className="stat__value">{session.bestStreak}</span>
+        <span className="stat__label">Best streak</span>
+      </div>
+      <div className="stat">
+        <span className="stat__value">{perCard.toFixed(2)}s</span>
+        <span className="stat__label">Per card</span>
+      </div>
+      <div className="stat stat--xp">
+        <span className="stat__value">
+          +{session.xpEarned.toLocaleString()}
+        </span>
+        <span className="stat__label">XP earned</span>
+      </div>
+    </section>
+  );
+}

--- a/src/games/flashcards/results/SplitsTable.tsx
+++ b/src/games/flashcards/results/SplitsTable.tsx
@@ -1,0 +1,98 @@
+import { Avatar } from "@/components/ui/kit";
+import { delta as formatDelta } from "@/engine/format";
+import type { Ghost, Session } from "@/engine/types";
+
+/**
+ * Card-by-card, with the rival's time alongside when there was one.
+ *
+ * A real <table> rather than a grid of divs: this is tabular data, the header
+ * row is what makes the rival and gap columns legible, and it's the one part
+ * of the results screen a parent is likely to read across.
+ */
+export function SplitsTable({
+  session,
+  ghost,
+  mySplits,
+  ghostSplits,
+}: {
+  session: Session;
+  ghost: Ghost | null;
+  /** Cumulative finish times, used only to compute the running gap. */
+  mySplits: number[];
+  ghostSplits: number[] | null;
+}) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Splits</h2>
+        {ghost && (
+          <span className="chip">
+            <Avatar profile={ghost.profile} size="1.2rem" />
+            {ghost.isSelf ? "Your best run" : ghost.profile.name}
+          </span>
+        )}
+      </div>
+      <div className="splits__scroll">
+        <table className="splits">
+          <thead>
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">Card</th>
+              <th scope="col">You</th>
+              {ghostSplits && <th scope="col">Rival</th>}
+              {ghostSplits && <th scope="col">Gap</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {session.cards.map((card, i) => {
+              const gap =
+                ghostSplits && ghostSplits[i] !== undefined
+                  ? mySplits[i] - ghostSplits[i]
+                  : null;
+              const rivalCard = ghost?.session.cards[i];
+              return (
+                <tr
+                  key={i}
+                  className={
+                    card.ok
+                      ? undefined
+                      : card.timedOut
+                        ? "splits__row--late"
+                        : "splits__row--miss"
+                  }
+                >
+                  <td className="u-mono splits__n">{i + 1}</td>
+                  <td className="splits__card">
+                    {card.prompt} = {card.answer}
+                    {!card.ok && (
+                      <span
+                        className={`splits__given${card.timedOut ? " is-late" : ""}`}
+                      >
+                        {card.timedOut
+                          ? "ran out of time"
+                          : `you said ${card.given}`}
+                      </span>
+                    )}
+                  </td>
+                  <td className="u-mono">{(card.ms / 1000).toFixed(2)}</td>
+                  {ghostSplits && (
+                    <td className="u-mono splits__rival">
+                      {rivalCard ? (rivalCard.ms / 1000).toFixed(2) : "—"}
+                    </td>
+                  )}
+                  {ghostSplits && (
+                    <td
+                      className={`u-mono splits__gap${gap !== null && gap < 0 ? " is-ahead" : " is-behind"}`}
+                    >
+                      {gap === null ? "—" : formatDelta(gap)}
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/games/flashcards/setup/ClockPicker.tsx
+++ b/src/games/flashcards/setup/ClockPicker.tsx
@@ -1,0 +1,100 @@
+import { Button, Input } from "@/components/ui/kit";
+import {
+  TIME_LIMITS,
+  TIME_MAX_MS,
+  TIME_MIN_MS,
+  TIME_STEP_MS,
+} from "@/engine/decks/flashcards";
+
+/**
+ * How long a player gets per card, or nothing at all.
+ *
+ * Two ways in, deliberately: presets for the common answers, and an exact
+ * field for the parent who knows their kid needs 3.75 seconds. The field keeps
+ * the raw text while it has focus and only snaps to the quarter-second grid on
+ * commit — otherwise typing "3.3" on the way to "3.35" would fight the caret.
+ */
+export function ClockPicker({
+  limitMs,
+  shownSeconds,
+  onPreset,
+  onStep,
+  onType,
+  onDraftEnd,
+}: {
+  limitMs: number | null;
+  /** Raw draft text while focused, otherwise the stored value. */
+  shownSeconds: string;
+  onPreset: (ms: number | null) => void;
+  onStep: (deltaMs: number) => void;
+  onType: (text: string) => void;
+  onDraftEnd: () => void;
+}) {
+  return (
+    <div className="control">
+      <span className="control__label">Time per card</span>
+      <div className="segmented">
+        {TIME_LIMITS.map(({ ms, label }) => {
+          const on = (limitMs ?? null) === ms;
+          return (
+            <Button
+              key={label}
+              variant="bare"
+              className={`segmented__btn u-mono${on ? " is-on" : ""}`}
+              onClick={() => onPreset(ms)}
+              pressed={on}
+            >
+              {label}
+            </Button>
+          );
+        })}
+      </div>
+
+      <div className="timelimit">
+        <Button
+          variant="bare"
+          className="timelimit__step u-mono"
+          onClick={() => onStep(-TIME_STEP_MS)}
+          aria-label="Quarter of a second less"
+        >
+          −
+        </Button>
+        <span className="timelimit__field">
+          <Input
+            className="timelimit__input u-mono"
+            type="number"
+            inputMode="decimal"
+            step={TIME_STEP_MS / 1000}
+            min={TIME_MIN_MS / 1000}
+            max={TIME_MAX_MS / 1000}
+            value={shownSeconds}
+            placeholder="off"
+            aria-label="Seconds per card"
+            blurOnEnter
+            onChange={onType}
+            onBlur={onDraftEnd}
+          />
+          <span className="timelimit__unit u-mono">s</span>
+        </span>
+        <Button
+          variant="bare"
+          className="timelimit__step u-mono"
+          onClick={() => onStep(TIME_STEP_MS)}
+          aria-label="Quarter of a second more"
+        >
+          +
+        </Button>
+        <span className="timelimit__hint">
+          Or set it exactly — quarter-second steps, down to {TIME_MIN_MS / 1000}
+          s. Clear the box for no clock.
+        </span>
+      </div>
+
+      <p className="numbers__note">
+        {limitMs
+          ? "Run out of time and the answer is shown, then the next card comes up. Anything you miss lands on your practice list."
+          : "No card clock. The whole race is timed instead — take as long as you need on any one card."}
+      </p>
+    </div>
+  );
+}

--- a/src/games/flashcards/setup/DeckPicker.tsx
+++ b/src/games/flashcards/setup/DeckPicker.tsx
@@ -1,0 +1,154 @@
+import { Button } from "@/components/ui/kit";
+import type { OperationSpec } from "@/engine/decks/flashcards";
+import type { FlashConfig } from "@/engine/types";
+
+/**
+ * Which numbers end up on the cards.
+ *
+ * Two grids, and the promise the layout makes is that a card only ever uses a
+ * number lit on BOTH sides — so unticking 12 on the left has to remove it from
+ * the right too, or the grid is lying. That rule lives in `onToggleFocus`,
+ * with the state it has to mutate.
+ *
+ * A drill arrives with its facts already chosen, so it replaces the grids
+ * entirely rather than trying to render as a selection.
+ */
+export function DeckPicker({
+  config,
+  spec,
+  focusNumbers,
+  pairNumbers,
+  sample,
+  onToggleFocus,
+  onTogglePair,
+  patch,
+  tap,
+}: {
+  config: FlashConfig;
+  spec: OperationSpec;
+  focusNumbers: number[];
+  pairNumbers: number[];
+  /** Three real cards from the current settings, so a tick shows its effect. */
+  sample: string[];
+  onToggleFocus: (n: number) => void;
+  onTogglePair: (n: number) => void;
+  patch: (next: Partial<FlashConfig>) => void;
+  tap: () => void;
+}) {
+  const drill = config.facts?.length ? config.facts : null;
+
+  if (drill) {
+    return (
+      <div className="control">
+        <span className="control__label">Practice set</span>
+        <p className="drill__lead">
+          The {drill.length} facts you&apos;ve been missing most. Answer each
+          one twice.
+        </p>
+        <ul className="factchips">
+          {drill.map(([a, b]) => (
+            <li key={`${a}:${b}`} className="factchip u-mono">
+              {a} {spec.symbol} {b}
+            </li>
+          ))}
+        </ul>
+        <div className="control__row">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              tap();
+              patch({ facts: undefined });
+            }}
+          >
+            Pick numbers instead
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="control">
+      <div className="numbers">
+        <div className="numbers__side">
+          <span className="control__label">{spec.focusLabel}</span>
+          <div className="tablegrid">
+            {focusNumbers.map((n) => (
+              <Button
+                key={n}
+                variant="bare"
+                className={`tablegrid__cell u-mono${config.tables.includes(n) ? " is-on" : ""}`}
+                onClick={() => onToggleFocus(n)}
+                pressed={config.tables.includes(n)}
+              >
+                {n}
+              </Button>
+            ))}
+          </div>
+          <div className="control__row">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ tables: focusNumbers })}
+            >
+              All
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ tables: [2, 5, 10] })}
+            >
+              Easy three
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ tables: [6, 7, 8, 9] })}
+            >
+              Tricky four
+            </Button>
+          </div>
+        </div>
+
+        <div className="numbers__side">
+          <span className="control__label">{spec.pairLabel}</span>
+          <div className="tablegrid">
+            {pairNumbers.map((n) => (
+              <Button
+                key={n}
+                variant="bare"
+                className={`tablegrid__cell u-mono${config.others.includes(n) ? " is-on" : ""}`}
+                onClick={() => onTogglePair(n)}
+                pressed={config.others.includes(n)}
+              >
+                {n}
+              </Button>
+            ))}
+          </div>
+          <div className="control__row">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ others: pairNumbers })}
+            >
+              All
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => patch({ others: [...config.tables] })}
+            >
+              Match tables
+            </Button>
+          </div>
+        </div>
+      </div>
+      <p className="numbers__note">
+        Cards only ever use numbers lit up on both sides. Unticking a number on
+        the left removes it from the right too.
+      </p>
+      <p className="numbers__preview u-mono">e.g. {sample.join(" · ")}</p>
+    </div>
+  );
+}

--- a/src/games/flashcards/setup/PresetRow.tsx
+++ b/src/games/flashcards/setup/PresetRow.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/kit";
+import { PRESETS, configKey } from "@/engine/decks/flashcards";
+import type { FlashConfig } from "@/engine/types";
+
+/**
+ * The one-tap answers, for the player who doesn't want to configure anything.
+ *
+ * A preset reads as chosen when the CURRENT config matches it exactly —
+ * compared by `configKey`, the same identity the record book uses to decide
+ * whether two runs are comparable. So tweaking any dial below silently
+ * un-chooses the preset, which is the honest thing for it to do.
+ */
+export function PresetRow({
+  currentKey,
+  onChoose,
+}: {
+  currentKey: string;
+  onChoose: (config: FlashConfig) => void;
+}) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Pick a race</h2>
+      </div>
+      <div className="preset-row">
+        {PRESETS.map((preset) => {
+          const chosen = configKey(preset.config) === currentKey;
+          return (
+            <Button
+              key={preset.id}
+              variant="bare"
+              className={`preset${chosen ? " is-chosen" : ""}`}
+              onClick={() => onChoose(preset.config)}
+              pressed={chosen}
+            >
+              <span className="preset__emoji" aria-hidden="true">
+                {preset.emoji}
+              </span>
+              <span className="preset__name u-display">{preset.name}</span>
+              <span className="preset__tag">{preset.tagline}</span>
+            </Button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/games/flashcards/setup/RivalList.tsx
+++ b/src/games/flashcards/setup/RivalList.tsx
@@ -1,0 +1,83 @@
+import { Avatar, Button } from "@/components/ui/kit";
+import { accuracyOf, raceTimeMs } from "@/engine/records";
+import { clock, percent, shortDate } from "@/engine/format";
+import type { Ghost } from "@/engine/types";
+
+/**
+ * Who the player is racing.
+ *
+ * Only runs at the exact same settings appear, because a ghost is a replay of
+ * a specific deck — racing one built from different cards wouldn't be a race.
+ * That filtering happens upstream in `ghostsFor`; this only has to render what
+ * survived it, and say why the list might be empty.
+ */
+export function RivalList({
+  rivals,
+  chosenId,
+  onChoose,
+  onStart,
+}: {
+  rivals: Ghost[];
+  /** null means "just the clock" — no ghost. */
+  chosenId: string | null;
+  onChoose: (id: string | null) => void;
+  onStart: () => void;
+}) {
+  return (
+    <section className="panel anim-rise setup__rivals">
+      <div className="panel__head">
+        <h2 className="panel__title">Who are you racing?</h2>
+      </div>
+      <p className="muted setup__rival-note">
+        Only runs with these exact settings show up here — same cards, same
+        order, fair race.
+      </p>
+
+      <ul className="rivals">
+        <li>
+          <Button
+            variant="bare"
+            className={`rival${chosenId === null ? " is-chosen" : ""}`}
+            onClick={() => onChoose(null)}
+            pressed={chosenId === null}
+          >
+            <span className="rival__icon" aria-hidden="true">
+              🕐
+            </span>
+            <span className="rival__body">
+              <span className="rival__name u-display">Just the clock</span>
+              <span className="rival__meta">No ghost — set a time to beat</span>
+            </span>
+          </Button>
+        </li>
+        {rivals.map((ghost) => (
+          <li key={ghost.session.id}>
+            <Button
+              variant="bare"
+              className={`rival${chosenId === ghost.session.id ? " is-chosen" : ""}`}
+              style={{ "--tint": ghost.profile.color } as React.CSSProperties}
+              onClick={() => onChoose(ghost.session.id)}
+              pressed={chosenId === ghost.session.id}
+            >
+              <Avatar profile={ghost.profile} size="2.4rem" />
+              <span className="rival__body">
+                <span className="rival__name u-display">
+                  {ghost.isSelf ? "Your best" : ghost.profile.name}
+                </span>
+                <span className="rival__meta u-mono">
+                  {clock(raceTimeMs(ghost.session))} ·{" "}
+                  {percent(accuracyOf(ghost.session))} ·{" "}
+                  {shortDate(ghost.session.finishedAt)}
+                </span>
+              </span>
+            </Button>
+          </li>
+        ))}
+      </ul>
+
+      <Button variant="go" className="setup__go" onClick={onStart}>
+        Start race
+      </Button>
+    </section>
+  );
+}


### PR DESCRIPTION
Ships epic #5 in full.

- All 55 hand-rolled controls now go through the kit (#1, #2, #3, #4)
- All four oversized modules split along their seams
- `rawControlsAllowlist` and `maxLinesAllowlist` deleted from `eslint.config.mjs`
- `summariseRun` moved out of the view layer into `src/engine/run.ts`
- 21 boundary tests, up from 11

Like-for-like: no pixels should move. Verified by browser checks on the setup,
race, results and progress screens plus the full smoke run, all with zero
console errors.

Merge commit, not squash.