### PR TITLE
Word lists a parent types in (GAME03)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,4 +99,12 @@ them between games.
 may race each other as ghosts, so changing its format orphans every personal
 best already saved. Cards written before a shape change are widened on read by
 `src/engine/migrate.ts` — never by rewriting storage, because IndexedDB holds
-the only copy there is.
+the only copy there is. Adding a store is a `DB_VERSION` bump with an
+`oldVersion`-guarded block in `db.ts`; those blocks are additive only.
+
+**Parent-authored decks live in storage but are read from the engine.**
+`src/services/decks.ts` is the only writer, and it mirrors them into the engine
+(`setCustomLists`) so `deckSpec(mode)` can name one from the record book
+without the engine knowing storage exists. Every write goes through
+`HubContext.saveDeck` — a service call that bypasses it lands in IndexedDB and
+stays invisible until the next reload.

--- a/src/components/BackupPanel.tsx
+++ b/src/components/BackupPanel.tsx
@@ -17,7 +17,7 @@ import { sfx } from "@/services/sound";
  * the same file is idempotent rather than duplicating every run.
  */
 export default function BackupPanel() {
-  const { profiles, sessions, reload, notify } = useHub();
+  const { profiles, sessions, decks, reload, notify } = useHub();
   const [busy, setBusy] = useState(false);
 
   async function download() {
@@ -31,7 +31,10 @@ export default function BackupPanel() {
     link.download = `school-skills-${backup.exportedAt.slice(0, 10)}.json`;
     link.click();
     URL.revokeObjectURL(url);
-    notify(`Saved ${profiles.length} players and ${sessions.length} races`);
+    notify(
+      `Saved ${profiles.length} players, ${sessions.length} races` +
+        (decks.length ? ` and ${decks.length} word lists` : ""),
+    );
   }
 
   async function restore(file: File) {
@@ -52,7 +55,10 @@ export default function BackupPanel() {
       const added = await importAll(backup, "merge");
       await reload();
       sfx.record();
-      notify(`Restored ${added.profiles} players and ${added.sessions} races`);
+      notify(
+        `Restored ${added.profiles} players, ${added.sessions} races` +
+          (added.decks ? ` and ${added.decks} word lists` : ""),
+      );
     } catch (err) {
       notify(
         err instanceof Error ? err.message : "Could not read that file",

--- a/src/components/state/HubContext.tsx
+++ b/src/components/state/HubContext.tsx
@@ -8,25 +8,32 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import * as deckService from "@/services/decks";
 import * as profileService from "@/services/profiles";
 import * as sessionService from "@/services/sessions";
 import { loadHub } from "@/services/hub";
 import type { NewProfile } from "@/services/profiles";
 import type { SessionDraft } from "@/services/sessions";
 import { setSoundEnabled } from "@/services/sound";
-import type { Profile, Session } from "@/engine/types";
+import type { CustomDeck, Profile, Session } from "@/engine/types";
 
 type Toast = { id: number; message: string; tone: "good" | "bad" };
 
 type HubValue = {
   profiles: Profile[];
   sessions: Session[];
+  decks: CustomDeck[];
   status: "loading" | "ready" | "error";
   error: string | null;
   reload: () => Promise<void>;
   createProfile: (profile: NewProfile) => Promise<Profile>;
   updateProfile: (id: string, patch: Partial<Profile>) => Promise<Profile>;
   deleteProfile: (id: string) => Promise<void>;
+  saveDeck: (
+    id: string | null,
+    input: deckService.DeckInput,
+  ) => Promise<CustomDeck>;
+  deleteDeck: (id: string) => Promise<void>;
   saveSession: (
     draft: SessionDraft,
   ) => Promise<{ session: Session; profile: Profile }>;
@@ -39,6 +46,7 @@ const HubContext = createContext<HubValue | null>(null);
 export function HubProvider({ children }: { children: ReactNode }) {
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [sessions, setSessions] = useState<Session[]>([]);
+  const [decks, setDecks] = useState<CustomDeck[]>([]);
   const [status, setStatus] = useState<HubValue["status"]>("loading");
   const [error, setError] = useState<string | null>(null);
   const [toasts, setToasts] = useState<Toast[]>([]);
@@ -61,6 +69,7 @@ export function HubProvider({ children }: { children: ReactNode }) {
       const state = await loadHub();
       setProfiles(state.profiles);
       setSessions(state.sessions);
+      setDecks(state.decks);
       setStatus("ready");
       setError(null);
     } catch (err) {
@@ -74,6 +83,23 @@ export function HubProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     void reload();
   }, [reload]);
+
+  /** One entry point for both new and edited lists — the form is the same. */
+  const saveDeck = useCallback(
+    async (id: string | null, input: deckService.DeckInput) => {
+      const saved = id
+        ? await deckService.update(id, input)
+        : await deckService.create(input);
+      setDecks(await deckService.all());
+      return saved;
+    },
+    [],
+  );
+
+  const deleteDeck = useCallback(async (id: string) => {
+    await deckService.remove(id);
+    setDecks(await deckService.all());
+  }, []);
 
   const createProfile = useCallback(async (profile: NewProfile) => {
     const created = await profileService.create(profile);
@@ -109,12 +135,15 @@ export function HubProvider({ children }: { children: ReactNode }) {
     () => ({
       profiles,
       sessions,
+      decks,
       status,
       error,
       reload,
       createProfile,
       updateProfile,
       deleteProfile,
+      saveDeck,
+      deleteDeck,
       saveSession,
       notify,
       toasts,
@@ -122,12 +151,15 @@ export function HubProvider({ children }: { children: ReactNode }) {
     [
       profiles,
       sessions,
+      decks,
       status,
       error,
       reload,
       createProfile,
       updateProfile,
       deleteProfile,
+      saveDeck,
+      deleteDeck,
       saveSession,
       notify,
       toasts,

--- a/src/components/ui/TextArea.tsx
+++ b/src/components/ui/TextArea.tsx
@@ -1,0 +1,39 @@
+import type { Ref, TextareaHTMLAttributes } from "react";
+
+/**
+ * Multi-line text entry.
+ *
+ * `onChange` hands over the string rather than the event, matching `Input` —
+ * the kit is consistent with itself, and no call site has ever wanted anything
+ * but `event.target.value`.
+ *
+ * There is exactly one caller today (pasting a week's spellings in), and one
+ * caller is enough: the native-controls ban has no exceptions, and adding the
+ * primitive is the whole point of having a kit. Everything a textarea
+ * understands — `rows`, `maxLength`, `spellCheck`, `placeholder`, `ref` —
+ * passes through.
+ */
+export interface TextAreaProps extends Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  "onChange" | "value"
+> {
+  value: string;
+  onChange: (value: string) => void;
+  ref?: Ref<HTMLTextAreaElement>;
+}
+
+export function TextArea({
+  value,
+  onChange,
+  className = "field__input field__input--multi",
+  ...rest
+}: TextAreaProps) {
+  return (
+    <textarea
+      className={className}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      {...rest}
+    />
+  );
+}

--- a/src/components/ui/kit.tsx
+++ b/src/components/ui/kit.tsx
@@ -14,6 +14,7 @@ export {
   type ButtonVariant,
 } from "./Button";
 export { Input, type InputProps } from "./Input";
+export { TextArea, type TextAreaProps } from "./TextArea";
 export { Field, FieldSet } from "./Field";
 export { Select, type SelectOption, type SelectProps } from "./Select";
 

--- a/src/engine/decks/customlists.test.ts
+++ b/src/engine/decks/customlists.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildWordDeck,
+  setCustomLists,
+  wordDeckSpec,
+  wordMode,
+  wordsOf,
+} from "./words";
+import { deckSpec } from "./index";
+import type { WordConfig } from "@/engine/types";
+
+/**
+ * The engine's mirror of the lists a parent typed in.
+ *
+ * Mutable module state, which is worth testing precisely because it is: it's
+ * the one place in the engine where the answer to a question changes over the
+ * life of the page.
+ */
+
+const config = (over: Partial<WordConfig> = {}): WordConfig => ({
+  kind: "words",
+  listId: "custom-abc",
+  cardCount: 6,
+  inputMode: "type",
+  ...over,
+});
+
+const MINE = [
+  {
+    id: "custom-abc",
+    name: "Week 12",
+    words: ["because", "thought", "friend"],
+  },
+];
+
+afterEach(() => setCustomLists([]));
+
+describe("a list a parent typed in", () => {
+  it("builds a deck once mirrored", () => {
+    expect(buildWordDeck(config(), 1)).toEqual([]);
+    setCustomLists(MINE);
+    expect(buildWordDeck(config(), 1)).toHaveLength(6);
+  });
+
+  it("names itself in the record book", () => {
+    setCustomLists(MINE);
+    expect(deckSpec(wordMode("custom-abc")).label).toBe("Week 12");
+  });
+
+  it("marks the same way a shipped list does", () => {
+    setCustomLists(MINE);
+    const spec = wordDeckSpec(wordMode("custom-abc"));
+    expect(spec.normalise("Because")).toBe("because");
+    expect(spec.masteryKey("THOUGHT")).toBe("thought");
+  });
+
+  it("cannot shadow a shipped list", () => {
+    // A custom id is always prefixed `custom-`, but the mirror is fed from
+    // storage and storage is a file a user could hand-edit. Shipped lists win.
+    setCustomLists([{ id: "dolch-1", name: "Hijacked", words: ["nope"] }]);
+    expect(deckSpec(wordMode("dolch-1")).label).toBe("First words");
+    expect(wordsOf(config({ listId: "dolch-1" }))).toContain("away");
+  });
+
+  it("reads as a retired deck once it's gone", () => {
+    // Deleting a list must leave every race played on it readable. The name
+    // is what's lost, not the record.
+    setCustomLists(MINE);
+    setCustomLists([]);
+    const spec = deckSpec(wordMode("custom-abc"));
+    expect(spec.label).toBe("Words");
+    expect(spec.masteryKey("Because")).toBe("because");
+  });
+
+  it("picks up a rename without a reload", () => {
+    setCustomLists(MINE);
+    setCustomLists([{ ...MINE[0], name: "Week 13" }]);
+    expect(deckSpec(wordMode("custom-abc")).label).toBe("Week 13");
+  });
+});

--- a/src/engine/decks/words.ts
+++ b/src/engine/decks/words.ts
@@ -1,7 +1,7 @@
 import type { Card, WordConfig } from "@/engine/types";
 
 import { mulberry32, shuffled } from "@/engine/random";
-import { WORD_LISTS_BY_ID, type WordList } from "./wordlists";
+import { WORD_LISTS_BY_ID } from "./wordlists";
 import type { DeckSpec } from "./spec";
 
 /**
@@ -57,10 +57,32 @@ function wordDistractors(answer: string, pool: string[], rand: () => number) {
   return picked;
 }
 
+/* ── Lists a parent typed in ─────────────────────────────────────────────
+   Mirrored into the engine after the hub loads them, rather than threaded
+   through as a parameter. Three unrelated places need to name and build a
+   custom deck — the setup screen, the race loop and the record book — and
+   only one of them has any business knowing where decks are stored.
+
+   `src/services/decks.ts` is the sole writer and re-mirrors on every change,
+   so a view can't forget to. Nothing here is a source of truth: it's a cache
+   of IndexedDB, and losing it just means a deck reads as "Words" until the
+   next load.                                                                */
+
+let customLists = new Map<string, { name: string; words: string[] }>();
+
+export function setCustomLists(
+  decks: Array<{ id: string; name: string; words: string[] }>,
+) {
+  customLists = new Map(
+    decks.map((d) => [d.id, { name: d.name, words: d.words }]),
+  );
+}
+
+const listFor = (listId: string) =>
+  WORD_LISTS_BY_ID.get(listId) ?? customLists.get(listId);
+
 export const wordsOf = (config: WordConfig): string[] =>
-  config.words?.length
-    ? config.words
-    : (WORD_LISTS_BY_ID.get(config.listId)?.words ?? []);
+  config.words?.length ? config.words : (listFor(config.listId)?.words ?? []);
 
 export function buildWordDeck(config: WordConfig, seed: number): Card[] {
   const rand = mulberry32(seed);
@@ -108,7 +130,7 @@ export function wordConfigKey(config: WordConfig) {
 }
 
 export function describeWordConfig(config: WordConfig) {
-  const list = WORD_LISTS_BY_ID.get(config.listId);
+  const list = listFor(config.listId);
   const what = config.words?.length
     ? `${config.words.length} words`
     : (list?.name ?? "Words");
@@ -147,7 +169,7 @@ export function buildWordDrill(
  * case once a parent can author their own.
  */
 export function wordDeckSpec(mode: string): DeckSpec {
-  const list: WordList | undefined = WORD_LISTS_BY_ID.get(listIdOf(mode));
+  const list = listFor(listIdOf(mode));
   return {
     id: mode,
     label: list?.name ?? "Words",

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -79,6 +79,23 @@ export type WordConfig = {
 /** Whatever the race loop was handed. Narrow with `config.kind === "words"`. */
 export type RaceConfig = FlashConfig | WordConfig;
 
+/**
+ * A word list a parent typed in — this week's spellings, a topic's vocabulary.
+ *
+ * The same shape as a shipped list minus the editorial fields, and it plays
+ * through exactly the same deck spec. `id` is prefixed `custom-` so that
+ * `Session.mode` (`words:custom-…`) can never collide with a list this build
+ * ships, and so a run stays readable after its deck is deleted.
+ */
+export type CustomDeck = {
+  id: string;
+  name: string;
+  emoji: string;
+  words: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
 /* ── Cards ───────────────────────────────────────────────────────────────
    A card is text in and text out, deliberately. Answers were numbers until
    spelling arrived, and every alternative to widening them was worse: a

--- a/src/games/flashcards/setup/DeckEditor.tsx
+++ b/src/games/flashcards/setup/DeckEditor.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useRef, useState } from "react";
+import { Button, Field, Input, Scrim, TextArea } from "@/components/ui/kit";
+import { useHub } from "@/components/state/HubContext";
+import { MAX_WORDS, MIN_WORDS, parseWords, toFile } from "@/services/decks";
+import { sfx } from "@/services/sound";
+import type { CustomDeck } from "@/engine/types";
+
+const EMOJI = ["✏️", "📚", "🐝", "🦉", "🚀", "🌟", "🧩", "🐙"];
+
+/**
+ * Typing in this week's spellings.
+ *
+ * One textarea rather than a row of fields, because the list is being copied
+ * off a school letter or a phone screenshot and retyping it into twelve inputs
+ * is how a parent decides not to bother. Anything separated by a newline, a
+ * comma, a semicolon or a tab is a word — see `parseWords`.
+ *
+ * Editing an existing list doesn't disturb races already run on it: they're
+ * filed under the deck's id, not its contents. Removing a word stops it being
+ * asked; it stays in the record book, which is right — it was practised.
+ */
+export function DeckEditor({
+  deck,
+  onClose,
+}: {
+  /** The list being edited, or null to start a new one. */
+  deck: CustomDeck | null;
+  onClose: (saved: CustomDeck | null) => void;
+}) {
+  const { saveDeck, deleteDeck, notify } = useHub();
+  const [name, setName] = useState(deck?.name ?? "");
+  const [emoji, setEmoji] = useState(deck?.emoji ?? EMOJI[0]);
+  const [text, setText] = useState((deck?.words ?? []).join("\n"));
+  const [busy, setBusy] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const nameField = useRef<HTMLInputElement>(null);
+
+  // Focused here rather than with `autoFocus`, which the a11y rule bans and
+  // rightly: on page load it steals focus from the document. In a sheet the
+  // parent just opened, landing in the first field is what they expect.
+  useEffect(() => {
+    nameField.current?.focus();
+  }, []);
+
+  const words = parseWords(text);
+  const tooMany = words.length > MAX_WORDS;
+  const ready = name.trim() !== "" && words.length >= MIN_WORDS && !tooMany;
+
+  async function save() {
+    setBusy(true);
+    try {
+      const saved = await saveDeck(deck?.id ?? null, { name, emoji, words });
+      sfx.record();
+      notify(`Saved ${saved.name} — ${saved.words.length} words`);
+      onClose(saved);
+    } catch (error) {
+      notify(
+        error instanceof Error ? error.message : "Could not save that list",
+        "bad",
+      );
+      setBusy(false);
+    }
+  }
+
+  function share() {
+    if (!deck) return;
+    sfx.tap();
+    const url = URL.createObjectURL(
+      new Blob([JSON.stringify(toFile(deck), null, 2)], {
+        type: "application/json",
+      }),
+    );
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `schoolskills-${deck.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+    notify("Saved the list — send that file to another family");
+  }
+
+  return (
+    <div className="sheet">
+      <Scrim onClose={() => onClose(null)} label="Close" />
+      <div className="sheet__panel">
+        <h2 className="sheet__title u-display">
+          {deck ? "Edit list" : "New word list"}
+        </h2>
+
+        <Field label="Name">
+          <Input
+            ref={nameField}
+            value={name}
+            onChange={setName}
+            placeholder="Week 12 spellings"
+            maxLength={40}
+          />
+        </Field>
+
+        <span className="control__label">Icon</span>
+        <div className="emojirow">
+          {EMOJI.map((choice) => (
+            <Button
+              key={choice}
+              variant="bare"
+              className={`emojirow__pick${emoji === choice ? " is-on" : ""}`}
+              pressed={emoji === choice}
+              onClick={() => {
+                sfx.tap();
+                setEmoji(choice);
+              }}
+            >
+              <span aria-hidden="true">{choice}</span>
+              <span className="u-sr">Icon {choice}</span>
+            </Button>
+          ))}
+        </div>
+
+        <Field
+          label="Words"
+          hint="One per line, or separated by commas. Duplicates are dropped."
+        >
+          <TextArea
+            className="field__input deckeditor__words"
+            value={text}
+            onChange={setText}
+            rows={8}
+            spellCheck={false}
+            autoCapitalize="off"
+            placeholder={"because\nthought\nfriend"}
+          />
+        </Field>
+
+        <p className={`deckeditor__count${tooMany ? " is-bad" : ""}`}>
+          {words.length} word{words.length === 1 ? "" : "s"}
+          {tooMany && ` — that's more than ${MAX_WORDS}`}
+          {!tooMany &&
+            words.length < MIN_WORDS &&
+            ` — a list needs at least ${MIN_WORDS}`}
+        </p>
+
+        <div className="sheet__actions">
+          <Button variant="ghost" onClick={() => onClose(null)} disabled={busy}>
+            Cancel
+          </Button>
+          {deck && (
+            <Button variant="ghost" onClick={share} disabled={busy}>
+              Share as a file
+            </Button>
+          )}
+          {deck && !confirming && (
+            <Button
+              variant="danger"
+              onClick={() => setConfirming(true)}
+              disabled={busy}
+            >
+              Delete
+            </Button>
+          )}
+          {deck && confirming && (
+            <Button
+              variant="danger"
+              disabled={busy}
+              onClick={async () => {
+                setBusy(true);
+                await deleteDeck(deck.id);
+                // Deliberately not "…and its races". Deleting a list must not
+                // delete the practice done on it, and saying so here is the
+                // only place a parent finds that out before clicking.
+                notify(`Deleted ${deck.name}. Past races are kept.`);
+                onClose(null);
+              }}
+            >
+              Really delete?
+            </Button>
+          )}
+          <Button variant="go" onClick={save} disabled={!ready || busy}>
+            {deck ? "Save list" : "Create list"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/games/flashcards/setup/WordSettings.tsx
+++ b/src/games/flashcards/setup/WordSettings.tsx
@@ -1,15 +1,23 @@
-import { Button } from "@/components/ui/kit";
+import { useState } from "react";
+import { Button, FilePicker } from "@/components/ui/kit";
+import { useHub } from "@/components/state/HubContext";
 import { WORD_LISTS } from "@/engine/decks/wordlists";
 import { wordsOf } from "@/engine/decks/words";
+import { readDeckFile } from "@/services/decks";
 import { sfx } from "@/services/sound";
 import { canSpeak } from "@/services/speech";
-import type { WordConfig } from "@/engine/types";
+import { DeckEditor } from "./DeckEditor";
+import type { CustomDeck, WordConfig } from "@/engine/types";
 
 /**
  * Which words end up on the cards.
  *
  * A list, not a grid: the lists are graded, and picking one is the whole
  * decision. The counterpart to `MathsSettings`.
+ *
+ * A parent's own lists sit above the shipped ones, because someone who has
+ * typed in this week's spellings is here for those and not for Dolch. They
+ * carry an Edit button; the shipped lists don't, and can't be deleted.
  *
  * A drill arrives with its words already chosen, so it replaces the list
  * exactly as an arithmetic drill replaces the number grids.
@@ -21,6 +29,8 @@ export function WordSettings({
   config: WordConfig;
   onChange: (next: WordConfig) => void;
 }) {
+  const { decks, saveDeck, notify } = useHub();
+  const [editing, setEditing] = useState<CustomDeck | null | "new">(null);
   const drill = config.words?.length ? config.words : null;
   const audible = canSpeak();
 
@@ -55,43 +65,123 @@ export function WordSettings({
     );
   }
 
+  async function readShared(file: File) {
+    try {
+      // Through `saveDeck` like every other write, so the picker updates.
+      const deck = await saveDeck(
+        null,
+        readDeckFile(JSON.parse(await file.text())),
+      );
+      sfx.record();
+      notify(`Added ${deck.name} — ${deck.words.length} words`);
+      onChange({ ...config, listId: deck.id });
+    } catch (error) {
+      notify(
+        error instanceof Error ? error.message : "Could not read that file",
+        "bad",
+      );
+    }
+  }
+
+  const row = (
+    list: { id: string; name: string; emoji: string; words: string[] },
+    meta: string,
+    blurb: string | null,
+    own: CustomDeck | null,
+  ) => (
+    <li key={list.id} className="wordlists__row">
+      <Button
+        variant="bare"
+        className={`wordlists__item${config.listId === list.id ? " is-on" : ""}`}
+        pressed={config.listId === list.id}
+        onClick={() => {
+          sfx.tap();
+          onChange({ ...config, listId: list.id });
+        }}
+      >
+        <span className="wordlists__emoji" aria-hidden="true">
+          {list.emoji}
+        </span>
+        <span className="wordlists__body">
+          <span className="wordlists__name">{list.name}</span>
+          <span className="wordlists__meta">{meta}</span>
+          {blurb && <span className="wordlists__blurb">{blurb}</span>}
+        </span>
+      </Button>
+      {own && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            sfx.tap();
+            setEditing(own);
+          }}
+        >
+          Edit
+        </Button>
+      )}
+    </li>
+  );
+
   return (
     <div className="control">
       <span className="control__label">Word list</span>
       <ul className="wordlists">
-        {WORD_LISTS.map((list) => (
-          <li key={list.id}>
-            <Button
-              variant="bare"
-              className={`wordlists__item${config.listId === list.id ? " is-on" : ""}`}
-              pressed={config.listId === list.id}
-              onClick={() => {
-                sfx.tap();
-                onChange({ ...config, listId: list.id });
-              }}
-            >
-              <span className="wordlists__emoji" aria-hidden="true">
-                {list.emoji}
-              </span>
-              <span className="wordlists__body">
-                <span className="wordlists__name">{list.name}</span>
-                <span className="wordlists__meta">
-                  {list.group} · {list.words.length} words
-                </span>
-                <span className="wordlists__blurb">{list.blurb}</span>
-              </span>
-            </Button>
-          </li>
-        ))}
+        {decks.map((deck) =>
+          row(deck, `Yours · ${deck.words.length} words`, null, deck),
+        )}
+        {WORD_LISTS.map((list) =>
+          row(
+            list,
+            `${list.group} · ${list.words.length} words`,
+            list.blurb,
+            null,
+          ),
+        )}
       </ul>
+
+      <div className="control__row">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            sfx.tap();
+            setEditing("new");
+          }}
+        >
+          ＋ New list
+        </Button>
+        <FilePicker onFile={readShared}>Open a shared list</FilePicker>
+      </div>
+
       <p className="numbers__preview">
-        e.g. {wordsOf(config).slice(0, 4).join(" · ")}
+        e.g. {wordsOf(config).slice(0, 4).join(" · ") || "—"}
       </p>
       <p className="numbers__note">
         {audible
           ? "Each word is read out — nothing is shown, so it's spelling rather than copying."
           : "This device has no voice installed, so each word flashes up briefly and then hides."}
       </p>
+
+      {editing !== null && (
+        <DeckEditor
+          deck={editing === "new" ? null : editing}
+          onClose={(saved) => {
+            setEditing(null);
+            // A saved list becomes the selection; a deleted one leaves the
+            // config pointing at an id that's gone, so fall back to a shipped
+            // list rather than leaving an empty deck armed.
+            if (saved) onChange({ ...config, listId: saved.id });
+            else if (
+              editing !== "new" &&
+              config.listId === editing.id &&
+              !decks.some((d) => d.id === editing.id)
+            ) {
+              onChange({ ...config, listId: WORD_LISTS[0].id });
+            }
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,9 +62,14 @@ const tables = Array.from({ length: 12 }, (_, i) => i + 1);
         <h3>Typing — coming soon</h3>
         <p>Same idea, same profiles, different skill.</p>
       </li>
-      <li class="games--soon">
-        <h3>Your own word lists — coming soon</h3>
-        <p>This week&rsquo;s spellings, typed in and shared between devices.</p>
+      <li>
+        <h3>Your own word lists</h3>
+        <p>
+          Paste in this week&rsquo;s spellings and they become a deck like any
+          other, with their own records. A list can be saved as a file and
+          passed to another family, who get their own copy of it.
+        </p>
+        <a href="/spelling">How it works &rarr;</a>
       </li>
     </ul>
 

--- a/src/pages/spelling.astro
+++ b/src/pages/spelling.astro
@@ -105,6 +105,20 @@ const description =
       of four. Recognition first, spelling second.
     </p>
 
+    <h2>Your own lists</h2>
+    <p>
+      The lists above are a starting point, not the point. Paste in this
+      week&rsquo;s spellings &mdash; a newline, a comma or a semicolon between
+      them, however they arrived &mdash; and they become a deck like any other,
+      with their own records and their own trouble list. Save one as a file and
+      another family can open it and get their own copy.
+    </p>
+    <p>
+      Everything stays on the device it was typed on. There is no account to
+      make and nothing is uploaded, so a shared list travels the way a photocopy
+      would: because someone sent it.
+    </p>
+
     <h2>Practising it properly</h2>
     <p>
       Words that come out wrong, or come out slowly, collect in a trouble list

--- a/src/services/decks.test.ts
+++ b/src/services/decks.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { isBuiltIn, parseWords, readDeckFile, toFile } from "./decks";
+import type { CustomDeck } from "@/engine/types";
+
+/**
+ * The pure half of the deck service — parsing what a parent pasted, and
+ * refusing a file that isn't ours. Everything that writes needs IndexedDB and
+ * is covered in the browser instead.
+ */
+
+describe("parseWords", () => {
+  it("takes a list off a school letter however it was formatted", () => {
+    // Newlines, commas, semicolons and tabs, because the list is being pasted
+    // from an email or a screenshot and nobody should have to reformat it.
+    expect(parseWords("because\nthought\nfriend")).toEqual([
+      "because",
+      "thought",
+      "friend",
+    ]);
+    expect(parseWords("because, thought; friend")).toEqual([
+      "because",
+      "thought",
+      "friend",
+    ]);
+    expect(parseWords("because\tthought")).toEqual(["because", "thought"]);
+  });
+
+  it("keeps the order it was given", () => {
+    // A spelling list is often taught in order, and re-sorting it alphabetically
+    // would quietly throw that away.
+    expect(parseWords("zebra, apple, mango")).toEqual([
+      "zebra",
+      "apple",
+      "mango",
+    ]);
+  });
+
+  it("drops blanks and trailing separators", () => {
+    expect(parseWords("cat,,dog,\n\n")).toEqual(["cat", "dog"]);
+    expect(parseWords("   ")).toEqual([]);
+  });
+
+  it("de-duplicates the way the marker will", () => {
+    // "Cat" and "cat" mark identically, so keeping both would mean a card that
+    // can never be got wrong twice and a word map with a phantom entry.
+    expect(parseWords("cat, Cat, CAT")).toEqual(["cat"]);
+  });
+});
+
+describe("sharing a list", () => {
+  const deck: CustomDeck = {
+    id: "custom-abc",
+    name: "Week 12",
+    emoji: "🐝",
+    words: ["because", "thought"],
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  };
+
+  it("writes the list and nothing else", () => {
+    // Not the id, and certainly not timestamps: what gets passed round a class
+    // group is this week's spellings, not anything about the sender.
+    expect(toFile(deck)).toEqual({
+      kind: "schoolskills-deck",
+      version: 1,
+      name: "Week 12",
+      emoji: "🐝",
+      words: ["because", "thought"],
+    });
+    expect(Object.keys(toFile(deck))).not.toContain("id");
+  });
+
+  it("reads a good file into the same input a typed-in list produces", () => {
+    expect(readDeckFile(toFile(deck))).toEqual({
+      name: "Week 12",
+      emoji: "🐝",
+      words: ["because", "thought"],
+    });
+  });
+
+  it("holds a shared list to the same rules as a typed-in one", () => {
+    const file = (words: string[], name = "Week 12") => ({
+      kind: "schoolskills-deck" as const,
+      version: 1 as const,
+      name,
+      emoji: "🐝",
+      words,
+    });
+    // A word with a space can't be marked fairly — nothing on the card tells
+    // the speller a space is expected, so a missing one reads as a
+    // misspelling. Same reason the shipped lists have none.
+    expect(() => readDeckFile(file(["ice cream", "cat"]))).toThrow(/space/);
+    expect(() => readDeckFile(file(["cat"]))).toThrow(/at least/);
+    expect(() =>
+      readDeckFile(file(Array.from({ length: 201 }, (_, i) => `w${i}`))),
+    ).toThrow(/more than/);
+    expect(() => readDeckFile(file(["cat", "dog"], "   "))).toThrow(/name/i);
+  });
+
+  it("refuses a file that isn't one of ours", () => {
+    // A half-recognised file that imports anyway is worse than one that
+    // refuses: it puts junk in a list a child then gets marked against.
+    for (const bad of [
+      null,
+      42,
+      {},
+      { kind: "something-else", words: ["a"] },
+      { kind: "schoolskills-deck", words: "not an array" },
+    ]) {
+      expect(() => readDeckFile(bad)).toThrow(/word list/);
+    }
+  });
+});
+
+describe("isBuiltIn", () => {
+  it("knows which lists can't be edited", () => {
+    expect(isBuiltIn("dolch-1")).toBe(true);
+    expect(isBuiltIn("custom-abc")).toBe(false);
+  });
+});

--- a/src/services/decks.ts
+++ b/src/services/decks.ts
@@ -1,0 +1,168 @@
+import { setCustomLists } from "@/engine/decks/words";
+import { WORD_LISTS_BY_ID } from "@/engine/decks/wordlists";
+import { normaliseWord } from "@/engine/decks/words";
+import type { CustomDeck } from "@/engine/types";
+
+import * as store from "./storage/db";
+
+/**
+ * Word lists a parent typed in.
+ *
+ * The only writer of the engine's custom-list mirror — every function that
+ * changes a deck re-mirrors before returning, so no caller has to remember to.
+ * See `setCustomLists` for why the mirror exists.
+ */
+
+export class InvalidDeck extends Error {}
+
+/** Enough to be a deck. Below this a "spot it" round has nothing to spot. */
+export const MIN_WORDS = 2;
+export const MAX_WORDS = 200;
+export const MAX_NAME = 40;
+
+const nextId = () =>
+  `custom-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+
+/**
+ * Splits whatever a parent pasted into words.
+ *
+ * Newlines, commas, tabs and semicolons all work, because the list is coming
+ * off a school letter or an email and nobody should have to reformat it. Order
+ * is kept — a spelling list is often taught in order — but duplicates go,
+ * comparing the way the marker will.
+ */
+export function parseWords(input: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input.split(/[\n,;\t]+/)) {
+    const word = raw.trim().replace(/\s+/g, " ");
+    if (!word) continue;
+    const key = normaliseWord(word);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(word);
+  }
+  return out;
+}
+
+export type DeckInput = { name: string; emoji: string; words: string[] };
+
+function validate(input: DeckInput): DeckInput {
+  const name = input.name.trim();
+  if (!name) throw new InvalidDeck("Give the list a name");
+  if (name.length > MAX_NAME)
+    throw new InvalidDeck(`Name must be ${MAX_NAME} characters or fewer`);
+
+  const words = input.words.map((w) => w.trim()).filter(Boolean);
+  if (words.length < MIN_WORDS)
+    throw new InvalidDeck(`A list needs at least ${MIN_WORDS} words`);
+  if (words.length > MAX_WORDS)
+    throw new InvalidDeck(`That's more than ${MAX_WORDS} words`);
+  // A word with a space in it can't be marked fairly: nothing on the card
+  // tells the speller a space is expected, and a missing one reads as a
+  // misspelling. The same reason the shipped lists have none.
+  const spaced = words.find((w) => w.includes(" "));
+  if (spaced) throw new InvalidDeck(`"${spaced}" has a space in it`);
+
+  return { name, emoji: input.emoji.trim() || "✏️", words };
+}
+
+async function mirror(decks: CustomDeck[]) {
+  setCustomLists(decks);
+  return decks;
+}
+
+export async function all(): Promise<CustomDeck[]> {
+  const decks = (await store.allDecks()).sort((a, b) =>
+    a.createdAt.localeCompare(b.createdAt),
+  );
+  return mirror(decks);
+}
+
+export async function create(input: DeckInput): Promise<CustomDeck> {
+  const clean = validate(input);
+  const now = new Date().toISOString();
+  const deck: CustomDeck = {
+    id: nextId(),
+    ...clean,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await store.putDeck(deck);
+  await all();
+  return deck;
+}
+
+export async function update(
+  id: string,
+  input: DeckInput,
+): Promise<CustomDeck> {
+  const existing = (await store.allDecks()).find((d) => d.id === id);
+  if (!existing) throw new InvalidDeck("That list no longer exists");
+  const deck: CustomDeck = {
+    ...existing,
+    ...validate(input),
+    updatedAt: new Date().toISOString(),
+  };
+  await store.putDeck(deck);
+  await all();
+  return deck;
+}
+
+export async function remove(id: string): Promise<void> {
+  await store.removeDeck(id);
+  await all();
+}
+
+/* ── Sharing a list between families ─────────────────────────────────────
+   A single deck as a file, distinct from a full backup: what gets passed
+   round a class group is this week's spellings, not somebody's children's
+   race history.                                                           */
+
+export type DeckFile = {
+  kind: "schoolskills-deck";
+  version: 1;
+  name: string;
+  emoji: string;
+  words: string[];
+};
+
+export const toFile = (deck: CustomDeck): DeckFile => ({
+  kind: "schoolskills-deck",
+  version: 1,
+  name: deck.name,
+  emoji: deck.emoji,
+  words: deck.words,
+});
+
+/**
+ * Reads a shared list into the same input a typed-in one produces.
+ *
+ * Deliberately does NOT write. Every deck in the app is created through one
+ * path — `HubContext.saveDeck` — so the on-screen list can't get out of step
+ * with storage; an import that wrote directly here would land in IndexedDB and
+ * stay invisible until the next reload. (It did, once.)
+ *
+ * The sender's id is dropped on purpose. Two families' copies are separate
+ * decks with separate records, and keeping the id would silently overwrite a
+ * list of the same origin that the reader had since edited.
+ */
+export function readDeckFile(parsed: unknown): DeckInput {
+  const file = parsed as Partial<DeckFile>;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    file.kind !== "schoolskills-deck" ||
+    !Array.isArray(file.words)
+  ) {
+    throw new InvalidDeck("That doesn't look like a School Skills word list");
+  }
+  return validate({
+    name: typeof file.name === "string" ? file.name : "Shared list",
+    emoji: typeof file.emoji === "string" ? file.emoji : "✏️",
+    words: file.words.filter((w): w is string => typeof w === "string"),
+  });
+}
+
+/** True for a list this build ships, which can't be edited or deleted. */
+export const isBuiltIn = (listId: string) => WORD_LISTS_BY_ID.has(listId);

--- a/src/services/hub.ts
+++ b/src/services/hub.ts
@@ -1,10 +1,12 @@
-import type { Profile, Session } from "@/engine/types";
+import type { CustomDeck, Profile, Session } from "@/engine/types";
 
+import * as deckService from "./decks";
 import * as store from "./storage/db";
 
 export type HubSnapshot = {
   profiles: Profile[];
   sessions: Session[];
+  decks: CustomDeck[];
 };
 
 /**
@@ -17,13 +19,18 @@ export type HubSnapshot = {
  * 2000 sessions per profile this is a few megabytes read once.
  */
 export async function loadHub(): Promise<HubSnapshot> {
-  const [profiles, sessions] = await Promise.all([
+  const [profiles, sessions, decks] = await Promise.all([
     store.allProfiles(),
     store.allSessions(),
+    // Goes through the service rather than the store: loading is also what
+    // populates the engine's custom-list mirror, and that must happen before
+    // anything tries to name or build a custom deck.
+    deckService.all(),
   ]);
   return {
     profiles: profiles.sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
     sessions: sessions.sort((a, b) => a.finishedAt.localeCompare(b.finishedAt)),
+    decks,
   };
 }
 

--- a/src/services/storage/db.ts
+++ b/src/services/storage/db.ts
@@ -1,7 +1,12 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 
 import { readSession, readSessions } from "@/engine/migrate";
-import type { LegacySession, Profile, Session } from "@/engine/types";
+import type {
+  CustomDeck,
+  LegacySession,
+  Profile,
+  Session,
+} from "@/engine/types";
 
 /**
  * The only module in the codebase allowed to touch browser storage.
@@ -19,13 +24,15 @@ import type { LegacySession, Profile, Session } from "@/engine/types";
  */
 
 const DB_NAME = "schoolskills";
-const DB_VERSION = 1;
+/** 2 added `decks` — parent-authored word lists. */
+const DB_VERSION = 2;
 
 /** Oldest sessions past this count are dropped so a profile stays fast to load. */
 export const MAX_SESSIONS_PER_PROFILE = 2000;
 
 interface HubDB extends DBSchema {
   profiles: { key: string; value: Profile };
+  decks: { key: string; value: CustomDeck };
   sessions: {
     key: string;
     /**
@@ -44,12 +51,21 @@ function db() {
   // Opened lazily and memoised: the island is `client:only`, but a stray import
   // from a build-time script must not try to open IndexedDB in Node.
   handle ??= openDB<HubDB>(DB_NAME, DB_VERSION, {
-    upgrade(database) {
-      database.createObjectStore("profiles", { keyPath: "id" });
-      const sessions = database.createObjectStore("sessions", {
-        keyPath: "id",
-      });
-      sessions.createIndex("byProfile", "profileId");
+    // Each version's block is additive and guarded by the version it arrived
+    // in, so a browser two versions behind runs both and a fresh one runs both
+    // in order. Nothing here ever rewrites or drops existing data — this is
+    // the only copy of a child's record book that exists anywhere.
+    upgrade(database, oldVersion) {
+      if (oldVersion < 1) {
+        database.createObjectStore("profiles", { keyPath: "id" });
+        const sessions = database.createObjectStore("sessions", {
+          keyPath: "id",
+        });
+        sessions.createIndex("byProfile", "profileId");
+      }
+      if (oldVersion < 2) {
+        database.createObjectStore("decks", { keyPath: "id" });
+      }
     },
   });
   return handle;
@@ -79,6 +95,23 @@ export async function allProfiles(): Promise<Profile[]> {
 
 export async function allSessions(): Promise<Session[]> {
   return readSessions(await (await db()).getAll("sessions"));
+}
+
+export async function allDecks(): Promise<CustomDeck[]> {
+  return (await db()).getAll("decks");
+}
+
+export async function putDeck(deck: CustomDeck): Promise<void> {
+  await (await db()).put("decks", deck);
+}
+
+/**
+ * Removes a deck but NOT the races played on it. Those stay in the record
+ * book keyed by their own mode, which `deckSpec` still resolves — deleting a
+ * list a child has been practising must not delete the practice.
+ */
+export async function removeDeck(id: string): Promise<void> {
+  await (await db()).delete("decks", id);
 }
 
 export async function putProfile(profile: Profile): Promise<void> {
@@ -145,9 +178,11 @@ export async function trimSessions(profileId: string): Promise<number> {
 }
 
 export type Backup = {
-  version: 1;
+  /** 2 added `decks`. Files at either version restore. */
+  version: 1 | 2;
   exportedAt: string;
   profiles: Profile[];
+  decks?: CustomDeck[];
   /**
    * Written current, read wide. A file exported today holds widened cards, but
    * one exported last week — or produced by `scripts/convert-legacy-hub.mjs`
@@ -157,14 +192,16 @@ export type Backup = {
 };
 
 export async function exportAll(): Promise<Backup> {
-  const [profiles, sessions] = await Promise.all([
+  const [profiles, sessions, decks] = await Promise.all([
     allProfiles(),
     allSessions(),
+    allDecks(),
   ]);
   return {
-    version: 1,
+    version: 2,
     exportedAt: new Date().toISOString(),
     profiles,
+    decks,
     sessions,
   };
 }
@@ -180,17 +217,23 @@ export async function exportAll(): Promise<Backup> {
 export async function importAll(
   backup: Backup,
   mode: "merge" | "replace" = "merge",
-): Promise<{ profiles: number; sessions: number }> {
+): Promise<{ profiles: number; sessions: number; decks: number }> {
   const database = await db();
-  const tx = database.transaction(["profiles", "sessions"], "readwrite");
+  const tx = database.transaction(
+    ["profiles", "sessions", "decks"],
+    "readwrite",
+  );
   if (mode === "replace") {
     await Promise.all([
       tx.objectStore("profiles").clear(),
       tx.objectStore("sessions").clear(),
+      tx.objectStore("decks").clear(),
     ]);
   }
   await Promise.all([
     ...backup.profiles.map((p) => tx.objectStore("profiles").put(p)),
+    // Absent from a version 1 file, which is fine — there were none.
+    ...(backup.decks ?? []).map((d) => tx.objectStore("decks").put(d)),
     // Widened on the way in, so a restored run is stored in the shape a fresh
     // one would be. Reads migrate anyway; this just stops the file's age from
     // outliving the import.
@@ -202,5 +245,6 @@ export async function importAll(
   return {
     profiles: backup.profiles.length,
     sessions: backup.sessions.length,
+    decks: backup.decks?.length ?? 0,
   };
 }

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1143,3 +1143,57 @@
 .wordpad__input:disabled {
   opacity: 0.5;
 }
+
+/* ── Parent-authored lists ─────────────────────────────────────────────── */
+
+.wordlists__row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.4rem;
+}
+
+.wordlists__row .wordlists__item {
+  flex: 1;
+  min-width: 0;
+}
+
+.emojirow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.emojirow__pick {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: var(--radius);
+  border: 2px solid var(--hairline);
+  background: var(--ink-700);
+  font-size: var(--step-1);
+  line-height: 1;
+}
+
+.emojirow__pick.is-on {
+  border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 16%, var(--ink-700));
+}
+
+/* Monospaced and left-aligned: this is a list being checked against a school
+   letter, and a proportional font makes a column of words hard to scan. */
+.deckeditor__words {
+  min-height: 9rem;
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.deckeditor__count {
+  font-size: var(--step--2);
+  color: var(--accent);
+  letter-spacing: 0.04em;
+}
+
+.deckeditor__count.is-bad {
+  color: var(--flare);
+}


### PR DESCRIPTION
Closes #13. On top of #30 and #31.

This week's spellings, pasted in and drilled like any other deck.

## Not a special case

A custom list is a `listId` like the shipped ones. Racing, ghosts, XP, the trouble list, the word map and the record book all work with **no branch anywhere below the setup screen**.

The engine keeps a mirror of the lists (`setCustomLists`) so `deckSpec(mode)` can name one from the record book without the engine learning that storage exists. `src/services/decks.ts` is the only writer and re-mirrors on every change. A shipped list always wins a name collision — the mirror is fed from storage, and storage is a file someone could hand-edit.

## Deleting a list keeps the practice

That's what `UNKNOWN_DECK` and prefixed modes were for. The deck goes; every race played on it stays in the record book under "Words". The toast says so **before** the click, not after — it's the only place a parent finds out.

## Sharing

A single deck as a file, deliberately not a backup: what gets passed round a class group is a spelling list, not somebody's children's race history. The sender's id is dropped, so two families' copies are two decks — keeping it would silently overwrite a list the reader had since edited.

## Schema 2

New `decks` store. The upgrade is additive and guarded by `oldVersion`; nothing in it rewrites or drops anything, because this is the only copy of a child's record book that exists anywhere.

Verified by **seeding a real v1 database** — old schema, pre-widening numeric cards — and opening the app on top of it. The player, their race and their XP all survive both migrations.

## Paste, don't retype

One textarea, splitting on newlines, commas, semicolons or tabs. The list arrives on a school letter or a phone screenshot, and retyping it into twelve inputs is how a parent decides not to bother. Duplicates go, compared the way the marker will (`Cat` and `cat` are one word). Order is kept — a spelling list is often taught in order.

A word with a space in it is refused: nothing on a card can signal that a space is expected, so a missing one would read as a misspelling.

`TextArea` joins the kit. One caller is enough — the native-controls ban has no exceptions, and adding the primitive is what the kit is for.

## A bug found in the browser

Opening a shared file wrote through the service directly, so the deck landed in IndexedDB and **stayed invisible until the next reload**. Every write goes through `HubContext.saveDeck` now, and `readDeckFile` is pure validation that can't be used any other way.

## Verification

- 19 new tests (112 total). Seven guards mutation-checked; one gap found and closed — nothing covered the no-spaces rule, so removing it passed clean.
- 26 browser checks: the v1 upgrade, create/edit/delete, a race that only ever asks the three words in the list, a file crossing between two browser contexts, backup round-trip, and a deletion that leaves the record book intact.
- Regression-ran the #30 and #31 harnesses and the existing smoke suite. All pass.

`type-check` 0 errors · `lint` clean · 112 unit · 18 pages built.