### PR TITLE
Make the card generic so a deck can be words, not just sums (GAME02a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,24 @@ OIDC — there are no long-lived AWS keys anywhere.
 
 ## Adding a game
 
-The card loop, XP, ghost racing and stats work off a generic `Card`, not off
-arithmetic. A new game is an entry in the operation/deck registry plus, if it
-needs one, an input control. It gets a route under `src/pages/<game>/` — a
-**path, not a subdomain**, because separate origins would partition browser
-storage and a player's profile could no longer follow them between games.
+The card loop, XP, ghost racing and stats work off `Card` and `CardResult`,
+which are text in and text out — `answer` is `"56"`, not `56`, and `factId` is
+`"7:8"` or `"because"`. Nothing in the loop knows about arithmetic.
+
+The three judgements a loop can't make generically live on a **`DeckSpec`**
+(`src/engine/decks/spec.ts`): fold two cards onto one fact (`masteryKey`,
+`drillKey`), name a fact on screen (`factLabel`), and decide whether what was
+typed matches (`normalise`). A new deck family implements that and registers in
+`src/engine/decks/registry.ts`; `deckSpec(mode)` never throws, because sessions
+outlive the decks they were played on.
+
+So a new game is a `DeckSpec`, an input control if the kit lacks one, and a
+route under `src/pages/<game>/` — a **path, not a subdomain**, because separate
+origins would partition browser storage and a player's profile could no longer
+follow them between games.
+
+**Saved runs are the constraint, not the code.** `configKey` decides which runs
+may race each other as ghosts, so changing its format orphans every personal
+best already saved. Cards written before a shape change are widened on read by
+`src/engine/migrate.ts` — never by rewriting storage, because IndexedDB holds
+the only copy there is.

--- a/src/components/screens/PlayerHub.tsx
+++ b/src/components/screens/PlayerHub.tsx
@@ -81,7 +81,7 @@ export default function PlayerHub() {
                 navigate(`/p/${profile.id}/race`, {
                   state: {
                     config: buildDrill(
-                      trouble.map((fact) => fact.facts),
+                      trouble.map((fact) => fact.factId),
                       {
                         operation: "multiply",
                         inputMode: profile.age <= 6 ? "choose" : "type",

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -123,7 +123,7 @@ export default function Progress() {
                 navigate(`/p/${profile.id}/race`, {
                   state: {
                     config: buildDrill(
-                      trouble.map((fact) => fact.facts),
+                      trouble.map((fact) => fact.factId),
                       {
                         operation,
                         inputMode: profile.age <= 6 ? "choose" : "type",
@@ -152,9 +152,9 @@ export default function Progress() {
             </p>
             <ul className="trouble">
               {trouble.map((fact) => (
-                <li key={fact.key} className="trouble__item">
+                <li key={fact.factId} className="trouble__item">
                   <span className="trouble__fact u-mono">
-                    {fact.facts[0]} {spec.symbol} {fact.facts[1]}
+                    {spec.factLabel(fact.factId)}
                   </span>
                   <span className="trouble__why">
                     {fact.timeouts > 0 && (

--- a/src/engine/decks/flashcards.test.ts
+++ b/src/engine/decks/flashcards.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OPERATIONS,
+  buildDeck,
+  buildDrill,
+  configKey,
+  readConfig,
+} from "./flashcards";
+import type { FlashConfig } from "@/engine/types";
+
+const config = (over: Partial<FlashConfig> = {}): FlashConfig => ({
+  operation: "multiply",
+  tables: [7],
+  others: [1, 2, 3],
+  cardCount: 6,
+  inputMode: "type",
+  ...over,
+});
+
+describe("buildDeck", () => {
+  it("is a pure function of its config and seed", () => {
+    // Ghost racing depends on this outright: a rival's run is replayed from a
+    // seed, so the same seed producing a different deck would race two people
+    // on different questions and call it a record.
+    const a = buildDeck(config(), 12345);
+    const b = buildDeck(config(), 12345);
+    expect(a).toEqual(b);
+    expect(buildDeck(config(), 12346)).not.toEqual(a);
+  });
+
+  it("answers with text, not numbers", () => {
+    for (const card of buildDeck(config(), 7)) {
+      expect(typeof card.answer).toBe("string");
+    }
+  });
+
+  it("gets the arithmetic right in every operation", () => {
+    const check: Record<string, (a: number, b: number) => number> = {
+      multiply: (a, b) => a * b,
+      add: (a, b) => a + b,
+    };
+    for (const operation of ["multiply", "add"] as const) {
+      for (const card of buildDeck(config({ operation }), 99)) {
+        const [left, , right] = card.prompt.split(" ");
+        expect(card.answer).toBe(
+          String(check[operation](Number(left), Number(right))),
+        );
+      }
+    }
+  });
+
+  it("never asks division to divide by zero", () => {
+    const deck = buildDeck(
+      config({ operation: "divide", others: [0, 1, 2, 3] }),
+      5,
+    );
+    for (const card of deck) {
+      expect(card.prompt).not.toMatch(/÷ 0$/);
+    }
+  });
+
+  it("keeps subtraction above zero", () => {
+    for (const card of buildDeck(config({ operation: "subtract" }), 5)) {
+      expect(Number(card.answer)).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("exhausts the pool before repeating a fact", () => {
+    // Three facts over six cards should be two full passes, not the same card
+    // four times while another never appears.
+    const seen = buildDeck(config({ cardCount: 6 }), 3).map((c) => c.factId);
+    expect(new Set(seen).size).toBe(3);
+  });
+
+  it("offers four distinct choices including the answer", () => {
+    for (const card of buildDeck(config({ inputMode: "choose" }), 8)) {
+      expect(card.choices).toHaveLength(4);
+      expect(new Set(card.choices).size).toBe(4);
+      expect(card.choices).toContain(card.answer);
+      for (const choice of card.choices!) expect(typeof choice).toBe("string");
+    }
+  });
+
+  it("builds no choices when the answer is typed", () => {
+    for (const card of buildDeck(config(), 8)) {
+      expect(card.choices).toBeUndefined();
+    }
+  });
+});
+
+describe("the marking rule", () => {
+  it("forgives a leading zero and stray whitespace", () => {
+    // The keypad lets a five-year-old lead with a zero and the number row
+    // lets anyone hit space. Neither is a wrong answer to 7 × 8.
+    const { normalise } = OPERATIONS.multiply;
+    expect(normalise("056")).toBe(normalise("56"));
+    expect(normalise(" 56 ")).toBe(normalise("56"));
+  });
+
+  it("does not forgive a different number", () => {
+    const { normalise } = OPERATIONS.multiply;
+    expect(normalise("57")).not.toBe(normalise("56"));
+  });
+
+  it("leaves a non-numeric entry alone rather than turning it into NaN", () => {
+    expect(OPERATIONS.multiply.normalise("abc")).toBe("abc");
+    expect(OPERATIONS.multiply.normalise("")).toBe("");
+  });
+});
+
+describe("factLabel", () => {
+  it("names a multiplication fact as the question it asks", () => {
+    expect(OPERATIONS.multiply.factLabel("7:8")).toBe("7 × 8");
+  });
+
+  it("names a division fact as the question it asks, not as its two numbers", () => {
+    // The pair behind "21 ÷ 3 = 7" is [3, 7]. Rendering that literally gives
+    // "3 ÷ 7", which is a different — and wrong — sum. The trouble list and
+    // the drill chips both used to show it that way.
+    expect(OPERATIONS.divide.factLabel("3:7")).toBe("21 ÷ 3");
+  });
+
+  it("does the same for subtraction", () => {
+    expect(OPERATIONS.subtract.factLabel("3:7")).toBe("10 − 3");
+  });
+});
+
+describe("configKey", () => {
+  // Pinned exactly. The key is how a run finds the ghosts it may race, so a
+  // change to its format doesn't break a test — it silently orphans every run
+  // already saved, and nobody's personal best lines up again.
+  it("is stable for a plain config", () => {
+    expect(configKey(config())).toBe("multiply|7|1.2.3|6|type");
+  });
+
+  it("appends the clock only when there is one", () => {
+    expect(configKey(config({ timeLimitMs: 8000 }))).toBe(
+      "multiply|7|1.2.3|6|type|t8000",
+    );
+    expect(configKey(config({ timeLimitMs: null }))).toBe(
+      "multiply|7|1.2.3|6|type",
+    );
+  });
+
+  it("sorts numerically, so 10 doesn't file itself before 2", () => {
+    expect(configKey(config({ tables: [10, 2, 1] }))).toContain("|1.2.10|");
+  });
+
+  it("reads a pre-`others` config through its old min/max range", () => {
+    expect(
+      readConfig({
+        operation: "multiply",
+        tables: [7],
+        otherMin: 1,
+        otherMax: 3,
+        cardCount: 6,
+        inputMode: "type",
+      }).others,
+    ).toEqual([1, 2, 3]);
+  });
+});
+
+describe("buildDrill", () => {
+  it("takes fact ids and files them as the persisted pair shape", () => {
+    const drill = buildDrill(["7:8", "6:9"], {
+      operation: "multiply",
+      inputMode: "type",
+    });
+    expect(drill.facts).toEqual([
+      [7, 8],
+      [6, 9],
+    ]);
+  });
+
+  it("de-duplicates", () => {
+    expect(
+      buildDrill(["7:8", "7:8"], { operation: "multiply", inputMode: "type" })
+        .facts,
+    ).toHaveLength(1);
+  });
+
+  it("fills the axes in from the facts so the run still describes itself", () => {
+    const drill = buildDrill(["7:8", "6:9"], {
+      operation: "multiply",
+      inputMode: "type",
+    });
+    expect(drill.tables).toEqual([6, 7]);
+    expect(drill.others).toEqual([8, 9]);
+  });
+
+  it("asks each fact twice, within bounds", () => {
+    expect(
+      buildDrill(["7:8"], { operation: "multiply", inputMode: "type" })
+        .cardCount,
+    ).toBe(6);
+    const many = Array.from({ length: 40 }, (_, i) => `1:${i}`);
+    expect(
+      buildDrill(many, { operation: "multiply", inputMode: "type" }).cardCount,
+    ).toBe(30);
+  });
+
+  it("builds a deck of only those facts", () => {
+    const drill = buildDrill(["7:8", "6:9"], {
+      operation: "multiply",
+      inputMode: "type",
+    });
+    const ids = new Set(buildDeck(drill, 4).map((c) => c.factId));
+    expect([...ids].sort()).toEqual(["6:9", "7:8"]);
+  });
+});

--- a/src/engine/decks/flashcards.ts
+++ b/src/engine/decks/flashcards.ts
@@ -6,18 +6,48 @@ import type {
 } from "@/engine/types";
 
 import { mulberry32, shuffled } from "@/engine/random";
+import type { DeckSpec } from "./spec";
 
 const RANGE_1_TO_12 = Array.from({ length: 12 }, (_, i) => i + 1);
 
+/* ── Fact ids ────────────────────────────────────────────────────────────
+   An arithmetic fact is its two numbers, as the deck chose them: the focus
+   (the table you picked) then the other operand. Not as the prompt shows
+   them — "7 × 8" and "8 × 7" are built from the same pair and must land on
+   the same square.                                                         */
+
+export const arithmeticFactId = (focus: number, other: number) =>
+  `${focus}:${other}`;
+
+export const factPair = (factId: string): [number, number] => {
+  const [a, b] = factId.split(":");
+  return [Number(a) || 0, Number(b) || 0];
+};
+
+const foldPair = (factId: string) => {
+  const [a, b] = factPair(factId);
+  return arithmeticFactId(Math.min(a, b), Math.max(a, b));
+};
+
 /**
- * A deck is described by an operation spec plus a config. Adding spelling
- * words or parent-authored decks later means adding another spec here (and a
- * matching input control) — the play loop, ghost racing, XP and stats all work
- * off `Card`, not off arithmetic.
+ * "07" is a correct answer to 7 × 1, and so is " 7 ". The keypad lets a kid
+ * lead with a zero and the number row lets them fat-finger a space, and
+ * neither is a wrong answer to an arithmetic question.
  */
-export type OperationSpec = {
+const normaliseNumber = (input: string) => {
+  const trimmed = input.trim();
+  if (trimmed === "") return "";
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? String(value) : trimmed;
+};
+
+/**
+ * A deck is described by an operation spec plus a config. A spelling list or
+ * a parent-authored deck is another `DeckSpec` elsewhere — the play loop,
+ * ghost racing, XP and stats all work off `Card`, not off arithmetic.
+ */
+export type OperationSpec = DeckSpec & {
   id: Operation;
-  label: string;
   symbol: string;
   /** What the "focus numbers" selector is called for this operation. */
   focusLabel: string;
@@ -33,9 +63,27 @@ export type OperationSpec = {
   ): Omit<Card, "choices">;
 };
 
-const flip = (rand: () => number) => rand() < 0.5;
+/**
+ * Everything about an operation that isn't shared. `ask` is the question a
+ * pair poses and its answer, and both the card and the fact label are built
+ * from it — so a fact can never be named on screen as something other than
+ * the question it was asked as.
+ */
+type OperationDef = Omit<
+  OperationSpec,
+  "masteryKey" | "drillKey" | "factLabel" | "normalise" | "build"
+> & {
+  /**
+   * Whether the two numbers can swap without changing the question. Decides
+   * both whether the prompt is shown either way round and whether the pair
+   * folds — 7 × 8 and 8 × 7 are one fact to practise, 21 ÷ 3 and 21 ÷ 7 are
+   * two.
+   */
+  commutative: boolean;
+  ask(focus: number, other: number): { prompt: string; answer: number };
+};
 
-export const OPERATIONS: Record<Operation, OperationSpec> = {
+const DEFS: Record<Operation, OperationDef> = {
   multiply: {
     id: "multiply",
     label: "Multiplication",
@@ -44,10 +92,8 @@ export const OPERATIONS: Record<Operation, OperationSpec> = {
     pairLabel: "Multiplied by",
     blurb: "The classic. Pick your tables and go.",
     minOther: 0,
-    build(focus, other, rand) {
-      const [a, b] = flip(rand) ? [focus, other] : [other, focus];
-      return { prompt: `${a} × ${b}`, answer: a * b, facts: [focus, other] };
-    },
+    commutative: true,
+    ask: (a, b) => ({ prompt: `${a} × ${b}`, answer: a * b }),
   },
   divide: {
     id: "divide",
@@ -57,13 +103,11 @@ export const OPERATIONS: Record<Operation, OperationSpec> = {
     pairLabel: "Answers between",
     blurb: "Times tables in reverse.",
     minOther: 1,
-    build(focus, other) {
-      return {
-        prompt: `${focus * other} ÷ ${focus}`,
-        answer: other,
-        facts: [focus, other],
-      };
-    },
+    commutative: false,
+    ask: (focus, other) => ({
+      prompt: `${focus * other} ÷ ${focus}`,
+      answer: other,
+    }),
   },
   add: {
     id: "add",
@@ -73,10 +117,8 @@ export const OPERATIONS: Record<Operation, OperationSpec> = {
     pairLabel: "Added to",
     blurb: "Warm up the engine.",
     minOther: 0,
-    build(focus, other, rand) {
-      const [a, b] = flip(rand) ? [focus, other] : [other, focus];
-      return { prompt: `${a} + ${b}`, answer: a + b, facts: [focus, other] };
-    },
+    commutative: true,
+    ask: (a, b) => ({ prompt: `${a} + ${b}`, answer: a + b }),
   },
   subtract: {
     id: "subtract",
@@ -86,15 +128,49 @@ export const OPERATIONS: Record<Operation, OperationSpec> = {
     pairLabel: "Answers between",
     blurb: "Never dips below zero.",
     minOther: 0,
-    build(focus, other) {
-      const total = focus + other;
+    commutative: false,
+    ask: (focus, other) => ({
+      prompt: `${focus + other} − ${focus}`,
+      answer: other,
+    }),
+  },
+};
+
+const flip = (rand: () => number) => rand() < 0.5;
+
+function toSpec(def: OperationDef): OperationSpec {
+  return {
+    ...def,
+    // The map is a symmetric 12×12 for every operation, so it always folds.
+    // Division's two questions therefore share a square on purpose; the drill
+    // key below is what keeps them apart where it matters.
+    masteryKey: foldPair,
+    drillKey: def.commutative ? foldPair : (factId) => factId,
+    factLabel: (factId) => def.ask(...factPair(factId)).prompt,
+    normalise: normaliseNumber,
+    build(focus, other, rand) {
+      // Which way round the prompt reads. Only a commutative operation both
+      // flips and draws from `rand` — and the short-circuit matters as much as
+      // the flip: spending a coin here for division would shift every
+      // subsequent card and rebuild a saved run's deck as a different one.
+      const swap = def.commutative && !flip(rand);
+      const { prompt, answer } = swap
+        ? def.ask(other, focus)
+        : def.ask(focus, other);
       return {
-        prompt: `${total} − ${focus}`,
-        answer: other,
-        facts: [focus, other],
+        prompt,
+        answer: String(answer),
+        factId: arithmeticFactId(focus, other),
       };
     },
-  },
+  };
+}
+
+export const OPERATIONS: Record<Operation, OperationSpec> = {
+  multiply: toSpec(DEFS.multiply),
+  divide: toSpec(DEFS.divide),
+  add: toSpec(DEFS.add),
+  subtract: toSpec(DEFS.subtract),
 };
 
 export const OPERATION_ORDER: Operation[] = [
@@ -133,7 +209,7 @@ function distractors(
     if (filler !== answer && !picked.includes(filler)) picked.push(filler);
     filler += 1;
   }
-  return picked;
+  return picked.map(String);
 }
 
 /**
@@ -178,7 +254,10 @@ export function buildDeck(config: LegacyFlashConfig, seed: number): Card[] {
     return {
       ...base,
       choices: shuffled(
-        [base.answer, ...distractors(base.answer, base.facts, rand)],
+        [
+          base.answer,
+          ...distractors(Number(base.answer), [focus, other], rand),
+        ],
         rand,
       ),
     };
@@ -268,14 +347,15 @@ export function timeLimitForAge(age: number) {
  * from the facts so the run still describes and files itself normally.
  */
 export function buildDrill(
-  facts: Array<[number, number]>,
+  factIds: string[],
   base: Pick<FlashConfig, "operation" | "inputMode"> & {
     timeLimitMs?: number | null;
   },
 ): FlashConfig {
-  const unique = [
-    ...new Map(facts.map((f) => [`${f[0]}:${f[1]}`, f])).values(),
-  ];
+  // Back to pairs on the way in: `FlashConfig.facts` is the persisted shape
+  // and `configKey` is built from it, so changing it would orphan every drill
+  // ghost already saved.
+  const unique = [...new Set(factIds)].map(factPair);
   const axis = (pick: 0 | 1) =>
     [...new Set(unique.map((f) => f[pick]))].sort((a, b) => a - b);
   return {

--- a/src/engine/decks/registry.ts
+++ b/src/engine/decks/registry.ts
@@ -1,0 +1,19 @@
+import { OPERATIONS } from "./flashcards";
+import { UNKNOWN_DECK, type DeckSpec } from "./spec";
+
+/**
+ * Every deck family the app knows how to read, keyed by `Session.mode`.
+ *
+ * A static object rather than a `register()` call at import time: the games
+ * are code-split islands, so a self-registering deck would only exist in the
+ * bundle that plays it — and the record book, which renders every mode a
+ * player has ever raced, is on a different route entirely.
+ */
+const DECKS: Record<string, DeckSpec> = { ...OPERATIONS };
+
+/** Never throws. See `UNKNOWN_DECK` for why a missing deck is expected. */
+export function deckSpec(mode: string): DeckSpec {
+  return DECKS[mode] ?? UNKNOWN_DECK;
+}
+
+export type { DeckSpec };

--- a/src/engine/decks/spec.ts
+++ b/src/engine/decks/spec.ts
@@ -1,0 +1,57 @@
+/**
+ * What every family of decks has to be able to say about its own cards.
+ *
+ * The race loop, XP, ghosts, badges and the record book work off `Card` and
+ * `CardResult` and know nothing about arithmetic. The three things they can't
+ * do generically are here: fold two cards onto one fact, name a fact on
+ * screen, and decide whether what a player typed matches the answer. Each is
+ * a judgement only the deck family can make — 7×8 and 8×7 are one fact while
+ * 21÷3 and 21÷7 are two, and "Cat" is a correct spelling of "cat" while "07"
+ * is only a correct sum because leading zeros don't count.
+ */
+export type DeckSpec = {
+  /** Matches `Session.mode`, so a saved run can find its way back here. */
+  id: string;
+  label: string;
+
+  /**
+   * The cell this fact occupies in the mastery view. Folds facts that are
+   * really the same question asked two ways.
+   */
+  masteryKey(factId: string): string;
+
+  /**
+   * The identity a practice deck rebuilds the card from. Usually the same as
+   * `masteryKey`, but not always: the mastery grid is deliberately lossy for
+   * division (21÷3 and 21÷7 share a square) where a drill must not be.
+   */
+  drillKey(factId: string): string;
+
+  /** How the fact reads on screen — "7 × 8", or just the word. */
+  factLabel(factId: string): string;
+
+  /**
+   * Both sides of an answer comparison pass through this before `===`. It is
+   * the whole of the marking rule, so widening it forgives more answers
+   * everywhere at once.
+   */
+  normalise(input: string): string;
+};
+
+/**
+ * Stands in for a deck that isn't in the registry.
+ *
+ * Sessions outlive the decks they were played on: a parent deletes the
+ * spelling list from three months ago and every race on it is still in the
+ * record book. Returning this instead of throwing means those runs keep their
+ * times, their XP and their place in the history — they just stop
+ * contributing to a mastery view that no longer has anything to show.
+ */
+export const UNKNOWN_DECK: DeckSpec = {
+  id: "unknown",
+  label: "Retired deck",
+  masteryKey: (factId) => factId,
+  drillKey: (factId) => factId,
+  factLabel: (factId) => factId,
+  normalise: (input) => input.trim(),
+};

--- a/src/engine/migrate.test.ts
+++ b/src/engine/migrate.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { readCard, readSession, readSessions } from "./migrate";
+import type { CardResult, LegacyCardResult, LegacySession } from "./types";
+
+/**
+ * The one piece of this codebase that reads data it did not write.
+ *
+ * Every race a child has ever run is in IndexedDB and nowhere else — there is
+ * no server holding a copy — so a mistake here is not a bug that gets fixed in
+ * the next deploy, it is a record book that silently stops adding up.
+ */
+
+const legacyCard = (
+  over: Partial<LegacyCardResult> = {},
+): LegacyCardResult => ({
+  prompt: "7 × 8",
+  answer: 56,
+  given: 56,
+  ok: true,
+  ms: 1200,
+  facts: [7, 8],
+  ...over,
+});
+
+const legacySession = (cards: LegacyCardResult[]): LegacySession => ({
+  id: "s1",
+  profileId: "p1",
+  game: "flashcards",
+  mode: "multiply",
+  configKey: "multiply|7|1.2|2|type",
+  config: {
+    operation: "multiply",
+    tables: [7],
+    others: [1, 2],
+    cardCount: 2,
+    inputMode: "type",
+  },
+  seed: 42,
+  finishedAt: "2026-08-01T10:00:00.000Z",
+  durationMs: 2400,
+  correct: 2,
+  incorrect: 0,
+  bestStreak: 2,
+  xpEarned: 30,
+  ghostSessionId: null,
+  beatGhost: null,
+  cards,
+});
+
+describe("readCard", () => {
+  it("widens a numeric answer and given to text", () => {
+    expect(readCard(legacyCard())).toMatchObject({ answer: "56", given: "56" });
+  });
+
+  it("keeps a timed-out card's missing answer as null, not the string 'null'", () => {
+    // `String(null)` is "null", which would render as a wrong answer of
+    // literally "null" on the splits table and never compare equal to anything.
+    const card = readCard(
+      legacyCard({ given: null, ok: false, timedOut: true }),
+    );
+    expect(card.given).toBeNull();
+  });
+
+  it("turns the ordered pair into a fact id and drops the old key", () => {
+    const card = readCard(legacyCard({ facts: [3, 7] }));
+    expect(card.factId).toBe("3:7");
+    expect("facts" in card).toBe(false);
+  });
+
+  it("preserves the pair's order, because division depends on it", () => {
+    // 21 ÷ 3 was built as focus 3, other 7. Folding it here would make it
+    // indistinguishable from 21 ÷ 7 and merge two separate drills.
+    expect(readCard(legacyCard({ facts: [3, 7] })).factId).toBe("3:7");
+    expect(readCard(legacyCard({ facts: [7, 3] })).factId).toBe("7:3");
+  });
+
+  it("returns an already-widened card by identity", () => {
+    // Not just equal — the same object. A normal load runs this over every
+    // card of every run, and re-allocating them all would be pure waste.
+    const current: CardResult = {
+      prompt: "7 × 8",
+      answer: "56",
+      given: "56",
+      ok: true,
+      ms: 1200,
+      factId: "7:8",
+    };
+    expect(readCard(current)).toBe(current);
+  });
+
+  it("is idempotent", () => {
+    const once = readCard(legacyCard());
+    expect(readCard(once)).toEqual(once);
+  });
+});
+
+describe("readSession", () => {
+  it("returns a session that needs nothing by identity", () => {
+    const current = readSession(legacySession([legacyCard()]));
+    expect(readSession(current)).toBe(current);
+  });
+
+  it("widens every card in a session", () => {
+    const migrated = readSession(
+      legacySession([
+        legacyCard(),
+        legacyCard({ facts: [7, 9], answer: 63, given: 62, ok: false }),
+      ]),
+    );
+    expect(migrated.cards.map((c) => c.answer)).toEqual(["56", "63"]);
+    expect(migrated.cards.map((c) => c.factId)).toEqual(["7:8", "7:9"]);
+  });
+
+  it("leaves everything that isn't a card alone", () => {
+    const before = legacySession([legacyCard()]);
+    const after = readSession(before);
+    expect(after.durationMs).toBe(before.durationMs);
+    expect(after.xpEarned).toBe(before.xpEarned);
+    expect(after.configKey).toBe(before.configKey);
+    expect(after.seed).toBe(before.seed);
+  });
+
+  it("survives a card with no fact information at all", () => {
+    // Not a shape we ever wrote, but a hand-edited backup could carry it, and
+    // a thrown exception here fails the whole hub's initial load.
+    const orphan = { ...legacyCard(), facts: undefined };
+    expect(() => readSessions([legacySession([orphan])])).not.toThrow();
+  });
+});

--- a/src/engine/migrate.ts
+++ b/src/engine/migrate.ts
@@ -1,0 +1,53 @@
+import type {
+  CardResult,
+  LegacyCardResult,
+  LegacySession,
+  Session,
+} from "./types";
+
+/**
+ * Reading runs that were saved before answers became text.
+ *
+ * Every race played up to 2026-08-13 stored a numeric `answer`/`given` and an
+ * ordered `facts` pair. Widening the card (see `Card` in `types.ts`) left that
+ * data on disk in a shape the engine no longer types.
+ *
+ * This runs on the way out of storage rather than as an IndexedDB upgrade, and
+ * that is a deliberate trade. An upgrade would retire the legacy branch for
+ * good, but it rewrites the only copy of data that by design exists nowhere
+ * else — there is no server holding a spare. A read-time widening is
+ * idempotent, costs one pass over a list already being deserialised, and
+ * cannot corrupt anything: the worst case is that it does nothing.
+ *
+ * So the branch below is permanent. Deleting it deletes years of a child's
+ * record book.
+ */
+
+/** Already-widened cards pass straight through, so a normal load allocates nothing. */
+const isCurrent = (card: LegacyCardResult | CardResult): card is CardResult =>
+  typeof card.answer === "string" && typeof card.factId === "string";
+
+export function readCard(card: LegacyCardResult | CardResult): CardResult {
+  if (isCurrent(card)) return card;
+  const { facts, ...rest } = card as LegacyCardResult;
+  return {
+    ...rest,
+    answer: String(card.answer),
+    // A timeout genuinely has no answer, and `String(null)` is "null".
+    given:
+      card.given === null || card.given === undefined
+        ? null
+        : String(card.given),
+    // Ordered as it was built, exactly as `arithmeticFactId` writes it, so a
+    // migrated run folds onto the same grid square as a fresh one.
+    factId: card.factId ?? (facts ? `${facts[0]}:${facts[1]}` : ""),
+  };
+}
+
+export function readSession(session: LegacySession | Session): Session {
+  if (session.cards.every(isCurrent)) return session as Session;
+  return { ...session, cards: session.cards.map(readCard) };
+}
+
+export const readSessions = (sessions: Array<LegacySession | Session>) =>
+  sessions.map(readSession);

--- a/src/engine/progress.ts
+++ b/src/engine/progress.ts
@@ -1,4 +1,5 @@
-import type { Operation, Session } from "@/engine/types";
+import { OPERATION_ORDER } from "@/engine/decks/flashcards";
+import type { Session } from "@/engine/types";
 
 /* ── Levels ──────────────────────────────────────────────────────────────
    Cumulative XP to reach level n is 125·n·(n−1), so early levels come fast
@@ -218,9 +219,10 @@ export function evaluateBadges({
     earned.add("beat-the-clock");
   if (session.config.facts?.length && perfect) earned.add("nemesis");
 
-  const operations = new Set<Operation>(history.map((s) => s.mode));
-  operations.add(session.mode);
-  if (operations.size >= 4) earned.add("all-rounder");
+  // Named outright rather than counted to four: `mode` also holds word-list
+  // ids now, and four spelling decks are not "all four operations".
+  const raced = new Set([session.mode, ...history.map((s) => s.mode)]);
+  if (OPERATION_ORDER.every((op) => raced.has(op))) earned.add("all-rounder");
 
   return [...earned];
 }

--- a/src/engine/records.test.ts
+++ b/src/engine/records.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import { factStats, factsToDrill, masteryOf, troubleFacts } from "./records";
+import type { CardResult, Session } from "./types";
+
+/**
+ * What counts as "the same fact" is now the deck's answer, not this module's.
+ * These pin the two rules that used to be a hard-coded table here, because
+ * getting either one wrong is invisible: the record book still renders, it
+ * just quietly merges or splits facts that shouldn't be.
+ */
+
+const card = (over: Partial<CardResult> = {}): CardResult => ({
+  prompt: "7 × 8",
+  answer: "56",
+  given: "56",
+  ok: true,
+  ms: 1200,
+  factId: "7:8",
+  ...over,
+});
+
+const session = (mode: string, cards: CardResult[]): Session => ({
+  id: `s-${mode}-${cards.length}`,
+  profileId: "p1",
+  game: "flashcards",
+  mode,
+  configKey: "k",
+  config: {
+    operation: "multiply",
+    tables: [7],
+    others: [8],
+    cardCount: cards.length,
+    inputMode: "type",
+  },
+  seed: 1,
+  finishedAt: "2026-08-01T10:00:00.000Z",
+  durationMs: cards.reduce((sum, c) => sum + c.ms, 0),
+  correct: cards.filter((c) => c.ok).length,
+  incorrect: cards.filter((c) => !c.ok).length,
+  bestStreak: 0,
+  xpEarned: 0,
+  ghostSessionId: null,
+  beatGhost: null,
+  cards,
+});
+
+describe("factStats", () => {
+  it("folds a commutative pair onto one square", () => {
+    const grid = factStats(
+      [session("multiply", [card({ factId: "7:8" }), card({ factId: "8:7" })])],
+      "multiply",
+    );
+    expect(grid.size).toBe(1);
+    expect(grid.get("7:8")?.attempts).toBe(2);
+  });
+
+  it("folds division too, because the map is deliberately symmetric", () => {
+    // 21 ÷ 3 and 21 ÷ 7 share a square on the fact map. That is a choice, not
+    // an oversight — the map is a 12×12 grid of number pairs for every
+    // operation. `drillKey` is what keeps the two questions apart.
+    const grid = factStats(
+      [session("divide", [card({ factId: "3:7" }), card({ factId: "7:3" })])],
+      "divide",
+    );
+    expect(grid.size).toBe(1);
+  });
+
+  it("ignores runs from another deck", () => {
+    const grid = factStats(
+      [
+        session("multiply", [card()]),
+        session("divide", [card({ factId: "3:7" })]),
+      ],
+      "multiply",
+    );
+    expect(grid.size).toBe(1);
+    expect(grid.get("7:8")?.attempts).toBe(1);
+  });
+
+  it("accumulates attempts, hits and time", () => {
+    const grid = factStats(
+      [
+        session("multiply", [
+          card({ ms: 1000 }),
+          card({ ms: 3000, ok: false, given: "54" }),
+        ]),
+      ],
+      "multiply",
+    );
+    expect(grid.get("7:8")).toEqual({
+      attempts: 2,
+      correct: 1,
+      totalMs: 4000,
+    });
+  });
+});
+
+describe("troubleFacts", () => {
+  const missed = (factId: string) =>
+    card({ factId, ok: false, given: "1", ms: 5000 });
+
+  it("folds a commutative pair into one entry", () => {
+    const trouble = troubleFacts(
+      [session("multiply", [missed("7:8"), missed("8:7")])],
+      "multiply",
+    );
+    expect(trouble).toHaveLength(1);
+    expect(trouble[0].attempts).toBe(2);
+  });
+
+  it("keeps division's two questions apart", () => {
+    // 21 ÷ 3 = 7 and 21 ÷ 7 = 3 are different things to practise, so a kid who
+    // only misses one must not be drilled on both.
+    const trouble = troubleFacts(
+      [session("divide", [missed("3:7"), missed("7:3")])],
+      "divide",
+    );
+    expect(trouble).toHaveLength(2);
+    expect(trouble.map((t) => t.factId).sort()).toEqual(["3:7", "7:3"]);
+  });
+
+  it("drops a fact once it's being answered quickly and correctly", () => {
+    const quick = Array.from({ length: 6 }, () => card({ ms: 900 }));
+    const trouble = troubleFacts(
+      [session("multiply", [missed("7:8"), ...quick])],
+      "multiply",
+    );
+    expect(trouble).toHaveLength(0);
+  });
+
+  it("ranks by how much trouble, worst first", () => {
+    const trouble = troubleFacts(
+      [
+        session("multiply", [
+          missed("7:8"),
+          missed("7:8"),
+          card({ factId: "6:6", ms: 9000 }),
+        ]),
+      ],
+      "multiply",
+    );
+    expect(trouble[0].factId).toBe("7:8");
+  });
+});
+
+describe("factsToDrill", () => {
+  it("de-duplicates through the deck's drill key", () => {
+    expect(
+      factsToDrill(
+        [card({ factId: "7:8" }), card({ factId: "8:7" })],
+        "multiply",
+      ),
+    ).toEqual(["7:8"]);
+  });
+
+  it("leaves division's pairs alone", () => {
+    expect(
+      factsToDrill(
+        [card({ factId: "3:7" }), card({ factId: "7:3" })],
+        "divide",
+      ),
+    ).toEqual(["3:7", "7:3"]);
+  });
+});
+
+describe("a deck that no longer exists", () => {
+  // A parent deletes last term's spelling list; every race on it stays in the
+  // record book. Throwing here would take down the whole Progress screen.
+  it("still reports stats, keyed by the raw fact id", () => {
+    const runs = [session("week-12-spellings", [card({ factId: "because" })])];
+    expect(() => factStats(runs, "week-12-spellings")).not.toThrow();
+    expect([...factStats(runs, "week-12-spellings").keys()]).toEqual([
+      "because",
+    ]);
+  });
+
+  it("still ranks its trouble spots", () => {
+    const runs = [
+      session("week-12-spellings", [
+        card({ factId: "because", ok: false, ms: 6000 }),
+      ]),
+    ];
+    expect(troubleFacts(runs, "week-12-spellings")[0].factId).toBe("because");
+  });
+});
+
+describe("masteryOf", () => {
+  it("needs speed as well as accuracy", () => {
+    // Right every time but worked out rather than recalled.
+    expect(masteryOf({ attempts: 10, correct: 10, totalMs: 10 * 6000 })).toBe(
+      "solid",
+    );
+    expect(masteryOf({ attempts: 10, correct: 10, totalMs: 10 * 1500 })).toBe(
+      "mastered",
+    );
+  });
+
+  it("calls an untouched fact untried, not wrong", () => {
+    expect(masteryOf(undefined)).toBe("untried");
+  });
+});

--- a/src/engine/records.ts
+++ b/src/engine/records.ts
@@ -2,10 +2,11 @@ import type {
   CardResult,
   FlashConfig,
   Ghost,
-  Operation,
   Profile,
   Session,
 } from "@/engine/types";
+
+import { deckSpec } from "@/engine/decks/registry";
 
 export const accuracyOf = (session: Pick<Session, "correct" | "incorrect">) => {
   const total = session.correct + session.incorrect;
@@ -136,49 +137,30 @@ export function lifetimeStats(sessions: Session[]): Lifetime {
 }
 
 /* ── Per-fact mastery ────────────────────────────────────────────────────
-   Facts are keyed by their unordered pair, so 7×8 and 8×7 feed the same
-   cell of the grid.                                                       */
+   Which cards count as the same fact is the deck's call, not this module's:
+   see `DeckSpec.masteryKey` and `DeckSpec.drillKey`. Everything here works
+   off the keys they return, which is what lets a spelling list accumulate
+   mastery through the same code as the times tables.                      */
 
 export type FactStat = { attempts: number; correct: number; totalMs: number };
 
+/** The arithmetic grid cell for a pair. Must agree with `masteryKey`. */
 export const factKey = (a: number, b: number) =>
   `${Math.min(a, b)}:${Math.max(a, b)}`;
 
-/**
- * 7 × 8 and 8 × 7 are the same fact; 21 ÷ 3 and 21 ÷ 7 are not. The fact map
- * is a symmetric 12×12 grid so it folds every operation, but a practice deck
- * has to rebuild the actual problem — and for these two, order carries it.
- */
-const COMMUTATIVE: Record<Operation, boolean> = {
-  multiply: true,
-  add: true,
-  divide: false,
-  subtract: false,
-};
-
-/** The pair as a drill needs it: folded only where the operation allows. */
-const drillPair = (
-  [a, b]: [number, number],
-  operation: Operation,
-): [number, number] =>
-  COMMUTATIVE[operation] ? [Math.min(a, b), Math.max(a, b)] : [a, b];
-
 /** De-duplicated facts behind a set of cards, ready to build a practice deck. */
-export function factsToDrill(cards: CardResult[], operation: Operation) {
-  const out = new Map<string, [number, number]>();
-  for (const card of cards) {
-    const pair = drillPair(card.facts, operation);
-    out.set(`${pair[0]}:${pair[1]}`, pair);
-  }
-  return [...out.values()];
+export function factsToDrill(cards: CardResult[], mode: string): string[] {
+  const spec = deckSpec(mode);
+  return [...new Set(cards.map((card) => spec.drillKey(card.factId)))];
 }
 
-export function factStats(sessions: Session[], operation: Operation) {
+export function factStats(sessions: Session[], mode: string) {
+  const spec = deckSpec(mode);
   const grid = new Map<string, FactStat>();
   for (const session of sessions) {
-    if (session.mode !== operation) continue;
+    if (session.mode !== mode) continue;
     for (const card of session.cards) {
-      const key = factKey(card.facts[0], card.facts[1]);
+      const key = spec.masteryKey(card.factId);
       const entry = grid.get(key) ?? { attempts: 0, correct: 0, totalMs: 0 };
       entry.attempts += 1;
       if (card.ok) entry.correct += 1;
@@ -210,8 +192,8 @@ export function masteryOf(stat: FactStat | undefined): Mastery {
    ones that were right but visibly counted out.                           */
 
 export type TroubleFact = {
-  key: string;
-  facts: [number, number];
+  /** The deck's drill key — both this fact's identity and its map key. */
+  factId: string;
   attempts: number;
   /** The per-card clock ran out. */
   timeouts: number;
@@ -230,19 +212,18 @@ export type TroubleFact = {
  */
 export function troubleFacts(
   sessions: Session[],
-  operation: Operation,
+  mode: string,
   take = 8,
 ): TroubleFact[] {
+  const spec = deckSpec(mode);
   const seen = new Map<string, TroubleFact>();
 
   for (const session of sessions) {
-    if (session.mode !== operation) continue;
+    if (session.mode !== mode) continue;
     for (const card of session.cards) {
-      const facts = drillPair(card.facts, operation);
-      const key = `${facts[0]}:${facts[1]}`;
-      const entry = seen.get(key) ?? {
-        key,
-        facts,
+      const factId = spec.drillKey(card.factId);
+      const entry = seen.get(factId) ?? {
+        factId,
         attempts: 0,
         timeouts: 0,
         wrong: 0,
@@ -259,7 +240,7 @@ export function troubleFacts(
       else if (!card.ok) entry.wrong += 1;
       else if (card.ms >= MASTERY_PACE_MS) entry.slow += 1;
       else entry.score -= 1;
-      seen.set(key, entry);
+      seen.set(factId, entry);
     }
   }
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -47,23 +47,40 @@ export type LegacyFlashConfig = Omit<FlashConfig, "others"> & {
   otherMax?: number;
 };
 
+/* ── Cards ───────────────────────────────────────────────────────────────
+   A card is text in and text out, deliberately. Answers were numbers until
+   spelling arrived, and every alternative to widening them was worse: a
+   `number | string` union puts a branch at every comparison, and a generic
+   `Card<T>` leaks type parameters into components that only ever render the
+   thing. What a deck family *does* know about its own answers — how to
+   compare "07" with "7", or "Cat" with "cat" — lives on its `DeckSpec`.     */
+
 export type Card = {
   /** Rendered prompt, e.g. "7 × 8". */
   prompt: string;
-  answer: number;
+  /** Text even when it's a number: "56", not 56. Compared via the spec. */
+  answer: string;
   /** Shuffled options, present only in multiple-choice mode. */
-  choices?: number[];
-  /** The two numbers the card exercises, for the mastery grid. */
-  facts: [number, number];
+  choices?: string[];
+  /**
+   * Which fact this card exercises, as the deck built it — "7:8" for
+   * arithmetic, the word itself for spelling. Stable across runs, because
+   * mastery and trouble spots accumulate against it for years.
+   *
+   * Ordered as built. Folding 7×8 and 8×7 into one cell is the deck spec's
+   * job, not this field's: 21÷3 and 21÷7 must not fold, and only the spec
+   * knows which of the two it is.
+   */
+  factId: string;
 };
 
 export type CardResult = {
   prompt: string;
-  answer: number;
-  given: number | null;
+  answer: string;
+  given: string | null;
   ok: boolean;
   ms: number;
-  facts: [number, number];
+  factId: string;
   /**
    * The per-card clock ran out before an answer arrived. Distinct from a wrong
    * answer: it's what "didn't solve it in time" means, and it's what the
@@ -72,11 +89,33 @@ export type CardResult = {
   timedOut?: boolean;
 };
 
+/**
+ * Cards as they were written before answers became text — numeric answers and
+ * an ordered pair instead of a fact id. Every run saved up to 2026-08-13 is
+ * this shape, so `readSession` widens them on the way out of storage.
+ */
+export type LegacyCardResult = Omit<
+  CardResult,
+  "answer" | "given" | "factId"
+> & {
+  answer: number | string;
+  given: number | string | null;
+  factId?: string;
+  facts?: [number, number];
+};
+
 export type Session = {
   id: string;
   profileId: string;
   game: "flashcards";
-  mode: Operation;
+  /**
+   * Which deck within the game — an `Operation` today, a word-list id once
+   * spelling lands. A plain string rather than a union because custom decks
+   * are user-named, and because a session must still load after the deck it
+   * was played on has been deleted. `deckSpec()` resolves it, and answers for
+   * anything it doesn't recognise.
+   */
+  mode: string;
   configKey: string;
   config: FlashConfig;
   seed: number;
@@ -89,6 +128,11 @@ export type Session = {
   ghostSessionId: string | null;
   beatGhost: boolean | null;
   cards: CardResult[];
+};
+
+/** A session as it may sit in storage, with cards from before the widening. */
+export type LegacySession = Omit<Session, "cards"> & {
+  cards: LegacyCardResult[];
 };
 
 export type HubState = {

--- a/src/games/flashcards/RaceResults.tsx
+++ b/src/games/flashcards/RaceResults.tsx
@@ -101,7 +101,9 @@ export default function RaceResults() {
     start({
       profileId: profile!.id,
       config: buildDrill(missedFacts, {
-        operation: session.mode,
+        // From the config, not from `mode`: same value, but `mode` is a plain
+        // string now and a drill is only ever arithmetic.
+        operation: session.config.operation,
         inputMode: session.config.inputMode,
         timeLimitMs: limitMs,
       }),

--- a/src/games/flashcards/RaceTrack.tsx
+++ b/src/games/flashcards/RaceTrack.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
-import { buildDeck, configKey } from "@/engine/decks/flashcards";
+import { OPERATIONS, buildDeck, configKey } from "@/engine/decks/flashcards";
 import {
   WRONG_ANSWER_PENALTY_MS,
   bestRun,
@@ -87,6 +87,8 @@ function Track({
   const { config, seed, ghost } = pending;
   /** Fixed for the whole run — a mid-race change isn't a thing. */
   const limitMs = config.timeLimitMs ?? null;
+  /** Owns the marking rule; see `DeckSpec.normalise`. Constant for the race. */
+  const spec = OPERATIONS[config.operation];
   const deck = useMemo(() => buildDeck(config, seed), [config, seed]);
   const ghostSplits = useMemo(
     () => (ghost ? cumulativeSplits(ghost.session) : null),
@@ -120,7 +122,7 @@ function Track({
    * times out, and `submit` needs the clock to bank the time. The ref lets the
    * clock be created first and still reach the real handler.
    */
-  const submitRef = useRef<(value: number | null) => void>(() => {});
+  const submitRef = useRef<(value: string | null) => void>(() => {});
 
   const card = deck[index];
   const total = deck.length;
@@ -192,7 +194,7 @@ function Track({
 
   /** `null` means the card's clock ran out before an answer arrived. */
   const submit = useCallback(
-    (value: number | null) => {
+    (value: string | null) => {
       const { phase, feedback, card, streak, total, limitMs } = live.current;
       if (phase !== "racing" || feedback !== null || hasFinished()) return;
       const lateOut = value === null;
@@ -200,7 +202,10 @@ function Track({
       // saved split all agree even if the timer fires a frame or two late.
       // Whole milliseconds keep the saved file readable and the totals exact.
       const ms = lateOut ? limitMs! : Math.round(onCard());
-      const ok = !lateOut && value === card.answer;
+      // Both sides through `normalise`, so "07" marks the same as "7" — and
+      // so that a deck can forgive more without this line changing.
+      const ok =
+        !lateOut && spec.normalise(value) === spec.normalise(card.answer);
       bank(ms);
       if (lateOut) spendFuse();
       results.current.push({
@@ -209,7 +214,7 @@ function Track({
         given: value,
         ok,
         ms,
-        facts: card.facts,
+        factId: card.factId,
         ...(lateOut && { timedOut: true }),
       });
 
@@ -247,7 +252,7 @@ function Track({
       // Every other value above comes from a ref; these are all pinned with
       // empty dependency lists precisely so this callback can stay stable.
     },
-    [bank, spendFuse, onCard, startCard, hasFinished],
+    [bank, spendFuse, onCard, startCard, hasFinished, spec],
   );
   submitRef.current = submit;
 
@@ -268,7 +273,7 @@ function Track({
     active: phase === "racing" && feedback === null,
     inputMode: config.inputMode,
     choices: card.choices,
-    answerLength: String(card.answer).length,
+    answerLength: card.answer.length,
     entry,
     entryRef,
     submit,
@@ -343,9 +348,7 @@ function Track({
         disabled={settled}
         onDigit={pushDigit}
         onBack={dropDigit}
-        onEnter={() =>
-          entryRef.current !== "" && submit(Number(entryRef.current))
-        }
+        onEnter={() => entryRef.current !== "" && submit(entryRef.current)}
         onChoose={submit}
       />
 

--- a/src/games/flashcards/race/AnswerPad.tsx
+++ b/src/games/flashcards/race/AnswerPad.tsx
@@ -19,12 +19,12 @@ export function AnswerPad({
   onChoose,
 }: {
   mode: InputMode;
-  choices: number[] | undefined;
+  choices: string[] | undefined;
   disabled: boolean;
   onDigit: (digit: string) => void;
   onBack: () => void;
   onEnter: () => void;
-  onChoose: (choice: number) => void;
+  onChoose: (choice: string) => void;
 }) {
   if (mode === "choose") {
     return (

--- a/src/games/flashcards/race/types.ts
+++ b/src/games/flashcards/race/types.ts
@@ -1,5 +1,5 @@
 /** How the card that just landed was answered, or null while it's still live. */
 export type Feedback = {
   kind: "right" | "wrong" | "timeout";
-  given: number | null;
+  given: string | null;
 } | null;

--- a/src/games/flashcards/race/useRaceKeyboard.ts
+++ b/src/games/flashcards/race/useRaceKeyboard.ts
@@ -24,12 +24,12 @@ export function useRaceKeyboard({
   /** Racing, and no card currently showing feedback. */
   active: boolean;
   inputMode: InputMode;
-  choices: number[] | undefined;
+  choices: string[] | undefined;
   /** Digits in the current card's answer, for the auto-submit below. */
   answerLength: number;
   entry: string;
   entryRef: React.RefObject<string>;
-  submit: (value: number | null) => void;
+  submit: (value: string | null) => void;
   pushDigit: (digit: string) => void;
   dropDigit: () => void;
 }) {
@@ -52,7 +52,7 @@ export function useRaceKeyboard({
         dropDigit();
       } else if (event.key === "Enter") {
         event.preventDefault();
-        if (entryRef.current !== "") submit(Number(entryRef.current));
+        if (entryRef.current !== "") submit(entryRef.current);
       }
     }
     window.addEventListener("keydown", onKey);
@@ -64,8 +64,7 @@ export function useRaceKeyboard({
   useEffect(() => {
     if (!active || inputMode !== "type") return;
     if (entry.length > 0 && entry.length === answerLength) {
-      const value = Number(entry);
-      const timer = window.setTimeout(() => submit(value), 90);
+      const timer = window.setTimeout(() => submit(entry), 90);
       return () => window.clearTimeout(timer);
     }
   }, [active, inputMode, entry, answerLength, submit]);

--- a/src/games/flashcards/setup/DeckPicker.tsx
+++ b/src/games/flashcards/setup/DeckPicker.tsx
@@ -1,5 +1,8 @@
 import { Button } from "@/components/ui/kit";
-import type { OperationSpec } from "@/engine/decks/flashcards";
+import {
+  arithmeticFactId,
+  type OperationSpec,
+} from "@/engine/decks/flashcards";
 import type { FlashConfig } from "@/engine/types";
 
 /**
@@ -48,7 +51,7 @@ export function DeckPicker({
         <ul className="factchips">
           {drill.map(([a, b]) => (
             <li key={`${a}:${b}`} className="factchip u-mono">
-              {a} {spec.symbol} {b}
+              {spec.factLabel(arithmeticFactId(a, b))}
             </li>
           ))}
         </ul>

--- a/src/services/storage/db.ts
+++ b/src/services/storage/db.ts
@@ -1,6 +1,7 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 
-import type { Profile, Session } from "@/engine/types";
+import { readSession, readSessions } from "@/engine/migrate";
+import type { LegacySession, Profile, Session } from "@/engine/types";
 
 /**
  * The only module in the codebase allowed to touch browser storage.
@@ -27,7 +28,12 @@ interface HubDB extends DBSchema {
   profiles: { key: string; value: Profile };
   sessions: {
     key: string;
-    value: Session;
+    /**
+     * Typed as the wider shape because that is honestly what's in there: runs
+     * saved before the card widened are still on disk in their original form.
+     * Reads go through `readSession`, which is where they become `Session`.
+     */
+    value: LegacySession;
     indexes: { byProfile: string };
   };
 }
@@ -72,7 +78,7 @@ export async function allProfiles(): Promise<Profile[]> {
 }
 
 export async function allSessions(): Promise<Session[]> {
-  return (await db()).getAll("sessions");
+  return readSessions(await (await db()).getAll("sessions"));
 }
 
 export async function putProfile(profile: Profile): Promise<void> {
@@ -142,7 +148,12 @@ export type Backup = {
   version: 1;
   exportedAt: string;
   profiles: Profile[];
-  sessions: Session[];
+  /**
+   * Written current, read wide. A file exported today holds widened cards, but
+   * one exported last week — or produced by `scripts/convert-legacy-hub.mjs`
+   * — does not, and restoring an old backup is the whole point of having one.
+   */
+  sessions: Array<LegacySession | Session>;
 };
 
 export async function exportAll(): Promise<Backup> {
@@ -180,7 +191,12 @@ export async function importAll(
   }
   await Promise.all([
     ...backup.profiles.map((p) => tx.objectStore("profiles").put(p)),
-    ...backup.sessions.map((s) => tx.objectStore("sessions").put(s)),
+    // Widened on the way in, so a restored run is stored in the shape a fresh
+    // one would be. Reads migrate anyway; this just stops the file's age from
+    // outliving the import.
+    ...backup.sessions.map((s) =>
+      tx.objectStore("sessions").put(readSession(s)),
+    ),
   ]);
   await tx.done;
   return {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,25 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+/**
+ * The engine suite runs in plain Node, with no Astro and no browser.
+ *
+ * That is the point of the model boundary: `src/engine/` is banned from
+ * importing React or Astro (see block A of `eslint.config.mjs`), so scoring,
+ * mastery and the deck registry can be exercised as ordinary functions over
+ * plain data — no DOM, no `client:only` island, no build step.
+ *
+ * The alias has to be restated here. `tsconfig.json` teaches the type checker
+ * what `@/` means and Astro teaches the bundler, but Vitest reads neither.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    include: ["**/*.test.{ts,tsx,mjs}"],
+    exclude: ["node_modules/**", "dist/**", ".sst/**", "e2e/**"],
+  },
+});


### PR DESCRIPTION
Groundwork for #12. No user-visible change except one bug fix, noted below.

## The premise in #12 was wrong

> The card engine was built generic for exactly this — `Card` is not arithmetic-specific.

The *loop* was. Ghost racing, XP, badges, the record book and the fuse never cared what a card asked. The **types** were arithmetic all the way down:

| | Before | After |
| --- | --- | --- |
| `Card.answer` | `number` | `string` |
| `Card.choices` | `number[]` | `string[]` |
| `Card.facts` | `[number, number]` | `factId: string` |
| `CardResult.given` | `number \| null` | `string \| null` |
| `Session.mode` | `Operation` | `string` |
| commutativity | a table inside `records.ts` | the deck's own `drillKey` |

## `DeckSpec`

Three judgements a generic loop can't make. Everything else stays where it is.

- **`masteryKey`** — fold two cards onto one square. 7×8 and 8×7 are one fact.
- **`drillKey`** — fold for practice. 21÷3 and 21÷7 are *two*, so the grid is deliberately lossy where a drill must not be.
- **`normalise`** — the marking rule. Both sides through it before `===`.

`deckSpec(mode)` never throws. Sessions outlive the decks they were played on: delete last term's spelling list and every race on it stays in the record book, keyed by its raw fact id.

## A regression this avoids

`Number("07") === 7` used to forgive a leading zero silently. Straight string equality would have started marking it wrong — a five-year-old on the keypad, told they got 7 × 1 wrong. `normalise` is what keeps it working, and it's the same hook case-insensitive spelling needs.

## Migration

Every run saved before today has numeric answers and a `facts` pair. They're widened **on read**, not by rewriting storage — IndexedDB holds the only copy of a child's record book that exists, and a read-time widening cannot corrupt anything. The branch is permanent and says so.

## The bug that fell out

`factLabel` builds a fact's name from the same `ask` the card is built from. The pair behind "21 ÷ 3 = 7" is `[3, 7]`, and the trouble list and drill chips rendered that literally as **"3 ÷ 7"** — a different, wrong sum. Now they read "21 ÷ 3". Same for subtraction.

Also: "race all four operations" is named rather than counted to four, since a mode can be a word list now and four spelling decks are not an all-rounder.

## Verification

The engine had no tests. It has 47 now, plus a vitest config for the `@/` alias.

More usefully, a throwaway differential suite ran the **old module against the new** over 96 configs — same prompts, answers, facts, choices, `configKey`s, drills, descriptions and presets. It caught two things I'd have shipped:

- the prompt coin landing the wrong way up, so decks read "7 × 2" where they used to read "2 × 7";
- division drawing a random number it never used to, which would have rebuilt every saved run's deck as a different one.

Every new guard mutation-checked — six mutations, each failing exactly the tests it should.

Browser-verified against a real race: both input modes mark correctly, the leading zero survives, and a **legacy-shaped session seeded straight into IndexedDB** reaches the fact map, the trouble list, the run list and a playable drill. Zero console errors.

`type-check` 0 errors · `lint` clean · 68 unit · 17 pages built.