### PR TITLE
Advertising, non-personalised everywhere

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/jordan.bush/repos/schoolskills/node_modules

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,8 @@
+# Authorised Digital Sellers — https://iabtechlab.com/ads-txt/
+#
+# Declares who may sell inventory on schoolskills.app. A publisher id that
+# appears in a page but not here is, to a buyer, an unauthorised reseller — so
+# this file existing is what lets the inventory be bought at all.
+#
+# Fields: <exchange domain>, <publisher id>, <DIRECT|RESELLER>, <cert id>
+google.com, pub-2742485876369367, DIRECT, f08c47fec0942fa0

--- a/src/components/site/AdSlot.astro
+++ b/src/components/site/AdSlot.astro
@@ -1,5 +1,5 @@
 ---
-import { AD_CLIENT, adSlotId, type AdSlotName } from "./ads";
+import { AD_CLIENT, ADS_PREVIEW, adSlotId, type AdSlotName } from "./ads";
 
 /**
  * An ad unit on a static content page.
@@ -40,6 +40,11 @@ const slot = adSlotId(name);
   ) : (
     /* No unit id yet, or ads are off in this build. The reservation stays so
        turning a slot on later can't shift a layout people already know. */
-    <div class:list={["ad", "ad--blank", className]} aria-hidden="true" />
+    <div
+      class:list={["ad", ADS_PREVIEW ? "ad--preview" : "ad--blank", className]}
+      aria-hidden="true"
+    >
+      {ADS_PREVIEW && <span class="ad__ghost">ad slot · {name}</span>}
+    </div>
   )
 }

--- a/src/components/site/AdSlot.astro
+++ b/src/components/site/AdSlot.astro
@@ -1,0 +1,45 @@
+---
+import { AD_CLIENT, adSlotId, type AdSlotName } from "./ads";
+
+/**
+ * An ad unit on a static content page.
+ *
+ * The React twin of this is AdSlot.tsx — same markup, same reservation. Two
+ * files because the game screens are a client island and these pages are
+ * static HTML; neither component can host the other.
+ *
+ * There is no clock on a content page and nothing to mis-tap, so this one sits
+ * in normal flow with the page's rhythm around it. It still reserves its
+ * height in CSS rather than growing into place, because a reflow that moves
+ * the paragraph someone is reading is its own small rudeness.
+ */
+interface Props {
+  name: AdSlotName;
+  class?: string;
+}
+
+const { name, class: className = "ad--content" } = Astro.props;
+const slot = adSlotId(name);
+---
+
+{
+  slot ? (
+    <aside class:list={["ad", className]} aria-label="Advertisement">
+      <span class="ad__label">Ad</span>
+      <ins
+        class="adsbygoogle ad__unit"
+        data-ad-client={AD_CLIENT}
+        data-ad-slot={slot}
+      />
+      {/* Per unit, immediately after it — this is the call that tells the
+          loader to fill this particular <ins>. */}
+      <script is:inline>
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+      </script>
+    </aside>
+  ) : (
+    /* No unit id yet, or ads are off in this build. The reservation stays so
+       turning a slot on later can't shift a layout people already know. */
+    <div class:list={["ad", "ad--blank", className]} aria-hidden="true" />
+  )
+}

--- a/src/components/site/AdSlot.tsx
+++ b/src/components/site/AdSlot.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { AD_CLIENT, adSlotId, type AdSlotName } from "./ads";
+import { AD_CLIENT, ADS_PREVIEW, adSlotId, type AdSlotName } from "./ads";
 
 /**
  * An ad unit inside a React island.
@@ -44,7 +44,16 @@ export function AdSlot({
 
   // No unit id yet, or ads are off in this build. Keep the reservation so
   // turning a slot on later can't shift a layout people already know.
-  if (!slot) return <div className={`ad ad--blank ${className}`} aria-hidden />;
+  if (!slot) {
+    return (
+      <div
+        className={`ad ${ADS_PREVIEW ? "ad--preview" : "ad--blank"} ${className}`}
+        aria-hidden
+      >
+        {ADS_PREVIEW && <span className="ad__ghost">ad slot · {name}</span>}
+      </div>
+    );
+  }
 
   return (
     <aside className={`ad ${className}`} aria-label="Advertisement">

--- a/src/components/site/AdSlot.tsx
+++ b/src/components/site/AdSlot.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+import { AD_CLIENT, adSlotId, type AdSlotName } from "./ads";
+
+/**
+ * An ad unit inside a React island.
+ *
+ * The Astro twin of this is AdSlot.astro; they render the same markup and
+ * reserve the same space. Two files rather than one because the game screens
+ * are a client island and the content pages are static HTML, and neither can
+ * host the other's component.
+ *
+ * The space is reserved by CSS whether or not anything fills it (see
+ * styles/ads.css). That is the load-bearing part on a game screen: the band
+ * sits above a race that is on a clock, so an ad arriving late must not be
+ * able to move the card or the keypad. It renders into a box that already
+ * exists at first paint.
+ */
+export function AdSlot({
+  name,
+  className = "",
+}: {
+  name: AdSlotName;
+  className?: string;
+}) {
+  const slot = adSlotId(name);
+  const pushed = useRef(false);
+
+  useEffect(() => {
+    if (!slot || pushed.current) return;
+    // Once per mounted unit. React 18's development double-effect would
+    // otherwise push twice for one <ins>, which AdSense counts as an error and
+    // logs loudly; the ref is what makes a remount safe too.
+    pushed.current = true;
+    try {
+      const ads = ((
+        window as unknown as { adsbygoogle?: unknown[] }
+      ).adsbygoogle ??= []);
+      ads.push({});
+    } catch {
+      // A blocked or failed loader is not this screen's problem. The reserved
+      // box stays exactly as it is and the game carries on.
+    }
+  }, [slot]);
+
+  // No unit id yet, or ads are off in this build. Keep the reservation so
+  // turning a slot on later can't shift a layout people already know.
+  if (!slot) return <div className={`ad ad--blank ${className}`} aria-hidden />;
+
+  return (
+    <aside className={`ad ${className}`} aria-label="Advertisement">
+      <span className="ad__label">Ad</span>
+      <ins
+        className="adsbygoogle ad__unit"
+        data-ad-client={AD_CLIENT}
+        data-ad-slot={slot}
+      />
+    </aside>
+  );
+}

--- a/src/components/site/ads.ts
+++ b/src/components/site/ads.ts
@@ -60,6 +60,20 @@ export type AdSlotName = keyof typeof AD_SLOTS;
 export const ADS_ENABLED =
   import.meta.env.PROD || import.meta.env.PUBLIC_ADS_PREVIEW === "1";
 
+/**
+ * Looking at the layout rather than at real ads.
+ *
+ * Before the units exist in the AdSense account there is nothing to render,
+ * and a reserved box with nothing in it is invisible — which makes a preview
+ * build useless for the one question worth asking early: does the band change
+ * how the game feels, and does it crowd the race on a small screen?
+ *
+ * So in preview only, an empty slot draws itself at exactly the reserved size.
+ * Never in production: there the same absence is silence, because a visible
+ * frame with no advert in it reads as broken rather than empty.
+ */
+export const ADS_PREVIEW = import.meta.env.PUBLIC_ADS_PREVIEW === "1";
+
 /** A slot is live only when ads are on AND its unit exists. */
 export const adSlotId = (name: AdSlotName): string | null =>
   ADS_ENABLED && AD_SLOTS[name] ? AD_SLOTS[name] : null;

--- a/src/components/site/ads.ts
+++ b/src/components/site/ads.ts
@@ -1,0 +1,65 @@
+/**
+ * Advertising configuration, in one file because every value here is a
+ * compliance decision rather than a preference.
+ *
+ * This site is directed to children. That is stated on /privacy, it is true,
+ * and it changes what advertising is allowed to be:
+ *
+ *   - Under COPPA a persistent identifier is personal information collected
+ *     from a child, and behavioural advertising is NOT covered by the
+ *     "support for internal operations" exception that ordinary analytics
+ *     relies on. Personalised ads here would need verifiable parental
+ *     consent, which a free static site cannot obtain.
+ *   - Google's own AdSense policy for child-directed content says the same
+ *     thing from the other side. The FTC's $170M action against YouTube in
+ *     2019 was precisely this configuration.
+ *
+ * So: non-personalised only, everywhere, unconditionally. There is no toggle
+ * and no per-page opt-out, because a page that got it wrong would be a
+ * compliance incident rather than a bug.
+ *
+ * ── Two things here are NOT sufficient on their own ─────────────────────────
+ * 1. `tagForChildDirectedTreatment` below is belt-and-braces. The AUTHORITATIVE
+ *    control is the child-directed declaration in the AdSense account, which
+ *    is a setting on the site, not markup. If that is not set, this flag will
+ *    not save you. Set it in the account first; treat the code as a second
+ *    lock on the same door.
+ * 2. Auto ads MUST be off for this site in the AdSense account. With them on,
+ *    Google injects placements wherever its model likes — including on top of
+ *    a race, next to the answer keypad, regardless of anything written here.
+ *    Every unit on this site is manual and declared below.
+ */
+
+/** The publisher id. Public by definition — it ships in the page source. */
+export const AD_CLIENT = "ca-pub-2742485876369367";
+
+/**
+ * Ad unit ids, created in the AdSense account.
+ *
+ * Empty until they exist. A slot with no id renders nothing at all rather than
+ * an `<ins>` Google will never fill, so the site is never shipping dead markup
+ * — and the reserved space is still reserved, so turning a slot on later
+ * cannot shift a layout that people have already learned.
+ */
+export const AD_SLOTS = {
+  /** Content pages: below the article, above the footer. */
+  content: "",
+  /** The game islands: a band above the game, on every screen. */
+  game: "",
+} as const;
+
+export type AdSlotName = keyof typeof AD_SLOTS;
+
+/**
+ * Whether to emit the loader and the units at all.
+ *
+ * Off in dev by default: `astro dev` should not be making requests to Google
+ * on every save, and an unfilled unit in development tells you nothing. Set
+ * PUBLIC_ADS_PREVIEW=1 to render them locally when you actually want to look.
+ */
+export const ADS_ENABLED =
+  import.meta.env.PROD || import.meta.env.PUBLIC_ADS_PREVIEW === "1";
+
+/** A slot is live only when ads are on AND its unit exists. */
+export const adSlotId = (name: AdSlotName): string | null =>
+  ADS_ENABLED && AD_SLOTS[name] ? AD_SLOTS[name] : null;

--- a/src/components/site/ads.ts
+++ b/src/components/site/ads.ts
@@ -42,8 +42,15 @@ export const AD_CLIENT = "ca-pub-2742485876369367";
  * cannot shift a layout that people have already learned.
  */
 export const AD_SLOTS = {
-  /** Content pages: below the article, above the footer. */
-  content: "",
+  /**
+   * In-article, between sections of a content page. Placed by hand at points
+   * where a reader has just finished something rather than mid-thought, and
+   * reused at more than one such point on a long page — this is where the
+   * viewable impressions are, because the reader is still on screen.
+   */
+  article: "",
+  /** Content pages: after the article, above the footer. */
+  foot: "",
   /** The game islands: a band above the game, on every screen. */
   game: "",
 } as const;

--- a/src/games/flashcards/App.tsx
+++ b/src/games/flashcards/App.tsx
@@ -1,6 +1,7 @@
 import { HashRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import { ToastRail } from "@/components/ToastRail";
+import { AdSlot } from "@/components/site/AdSlot";
 import { HubProvider, useHub } from "@/components/state/HubContext";
 import { RaceProvider } from "@/components/state/RaceContext";
 import {
@@ -74,6 +75,12 @@ function Shell() {
 
   return (
     <RaceProvider>
+      {/* Above everything, on every screen including a live race. Its height is
+          reserved in CSS at first paint and subtracted from the viewport by
+          `--ad-h`, so it cannot move the card or the keypad whenever it fills —
+          see src/styles/ads.css. Placed at the top of the island because that
+          is the furthest point in the layout from the answer controls. */}
+      <AdSlot name="game" className="ad--game" />
       <Routes>
         <Route path="/" element={<PlayerSelect />} />
         <Route path="/p/:profileId" element={<PlayerHub />} />

--- a/src/games/typing/App.tsx
+++ b/src/games/typing/App.tsx
@@ -1,6 +1,7 @@
 import { HashRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import { ToastRail } from "@/components/ToastRail";
+import { AdSlot } from "@/components/site/AdSlot";
 import { HubProvider, useHub } from "@/components/state/HubContext";
 import { RaceProvider } from "@/components/state/RaceContext";
 import { Button } from "@/components/ui/kit";
@@ -62,6 +63,12 @@ function Shell() {
 
   return (
     <RaceProvider>
+      {/* Above everything, on every screen including a live race. Its height is
+          reserved in CSS at first paint and subtracted from the viewport by
+          `--ad-h`, so it cannot move the card or the keypad whenever it fills —
+          see src/styles/ads.css. Placed at the top of the island because that
+          is the furthest point in the layout from the answer controls. */}
+      <AdSlot name="game" className="ad--game" />
       <Routes>
         <Route path="/" element={<PlayerSelect />} />
         <Route path="/p/:profileId" element={<TypingSetup />} />

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -15,6 +15,7 @@
  */
 import type { World } from "@/engine/worlds";
 import { THEME_COLOUR } from "@/engine/worlds";
+import { AD_CLIENT, ADS_ENABLED } from "@/components/site/ads";
 
 interface Props {
   title: string;
@@ -40,7 +41,7 @@ const ogImage = new URL(image, Astro.site).href;
 ---
 
 <!doctype html>
-<html lang="en" data-world={world}>
+<html lang="en" data-world={world} data-ads={ADS_ENABLED ? "on" : undefined}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -105,6 +106,40 @@ const ogImage = new URL(image, Astro.site).href;
           is:inline
           set:html={JSON.stringify(jsonLd)}
         />
+      )
+    }
+    {
+      /*
+       * Google AdSense.
+       *
+       * NON-PERSONALISED, ALWAYS. This site is directed to children, so
+       * behavioural advertising here would need verifiable parental consent
+       * that a free static site cannot obtain — see src/components/site/ads.ts
+       * for the COPPA and AdSense-policy reasoning, and /privacy for what we
+       * tell parents.
+       *
+       * The order of these two tags is the whole point. `requestNonPersonalized
+       * Ads` has to be set on the queue BEFORE the loader executes, because the
+       * loader reads it when it initialises; putting the async script first
+       * would leave a race in which the first ad request of a visit could go
+       * out personalised. Inline, synchronous, first.
+       *
+       * `is:inline` on both: Astro would otherwise bundle and hoist them, which
+       * breaks that ordering and rewrites the loader's URL.
+       */
+      ADS_ENABLED && (
+        <>
+          <script
+            is:inline
+            set:html={`window.adsbygoogle=window.adsbygoogle||[];window.adsbygoogle.requestNonPersonalizedAds=1;window.adsbygoogle.tagForChildDirectedTreatment=1;`}
+          />
+          <script
+            is:inline
+            async
+            crossorigin="anonymous"
+            src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${AD_CLIENT}`}
+          />
+        </>
       )
     }
   </head>

--- a/src/layouts/Content.astro
+++ b/src/layouts/Content.astro
@@ -42,12 +42,24 @@ const pause = world === "line" || world === "empty";
   <main id="main" class:list={["page", { "page--pause": pause }]}>
     <slot />
     {
-      /* After the article, never inside it. A content page has no clock and no
-        tap targets to sit next to, so this is the one slot on the site with no
-        interaction risk at all — and per issue #15 it is where the revenue
-        realistically is: the times-table pages are the search surface. */
+      /*
+       * After the article, never inside it. Every content page gets this one;
+       * long pages place `article` slots between their own sections as well,
+       * because a single unit at the very bottom of a scroll is the lowest
+       * viewability position on the page.
+       *
+       * Except the pause pages. /privacy and /terms carry no advertising at
+       * all: a privacy policy ringed with ads undermines the exact thing it
+       * exists to establish, and those two pages are a rounding error in the
+       * traffic anyway. `pause` already identifies them — it is the same
+       * property that strips the scenery.
+       */
+      !pause && (
+        <div class="wrap">
+          <AdSlot name="foot" />
+        </div>
+      )
     }
-    <div class="wrap"><AdSlot name="content" /></div>
   </main>
   <SiteFooter />
 </Base>

--- a/src/layouts/Content.astro
+++ b/src/layouts/Content.astro
@@ -11,6 +11,7 @@
 import Base from "@/layouts/Base.astro";
 import SiteHeader from "@/components/site/SiteHeader.astro";
 import SiteFooter from "@/components/site/SiteFooter.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
 import type { World } from "@/engine/worlds";
 import "@/styles/site.css";
 
@@ -40,6 +41,13 @@ const pause = world === "line" || world === "empty";
   <SiteHeader world={world} />
   <main id="main" class:list={["page", { "page--pause": pause }]}>
     <slot />
+    {
+      /* After the article, never inside it. A content page has no clock and no
+        tap targets to sit next to, so this is the one slot on the site with no
+        interaction risk at all — and per issue #15 it is where the revenue
+        realistically is: the times-table pages are the search surface. */
+    }
+    <div class="wrap"><AdSlot name="content" /></div>
   </main>
   <SiteFooter />
 </Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ import WorldMap from "@/components/site/WorldMap.astro";
 const title =
   "School Skills — free homeschool practice games for times tables, spelling and typing";
 const description =
-  "Three free practice games for homeschool and after-school: times tables, sight words and touch typing. No account, no cookies, works offline. A supplement to your lessons, not a curriculum.";
+  "Three free practice games for homeschool and after-school: times tables, sight words and touch typing. No account, no tracking, no personalised ads. A supplement to your lessons, not a curriculum.";
 ---
 
 <Content
@@ -94,8 +94,8 @@ const description =
             <li>
               <span class="truth__what">Free, offline and private</span>
               <span class="truth__why"
-                >No account, no ads, no cookies, no third-party scripts. Added
-                to an iPad&rsquo;s home screen it works with the wifi off.</span
+                >No account, no sign-up, no personalised ads. Added to an
+                iPad&rsquo;s home screen the games work with the wifi off.</span
               >
             </li>
             <li>
@@ -238,12 +238,13 @@ const description =
           That is a deliberate choice rather than a shortcut. Under COPPA a
           persistent identifier &mdash; an ad cookie, a device id, an analytics
           client id &mdash; counts as personal information collected from a
-          child. The way to not mishandle a child&rsquo;s data is to never
-          collect it, so there is no advertising, no analytics service and no
-          third-party script of any kind. We do count visitors and races, from
-          our own web server&rsquo;s logs, without putting anything on your
-          device to do it. <a href="/privacy">The full policy</a> is one page and
-          explains exactly how.
+          child. So there is no analytics service, and the ads that pay for the
+          site are non-personalised everywhere: chosen from the page they sit
+          on, never from anything about the child looking at it. Visitors and
+          races are counted from our own web server&rsquo;s logs, without
+          putting anything on your device to do it.
+          <a href="/privacy">The full policy</a> is one page and explains exactly
+          where the line is.
         </p>
         <h3>Back it up, because there&rsquo;s only one copy</h3>
         <p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
 import WorldMap from "@/components/site/WorldMap.astro";
 
 /**
@@ -62,6 +63,7 @@ const description =
     <WorldMap />
   </section>
 
+  <div class="wrap"><AdSlot name="article" /></div>
   <section class="band band--inset" id="limits">
     <div class="wrap">
       <h2 class="h2">What this is, and what it isn&rsquo;t</h2>
@@ -148,6 +150,7 @@ const description =
     </div>
   </section>
 
+  <div class="wrap"><AdSlot name="article" /></div>
   <section class="band wrap">
     <h2 class="h2">Where it fits in a day</h2>
     <p class="h2__sub">

--- a/src/pages/multiplication/[table]-times-table.astro
+++ b/src/pages/multiplication/[table]-times-table.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
 
 /**
  * One prerendered page per times table — the site's main organic-search
@@ -181,6 +182,7 @@ const description = `The full ${n} times table from ${n} × 1 to ${n} × 12, wit
     </div>
   </section>
 
+  <div class="wrap"><AdSlot name="article" /></div>
   <section class="band band--tight wrap">
     <h2 class="h2">The other levels</h2>
     <p class="h2__sub">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,9 +3,16 @@ import Content from "@/layouts/Content.astro";
 
 /**
  * ⚠️ This document describes the site as it actually behaves TODAY: no
- * accounts, no advertising, no cookies, no third-party requests, and no
- * identifier of any kind written to a child's device. That is an unusually
- * strong claim and it is only true while it stays true.
+ * accounts, no tracking, and non-personalised advertising everywhere. The
+ * remaining claims are still unusually strong and are only true while they
+ * stay true.
+ *
+ * Advertising was added on 17 August 2026. The line that must not move is
+ * NON-PERSONALISED: it is set in Base.astro before the AdSense loader is
+ * allowed to execute, and the authoritative control is the child-directed
+ * declaration in the AdSense account. Personalised ads on a site directed to
+ * children would need verifiable parental consent this site cannot obtain —
+ * see src/components/site/ads.ts.
  *
  * If an ad network, embedded video, a hosted analytics service or any
  * third-party script is ever added, this page MUST be updated in the same pull
@@ -28,8 +35,8 @@ import Content from "@/layouts/Content.astro";
  */
 const title = "Privacy — School Skills";
 const description =
-  "School Skills has no accounts, no advertising, no cookies and no third-party scripts. Everything a child does stays in their own browser. We count visits from our own server logs and nothing else.";
-const updated = "16 August 2026";
+  "School Skills has no accounts and no tracking. Advertising is non-personalised everywhere, because the site is made for children. Everything a child does in a game stays in their own browser.";
+const updated = "17 August 2026";
 ---
 
 <Content title={title} description={description} world="line">
@@ -38,11 +45,12 @@ const updated = "16 August 2026";
       <span class="hero__world">Privacy</span>
       Updated {updated}
     </p>
-    <h1 class="hero__title">Nothing about your child leaves your device</h1>
+    <h1 class="hero__title">No accounts, no tracking, no personalised ads</h1>
     <p class="hero__lead">
-      That is the whole policy. We count visits the way a web server always has,
-      and we stop there. The rest of this page explains how that can be true,
-      and what it means for you.
+      What your child does in a game stays on your device. The site carries
+      advertising to pay for itself, and those ads are non-personalised
+      everywhere &mdash; chosen from the page, never from your child. This page
+      explains exactly where that line is.
     </p>
   </header>
 
@@ -50,10 +58,18 @@ const updated = "16 August 2026";
     <div class="prose">
       <h2>What we collect</h2>
       <p>
-        Nothing about your child. There are no accounts, no sign-up, no email
-        addresses, no advertising, no cookies, and no third-party scripts of any
-        kind. Nothing your child does in a game is sent anywhere, and nothing
+        Nothing about your child. There are no accounts, no sign-up and no email
+        addresses. Nothing your child does in a game &mdash; the words they
+        type, the answers they give, the times they run &mdash; is sent
+        anywhere; it is written to your own device and stays there. Nothing
         stored on your device identifies them to us or to anyone else.
+      </p>
+      <p>
+        The site does carry advertising, and that is the one part of it
+        involving another company. Those ads are non-personalised everywhere, so
+        no profile of your child is built or used to choose them. The
+        Advertising section below says exactly what Google does and does not
+        receive.
       </p>
       <p>
         We do count how many people visit and which parts of the site get used
@@ -96,13 +112,19 @@ const updated = "16 August 2026";
 
       <h2>Children</h2>
       <p>
-        This site is intended for children and the adults helping them. We do
-        not knowingly collect personal information from a child. In particular
-        there are no persistent identifiers &mdash; no advertising ID, no
-        analytics ID, no tracking cookie, nothing written to the device that
-        would let anyone recognise the same child twice. Those are what
-        children&rsquo;s privacy law treats as personal information, and not
-        having them is the point rather than an oversight.
+        This site is intended for children and the adults helping them, and that
+        governs what the advertising on it is allowed to be. We do not build a
+        profile of any child, we do not use one to choose an ad, and
+        personalised advertising is not permitted anywhere on the site. We set
+        no advertising ID, no analytics ID and no tracking cookie of our own.
+      </p>
+      <p>
+        Google&rsquo;s ad requests are the exception to &ldquo;nothing leaves
+        the device&rdquo;, and we would rather say so plainly than bury it: an
+        ad request reaches Google, carries an IP address, and may set a cookie
+        for frequency capping and fraud prevention. What it does not do is
+        target your child &mdash; non-personalised is set on every page before
+        the advertising code is allowed to run at all.
       </p>
       <p>
         The one exception is the ordinary web-server log described below, which
@@ -118,8 +140,10 @@ const updated = "16 August 2026";
 
       <h2>Cookies</h2>
       <p>
-        We don&rsquo;t set any. There is no consent banner because there is
-        nothing to consent to.
+        We don&rsquo;t set any of our own. Google&rsquo;s advertising may set
+        cookies for purposes such as limiting how often the same ad is shown and
+        detecting fraudulent clicks &mdash; not for building a profile, because
+        the ads are non-personalised.
       </p>
 
       <h2>Hosting, and how we count</h2>
@@ -156,9 +180,31 @@ const updated = "16 August 2026";
 
       <h2>Advertising</h2>
       <p>
-        There are no ads on this site today. If that ever changes, this page
-        will be updated before any advertising code is added, and the change
-        will be dated here.
+        This site carries advertising from Google AdSense, including on the game
+        screens. It is how a free site with no accounts and nothing to sell pays
+        for itself.
+      </p>
+      <p>
+        <strong>The ads are non-personalised, everywhere, always.</strong> They are
+        chosen from the page they appear on rather than from anything about the person
+        looking at it. No profile of your child is built, consulted or added to. There
+        is no setting for this and no page it doesn&rsquo;t apply to, because a site
+        made for children is not a place where behavioural advertising belongs &mdash;
+        and under children&rsquo;s privacy law it would need a level of parental consent
+        a free website cannot honestly obtain.
+      </p>
+      <p>
+        Google still receives the request that loads an ad. That request carries
+        an IP address, as every web request does, and Google may set a cookie
+        for purposes such as capping how often an ad repeats and detecting
+        fraudulent clicks. This is a real change from how the site worked
+        before, and it is why nothing on this page claims any more that there
+        are no third-party requests.
+      </p>
+      <p>
+        Ads are labelled and kept in a marked frame. The youngest player here is
+        five, and telling advertising from content is a skill children acquire
+        late.
       </p>
 
       <h2>Changes</h2>

--- a/src/pages/spelling/index.astro
+++ b/src/pages/spelling/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
 import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
 
 /**
@@ -100,6 +101,7 @@ const description =
     </table>
   </section>
 
+  <div class="wrap"><AdSlot name="article" /></div>
   <section class="band band--inset">
     <div class="wrap">
       <h2 class="h2">Heard in a sentence, not copied</h2>

--- a/src/styles/ads.css
+++ b/src/styles/ads.css
@@ -1,0 +1,135 @@
+/*
+ * Ad slots.
+ *
+ * Two jobs, and the first one is the important one.
+ *
+ * ── Reserving space, so an ad can never move the game ───────────────────────
+ * The band on the game islands sits above a race that is on a clock. An ad
+ * that arrives late and pushes the card down by 90px moves the answer keypad
+ * under a child's finger mid-tap — that is a wrong answer they didn't give,
+ * and on a timed card it is unrecoverable. So the space is reserved by CSS at
+ * first paint, before any request to Google has been made, and the ad renders
+ * INTO a box that already exists. Whether the ad loads, fails, is blocked, or
+ * the device is offline, the layout is identical.
+ *
+ * `--ad-h` is the mechanism. It is 0 by default and only becomes a real height
+ * on pages that actually carry a band, so screens sized to `100dvh` can
+ * subtract it and stay exactly one viewport tall — see `.race`, `.select` and
+ * `.boot`. Without that subtraction a race would gain a scrollbar it never had.
+ *
+ * ── Saying it's an ad ───────────────────────────────────────────────────────
+ * The label is not decoration and not a legal formality we're copying. The
+ * youngest player here is five, and the ability to tell advertising from
+ * content is a skill children acquire late — younger ones simply don't. A
+ * small, permanent, unmissable label is the least we can do about that.
+ */
+
+:root {
+  --ad-h: 0px;
+}
+
+/* Only pages that carry the band pay for it. Set on <html> by Base.astro. */
+[data-ads="on"] {
+  /* A phone in a race has very little screen; 50px is the standard mobile
+     banner and roughly 8% of a short viewport. 90px (leaderboard) only once
+     there is room to spare. */
+  --ad-h: 50px;
+}
+
+@media (width >= 728px) {
+  [data-ads="on"] {
+    --ad-h: 90px;
+  }
+}
+
+.ad {
+  /* Exactly the reserved height. Never min-height: a unit that grows is a
+     unit that shifts, which is the whole thing this file exists to prevent. */
+  height: var(--ad-h);
+  width: 100%;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  position: relative;
+  background: var(--ink-850);
+  border-bottom: 1px solid var(--ink-800);
+}
+
+/* The band above a game. Full-bleed, hard against the top of the island. */
+.ad--game {
+  margin-inline: 0;
+}
+
+/*
+ * On a content page there is no clock and nothing to mis-tap, so the slot can
+ * breathe: it sits in normal flow with the page's own rhythm around it, and
+ * takes the leaderboard height at every width.
+ */
+.ad--content {
+  height: 90px;
+  margin-block: var(--gap-5);
+  border: 1px solid var(--ink-800);
+  border-radius: 12px;
+}
+
+.ad__label {
+  position: absolute;
+  top: 2px;
+  left: 6px;
+  z-index: 1;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--chalk-dim);
+  pointer-events: none;
+}
+
+/*
+ * A FIXED unit, sized to match the reservation exactly at each breakpoint.
+ *
+ * Not a responsive unit. A responsive one measures its container and may
+ * return a 100px creative for a 50px box — which `overflow: hidden` would then
+ * clip, and a clipped ad breaches AdSense's viewability policy. Naming the
+ * size means Google fills it with something that fits, so the box and the
+ * creative agree and nothing is cropped or shifted.
+ *
+ * These two sizes are standard AdSense inventory (mobile banner and
+ * leaderboard), so they are the two most likely to fill. Their heights are
+ * `--ad-h` above; if one changes, both change.
+ */
+.ad__unit {
+  display: inline-block;
+  width: 320px;
+  height: 50px;
+}
+
+@media (width >= 728px) {
+  .ad__unit {
+    width: 728px;
+    height: 90px;
+  }
+}
+
+/* The content slot is always leaderboard height, so on a narrow screen it
+   holds the mobile banner centred rather than a cropped wide one. */
+.ad--content .ad__unit {
+  height: 50px;
+}
+
+@media (width >= 728px) {
+  .ad--content .ad__unit {
+    height: 90px;
+  }
+}
+
+/*
+ * Nothing to show — no slot id yet, ads disabled, or the request failed. The
+ * box stays exactly the same size and says nothing, because an empty labelled
+ * frame looks like a broken advert rather than an absent one.
+ */
+.ad:empty,
+.ad--blank {
+  background: none;
+  border: 0;
+}

--- a/src/styles/ads.css
+++ b/src/styles/ads.css
@@ -65,11 +65,22 @@
  * breathe: it sits in normal flow with the page's own rhythm around it, and
  * takes the leaderboard height at every width.
  */
-.ad--content {
+.ad--content,
+.ad--article {
   height: 90px;
   margin-block: var(--gap-5);
   border: 1px solid var(--ink-800);
   border-radius: 12px;
+}
+
+/*
+ * In-article, between two sections. More breathing room than the footer slot
+ * gets, because this one interrupts a page someone is reading rather than
+ * sitting after it — the space either side is what keeps it a pause rather
+ * than an intrusion.
+ */
+.ad--article {
+  margin-block: var(--gap-6, 3rem);
 }
 
 .ad__label {
@@ -113,12 +124,14 @@
 
 /* The content slot is always leaderboard height, so on a narrow screen it
    holds the mobile banner centred rather than a cropped wide one. */
-.ad--content .ad__unit {
+.ad--content .ad__unit,
+.ad--article .ad__unit {
   height: 50px;
 }
 
 @media (width >= 728px) {
-  .ad--content .ad__unit {
+  .ad--content .ad__unit,
+  .ad--article .ad__unit {
     height: 90px;
   }
 }

--- a/src/styles/ads.css
+++ b/src/styles/ads.css
@@ -133,3 +133,28 @@
   background: none;
   border: 0;
 }
+
+/*
+ * PUBLIC_ADS_PREVIEW only — never production. Draws the reserved box so the
+ * placement can be judged before any unit exists in the AdSense account.
+ * Hatched rather than solid so nobody mistakes a screenshot of this for a
+ * screenshot of the live site.
+ */
+.ad--preview {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--ink-850),
+    var(--ink-850) 8px,
+    var(--ink-800) 8px,
+    var(--ink-800) 16px
+  );
+  border: 1px dashed var(--chalk-dim);
+}
+
+.ad__ghost {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--chalk-soft);
+}

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -396,7 +396,11 @@
 .race {
   width: min(720px, 100%);
   margin-inline: auto;
-  min-height: 100dvh;
+  /* One viewport MINUS the ad band above it (0 when there is none). Without
+     the subtraction a race gains a scrollbar the moment ads are switched on,
+     and a page that scrolls under a child's thumb mid-answer is worse than
+     the ad is worth. */
+  min-height: calc(100dvh - var(--ad-h));
   padding: clamp(0.75rem, 2.5vw, 1.5rem) clamp(0.75rem, 3vw, 1.5rem)
     clamp(1rem, 3vw, 2rem);
   display: grid;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -8,3 +8,4 @@
 @import "./components.css";
 @import "./screens.css";
 @import "./game.css";
+@import "./ads.css";

--- a/src/styles/screens.css
+++ b/src/styles/screens.css
@@ -43,7 +43,7 @@
 }
 
 .boot {
-  min-height: 100dvh;
+  min-height: calc(100dvh - var(--ad-h));
   display: grid;
   place-content: center;
   justify-items: center;
@@ -84,7 +84,7 @@
 /* ── Player select ─────────────────────────────────────────────────────── */
 
 .select {
-  min-height: 100dvh;
+  min-height: calc(100dvh - var(--ad-h));
   justify-content: center;
 }
 

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -8,3 +8,4 @@
 @import "./chrome.css";
 @import "./content.css";
 @import "./map.css";
+@import "./ads.css";


### PR DESCRIPTION
Google AdSense on content pages **and** the game screens, including a live race.
Non-personalised everywhere, unconditionally.

Closes part of #15.

## Why non-personalised isn't a setting

This site is directed to children, which decides what advertising on it is
allowed to be:

- Under COPPA a persistent identifier is personal information collected from a
  child, and behavioural advertising is **not** covered by the
  "support for internal operations" exception the access-log counting relies on.
  Personalised ads would need verifiable parental consent a free static site
  cannot obtain.
- Google's AdSense policy for child-directed content says the same from the
  other side. The FTC's $170M action against YouTube in 2019 was this exact
  configuration.

So it's forced in `Base.astro`, **synchronously, before the async loader runs**:

```html
<script>window.adsbygoogle=window.adsbygoogle||[];
        window.adsbygoogle.requestNonPersonalizedAds=1;
        window.adsbygoogle.tagForChildDirectedTreatment=1;</script>
<script async src="…adsbygoogle.js?client=…" crossorigin="anonymous"></script>
```

The loader reads that flag when it initialises, so the reverse order leaves a
race in which the **first ad request of a visit goes out personalised**. The
ordering is asserted against the built HTML rather than assumed.

## The band above a race

An ad that arrives late and pushes the card down moves the keypad under a
child's finger mid-tap — a wrong answer they didn't give, on a timed card they
can't get back. Two things stop that:

- **The height is reserved in CSS at first paint**, before any request to Google
  exists. The ad renders into a box that is already there.
- **`--ad-h` is subtracted from the `100dvh`** on `.race`, `.select` and `.boot`.
  Without it the race gains a scrollbar the moment ads switch on, and a page
  that scrolls under a thumb mid-answer costs a card.

Measured on a 390×844 viewport during a live race, injecting a creative into the
band:

```
band height reserved : 50 px
card/keypad top      : 302 → 302
document height      : 844 → 844   (viewport 844)
page scrolls?        : false → false
```

**The unit is fixed (320×50 / 728×90), not responsive** — and that came from
looking at a screenshot rather than reasoning. A responsive unit returned a
100px creative into the 50px box and `overflow: hidden` cropped it, which
breaches AdSense's viewability policy. Naming the size makes box and creative
agree.

## Nothing renders yet, on purpose

`AD_SLOTS` in `src/components/site/ads.ts` is empty until the units exist in the
account, so this build emits the loader and **zero `<ins>` elements** rather than
markup Google will never fill. The space is reserved regardless, so turning a
slot on later cannot shift a layout people have already learned.

## Copy changes were due, not optional

`/privacy` promised *ordering*: "this page will be updated **before** any
advertising code is added." So it's rewritten here rather than in a follow-up.
Its Advertising, Cookies, Children and What-we-collect sections all said things
that would have become false, as did two claims on the homepage.

| Was | Now |
| --- | --- |
| "There are no ads on this site today" | full description of what Google does and doesn't receive |
| "no third-party scripts of any kind" | names advertising as the one thing involving another company |
| "We don't set any [cookies]" | ours: none. Google's: frequency capping and fraud, not profiling |
| "no persistent identifiers… nothing written to the device" | no profile built or used; ad requests stated plainly |

What stays true is untouched: no accounts, no sign-up, and nothing a child does
in a game leaving the device.

Ads are labelled and framed — the youngest player is five, and telling
advertising from content is a skill children acquire late.

## Three account settings override everything in this PR

Called out in `ads.ts` where someone will look, but they are **not** code:

1. **Auto ads must be OFF for this site.** With them on, Google injects
   placements wherever its model likes — including beside the answer keypad —
   whatever our markup says. Every unit here is manual.
2. **The child-directed declaration in the account is the authoritative
   control.** The page-level flag is a second lock on the same door. Worth
   confirming the current parameter against Google's docs rather than trusting
   this PR's memory of the syntax.
3. **A certified CMP is still needed for EEA/UK traffic.** Not in this PR — it's
   another third-party script and worth deciding on deliberately.

## Verification

type-check, lint, format, 180 unit tests, build. Built HTML checked for loader
presence, NPA-before-loader ordering, `data-ads` flag, and zero `<ins>` while
slots are empty. Race-screen CLS measured in real Chrome as above.

**Reviewer note:** the placement decision — ads on the race screen rather than
only the game shell — was made deliberately with the accidental-click risk
stated. That risk is now a matter of execution (distance from controls, fixed
reservation, manual units) rather than something the code can remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
