### PR TITLE
Ads dormant until the site is actually approved

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/jordan.bush/repos/schoolskills/node_modules

--- a/src/components/site/AdSlot.astro
+++ b/src/components/site/AdSlot.astro
@@ -1,5 +1,11 @@
 ---
-import { AD_CLIENT, ADS_PREVIEW, adSlotId, type AdSlotName } from "./ads";
+import {
+  AD_CLIENT,
+  ADS_ENABLED,
+  ADS_PREVIEW,
+  adSlotId,
+  type AdSlotName,
+} from "./ads";
 
 /**
  * An ad unit on a static content page.
@@ -23,7 +29,11 @@ const slot = adSlotId(name);
 ---
 
 {
-  slot ? (
+  /* Ads off entirely (see ADS_LIVE): nothing at all, not even the reservation.
+     A reserved box with no advertising behind it is just a gap in the page. */
+}
+{
+  !ADS_ENABLED ? null : slot ? (
     <aside class:list={["ad", className]} aria-label="Advertisement">
       <span class="ad__label">Ad</span>
       <ins

--- a/src/components/site/AdSlot.tsx
+++ b/src/components/site/AdSlot.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useRef } from "react";
-import { AD_CLIENT, ADS_PREVIEW, adSlotId, type AdSlotName } from "./ads";
+import {
+  AD_CLIENT,
+  ADS_ENABLED,
+  ADS_PREVIEW,
+  adSlotId,
+  type AdSlotName,
+} from "./ads";
 
 /**
  * An ad unit inside a React island.
@@ -42,8 +48,15 @@ export function AdSlot({
     }
   }, [slot]);
 
-  // No unit id yet, or ads are off in this build. Keep the reservation so
-  // turning a slot on later can't shift a layout people already know.
+  // Ads off entirely (see ADS_LIVE): render nothing at all, not even the
+  // reservation. A reserved box with no advertising behind it is just a gap in
+  // the page — the reservation exists to stop a KNOWN unit shifting things, not
+  // to hold space for advertising that isn't running.
+  if (!ADS_ENABLED) return null;
+
+  // Ads are on but this unit doesn't exist in the account yet. Keep the
+  // reservation so turning it on later can't shift a layout people already
+  // know.
   if (!slot) {
     return (
       <div

--- a/src/components/site/ads.ts
+++ b/src/components/site/ads.ts
@@ -19,11 +19,16 @@
  * compliance incident rather than a bug.
  *
  * ── Two things here are NOT sufficient on their own ─────────────────────────
- * 1. `tagForChildDirectedTreatment` below is belt-and-braces. The AUTHORITATIVE
- *    control is the child-directed declaration in the AdSense account, which
- *    is a setting on the site, not markup. If that is not set, this flag will
- *    not save you. Set it in the account first; treat the code as a second
- *    lock on the same door.
+ * 1. `tagForChildDirectedTreatment` in Base.astro DOES NOTHING. That is not a
+ *    guess: the live ad request was captured from production and carried
+ *    `npa=1` but no `tfcd` and no `tag_for_child_directed_treatment` at all.
+ *    The property is a GPT/AdMob mechanism and AdSense's loader ignores it.
+ *
+ *    So the child-directed declaration in the AdSense account is not a backup
+ *    to the code — it is the ONLY thing that sets this signal. It is left in
+ *    the markup because it is harmless and may one day be honoured, but do
+ *    not read it as protection. `requestNonPersonalizedAds`, by contrast, was
+ *    confirmed working: `npa=1` was present on every request.
  * 2. Auto ads MUST be off for this site in the AdSense account. With them on,
  *    Google injects placements wherever its model likes — including on top of
  *    a race, next to the answer keypad, regardless of anything written here.
@@ -58,14 +63,34 @@ export const AD_SLOTS = {
 export type AdSlotName = keyof typeof AD_SLOTS;
 
 /**
+ * Is this site actually live in the AdSense account?
+ *
+ * FALSE, and it stays false until the site is approved and serving. This is
+ * not caution for its own sake — a loader on an unapproved site is the worst
+ * of both worlds. It contacts pagead2.googlesyndication.com and
+ * googleads.g.doubleclick.net on every page load, from a child's device, and
+ * receives `unfilled` in return. All of the privacy cost, none of the revenue.
+ *
+ * That is exactly what production was doing after the site was removed from
+ * AdSense, which is what this constant exists to prevent happening again.
+ *
+ * Flipping it to true is a one-line change and MUST be made in the same pull
+ * request that restores the advertising sections of /privacy — that page has
+ * to describe what the site does, in both directions. See the header there.
+ */
+const ADS_LIVE = false;
+
+/**
  * Whether to emit the loader and the units at all.
  *
- * Off in dev by default: `astro dev` should not be making requests to Google
+ * Off in dev regardless: `astro dev` should not be making requests to Google
  * on every save, and an unfilled unit in development tells you nothing. Set
- * PUBLIC_ADS_PREVIEW=1 to render them locally when you actually want to look.
+ * PUBLIC_ADS_PREVIEW=1 to render them locally when you want to look at the
+ * layout — that path draws placeholders and never loads the real script.
  */
 export const ADS_ENABLED =
-  import.meta.env.PROD || import.meta.env.PUBLIC_ADS_PREVIEW === "1";
+  (ADS_LIVE && import.meta.env.PROD) ||
+  import.meta.env.PUBLIC_ADS_PREVIEW === "1";
 
 /**
  * Looking at the layout rather than at real ads.

--- a/src/components/site/ads.ts
+++ b/src/components/site/ads.ts
@@ -74,6 +74,12 @@ export type AdSlotName = keyof typeof AD_SLOTS;
  * That is exactly what production was doing after the site was removed from
  * AdSense, which is what this constant exists to prevent happening again.
  *
+ * False does NOT block getting approved. AdSense verifies ownership by ad
+ * code, by ads.txt, or by a meta tag, and Base.astro emits the meta tag
+ * unconditionally while public/ads.txt names the same publisher. So the site
+ * can be added, verified and reviewed with the loader still dark, and the
+ * only thing waiting on approval is the moment ads actually serve.
+ *
  * Flipping it to true is a one-line change and MUST be made in the same pull
  * request that restores the advertising sections of /privacy — that page has
  * to describe what the site does, in both directions. See the header there.

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -128,6 +128,22 @@ const ogImage = new URL(image, Astro.site).href;
         />
       )
     }
+    <!--
+      Proves to AdSense that we own this domain, and nothing else.
+
+      It is inert markup: no script, no request, no identifier — so unlike the
+      loader below it costs a visitor nothing and is emitted unconditionally,
+      including while ADS_LIVE is false. That combination is the point.
+      AdSense will verify a site by ad code, by ads.txt, OR by this tag, and
+      the tag exists precisely for publishers who do not want the loader on
+      the page. So the site can sit in review, or sit approved-but-dark, with
+      no child's browser ever contacting Google.
+
+      Keep it in step with AD_CLIENT and with public/ads.txt: all three name
+      the same publisher, and a mismatch fails verification silently.
+    -->
+    <meta name="google-adsense-account" content={AD_CLIENT} />
+
     {
       /*
        * Google AdSense.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ import WorldMap from "@/components/site/WorldMap.astro";
 const title =
   "School Skills — free homeschool practice games for times tables, spelling and typing";
 const description =
-  "Three free practice games for homeschool and after-school: times tables, sight words and touch typing. No account, no tracking, no personalised ads. A supplement to your lessons, not a curriculum.";
+  "Three free practice games for homeschool and after-school: times tables, sight words and touch typing. No account, no cookies, works offline. A supplement to your lessons, not a curriculum.";
 ---
 
 <Content
@@ -96,8 +96,8 @@ const description =
             <li>
               <span class="truth__what">Free, offline and private</span>
               <span class="truth__why"
-                >No account, no sign-up, no personalised ads. Added to an
-                iPad&rsquo;s home screen the games work with the wifi off.</span
+                >No account, no ads, no cookies, no third-party scripts. Added
+                to an iPad&rsquo;s home screen it works with the wifi off.</span
               >
             </li>
             <li>
@@ -241,13 +241,12 @@ const description =
           That is a deliberate choice rather than a shortcut. Under COPPA a
           persistent identifier &mdash; an ad cookie, a device id, an analytics
           client id &mdash; counts as personal information collected from a
-          child. So there is no analytics service, and the ads that pay for the
-          site are non-personalised everywhere: chosen from the page they sit
-          on, never from anything about the child looking at it. Visitors and
-          races are counted from our own web server&rsquo;s logs, without
-          putting anything on your device to do it.
-          <a href="/privacy">The full policy</a> is one page and explains exactly
-          where the line is.
+          child. The way to not mishandle a child&rsquo;s data is to never
+          collect it, so there is no advertising, no analytics service and no
+          third-party script of any kind. We do count visitors and races, from
+          our own web server&rsquo;s logs, without putting anything on your
+          device to do it. <a href="/privacy">The full policy</a> is one page and
+          explains exactly how.
         </p>
         <h3>Back it up, because there&rsquo;s only one copy</h3>
         <p>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,20 +3,21 @@ import Content from "@/layouts/Content.astro";
 
 /**
  * ⚠️ This document describes the site as it actually behaves TODAY: no
- * accounts, no tracking, and non-personalised advertising everywhere. The
- * remaining claims are still unusually strong and are only true while they
- * stay true.
- *
- * Advertising was added on 17 August 2026. The line that must not move is
- * NON-PERSONALISED: it is set in Base.astro before the AdSense loader is
- * allowed to execute, and the authoritative control is the child-directed
- * declaration in the AdSense account. Personalised ads on a site directed to
- * children would need verifiable parental consent this site cannot obtain —
- * see src/components/site/ads.ts.
+ * accounts, no advertising, no cookies, no third-party requests, and no
+ * identifier of any kind written to a child's device. That is an unusually
+ * strong claim and it is only true while it stays true.
  *
  * If an ad network, embedded video, a hosted analytics service or any
  * third-party script is ever added, this page MUST be updated in the same pull
- * request. Under COPPA a persistent identifier — an ad cookie, a device id, an
+ * request. That rule bites in BOTH directions: advertising shipped on
+ * 17 August 2026 and this page described it, then the site was removed from
+ * AdSense and the text came back here, because a policy page that claims data
+ * flows which are not happening is as wrong as one that hides flows that are.
+ *
+ * The advertising code is still in the tree, dormant behind `ADS_LIVE` in
+ * src/components/site/ads.ts. Turning that back on means restoring the
+ * advertising sections of this page in the SAME pull request. Do not do one
+ * without the other. Under COPPA a persistent identifier — an ad cookie, a device id, an
  * analytics client id — counts as personal information collected from a child,
  * and shipping one while this page says otherwise turns a technical change into
  * a false statement.
@@ -35,8 +36,8 @@ import Content from "@/layouts/Content.astro";
  */
 const title = "Privacy — School Skills";
 const description =
-  "School Skills has no accounts and no tracking. Advertising is non-personalised everywhere, because the site is made for children. Everything a child does in a game stays in their own browser.";
-const updated = "17 August 2026";
+  "School Skills has no accounts, no advertising, no cookies and no third-party scripts. Everything a child does stays in their own browser. We count visits from our own server logs and nothing else.";
+const updated = "16 August 2026";
 ---
 
 <Content title={title} description={description} world="line">
@@ -45,12 +46,11 @@ const updated = "17 August 2026";
       <span class="hero__world">Privacy</span>
       Updated {updated}
     </p>
-    <h1 class="hero__title">No accounts, no tracking, no personalised ads</h1>
+    <h1 class="hero__title">Nothing about your child leaves your device</h1>
     <p class="hero__lead">
-      What your child does in a game stays on your device. The site carries
-      advertising to pay for itself, and those ads are non-personalised
-      everywhere &mdash; chosen from the page, never from your child. This page
-      explains exactly where that line is.
+      That is the whole policy. We count visits the way a web server always has,
+      and we stop there. The rest of this page explains how that can be true,
+      and what it means for you.
     </p>
   </header>
 
@@ -58,18 +58,10 @@ const updated = "17 August 2026";
     <div class="prose">
       <h2>What we collect</h2>
       <p>
-        Nothing about your child. There are no accounts, no sign-up and no email
-        addresses. Nothing your child does in a game &mdash; the words they
-        type, the answers they give, the times they run &mdash; is sent
-        anywhere; it is written to your own device and stays there. Nothing
+        Nothing about your child. There are no accounts, no sign-up, no email
+        addresses, no advertising, no cookies, and no third-party scripts of any
+        kind. Nothing your child does in a game is sent anywhere, and nothing
         stored on your device identifies them to us or to anyone else.
-      </p>
-      <p>
-        The site does carry advertising, and that is the one part of it
-        involving another company. Those ads are non-personalised everywhere, so
-        no profile of your child is built or used to choose them. The
-        Advertising section below says exactly what Google does and does not
-        receive.
       </p>
       <p>
         We do count how many people visit and which parts of the site get used
@@ -112,19 +104,13 @@ const updated = "17 August 2026";
 
       <h2>Children</h2>
       <p>
-        This site is intended for children and the adults helping them, and that
-        governs what the advertising on it is allowed to be. We do not build a
-        profile of any child, we do not use one to choose an ad, and
-        personalised advertising is not permitted anywhere on the site. We set
-        no advertising ID, no analytics ID and no tracking cookie of our own.
-      </p>
-      <p>
-        Google&rsquo;s ad requests are the exception to &ldquo;nothing leaves
-        the device&rdquo;, and we would rather say so plainly than bury it: an
-        ad request reaches Google, carries an IP address, and may set a cookie
-        for frequency capping and fraud prevention. What it does not do is
-        target your child &mdash; non-personalised is set on every page before
-        the advertising code is allowed to run at all.
+        This site is intended for children and the adults helping them. We do
+        not knowingly collect personal information from a child. In particular
+        there are no persistent identifiers &mdash; no advertising ID, no
+        analytics ID, no tracking cookie, nothing written to the device that
+        would let anyone recognise the same child twice. Those are what
+        children&rsquo;s privacy law treats as personal information, and not
+        having them is the point rather than an oversight.
       </p>
       <p>
         The one exception is the ordinary web-server log described below, which
@@ -140,10 +126,8 @@ const updated = "17 August 2026";
 
       <h2>Cookies</h2>
       <p>
-        We don&rsquo;t set any of our own. Google&rsquo;s advertising may set
-        cookies for purposes such as limiting how often the same ad is shown and
-        detecting fraudulent clicks &mdash; not for building a profile, because
-        the ads are non-personalised.
+        We don&rsquo;t set any. There is no consent banner because there is
+        nothing to consent to.
       </p>
 
       <h2>Hosting, and how we count</h2>
@@ -180,31 +164,9 @@ const updated = "17 August 2026";
 
       <h2>Advertising</h2>
       <p>
-        This site carries advertising from Google AdSense, including on the game
-        screens. It is how a free site with no accounts and nothing to sell pays
-        for itself.
-      </p>
-      <p>
-        <strong>The ads are non-personalised, everywhere, always.</strong> They are
-        chosen from the page they appear on rather than from anything about the person
-        looking at it. No profile of your child is built, consulted or added to. There
-        is no setting for this and no page it doesn&rsquo;t apply to, because a site
-        made for children is not a place where behavioural advertising belongs &mdash;
-        and under children&rsquo;s privacy law it would need a level of parental consent
-        a free website cannot honestly obtain.
-      </p>
-      <p>
-        Google still receives the request that loads an ad. That request carries
-        an IP address, as every web request does, and Google may set a cookie
-        for purposes such as capping how often an ad repeats and detecting
-        fraudulent clicks. This is a real change from how the site worked
-        before, and it is why nothing on this page claims any more that there
-        are no third-party requests.
-      </p>
-      <p>
-        Ads are labelled and kept in a marked frame. The youngest player here is
-        five, and telling advertising from content is a skill children acquire
-        late.
+        There are no ads on this site today. If that ever changes, this page
+        will be updated before any advertising code is added, and the change
+        will be dated here.
       </p>
 
       <h2>Changes</h2>


### PR DESCRIPTION
The site was removed from AdSense and **production kept calling Google anyway**.
Every page load, from a child's device, contacted
`pagead2.googlesyndication.com` and `googleads.g.doubleclick.net` and got
`unfilled` back. All of the privacy cost, none of the revenue — the worst state
this can be in, and nothing in the code prevented it.

```js
const ADS_LIVE = false;
```

One switch, off by default. The loader is emitted only when it's true *and* the
build is production. Flipping it back is one line.

Slots now render **nothing** when ads are off — not even the reserved box. The
reservation exists to stop a *known* unit shifting a layout, not to hold space
for advertising that isn't running; without this, content pages kept 90px gaps.

Verified: no `pagead2` URL anywhere in the build, and zero ad markup on any page.

## /privacy and the home page go back

That page's rule bites in both directions. It described advertising, Google
receiving ad requests, and cookies for frequency capping — none of which is
happening. **A policy page claiming data flows that don't exist is as wrong as
one hiding flows that do.** The advertising text is reverted alongside the code,
and the header now records that the ad code is dormant rather than absent, so
nobody re-enables one half without the other.

`ads.txt` stays — it's a declaration to ad buyers rather than a statement to
visitors, harmless while nothing serves, and re-approval will want it.

## Correcting something the code claimed

`tagForChildDirectedTreatment` was commented as "belt-and-braces… a second lock
on the same door." **It is not a lock at all.** The live ad request, captured
from production before this change:

```
npa                              1
tfcd                             (absent)
tag_for_child_directed_treatment (absent)
```

`requestNonPersonalizedAds` **works** — `npa=1` was on every request, so the
COPPA-relevant line held the whole time it was live. But the child-directed
property is a GPT/AdMob mechanism AdSense's loader ignores, so the account-level
declaration isn't a backup to the code — it's the only thing that sets that
signal. The comment now says so.

Also confirmed while production was serving: **Auto ads was ON**, injecting an
`<ins>` we never shipped. Unfilled, so nothing rendered and the race was
untouched — but that's why Auto ads must be off *before* anything is approved.

## Verification

type-check, lint, format, 180 tests, build. Built output checked for loader
absence, ad markup, and that the privacy page's no-advertising claims are back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)