### PR TITLE
Ads on, an About page, and a space that wasn't there

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ That is a real structure, not a metaphor in the copy:
 | `grid`   | `/flash-cards`, `/multiplication/*` | times tables (space)       |
 | `jungle` | `/spelling/play`, `/spelling`       | spelling and sight words   |
 | `ice`    | `/typing`                           | touch typing (glacier)     |
-| `line`   | `/privacy`, `/terms`                | the pause menu             |
+| `line`   | `/privacy`, `/terms`, `/about`      | the pause menu             |
 | `empty`  | `/404`                              | literally nothing          |
 
 A world is `data-world` on `<html>` and **nothing else**. Every screen already

--- a/src/components/site/SiteFooter.astro
+++ b/src/components/site/SiteFooter.astro
@@ -57,6 +57,7 @@ const guides = WORLDS.flatMap((w) => (w.guide ? [w.guide] : []));
     <nav class="foot__col" aria-label="About">
       <p class="foot__head">The small print</p>
       <a href="/#for-parents">For parents</a>
+      <a href="/about">About &amp; contact</a>
       <a href="/privacy">Privacy</a>
       <a href="/terms">Terms</a>
     </nav>

--- a/src/components/site/ads.ts
+++ b/src/components/site/ads.ts
@@ -19,15 +19,23 @@
  * compliance incident rather than a bug.
  *
  * ── Two things here are NOT sufficient on their own ─────────────────────────
- * 1. `tagForChildDirectedTreatment` in Base.astro DOES NOTHING. That is not a
- *    guess: the live ad request was captured from production and carried
- *    `npa=1` but no `tfcd` and no `tag_for_child_directed_treatment` at all.
- *    The property is a GPT/AdMob mechanism and AdSense's loader ignores it.
+ * 1. The age signal in Base.astro is NOT PROVEN. `tagForChildDirectedTreatment`
+ *    used to be set there and did nothing: the live ad request was captured
+ *    from production and carried `npa=1` but no `tfcd` and no
+ *    `tag_for_child_directed_treatment` at all. It is a GPT/AdMob mechanism
+ *    that AdSense's loader ignores, so it has been replaced with the variable
+ *    AdSense actually documents — `google_tag_for_age_treatment = 1`, where 1
+ *    is child-restricted (support.google.com/adsense/answer/3248194).
  *
- *    So the child-directed declaration in the AdSense account is not a backup
- *    to the code — it is the ONLY thing that sets this signal. It is left in
- *    the markup because it is harmless and may one day be honoured, but do
- *    not read it as protection. `requestNonPersonalizedAds`, by contrast, was
+ *    That replacement is UNVERIFIED. Nothing has served yet, so no ad request
+ *    exists to check it against, and the last thing believed about this line
+ *    turned out to be false. Capture a live request the first time an ad
+ *    fills and confirm `tfat=1` is on it. Until then assume it does nothing.
+ *
+ *    Which means: the site-level child-directed declaration in SEARCH CONSOLE
+ *    (search.google.com/search-console/coppa — not the AdSense UI) is the only
+ *    thing known to set this signal, and it is where Google's own COPPA
+ *    guidance points publishers. `requestNonPersonalizedAds`, by contrast, was
  *    confirmed working: `npa=1` was present on every request.
  * 2. Auto ads MUST be off for this site in the AdSense account. With them on,
  *    Google injects placements wherever its model likes — including on top of
@@ -63,28 +71,27 @@ export const AD_SLOTS = {
 export type AdSlotName = keyof typeof AD_SLOTS;
 
 /**
- * Is this site actually live in the AdSense account?
+ * Should the loader ship at all?
  *
- * FALSE, and it stays false until the site is approved and serving. This is
- * not caution for its own sake — a loader on an unapproved site is the worst
- * of both worlds. It contacts pagead2.googlesyndication.com and
- * googleads.g.doubleclick.net on every page load, from a child's device, and
- * receives `unfilled` in return. All of the privacy cost, none of the revenue.
+ * TRUE. Turning it off is a one-line kill switch for every ad request the site
+ * makes — reach for it if the account is suspended, if a placement turns out
+ * to be wrong on a child's screen, or if anything about Google's behaviour
+ * stops matching what /privacy says.
  *
- * That is exactly what production was doing after the site was removed from
- * AdSense, which is what this constant exists to prevent happening again.
+ * It moves TOGETHER with the advertising sections of /privacy, in both
+ * directions. That page has to describe what the site actually does, and a
+ * policy claiming ad requests that aren't happening is as wrong as one hiding
+ * requests that are. It was false for exactly that reason once already: the
+ * site was removed from AdSense while the loader kept calling
+ * pagead2.googlesyndication.com on every page load, from a child's device,
+ * getting `unfilled` back — all of the privacy cost, none of the revenue.
  *
- * False does NOT block getting approved. AdSense verifies ownership by ad
- * code, by ads.txt, or by a meta tag, and Base.astro emits the meta tag
- * unconditionally while public/ads.txt names the same publisher. So the site
- * can be added, verified and reviewed with the loader still dark, and the
- * only thing waiting on approval is the moment ads actually serve.
- *
- * Flipping it to true is a one-line change and MUST be made in the same pull
- * request that restores the advertising sections of /privacy — that page has
- * to describe what the site does, in both directions. See the header there.
+ * Note what true does NOT mean. Verification and review never needed it:
+ * AdSense accepts ad code, ads.txt, OR a meta tag, and Base.astro emits the
+ * meta tag unconditionally while public/ads.txt names the same publisher. So
+ * this being false was never what stood between the site and approval.
  */
-const ADS_LIVE = false;
+const ADS_LIVE = true;
 
 /**
  * Whether to emit the loader and the units at all.

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -160,6 +160,15 @@ const ogImage = new URL(image, Astro.site).href;
        * would leave a race in which the first ad request of a visit could go
        * out personalised. Inline, synchronous, first.
        *
+       * `google_tag_for_age_treatment = 1` is child-restricted treatment, and
+       * it is a bare global rather than a property on the queue — that is the
+       * form AdSense documents (answer/3248194). It REPLACES
+       * `tagForChildDirectedTreatment`, which sat here for a while doing
+       * nothing at all: a captured production ad request carried `npa=1` but
+       * no `tfcd` of any spelling. Treat this one as unproven too until a live
+       * request is captured showing `tfat=1`; the declaration that is known to
+       * work is the site-level one in Search Console.
+       *
        * `is:inline` on both: Astro would otherwise bundle and hoist them, which
        * breaks that ordering and rewrites the loader's URL.
        */
@@ -167,7 +176,7 @@ const ogImage = new URL(image, Astro.site).href;
         <>
           <script
             is:inline
-            set:html={`window.adsbygoogle=window.adsbygoogle||[];window.adsbygoogle.requestNonPersonalizedAds=1;window.adsbygoogle.tagForChildDirectedTreatment=1;`}
+            set:html={`window.adsbygoogle=window.adsbygoogle||[];window.adsbygoogle.requestNonPersonalizedAds=1;window.google_tag_for_age_treatment=1;`}
           />
           <script
             is:inline

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,145 @@
+---
+import Content from "@/layouts/Content.astro";
+
+/**
+ * Who made this and how to reach them.
+ *
+ * Every other page here sells a subject. This one answers the question a
+ * parent asks before letting a child type into a website at all — who is
+ * behind it, what do they want, and what happens if something is wrong. That
+ * is a different job from /privacy, which says what the site does with data;
+ * this says who is answerable for it.
+ *
+ * Line world, like /privacy and /terms: it is the pause menu rather than a
+ * place. Which also means it carries no advertising, because `pause` in
+ * Content.astro strips the foot slot — a page whose entire purpose is to be
+ * trusted should not be ringed with ads.
+ *
+ * The contact address is real and is the same one on /privacy and /terms.
+ * Three pages promise it; if it ever stops forwarding, all three are lying.
+ */
+const title = "About School Skills — who made it and how to reach us";
+const description =
+  "School Skills is a free set of practice games built by a parent for four kids, then shared. No accounts, no tracking, and a real address to write to.";
+const updated = "16 August 2026";
+---
+
+<Content
+  title={title}
+  description={description}
+  world="line"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    name: title,
+    description,
+    url: "https://schoolskills.app/about",
+    mainEntity: {
+      "@type": "Organization",
+      name: "School Skills",
+      url: "https://schoolskills.app",
+      email: "hello@schoolskills.app",
+      description:
+        "Free browser games for times tables, spelling and touch typing. Built for children, with no accounts and nothing uploaded.",
+    },
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">About</span>
+      Updated {updated}
+    </p>
+    <h1 class="hero__title">Built for four kids, then shared</h1>
+    <p class="hero__lead">
+      School Skills started as a way to get my own children through the handful
+      of things that only ever come with repetition. It works, so it&rsquo;s
+      here, free, for anyone else in the same position.
+    </p>
+  </header>
+
+  <section class="band band--tight wrap">
+    <div class="prose">
+      <h2>Why it exists</h2>
+      <p>
+        Some things can be taught. The seven times table, <em>because</em>,{" "}
+        <em>enough</em>, and where your left hand goes on a keyboard cannot
+        &mdash; they only come from doing them again, and again, on a day when
+        nobody feels like it. That is a miserable job for a parent and a worse
+        one for a child, and it is the entire problem this site tries to solve.
+      </p>
+      <p>
+        So the games are built around the two things that actually make
+        repetition bearable: a clock, and a version of yourself from last week
+        to race. A child who is bored of being told they are improving can
+        instead watch a ghost of their own previous run and beat it.
+      </p>
+
+      <h2>What it is, and what it isn&rsquo;t</h2>
+      <p>
+        It is practice for facts a child has already been taught. It is not a
+        curriculum, not a scheme of work, and not an assessment &mdash; nothing
+        here diagnoses anything, and a bad afternoon on the six times table
+        means a child was tired. Use it as ten minutes alongside the real
+        lessons, which is what it was built to be.
+      </p>
+      <p>
+        There is no account, no sign-up and no email address to give. Progress
+        is saved in your own browser and never sent anywhere, which is why the
+        player screen has a <strong>Back up progress</strong> button &mdash; we cannot
+        restore what we never receive.{" "}
+        <a href="/privacy">The privacy policy</a> is one page and explains exactly
+        where every line is.
+      </p>
+
+      <h2>How it pays for itself</h2>
+      <p>
+        There is nothing to buy here, no premium tier, and no plan to add one.
+        The site is paid for by advertising, and those ads are{" "}
+        <strong>non-personalised everywhere</strong> &mdash; chosen from the page
+        they sit on, never from anything about the child looking at it. That is not
+        a setting we might revisit: a site made for children is not a place where
+        behavioural advertising belongs.
+      </p>
+      <p>
+        The trade is stated plainly rather than buried. Advertising is the one
+        part of this site that involves another company, and the{" "}
+        <a href="/privacy#advertising"
+          >Advertising section of the privacy policy</a
+        > says exactly what Google does and does not receive.
+      </p>
+
+      <h2>Write to us</h2>
+      <p>
+        <a href="mailto:hello@schoolskills.app">hello@schoolskills.app</a>{" "}
+        &mdash; a real address, read by a person.
+      </p>
+      <p>Worth writing about, specifically:</p>
+      <ul>
+        <li>
+          <strong>A right answer marked wrong.</strong> These are the ones we most
+          want to hear about. Tell us the word or the sum and what you typed, and
+          it gets fixed.
+        </li>
+        <li>
+          <strong>A word spelled differently where you live.</strong> The word lists
+          are American English. If your child is being marked down for{" "}
+          <em>colour</em>, that is our problem and not theirs.
+        </li>
+        <li>
+          <strong>Anything broken, confusing or unreadable</strong> &mdash; especially
+          on a school device, an old tablet, or with a screen reader.
+        </li>
+        <li>
+          <strong
+            >An ad you think shouldn&rsquo;t be on a children&rsquo;s site.</strong
+          > We can block advertisers, but only ones we know about. Say what you saw
+          and where.
+        </li>
+      </ul>
+      <p>
+        It&rsquo;s one person answering, so a reply may take a few days. Every
+        message gets read.
+      </p>
+    </div>
+  </section>
+</Content>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ import WorldMap from "@/components/site/WorldMap.astro";
 const title =
   "School Skills — free homeschool practice games for times tables, spelling and typing";
 const description =
-  "Three free practice games for homeschool and after-school: times tables, sight words and touch typing. No account, no cookies, works offline. A supplement to your lessons, not a curriculum.";
+  "Three free practice games for homeschool and after-school: times tables, sight words and touch typing. No account, no tracking, no personalised ads. A supplement to your lessons, not a curriculum.";
 ---
 
 <Content
@@ -96,8 +96,8 @@ const description =
             <li>
               <span class="truth__what">Free, offline and private</span>
               <span class="truth__why"
-                >No account, no ads, no cookies, no third-party scripts. Added
-                to an iPad&rsquo;s home screen it works with the wifi off.</span
+                >No account, no sign-up, no personalised ads. Added to an
+                iPad&rsquo;s home screen the games work with the wifi off.</span
               >
             </li>
             <li>
@@ -241,12 +241,13 @@ const description =
           That is a deliberate choice rather than a shortcut. Under COPPA a
           persistent identifier &mdash; an ad cookie, a device id, an analytics
           client id &mdash; counts as personal information collected from a
-          child. The way to not mishandle a child&rsquo;s data is to never
-          collect it, so there is no advertising, no analytics service and no
-          third-party script of any kind. We do count visitors and races, from
-          our own web server&rsquo;s logs, without putting anything on your
-          device to do it. <a href="/privacy">The full policy</a> is one page and
-          explains exactly how.
+          child. So there is no analytics service, and the ads that pay for the
+          site are non-personalised everywhere: chosen from the page they sit
+          on, never from anything about the child looking at it. Visitors and
+          races are counted from our own web server&rsquo;s logs, without
+          putting anything on your device to do it.{" "}
+          <a href="/privacy">The full policy</a> is one page and explains exactly
+          where the line is.
         </p>
         <h3>Back it up, because there&rsquo;s only one copy</h3>
         <p>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,21 +3,31 @@ import Content from "@/layouts/Content.astro";
 
 /**
  * ⚠️ This document describes the site as it actually behaves TODAY: no
- * accounts, no advertising, no cookies, no third-party requests, and no
- * identifier of any kind written to a child's device. That is an unusually
- * strong claim and it is only true while it stays true.
+ * accounts, no tracking, and non-personalised advertising everywhere. The
+ * remaining claims are still unusually strong and are only true while they
+ * stay true.
+ *
+ * Advertising: the AdSense loader runs on every page again as of 16 August
+ * 2026, after a spell dormant behind `ADS_LIVE` in src/components/site/ads.ts.
+ * That switch and this text move TOGETHER, in both directions — a policy page
+ * claiming flows that are not happening is as wrong as one hiding flows that
+ * are. This page is written to be true from the moment the loader ships,
+ * which is before any ad unit exists to fill: Google receives the request
+ * either way, and that is the part a parent needs told.
+ *
+ * The line that must not move is NON-PERSONALISED. `requestNonPersonalizedAds`
+ * is set in Base.astro before the loader is allowed to execute, and it is
+ * confirmed working — `npa=1` was captured on live ad requests from
+ * production. The site-level child-directed declaration is made in SEARCH
+ * CONSOLE (search.google.com/search-console/coppa), not in the AdSense
+ * account; `google_tag_for_age_treatment` alongside it is unverified until a
+ * real ad request can be captured. Personalised ads on a site directed to
+ * children would need verifiable parental consent this site cannot obtain —
+ * see src/components/site/ads.ts.
  *
  * If an ad network, embedded video, a hosted analytics service or any
  * third-party script is ever added, this page MUST be updated in the same pull
- * request. That rule bites in BOTH directions: advertising shipped on
- * 17 August 2026 and this page described it, then the site was removed from
- * AdSense and the text came back here, because a policy page that claims data
- * flows which are not happening is as wrong as one that hides flows that are.
- *
- * The advertising code is still in the tree, dormant behind `ADS_LIVE` in
- * src/components/site/ads.ts. Turning that back on means restoring the
- * advertising sections of this page in the SAME pull request. Do not do one
- * without the other. Under COPPA a persistent identifier — an ad cookie, a device id, an
+ * request. Under COPPA a persistent identifier — an ad cookie, a device id, an
  * analytics client id — counts as personal information collected from a child,
  * and shipping one while this page says otherwise turns a technical change into
  * a false statement.
@@ -36,7 +46,7 @@ import Content from "@/layouts/Content.astro";
  */
 const title = "Privacy — School Skills";
 const description =
-  "School Skills has no accounts, no advertising, no cookies and no third-party scripts. Everything a child does stays in their own browser. We count visits from our own server logs and nothing else.";
+  "School Skills has no accounts and no tracking. Advertising is non-personalised everywhere, because the site is made for children. Everything a child does in a game stays in their own browser.";
 const updated = "16 August 2026";
 ---
 
@@ -46,11 +56,12 @@ const updated = "16 August 2026";
       <span class="hero__world">Privacy</span>
       Updated {updated}
     </p>
-    <h1 class="hero__title">Nothing about your child leaves your device</h1>
+    <h1 class="hero__title">No accounts, no tracking, no personalised ads</h1>
     <p class="hero__lead">
-      That is the whole policy. We count visits the way a web server always has,
-      and we stop there. The rest of this page explains how that can be true,
-      and what it means for you.
+      What your child does in a game stays on your device. The site carries
+      advertising to pay for itself, and those ads are non-personalised
+      everywhere &mdash; chosen from the page, never from your child. This page
+      explains exactly where that line is.
     </p>
   </header>
 
@@ -58,10 +69,18 @@ const updated = "16 August 2026";
     <div class="prose">
       <h2>What we collect</h2>
       <p>
-        Nothing about your child. There are no accounts, no sign-up, no email
-        addresses, no advertising, no cookies, and no third-party scripts of any
-        kind. Nothing your child does in a game is sent anywhere, and nothing
+        Nothing about your child. There are no accounts, no sign-up and no email
+        addresses. Nothing your child does in a game &mdash; the words they
+        type, the answers they give, the times they run &mdash; is sent
+        anywhere; it is written to your own device and stays there. Nothing
         stored on your device identifies them to us or to anyone else.
+      </p>
+      <p>
+        The site does carry advertising, and that is the one part of it
+        involving another company. Those ads are non-personalised everywhere, so
+        no profile of your child is built or used to choose them. The
+        Advertising section below says exactly what Google does and does not
+        receive.
       </p>
       <p>
         We do count how many people visit and which parts of the site get used
@@ -104,13 +123,19 @@ const updated = "16 August 2026";
 
       <h2>Children</h2>
       <p>
-        This site is intended for children and the adults helping them. We do
-        not knowingly collect personal information from a child. In particular
-        there are no persistent identifiers &mdash; no advertising ID, no
-        analytics ID, no tracking cookie, nothing written to the device that
-        would let anyone recognise the same child twice. Those are what
-        children&rsquo;s privacy law treats as personal information, and not
-        having them is the point rather than an oversight.
+        This site is intended for children and the adults helping them, and that
+        governs what the advertising on it is allowed to be. We do not build a
+        profile of any child, we do not use one to choose an ad, and
+        personalised advertising is not permitted anywhere on the site. We set
+        no advertising ID, no analytics ID and no tracking cookie of our own.
+      </p>
+      <p>
+        Google&rsquo;s ad requests are the exception to &ldquo;nothing leaves
+        the device&rdquo;, and we would rather say so plainly than bury it: an
+        ad request reaches Google, carries an IP address, and may set a cookie
+        for frequency capping and fraud prevention. What it does not do is
+        target your child &mdash; non-personalised is set on every page before
+        the advertising code is allowed to run at all.
       </p>
       <p>
         The one exception is the ordinary web-server log described below, which
@@ -126,8 +151,10 @@ const updated = "16 August 2026";
 
       <h2>Cookies</h2>
       <p>
-        We don&rsquo;t set any. There is no consent banner because there is
-        nothing to consent to.
+        We don&rsquo;t set any of our own. Google&rsquo;s advertising may set
+        cookies for purposes such as limiting how often the same ad is shown and
+        detecting fraudulent clicks &mdash; not for building a profile, because
+        the ads are non-personalised.
       </p>
 
       <h2>Hosting, and how we count</h2>
@@ -162,11 +189,36 @@ const updated = "16 August 2026";
         chose, their name, or their age.
       </p>
 
-      <h2>Advertising</h2>
+      <h2 id="advertising">Advertising</h2>
       <p>
-        There are no ads on this site today. If that ever changes, this page
-        will be updated before any advertising code is added, and the change
-        will be dated here.
+        This site carries advertising from Google AdSense, including on the game
+        screens. It is how a free site with no accounts and nothing to sell pays
+        for itself. Google&rsquo;s advertising code runs on every page, whether
+        or not an ad is actually shown on it &mdash; so treat everything below
+        as describing every visit, not only the ones where you see an advert.
+      </p>
+      <p>
+        <strong>The ads are non-personalised, everywhere, always.</strong> They are
+        chosen from the page they appear on rather than from anything about the person
+        looking at it. No profile of your child is built, consulted or added to. There
+        is no setting for this and no page it doesn&rsquo;t apply to, because a site
+        made for children is not a place where behavioural advertising belongs &mdash;
+        and under children&rsquo;s privacy law it would need a level of parental consent
+        a free website cannot honestly obtain.
+      </p>
+      <p>
+        Google does receive requests from your browser. Loading the advertising
+        code is one, and asking for an advert is another; both carry an IP
+        address, as every web request does, and Google may set a cookie for
+        purposes such as capping how often an ad repeats and detecting
+        fraudulent clicks. This is a real change from how the site worked
+        before, and it is why nothing on this page claims any more that there
+        are no third-party requests.
+      </p>
+      <p>
+        Ads are labelled and kept in a marked frame. The youngest player here is
+        five, and telling advertising from content is a skill children acquire
+        late.
       </p>
 
       <h2>Changes</h2>

--- a/src/pages/spelling/index.astro
+++ b/src/pages/spelling/index.astro
@@ -113,10 +113,10 @@ const description =
           particular needs.
         </p>
         <p>
-          It needs it because these words collide.
+          It needs it because these words collide.{" "}
           <em>Their</em>, <em>there</em> and <em>they&rsquo;re</em> are one sound;
-          so are <em>to</em>, <em>too</em> and <em>two</em>,
-          <em>one</em> and <em>won</em>, <em>ate</em> and <em>eight</em>,
+          so are <em>to</em>, <em>too</em> and <em>two</em>,{" "}
+          <em>one</em> and <em>won</em>, <em>ate</em> and <em>eight</em>,{" "}
           <em>no</em> and <em>know</em>. Asked to spell the sound on its own, a
           child cannot be wrong, because there is no answer. The commonest words
           are exactly the ones English has the most collisions in, which is why
@@ -127,7 +127,7 @@ const description =
           left as a blank &mdash; <em>&ldquo;This is ____ house&rdquo;</em>.
           That gives away which word is meant and nothing at all about how it is
           spelt. It also rescues the words a device&rsquo;s built-in voice
-          mumbles: <em>sleep</em> is one soft consonant away from
+          mumbles: <em>sleep</em> is one soft consonant away from{" "}
           <em>sleeve</em> on several of them, and context repairs a mis-heard sound
           the way it always does.
         </p>


### PR DESCRIPTION
Three things asked for, plus one bug found on the way.

## `/about` — who made this, and how to complain

The site had no page saying who is behind it or where to write. That is a gap for a parent deciding whether to let a child type into a website, and a routine reason AdSense rejects a site.

It answers what `/privacy` doesn't: why this exists, what it is **not** (not a curriculum, not an assessment), how it pays for itself, and where to write. Line world, so it inherits the pause-menu treatment and carries **no advertising** — a page whose whole job is to be trusted should not be ringed with ads.

`hello@schoolskills.app` was already promised on `/privacy` and `/terms`. **It has no MX records and bounces today** — three pages now depend on it forwarding, so Cloudflare Email Routing needs setting up.

## `ADS_LIVE = true`, and `/privacy` moves with it

The switch and the advertising sections of `/privacy` travel together in both directions. The text is written to be true from the moment the **loader** ships rather than the moment an ad fills — Google receives the request either way, and that is the part a parent needs told.

`AD_SLOTS` is still empty, so **nothing renders yet**. With Auto ads off, this ships ad requests and zero ads until the three unit ids exist.

## The age signal was wrong; its replacement is unproven

`tagForChildDirectedTreatment` is gone. A captured production ad request carried `npa=1` but no `tfcd` of any spelling — it is a GPT/AdMob mechanism AdSense ignores.

Replaced with `google_tag_for_age_treatment = 1`, the variable AdSense documents ([answer/3248194](https://support.google.com/adsense/answer/3248194)), as a bare global because that is the documented form. **Marked UNVERIFIED in both files, deliberately** — nothing has served, so there is no ad request to check it against, and the last belief about this line turned out false. The declaration known to work is the site-level one in **Search Console**, not the AdSense UI.

## A whitespace bug that was already live

Astro drops the whitespace when a line break falls between text and an inline element, so the built HTML read:

```
words collide.<em>Their</em>          (/spelling)
do it.<a>The full policy</a>          (home page)
```

Nine instances across `/spelling`, the home page and the new `/about` — visible typos on the two biggest content pages, shipped and unnoticed. Fixed with explicit `{" "}`. The build now greps clean for text glued to `<a>`, `<em>`, `<strong>` or `<code>` in either direction.

## Verified

- type-check 0 errors, lint clean, 180/180 tests, build static
- `/about` in the sitemap → picked up by the post-deploy smoke automatically
- Every internal link on `/about` returns 200; `/privacy#advertising` anchor exists
- Loader, `npa=1` and `tfat=1` present on all pages; `tagForChildDirectedTreatment` absent from `dist`
- Screenshotted at 390px and 1280px

🤖 Generated with [Claude Code](https://claude.com/claude-code)