### PR TITLE
Keep the game routes out of search

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@
 import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
+import { WORLDS } from "./src/engine/worlds";
 
 /**
  * Static output, deliberately.
@@ -18,7 +19,27 @@ import sitemap from "@astrojs/sitemap";
 export default defineConfig({
   site: "https://schoolskills.app",
   output: "static",
-  integrations: [react(), sitemap()],
+  integrations: [
+    react(),
+    sitemap({
+      /*
+       * The game routes are not in the sitemap, because they carry
+       * `noindex` (see Base.astro): each one is a `client:only` island whose
+       * prerendered body is two words, so there is nothing to rank and a
+       * shelf of near-empty pages is a thin-content signal against the whole
+       * domain. Submitting a URL while telling Google to ignore it is a
+       * contradiction Search Console reports back at you.
+       *
+       * Derived from WORLDS rather than written out, so a new world cannot
+       * be added to the map and quietly left in the sitemap — `href` on a
+       * world IS its game route.
+       */
+      filter: (page) => {
+        const path = new URL(page).pathname.replace(/\/$/, "");
+        return !WORLDS.some((world) => world.href === path);
+      },
+    }),
+  ],
   // Emit `/about/index.html` rather than `/about.html` so CloudFront can serve
   // clean URLs from S3 without a rewrite function.
   build: { format: "directory" },

--- a/scripts/post-deploy-smoke.sh
+++ b/scripts/post-deploy-smoke.sh
@@ -135,6 +135,27 @@ else
   echo "  ✓ ${pagecount} pages listed in the sitemap"
 fi
 
+# --- the game routes ---------------------------------------------------------
+#
+# Deliberately NOT in the sitemap: each is a `client:only` island whose
+# prerendered body is two words, so they carry `noindex` and are filtered out
+# in astro.config.mjs. That is correct for search and it silently removed them
+# from the loop above, which discovers pages FROM the sitemap — leaving the
+# three most important URLs on the site unchecked after a deploy.
+#
+# So they are named here. A new world means a new line here as well as an entry
+# in src/engine/worlds.ts; there is no way to derive one from the other in a
+# script that only has an origin to talk to.
+echo "Game routes (noindex, so not in the sitemap):"
+for path in /flash-cards/ /spelling/play/ /typing/; do
+  try "${path}" "200" status "${BASE}${path}"
+  # The noindex is the point of excluding them, so it is worth asserting: a
+  # game route that lost its robots tag would start competing with the content
+  # page written to rank for exactly that query.
+  try "${path} is noindex" "yes" \
+    body_contains "${BASE}${path}" 'name="robots" content="noindex'
+done
+
 # --- everything that isn't a page --------------------------------------------
 
 echo "Delivery:"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,6 +25,24 @@ interface Props {
   jsonLd?: Record<string, unknown>;
   /** Which world this page is in. Drives every colour on it. */
   world?: World;
+  /**
+   * Keep this page out of search results.
+   *
+   * For the game routes, which are `client:only` islands: their prerendered
+   * body is two words, so there is nothing for a crawler to rank and a shelf
+   * of near-empty pages is a thin-content signal against the whole domain.
+   * The crawlable surface is the content pages AROUND the islands — that is
+   * the split the architecture is built on, and this is the half of it that
+   * was missing.
+   *
+   * `follow` rather than `nofollow`: the page is not worth indexing, but the
+   * links out of it — to the map, to the other worlds — still are.
+   *
+   * Anything set here must also be excluded from the sitemap; listing a URL
+   * you have told Google to ignore is a contradiction it reports back to you.
+   * astro.config.mjs does that from the same list of routes.
+   */
+  noindex?: boolean;
 }
 
 const {
@@ -33,6 +51,7 @@ const {
   image = "/og-default.png",
   jsonLd,
   world = "grid",
+  noindex = false,
 } = Astro.props;
 
 const canonical = new URL(Astro.url.pathname, Astro.site).href;
@@ -47,6 +66,7 @@ const ogImage = new URL(image, Astro.site).href;
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonical} />
+    {noindex && <meta name="robots" content="noindex, follow" />}
 
     <meta property="og:type" content="website" />
     <meta property="og:title" content={title} />

--- a/src/pages/flash-cards.astro
+++ b/src/pages/flash-cards.astro
@@ -26,6 +26,7 @@ const description =
   title={title}
   description={description}
   world="grid"
+  noindex
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/spelling/play.astro
+++ b/src/pages/spelling/play.astro
@@ -26,6 +26,7 @@ const description =
   title={title}
   description={description}
   world="jungle"
+  noindex
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/typing.astro
+++ b/src/pages/typing.astro
@@ -23,6 +23,7 @@ const description =
   title={title}
   description={description}
   world="ice"
+  noindex
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",


### PR DESCRIPTION
`/flash-cards`, `/spelling/play` and `/typing` are `client:only` islands whose
prerendered body is **two words each**. There is nothing on them for a crawler
to read, and `/spelling/play` was competing with `/spelling` — the page
actually written to answer "what are sight words" — for its own query.

- `noindex, follow` via a new prop on `Base.astro`. `follow` because the page
  isn't worth indexing but the links out of it are.
- Filtered from the sitemap in `astro.config.mjs`, derived from `WORLDS` so a
  new world can't be added to the map and left in the sitemap by accident.
  Submitting a URL you've told Google to ignore is a contradiction Search
  Console reports back at you.

Sitemap goes **19 → 16**.

## The regression this nearly caused

The post-deploy smoke discovers pages **from the deployed sitemap** — a
deliberate design that caught a real outage once. But that means removing a
route from the sitemap silently removes it from post-deploy verification, and
these are the three most important URLs on the site. `/flash-cards` could have
started 404ing after a deploy with nothing to say so.

The smoke now names them explicitly and asserts the `noindex` tag as well as
the status:

```
Game routes (noindex, so not in the sitemap):
  ✓ /flash-cards/
  ✓ /flash-cards/ is noindex
  ✓ /spelling/play/
  ✓ /spelling/play/ is noindex
  ✓ /typing/
  ✓ /typing/ is noindex
```

## Worth knowing before merging

**Frost Keys now has no crawlable surface at all.** `/typing` was its only
page, and unlike the other two it has no guide behind it — The Grid has the
twelve times-table pages, Word Jungle has `/spelling`. A two-word page was
never going to rank for "typing practice for kids" anyway, so nothing is lost
today, but the real fix is a guide page and that's its own story.

## Verification

type-check, lint, format, 180 tests, build. Sitemap contents checked (16 URLs,
no game routes), robots meta confirmed present on all three game routes and
absent from every content page, smoke run against a local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)