### PR TITLE
PRINT01: a sheet engine spine — a worksheet is plain data

### DIFF
--- a/src/engine/sheets/blank.ts
+++ b/src/engine/sheets/blank.ts
@@ -12,19 +12,41 @@
 import type { BlankConfig, Sheet } from "./types";
 
 import { blockBox } from "./layout";
+import { inches } from "./paper";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "./spec";
+
+/**
+ * What the header and footer take out of the page.
+ *
+ * Declared, not measured — the bargain `blockBox` is built on (§4). An inch is
+ * a title with a name and date line under it; a quarter is one small line of
+ * credit. A family that reserved nothing would hand back a block the height of
+ * the whole content area and print a page and a bit.
+ */
+const HEADER_HEIGHT = inches(1);
+const FOOTER_HEIGHT = inches(0.25);
 
 export function buildBlankSheet(config: BlankConfig, seed: number): Sheet {
   return {
     paper: config.paper,
+    fontPt: config.fontPt,
     header: {
       title: config.title ?? "",
       instructions: config.instructions,
       fields: config.fields,
     },
-    // One spacer the height of the page, so the sheet holds its shape rather
-    // than collapsing to its header. The height is arithmetic, not a guess.
-    blocks: [{ kind: "spacer", height: blockBox(config.paper).height }],
+    // One spacer filling what the chrome leaves, so the sheet holds its shape
+    // rather than collapsing to its header. The height is arithmetic, not a
+    // guess: the content box less the two reservations above.
+    blocks: [
+      {
+        kind: "spacer",
+        height: blockBox(config.paper, {
+          header: HEADER_HEIGHT,
+          footer: FOOTER_HEIGHT,
+        }).height,
+      },
+    ],
     footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
     answers: false,
   };

--- a/src/engine/sheets/blank.ts
+++ b/src/engine/sheets/blank.ts
@@ -1,0 +1,43 @@
+/**
+ * The blank page.
+ *
+ * Not one of the sheet families in §11 — it generates no problems, so it has
+ * no answers to key and no seed to vary. It is the spine's own sheet: the page
+ * the builder opens on, and the smallest thing that proves the front door
+ * routes a config to a spec, builds it deterministically and can key it.
+ *
+ * It is still a sheet somebody would print. A page with a name line, a title
+ * and nothing else is what a child writes a story on.
+ */
+import type { BlankConfig, Sheet } from "./types";
+
+import { blockBox } from "./layout";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "./spec";
+
+export function buildBlankSheet(config: BlankConfig, seed: number): Sheet {
+  return {
+    paper: config.paper,
+    header: {
+      title: config.title ?? "",
+      instructions: config.instructions,
+      fields: config.fields,
+    },
+    // One spacer the height of the page, so the sheet holds its shape rather
+    // than collapsing to its header. The height is arithmetic, not a guess.
+    blocks: [{ kind: "spacer", height: blockBox(config.paper).height }],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const BLANK_SHEET: SheetSpec<BlankConfig> = {
+  id: "blank",
+  label: "Blank page",
+  world: SHEET_WORLD,
+  build: buildBlankSheet,
+  // Nothing to fill in. Returned as-is rather than with `answers: true`,
+  // because a key that is indistinguishable from the sheet should also be
+  // identical to it.
+  key: (sheet) => sheet,
+  describe: () => "A blank page",
+};

--- a/src/engine/sheets/index.test.ts
+++ b/src/engine/sheets/index.test.ts
@@ -7,7 +7,7 @@ import {
   listSheets,
   sheetSpec,
 } from "./index";
-import { SHEET_WORLD, UNKNOWN_SHEET } from "./spec";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, UNKNOWN_SHEET } from "./spec";
 import { DEFAULT_PAPER } from "./paper";
 import type { BlankConfig, SheetConfig } from "./types";
 
@@ -32,6 +32,18 @@ describe("the registry", () => {
     const sheet = sheetSpec("long-division-2027").build(config(), 1);
     expect(sheet.blocks).toEqual([]);
     expect(sheet.header.title).toBe("Sheet unavailable");
+  });
+
+  it("is not fooled by a kind that names something on Object.prototype", () => {
+    // `kind` comes from a URL or a saved sheet, so it can be any string at all.
+    // A plain `SHEETS[kind] ?? UNKNOWN_SHEET` hands back the inherited function
+    // for these three — truthy, not a spec — and `buildSheet` throws.
+    for (const kind of ["toString", "constructor", "valueOf"]) {
+      expect(sheetSpec(kind)).toBe(UNKNOWN_SHEET);
+      const stale = { ...config(), kind } as SheetConfig;
+      expect(() => buildSheet(stale, 1)).not.toThrow();
+      expect(buildSheet(stale, 1).header.title).toBe("Sheet unavailable");
+    }
   });
 
   it("falls back to Letter when the saved config has no paper at all", () => {
@@ -93,6 +105,9 @@ describe("buildSheet", () => {
   });
 
   it("sizes the page from geometry, not from a guess", () => {
+    // Letter, half-inch margins: 11in less 1in of margin is 10in of content,
+    // less the 1¼in the header and footer reserve. A4 wide: 11.693in less 2in
+    // of margin, less the same 1¼in. The block fits *inside* the chrome.
     const letter = buildSheet(config(), 1).blocks[0];
     const a4 = buildSheet(
       config({
@@ -100,8 +115,32 @@ describe("buildSheet", () => {
       }),
       1,
     ).blocks[0];
-    expect(letter).toEqual({ kind: "spacer", height: 10_000 });
-    expect(a4).toEqual({ kind: "spacer", height: 9693 });
+    expect(letter).toEqual({ kind: "spacer", height: 8750 });
+    expect(a4).toEqual({ kind: "spacer", height: 8443 });
+  });
+
+  it("carries the type size onto the sheet, where a renderer can reach it", () => {
+    // §17's larger type is a config option, so it has to arrive at the output:
+    // a renderer is handed a Sheet and nothing else. Two configs that differ
+    // only in fontPt must not build the same sheet.
+    expect(buildSheet(config({ fontPt: 18 }), 1).fontPt).toBe(18);
+    expect(buildSheet(config({ fontPt: 18 }), 1)).not.toEqual(
+      buildSheet(config({ fontPt: 12 }), 1),
+    );
+  });
+
+  it("credits the site on every sheet, including the retired one", () => {
+    // §19: the credit is a constant in the engine and prints on every sheet,
+    // and §16 makes the URL the way back from paper to the games.
+    for (const sheet of [
+      buildSheet(config(), 1),
+      UNKNOWN_SHEET.build(config(), 1),
+    ]) {
+      expect(sheet.footer).toMatchObject({
+        credit: SHEET_CREDIT,
+        url: SHEET_URL,
+      });
+    }
   });
 });
 

--- a/src/engine/sheets/index.test.ts
+++ b/src/engine/sheets/index.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  answerKey,
+  buildSheet,
+  describeSheet,
+  listSheets,
+  sheetSpec,
+} from "./index";
+import { SHEET_WORLD, UNKNOWN_SHEET } from "./spec";
+import { DEFAULT_PAPER } from "./paper";
+import type { BlankConfig, SheetConfig } from "./types";
+
+const config = (over: Partial<BlankConfig> = {}): SheetConfig => ({
+  kind: "blank",
+  paper: DEFAULT_PAPER,
+  fontPt: 12,
+  fields: ["name", "date"],
+  ...over,
+});
+
+describe("the registry", () => {
+  it("routes a kind to its family", () => {
+    expect(sheetSpec("blank").label).toBe("Blank page");
+    expect(describeSheet(config())).toBe("A blank page");
+  });
+
+  it("answers for a kind this build has never heard of, rather than throwing", () => {
+    // A config from a URL somebody bookmarked in March has to open in June,
+    // after the family it named was renamed. Same promise as `deckSpec`.
+    expect(sheetSpec("long-division-2027")).toBe(UNKNOWN_SHEET);
+    const sheet = sheetSpec("long-division-2027").build(config(), 1);
+    expect(sheet.blocks).toEqual([]);
+    expect(sheet.header.title).toBe("Sheet unavailable");
+  });
+
+  it("falls back to Letter when the saved config has no paper at all", () => {
+    // The one config the engine treats as untrusted: it came from outside this
+    // build, so the field its type promises may not be there.
+    const stale = { kind: "gone" } as unknown as SheetConfig;
+    expect(UNKNOWN_SHEET.build(stale, 7).paper).toEqual(DEFAULT_PAPER);
+  });
+
+  it("prints in the world every sheet prints in", () => {
+    for (const spec of [...listSheets(), UNKNOWN_SHEET]) {
+      expect(spec.world).toBe(SHEET_WORLD);
+    }
+  });
+
+  it("lists what this build can make", () => {
+    expect(listSheets().map((spec) => spec.id)).toContain("blank");
+  });
+});
+
+describe("buildSheet", () => {
+  it("is a pure function of its config and seed", () => {
+    // Three features rest on this, not one (§7): the answer key is the same
+    // build, "another sheet like this one" is seed + 1, and a shared URL
+    // reproduces a sheet because the seed travels in it.
+    for (const seed of [0, 1, 4242]) {
+      const once = buildSheet(config(), seed);
+      const twice = buildSheet(config(), seed);
+      expect(once).not.toBe(twice);
+      expect(once).toEqual(twice);
+    }
+  });
+
+  it("stays deterministic across papers, margins and options", () => {
+    const variants: SheetConfig[] = [
+      config(),
+      config({
+        paper: { size: "a4", orientation: "landscape", margin: "wide" },
+      }),
+      config({ title: "Story paper", instructions: "Write about your week." }),
+      config({ fields: [] }),
+    ];
+    for (const variant of variants) {
+      expect(buildSheet(variant, 9)).toEqual(buildSheet(variant, 9));
+    }
+  });
+
+  it("carries the seed into the footer, which is what makes it repeatable", () => {
+    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
+    expect(buildSheet(config(), 12_346).footer.seed).toBe(12_346);
+  });
+
+  it("prints the name line blank, because it has nothing to fill it with", () => {
+    const sheet = buildSheet(config(), 1);
+    // A `HeaderField` is a marker, not a value: a config has nowhere to put a
+    // child's name, which is what §1 means by print-blank by default.
+    expect(sheet.header.fields).toEqual(["name", "date"]);
+    expect(sheet.header).not.toHaveProperty("name");
+  });
+
+  it("sizes the page from geometry, not from a guess", () => {
+    const letter = buildSheet(config(), 1).blocks[0];
+    const a4 = buildSheet(
+      config({
+        paper: { size: "a4", orientation: "portrait", margin: "wide" },
+      }),
+      1,
+    ).blocks[0];
+    expect(letter).toEqual({ kind: "spacer", height: 10_000 });
+    expect(a4).toEqual({ kind: "spacer", height: 9693 });
+  });
+});
+
+describe("answerKey", () => {
+  it("is the same build, keyed — never a second generation", () => {
+    const spec = sheetSpec("blank");
+    expect(answerKey(config(), 3)).toEqual(spec.key(spec.build(config(), 3)));
+  });
+
+  it("is deterministic too", () => {
+    expect(answerKey(config(), 3)).toEqual(answerKey(config(), 3));
+  });
+
+  it("leaves a sheet with nothing to answer exactly as it was", () => {
+    expect(answerKey(config(), 3)).toEqual(buildSheet(config(), 3));
+  });
+});

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -25,9 +25,14 @@ const SHEETS: Record<string, SheetSpec> = {
 /**
  * Resolves a sheet family. Never throws — see `UNKNOWN_SHEET` for why a kind
  * this build has never heard of has to print something rather than fail.
+ *
+ * The lookup asks for an *own* property, because `kind` arrives from outside
+ * this build. Plain `SHEETS[kind]` would answer `sheetSpec("toString")` with
+ * `Object.prototype.toString`, which is truthy, is not a spec, and turns a
+ * promise never to throw into a `TypeError` one line later in `buildSheet`.
  */
 export function sheetSpec(kind: string): SheetSpec {
-  return SHEETS[kind] ?? UNKNOWN_SHEET;
+  return Object.hasOwn(SHEETS, kind) ? SHEETS[kind] : UNKNOWN_SHEET;
 }
 
 /** Everything this build can make, for the catalog and the builder's picker. */

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -1,0 +1,65 @@
+/**
+ * The sheet layer's front door.
+ *
+ * Everything above the engine asks for a sheet here rather than from a family
+ * module, so a catalog page, the builder and a unit test all go through the
+ * same three functions and none of them learns whether it is holding long
+ * division or a handwriting rule.
+ *
+ * The `SheetConfig` union is narrowed in exactly one place: the registry lookup
+ * in `sheetSpec`. A spec is keyed by the same string its config carries as
+ * `kind`, so looking one up *is* the narrowing — there is no `if (isLined)`
+ * chain to keep in step with the union, and adding a family is an entry in the
+ * table below plus a `kind` in types.ts. See the note on `SheetSpec` for the
+ * one thing that makes that typecheck.
+ */
+import type { Sheet, SheetConfig } from "./types";
+
+import { BLANK_SHEET } from "./blank";
+import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
+
+const SHEETS: Record<string, SheetSpec> = {
+  [BLANK_SHEET.id]: BLANK_SHEET,
+};
+
+/**
+ * Resolves a sheet family. Never throws — see `UNKNOWN_SHEET` for why a kind
+ * this build has never heard of has to print something rather than fail.
+ */
+export function sheetSpec(kind: string): SheetSpec {
+  return SHEETS[kind] ?? UNKNOWN_SHEET;
+}
+
+/** Everything this build can make, for the catalog and the builder's picker. */
+export function listSheets(): SheetSpec[] {
+  return Object.values(SHEETS);
+}
+
+/**
+ * Build a sheet. Deterministic in `(config, seed)`, which is the mechanism
+ * behind three of the features in §7 rather than one: an answer key is the
+ * same build, "another sheet like this one" is `seed + 1`, and a sheet is
+ * reproducible from a shared URL because the seed is in it.
+ */
+export function buildSheet(config: SheetConfig, seed: number): Sheet {
+  return sheetSpec(config.kind).build(config, seed);
+}
+
+/**
+ * The same sheet with the answers drawn in.
+ *
+ * A second build from the same seed, not a second generation of the answers:
+ * they were computed when the sheet was built and `key` only decides to print
+ * them, so a key cannot disagree with the sheet it belongs to.
+ */
+export function answerKey(config: SheetConfig, seed: number): Sheet {
+  const spec = sheetSpec(config.kind);
+  return spec.key(spec.build(config, seed));
+}
+
+/** One line naming what a config prints, for the catalog and the record. */
+export function describeSheet(config: SheetConfig): string {
+  return sheetSpec(config.kind).describe(config);
+}
+
+export type { SheetSpec };

--- a/src/engine/sheets/layout.test.ts
+++ b/src/engine/sheets/layout.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  blockBox,
+  capacity,
+  columnWidth,
+  contentBox,
+  fitAcross,
+  pageCount,
+  ruleCapacity,
+  ruledLines,
+} from "./layout";
+import { MARGINS, RULINGS, inches, toInches } from "./paper";
+import type { MarginSize, Paper, PaperSize, Rule } from "./types";
+
+const MARGIN_SIZES = Object.keys(MARGINS) as MarginSize[];
+
+const paper = (size: PaperSize, margin: MarginSize): Paper => ({
+  size,
+  orientation: "portrait",
+  margin,
+});
+
+/** The rule sets on a page, measured the way a ruler would: line to line. */
+const gaps = (values: number[]) =>
+  values.slice(1).map((value, i) => value - values[i]);
+
+describe("boxes", () => {
+  it("takes the margin off all four sides", () => {
+    expect(contentBox(paper("letter", "normal"))).toEqual({
+      x: 500,
+      y: 500,
+      width: 7500,
+      height: 10000,
+    });
+    expect(contentBox(paper("letter", "none"))).toEqual({
+      x: 0,
+      y: 0,
+      width: 8500,
+      height: 11000,
+    });
+  });
+
+  it("hands blocks what the header and footer left them", () => {
+    const box = blockBox(paper("letter", "normal"), {
+      header: 1000,
+      footer: 500,
+    });
+    expect(box).toEqual({ x: 500, y: 1500, width: 7500, height: 8500 });
+  });
+
+  it("never returns a negative box, however greedy the chrome is", () => {
+    const box = blockBox(paper("letter", "wide"), { header: 99_000 });
+    expect(box.height).toBe(0);
+  });
+});
+
+describe("rule geometry", () => {
+  it("keeps a ⅝ rule 0.625in apart, on Letter and A4, at every margin", () => {
+    // The assertion the whole unit choice exists for. An off-by-one in a
+    // repeat is invisible on screen and obvious on paper, and a child taught
+    // to write between two lines finds it before an adult does.
+    for (const size of ["letter", "a4"] as PaperSize[]) {
+      for (const margin of MARGIN_SIZES) {
+        for (const descender of [true, false]) {
+          const rule: Rule = { style: "hand-5-8", descender };
+          const box = contentBox(paper(size, margin));
+          const lines = ruledLines(box, rule);
+          const baselines = lines
+            .filter((line) => line.role === "base")
+            .map((line) => line.y);
+
+          expect(baselines.length).toBeGreaterThan(10);
+          for (const gap of gaps(baselines)) {
+            expect(gap).toBe(625);
+            expect(toInches(gap)).toBeCloseTo(0.625, 6);
+          }
+        }
+      }
+    }
+  });
+
+  it("spaces every other ruling at its own pitch too, on both stocks", () => {
+    for (const size of ["letter", "a4"] as PaperSize[]) {
+      for (const margin of MARGIN_SIZES) {
+        for (const ruling of Object.values(RULINGS)) {
+          if (ruling.pitch === 0 || ruling.grid) continue;
+          const box = contentBox(paper(size, margin));
+          const tops = ruledLines(box, { style: ruling.id })
+            .filter((line) => line.role !== "mid")
+            .map((line) => line.y);
+          for (const gap of gaps(tops)) expect(gap).toBe(ruling.pitch);
+        }
+      }
+    }
+  });
+
+  it("keeps every line inside the box it was given", () => {
+    for (const size of ["letter", "a4", "legal"] as PaperSize[]) {
+      for (const margin of MARGIN_SIZES) {
+        const box = contentBox(paper(size, margin));
+        for (const line of ruledLines(box, { style: "hand-5-8" })) {
+          expect(line.y).toBeGreaterThanOrEqual(box.y);
+          expect(line.y).toBeLessThanOrEqual(box.y + box.height);
+        }
+      }
+    }
+  });
+
+  it("draws a shared line once when there is no descender space", () => {
+    // One set's baseline is the next set's top line. Two strokes at the same
+    // y print as one heavy line — fine on screen, wrong on paper.
+    const box = { x: 0, y: 0, width: 7500, height: inches(5) };
+    const lines = ruledLines(box, { style: "hand-5-8" });
+    expect(new Set(lines.map((line) => line.y)).size).toBe(lines.length);
+    // Eight repeats: a top and a base each, sharing seven of them, plus a
+    // midline apiece.
+    expect(ruleCapacity(box.height, { style: "hand-5-8" })).toBe(8);
+    expect(lines).toHaveLength(8 * 2 + 1);
+  });
+
+  it("counts no repeats at all on blank paper", () => {
+    expect(ruleCapacity(inches(10), { style: "blank" })).toBe(0);
+    expect(
+      ruledLines(contentBox(paper("letter", "normal")), { style: "blank" }),
+    ).toEqual([]);
+  });
+});
+
+describe("capacity", () => {
+  it("counts n cells and n − 1 gaps", () => {
+    expect(fitAcross(1000, 300, 0)).toBe(3);
+    // 3 × 300 + 2 × 50 = 1000 exactly; a fourth would need 1350.
+    expect(fitAcross(1000, 300, 50)).toBe(3);
+    expect(fitAcross(1349, 300, 50)).toBe(3);
+    expect(fitAcross(1350, 300, 50)).toBe(4);
+  });
+
+  it("fits nothing rather than dividing by zero", () => {
+    expect(fitAcross(1000, 0)).toBe(0);
+    expect(fitAcross(0, 300)).toBe(0);
+    expect(fitAcross(-500, 300)).toBe(0);
+  });
+
+  it("never returns more than fits, at any stock, margin or cell size", () => {
+    // The capacity promise in §20. A row too many is a row that prints on a
+    // second page nobody asked for.
+    for (const size of ["letter", "a4", "legal"] as PaperSize[]) {
+      for (const margin of MARGIN_SIZES) {
+        for (const orientation of ["portrait", "landscape"] as const) {
+          const box = contentBox({ size, orientation, margin });
+          for (const cell of [
+            { width: 900, height: 400 },
+            { width: 2500, height: 1000 },
+            { width: 7000, height: 300 },
+          ]) {
+            const gap = { x: 100, y: 60 };
+            const { columns, rows } = capacity(box, cell, gap);
+            expect(
+              columns * cell.width + (columns - 1) * gap.x,
+            ).toBeLessThanOrEqual(box.width);
+            expect(rows * cell.height + (rows - 1) * gap.y).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("splits a fixed column count without overflowing the box", () => {
+    const box = contentBox(paper("letter", "normal"));
+    for (const columns of [1, 2, 3, 4, 5]) {
+      const width = columnWidth(box, columns, 100);
+      expect(columns * width + (columns - 1) * 100).toBeLessThanOrEqual(
+        box.width,
+      );
+    }
+    expect(columnWidth(box, 0)).toBe(0);
+  });
+
+  it("counts pages without ever dividing by zero", () => {
+    expect(pageCount(0, 20)).toBe(0);
+    expect(pageCount(20, 20)).toBe(1);
+    expect(pageCount(21, 20)).toBe(2);
+    // A page that fits nothing still has to be a page, or a sheet vanishes.
+    expect(pageCount(5, 0)).toBe(1);
+  });
+});

--- a/src/engine/sheets/layout.ts
+++ b/src/engine/sheets/layout.ts
@@ -1,0 +1,129 @@
+/**
+ * How much fits on a page — from geometry alone.
+ *
+ * There is no DOM here and no measurement, because there can't be: the catalog
+ * pages are built at build time and the engine is unit-tested in plain Node
+ * (§4). So a cell has a *declared* size rather than a measured one, capacity is
+ * usable height ÷ row height, and the renderer honours the layout instead of
+ * discovering it. That is a real constraint on the design of every sheet
+ * family, and the right one — it is also what makes "did it fit?" a question a
+ * test can answer without a browser.
+ *
+ * Everything is in `Mil`, thousandths of an inch. Positions are computed from a
+ * repeat index rather than accumulated, so the last rule on a page is exactly
+ * as far from the first as the arithmetic says.
+ */
+import type { Mil, Paper, Rule } from "./types";
+
+import {
+  marginOf,
+  pageSize,
+  ruleLines,
+  rulePitch,
+  type RuleRole,
+} from "./paper";
+
+export type Box = { x: Mil; y: Mil; width: Mil; height: Mil };
+
+/** The paper minus its margins: everything a sheet is allowed to print in. */
+export function contentBox(paper: Paper): Box {
+  const { width, height } = pageSize(paper);
+  const margin = marginOf(paper);
+  return {
+    x: margin,
+    y: margin,
+    width: Math.max(0, width - margin * 2),
+    height: Math.max(0, height - margin * 2),
+  };
+}
+
+/**
+ * What's left for blocks once the header and footer have taken their share.
+ *
+ * Both heights are declared by the family rather than measured, which is the
+ * same bargain as a problem cell: state what you will use, and the arithmetic
+ * stays honest.
+ */
+export function blockBox(
+  paper: Paper,
+  chrome: { header?: Mil; footer?: Mil } = {},
+): Box {
+  const box = contentBox(paper);
+  const header = Math.max(0, chrome.header ?? 0);
+  const footer = Math.max(0, chrome.footer ?? 0);
+  return {
+    x: box.x,
+    y: box.y + header,
+    width: box.width,
+    height: Math.max(0, box.height - header - footer),
+  };
+}
+
+/**
+ * How many cells of a declared size fit along a span: `n` cells and `n − 1`
+ * gaps, which is why the gap is added to the span before dividing.
+ */
+export function fitAcross(span: Mil, cell: Mil, gap: Mil = 0): number {
+  if (cell <= 0 || span <= 0) return 0;
+  return Math.max(0, Math.floor((span + gap) / (cell + gap)));
+}
+
+export type Cell = { width: Mil; height: Mil };
+export type Gap = { x?: Mil; y?: Mil };
+export type Capacity = { columns: number; rows: number; perPage: number };
+
+/** Rows, columns and the product — how many problems go on one page. */
+export function capacity(box: Box, cell: Cell, gap: Gap = {}): Capacity {
+  const columns = fitAcross(box.width, cell.width, gap.x ?? 0);
+  const rows = fitAcross(box.height, cell.height, gap.y ?? 0);
+  return { columns, rows, perPage: columns * rows };
+}
+
+/** The width of one column when the family has fixed the column count. */
+export function columnWidth(box: Box, columns: number, gap: Mil = 0): Mil {
+  if (columns <= 0) return 0;
+  return Math.max(0, Math.floor((box.width - gap * (columns - 1)) / columns));
+}
+
+/** Pages needed for a run of items, at a given capacity. Never divides by zero. */
+export function pageCount(items: number, perPage: number): number {
+  if (items <= 0) return 0;
+  if (perPage <= 0) return 1;
+  return Math.ceil(items / perPage);
+}
+
+/** How many whole repeats of a ruling fit in a height. Never more than fit. */
+export function ruleCapacity(height: Mil, rule: Rule): number {
+  const pitch = rulePitch(rule);
+  if (pitch <= 0 || height <= 0) return 0;
+  return Math.floor(height / pitch);
+}
+
+export type RuledLine = { y: Mil; role: RuleRole; dashed: boolean };
+
+/**
+ * Where every rule line lands inside a box, top down.
+ *
+ * With no descender space a set's baseline is the next set's top line, so the
+ * coincident pair is emitted once — two strokes at the same y print as one
+ * heavy line, which is exactly the sort of thing that looks fine on screen and
+ * wrong on paper.
+ */
+export function ruledLines(box: Box, rule: Rule): RuledLine[] {
+  const pitch = rulePitch(rule);
+  const lines = ruleLines(rule);
+  if (lines.length === 0) return [];
+
+  const sets = ruleCapacity(box.height, rule);
+  const out: RuledLine[] = [];
+  const seen = new Set<Mil>();
+  for (let set = 0; set < sets; set++) {
+    for (const line of lines) {
+      const y = box.y + set * pitch + line.at;
+      if (seen.has(y)) continue;
+      seen.add(y);
+      out.push({ y, role: line.role, dashed: line.dashed });
+    }
+  }
+  return out;
+}

--- a/src/engine/sheets/paper.test.ts
+++ b/src/engine/sheets/paper.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GRID_PITCHES,
+  MARGINS,
+  PAPERS,
+  RULINGS,
+  gridPitch,
+  inches,
+  mm,
+  pageSize,
+  points,
+  ruleLines,
+  rulePitch,
+  rulingOf,
+  toInches,
+  toMm,
+  toPoints,
+} from "./paper";
+import type { Paper, Rule, RuleStyle } from "./types";
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+describe("units", () => {
+  it("counts a thousandth of an inch, whichever unit the size was quoted in", () => {
+    expect(inches(1)).toBe(1000);
+    expect(mm(25.4)).toBe(1000);
+    expect(points(72)).toBe(1000);
+  });
+
+  it("converts back for the renderer, which has to write CSS in real units", () => {
+    expect(toInches(625)).toBeCloseTo(0.625, 6);
+    expect(toMm(500)).toBeCloseTo(12.7, 6);
+    expect(toPoints(1000)).toBeCloseTo(72, 6);
+  });
+
+  it("stays a whole number, so a pitch can't drift", () => {
+    for (const value of [0.625, 0.34375, 1 / 3, 11 / 32]) {
+      expect(Number.isInteger(inches(value))).toBe(true);
+    }
+  });
+});
+
+describe("stock", () => {
+  it("is the size the standard says it is", () => {
+    expect(PAPERS.letter).toMatchObject({ width: 8500, height: 11000 });
+    expect(PAPERS.legal).toMatchObject({ width: 8500, height: 14000 });
+    // A4 is metric, so it lands on a whole thousandth only approximately —
+    // within eight microns, which no printer and no child can find.
+    expect(toMm(PAPERS.a4.width)).toBeCloseTo(210, 1);
+    expect(toMm(PAPERS.a4.height)).toBeCloseTo(297, 1);
+  });
+
+  it("defaults every stock to the same half inch of margin", () => {
+    // Which is why §4 quotes A4's default as 12.7mm: it is the same number.
+    expect(MARGINS.normal).toBe(inches(0.5));
+    expect(toMm(MARGINS.normal)).toBeCloseTo(12.7, 6);
+  });
+
+  it("turns the page over for landscape", () => {
+    expect(pageSize(paper())).toEqual({ width: 8500, height: 11000 });
+    expect(pageSize(paper({ orientation: "landscape" }))).toEqual({
+      width: 11000,
+      height: 8500,
+    });
+  });
+});
+
+describe("the rulings of §5", () => {
+  it("gives every handwriting size the pitch it is named after", () => {
+    expect(RULINGS["hand-1"].pitch).toBe(inches(1));
+    expect(RULINGS["hand-3-4"].pitch).toBe(inches(0.75));
+    expect(RULINGS["hand-5-8"].pitch).toBe(inches(0.625));
+    expect(RULINGS["hand-1-2"].pitch).toBe(inches(0.5));
+    expect(RULINGS["hand-3-8"].pitch).toBe(inches(0.375));
+  });
+
+  it("rules a notebook at 11/32 and 9/32, to the nearest thousandth", () => {
+    expect(toInches(RULINGS.wide.pitch)).toBeCloseTo(11 / 32, 3);
+    expect(toInches(RULINGS.college.pitch)).toBeCloseTo(9 / 32, 3);
+    expect(RULINGS.narrow.pitch).toBe(inches(0.25));
+  });
+
+  it("puts the margin line on the two rulings that have one", () => {
+    expect(RULINGS.wide.marginLine).toBe(inches(1.25));
+    expect(RULINGS.college.marginLine).toBe(inches(1.25));
+    expect(RULINGS.narrow.marginLine).toBeUndefined();
+    expect(RULINGS["hand-5-8"].marginLine).toBeUndefined();
+  });
+
+  it("offers the four squares a grid can be drawn at", () => {
+    expect(GRID_PITCHES["quarter-inch"]).toBe(inches(0.25));
+    expect(GRID_PITCHES["fifth-inch"]).toBe(inches(0.2));
+    expect(toMm(GRID_PITCHES.centimetre)).toBeCloseTo(10, 1);
+    expect(toMm(GRID_PITCHES["half-centimetre"])).toBeCloseTo(5, 1);
+  });
+
+  it("answers for a ruling this build has never heard of", () => {
+    // Same promise as `deckSpec`: a sheet saved last term must still print
+    // after its ruling was renamed. Blank paper is the honest fallback.
+    const retired = { style: "hand-9-16" as RuleStyle };
+    expect(rulingOf(retired).id).toBe("blank");
+    expect(ruleLines(retired)).toEqual([]);
+    expect(rulePitch(retired)).toBe(0);
+  });
+});
+
+describe("ruleLines", () => {
+  const hand = (over: Partial<Rule> = {}): Rule => ({
+    style: "hand-5-8",
+    ...over,
+  });
+
+  it("draws a handwriting set as top, midline and baseline", () => {
+    expect(ruleLines(hand())).toEqual([
+      { at: 0, role: "top", dashed: false },
+      { at: 313, role: "mid", dashed: true },
+      { at: 625, role: "base", dashed: false },
+    ]);
+  });
+
+  it("takes the descender space out of the repeat, not out of the pitch", () => {
+    // The tail space is a third of the repeat, so the writing space shrinks
+    // and the ⅝ paper stays ⅝ paper. Anything else would silently reprice
+    // every ruling the moment a parent ticked the box.
+    const lines = ruleLines(hand({ descender: true }));
+    expect(lines.at(-1)).toEqual({ at: 417, role: "base", dashed: false });
+    expect(rulePitch(hand({ descender: true }))).toBe(625);
+  });
+
+  it("dashes the midline unless asked not to", () => {
+    expect(ruleLines(hand())[1].dashed).toBe(true);
+    expect(ruleLines(hand({ midline: "solid" }))[1].dashed).toBe(false);
+    expect(ruleLines(hand({ midline: "none" })).map((l) => l.role)).toEqual([
+      "top",
+      "base",
+    ]);
+  });
+
+  it("gives a notebook rule one line, at the foot of its repeat", () => {
+    // You write on top of the line, so it belongs at the bottom of the space.
+    expect(ruleLines({ style: "college" })).toEqual([
+      { at: RULINGS.college.pitch, role: "line", dashed: false },
+    ]);
+  });
+
+  it("leaves grid rulings to the renderer", () => {
+    // Two pitches and a stroke pattern, not a list of offsets.
+    for (const style of ["graph", "dot", "isometric"] as const) {
+      expect(ruleLines({ style })).toEqual([]);
+    }
+  });
+});
+
+describe("grid pitches", () => {
+  it("lets a graph or dot sheet override the square", () => {
+    expect(gridPitch({ style: "graph" })).toBe(inches(0.25));
+    expect(gridPitch({ style: "graph", pitch: GRID_PITCHES.centimetre })).toBe(
+      GRID_PITCHES.centimetre,
+    );
+  });
+
+  it("ignores an override on a ruling that doesn't have squares", () => {
+    expect(rulePitch({ style: "hand-5-8", pitch: 999 })).toBe(625);
+  });
+
+  it("spaces isometric rows by the height of the triangle, not its side", () => {
+    // A quarter-inch side at 30° puts the rows 0.2165in apart. Using the side
+    // would stretch the grid vertically and stop it being isometric at all.
+    expect(gridPitch({ style: "isometric" })).toBe(250);
+    expect(rulePitch({ style: "isometric" })).toBe(217);
+    expect(toInches(rulePitch({ style: "isometric" }))).toBeCloseTo(0.2165, 2);
+  });
+});

--- a/src/engine/sheets/paper.test.ts
+++ b/src/engine/sheets/paper.test.ts
@@ -7,6 +7,7 @@ import {
   RULINGS,
   gridPitch,
   inches,
+  marginOf,
   mm,
   pageSize,
   points,
@@ -17,7 +18,7 @@ import {
   toMm,
   toPoints,
 } from "./paper";
-import type { Paper, Rule, RuleStyle } from "./types";
+import type { MarginSize, Paper, PaperSize, Rule, RuleStyle } from "./types";
 
 const paper = (over: Partial<Paper> = {}): Paper => ({
   size: "letter",
@@ -108,6 +109,29 @@ describe("the rulings of §5", () => {
     expect(ruleLines(retired)).toEqual([]);
     expect(rulePitch(retired)).toBe(0);
   });
+
+  it("is not fooled by a style that names something on Object.prototype", () => {
+    // The fallback exists for strings from outside this build, and these are
+    // strings from outside this build. Looked up with `??` they resolve to an
+    // inherited function, which is truthy, so `ruling.pitch` is undefined and
+    // every length computed from it turns into NaN without a single throw.
+    for (const style of ["toString", "constructor", "valueOf"]) {
+      const stale = { style: style as RuleStyle };
+      expect(rulingOf(stale).id).toBe("blank");
+      expect(rulePitch(stale)).toBe(0);
+      expect(gridPitch(stale)).toBe(0);
+      expect(ruleLines(stale)).toEqual([]);
+    }
+  });
+
+  it("falls back to Letter and normal margins for the same reason", () => {
+    const stale = paper({
+      size: "constructor" as PaperSize,
+      margin: "toString" as MarginSize,
+    });
+    expect(pageSize(stale)).toEqual({ width: 8500, height: 11000 });
+    expect(marginOf(stale)).toBe(MARGINS.normal);
+  });
 });
 
 describe("ruleLines", () => {
@@ -167,6 +191,10 @@ describe("grid pitches", () => {
 
   it("ignores an override on a ruling that doesn't have squares", () => {
     expect(rulePitch({ style: "hand-5-8", pitch: 999 })).toBe(625);
+    // And reports no square at all, rather than the vertical pitch: a
+    // handwriting rule has no grid for a renderer to draw.
+    expect(gridPitch({ style: "hand-5-8", pitch: 999 })).toBe(0);
+    expect(gridPitch({ style: "college" })).toBe(0);
   });
 
   it("spaces isometric rows by the height of the triangle, not its side", () => {

--- a/src/engine/sheets/paper.ts
+++ b/src/engine/sheets/paper.ts
@@ -37,6 +37,24 @@ export const toInches = (mil: Mil): number => mil / MIL_PER_INCH;
 export const toMm = (mil: Mil): number => (mil * 25.4) / MIL_PER_INCH;
 export const toPoints = (mil: Mil): number => (mil * 72) / MIL_PER_INCH;
 
+/* ── Lookups ───────────────────────────────────────────────────────────── */
+
+/**
+ * A table lookup that survives a key from outside this build.
+ *
+ * Every table below is keyed by a string union, and every one of them is asked
+ * about a value that may have arrived from a bookmarked URL or a sheet saved
+ * before a ruling was renamed — so each needs a fallback. `table[key] ??
+ * fallback` is not that fallback: `"toString"`, `"constructor"` and the rest of
+ * `Object.prototype` resolve to inherited functions, which are truthy, so the
+ * `??` never fires and the caller is handed a function where it expected a
+ * stock or a pitch. Nothing throws at that point; the lengths computed from it
+ * just quietly become `NaN`. Asking for an *own* property is the whole fix.
+ */
+function own<T>(table: Record<string, T>, key: string, fallback: T): T {
+  return Object.hasOwn(table, key) ? table[key] : fallback;
+}
+
 /* ── Stock ─────────────────────────────────────────────────────────────── */
 
 export type PaperStock = {
@@ -88,16 +106,24 @@ export const DEFAULT_PAPER: Paper = {
   margin: "normal",
 };
 
+/**
+ * The body size a sheet is set at when its config doesn't say. Points, because
+ * that is what a type size means on paper — and 12pt because it is what a
+ * worksheet for a reader who has finished learning to read is printed at. The
+ * larger sizes of §17 are the config's job, not a fallback's.
+ */
+export const DEFAULT_FONT_PT = 12;
+
 /** The sheet of paper itself, with landscape already applied. */
 export function pageSize(paper: Paper): { width: Mil; height: Mil } {
-  const stock = PAPERS[paper.size] ?? PAPERS.letter;
+  const stock = own(PAPERS, paper.size, PAPERS.letter);
   return paper.orientation === "landscape"
     ? { width: stock.height, height: stock.width }
     : { width: stock.width, height: stock.height };
 }
 
 export function marginOf(paper: Paper): Mil {
-  return MARGINS[paper.margin] ?? MARGINS.normal;
+  return own(MARGINS, paper.margin, MARGINS.normal);
 }
 
 /* ── Rulings ───────────────────────────────────────────────────────────── */
@@ -232,7 +258,7 @@ export const GRID_PITCHES = {
  * and blank paper is the honest answer to "I don't know that one".
  */
 export function rulingOf(rule: Rule): Ruling {
-  return RULINGS[rule.style] ?? RULINGS.blank;
+  return own(RULINGS, rule.style, RULINGS.blank);
 }
 
 /**
@@ -260,10 +286,17 @@ export function rulePitch(rule: Rule): Mil {
   return pitch;
 }
 
-/** The square, or the triangle's side, across the page. */
+/**
+ * The square, or the triangle's side, across the page.
+ *
+ * Zero for every ruling that doesn't repeat across the page, which is the
+ * mirror of `ruleLines` returning nothing for the ones that do: a handwriting
+ * rule has no square, and answering with its vertical pitch would invite a
+ * renderer to draw one that isn't there.
+ */
 export function gridPitch(rule: Rule): Mil {
   const ruling = rulingOf(rule);
-  return ruling.grid ? (rule.pitch ?? ruling.pitch) : ruling.pitch;
+  return ruling.grid ? (rule.pitch ?? ruling.pitch) : 0;
 }
 
 /**

--- a/src/engine/sheets/paper.ts
+++ b/src/engine/sheets/paper.ts
@@ -1,0 +1,300 @@
+/**
+ * Paper and rulings, in real units.
+ *
+ * Everything here is a whole number of thousandths of an inch (`Mil`). The
+ * conversions are one-way on purpose: a size is written in whichever unit it is
+ * genuinely specified in — 8.5 inches, 210 millimetres, 12 points — and stored
+ * as mil, so nothing downstream has to remember which stock came from which
+ * standard.
+ *
+ * Where a ruling's pitch isn't a whole thousandth (wide ruled is 11/32in, or
+ * 343.75) it is rounded to the nearest one. That is a quarter of a thousandth
+ * of an inch, about six microns, and positions are computed from the repeat
+ * index rather than accumulated (see layout.ts) so it never compounds down the
+ * page.
+ */
+import type {
+  Mil,
+  MarginSize,
+  Paper,
+  PaperSize,
+  Rule,
+  RuleStyle,
+} from "./types";
+
+/* ── Units ─────────────────────────────────────────────────────────────── */
+
+export const MIL_PER_INCH = 1000;
+
+export const inches = (value: number): Mil => Math.round(value * MIL_PER_INCH);
+export const mm = (value: number): Mil =>
+  Math.round((value * MIL_PER_INCH) / 25.4);
+/** Type is specified in points, and 72 of them are an inch. */
+export const points = (value: number): Mil =>
+  Math.round((value * MIL_PER_INCH) / 72);
+
+export const toInches = (mil: Mil): number => mil / MIL_PER_INCH;
+export const toMm = (mil: Mil): number => (mil * 25.4) / MIL_PER_INCH;
+export const toPoints = (mil: Mil): number => (mil * 72) / MIL_PER_INCH;
+
+/* ── Stock ─────────────────────────────────────────────────────────────── */
+
+export type PaperStock = {
+  id: PaperSize;
+  label: string;
+  width: Mil;
+  height: Mil;
+};
+
+/**
+ * Letter is the default because most of the audience is American. A4 is a
+ * switch rather than an afterthought (§4): a sheet whose last rule falls off
+ * the bottom of the page is worse than no sheet at all.
+ */
+export const PAPERS: Record<PaperSize, PaperStock> = {
+  letter: {
+    id: "letter",
+    label: "Letter",
+    width: inches(8.5),
+    height: inches(11),
+  },
+  a4: { id: "a4", label: "A4", width: mm(210), height: mm(297) },
+  legal: {
+    id: "legal",
+    label: "Legal",
+    width: inches(8.5),
+    height: inches(14),
+  },
+};
+
+/**
+ * The margin presets, and the reason the A4 default in §4 reads as 12.7mm:
+ * that is half an inch exactly, so every stock defaults to the same number.
+ *
+ * `none` is offered because `@page` margin is zero and the sheet owns its own
+ * geometry — a full-bleed grid is a legitimate thing to print, even if most
+ * printers will clip a few thousandths of it.
+ */
+export const MARGINS: Record<MarginSize, Mil> = {
+  none: 0,
+  narrow: inches(0.25),
+  normal: inches(0.5),
+  wide: inches(1),
+};
+
+export const DEFAULT_PAPER: Paper = {
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+};
+
+/** The sheet of paper itself, with landscape already applied. */
+export function pageSize(paper: Paper): { width: Mil; height: Mil } {
+  const stock = PAPERS[paper.size] ?? PAPERS.letter;
+  return paper.orientation === "landscape"
+    ? { width: stock.height, height: stock.width }
+    : { width: stock.width, height: stock.height };
+}
+
+export function marginOf(paper: Paper): Mil {
+  return MARGINS[paper.margin] ?? MARGINS.normal;
+}
+
+/* ── Rulings ───────────────────────────────────────────────────────────── */
+
+export type RuleRole = "top" | "mid" | "base" | "line";
+
+/** One line of a ruling, as an offset down from the top of its repeat. */
+export type RuleLine = { at: Mil; role: RuleRole; dashed: boolean };
+
+export type Ruling = {
+  id: RuleStyle;
+  label: string;
+  /** How far it is from one repeat to the next. Zero for blank paper. */
+  pitch: Mil;
+  /** Whether the repeat runs across the page as well as down it. */
+  grid: boolean;
+  /** Handwriting rules have a midline and a descender space; the rest don't. */
+  handwriting: boolean;
+  /** A vertical line this far in from the left edge of the paper. */
+  marginLine?: Mil;
+};
+
+/**
+ * Every ruling in §5, and nothing else claims to be one.
+ *
+ * Handwriting sizes are named by their pitch because that is what a teacher
+ * says out loud — "we're on ⅝ paper this year" — and what a parent searches
+ * for. Wide and college ruled carry the margin line at 1.25in that makes a
+ * page look like notebook paper rather than lined paper.
+ */
+export const RULINGS: Record<RuleStyle, Ruling> = {
+  blank: {
+    id: "blank",
+    label: "Blank",
+    pitch: 0,
+    grid: false,
+    handwriting: false,
+  },
+  "hand-1": {
+    id: "hand-1",
+    label: 'Handwriting 1"',
+    pitch: inches(1),
+    grid: false,
+    handwriting: true,
+  },
+  "hand-3-4": {
+    id: "hand-3-4",
+    label: 'Handwriting ¾"',
+    pitch: inches(0.75),
+    grid: false,
+    handwriting: true,
+  },
+  "hand-5-8": {
+    id: "hand-5-8",
+    label: 'Handwriting ⅝"',
+    pitch: inches(0.625),
+    grid: false,
+    handwriting: true,
+  },
+  "hand-1-2": {
+    id: "hand-1-2",
+    label: 'Handwriting ½"',
+    pitch: inches(0.5),
+    grid: false,
+    handwriting: true,
+  },
+  "hand-3-8": {
+    id: "hand-3-8",
+    label: 'Handwriting ⅜"',
+    pitch: inches(0.375),
+    grid: false,
+    handwriting: true,
+  },
+  // 11/32in and 9/32in — the two rulings a notebook is actually printed at.
+  wide: {
+    id: "wide",
+    label: "Wide ruled",
+    pitch: inches(11 / 32),
+    grid: false,
+    handwriting: false,
+    marginLine: inches(1.25),
+  },
+  college: {
+    id: "college",
+    label: "College ruled",
+    pitch: inches(9 / 32),
+    grid: false,
+    handwriting: false,
+    marginLine: inches(1.25),
+  },
+  narrow: {
+    id: "narrow",
+    label: "Narrow ruled",
+    pitch: inches(0.25),
+    grid: false,
+    handwriting: false,
+  },
+  graph: {
+    id: "graph",
+    label: "Graph",
+    pitch: inches(0.25),
+    grid: true,
+    handwriting: false,
+  },
+  dot: {
+    id: "dot",
+    label: "Dot grid",
+    pitch: inches(0.25),
+    grid: true,
+    handwriting: false,
+  },
+  isometric: {
+    id: "isometric",
+    label: "Isometric",
+    pitch: inches(0.25),
+    grid: true,
+    handwriting: false,
+  },
+};
+
+/** The squares a graph, dot or isometric sheet can be drawn at (§5). */
+export const GRID_PITCHES = {
+  "quarter-inch": inches(0.25),
+  "fifth-inch": inches(0.2),
+  centimetre: mm(10),
+  "half-centimetre": mm(5),
+} as const;
+
+/**
+ * Resolves a ruling. Never throws, for the same reason `deckSpec` doesn't: a
+ * sheet saved last term must still print after its ruling has been renamed,
+ * and blank paper is the honest answer to "I don't know that one".
+ */
+export function rulingOf(rule: Rule): Ruling {
+  return RULINGS[rule.style] ?? RULINGS.blank;
+}
+
+/**
+ * How a handwriting repeat divides.
+ *
+ * With descender space on, the writing space (top line down to the baseline)
+ * takes two thirds of the repeat and the tail space below it one third — the
+ * proportion primary paper is printed at, and the difference between a sheet a
+ * child can write a `g` on and one they can't. With it off there is no tail
+ * space, so one set's baseline is the next set's top line.
+ */
+const DESCENDER_SHARE = 1 / 3;
+
+/**
+ * How far it is from one repeat of a ruling to the next, down the page.
+ *
+ * Isometric is the one place the declared pitch isn't the answer: its rows are
+ * the height of an equilateral triangle of that side, which is what makes the
+ * grid 30° rather than square.
+ */
+export function rulePitch(rule: Rule): Mil {
+  const ruling = rulingOf(rule);
+  const pitch = ruling.grid ? (rule.pitch ?? ruling.pitch) : ruling.pitch;
+  if (rule.style === "isometric") return Math.round((pitch * Math.sqrt(3)) / 2);
+  return pitch;
+}
+
+/** The square, or the triangle's side, across the page. */
+export function gridPitch(rule: Rule): Mil {
+  const ruling = rulingOf(rule);
+  return ruling.grid ? (rule.pitch ?? ruling.pitch) : ruling.pitch;
+}
+
+/**
+ * The lines of one repeat, as offsets down from the top of it.
+ *
+ * A notebook rule is one line at the foot of its repeat, because you write on
+ * top of it. A handwriting rule is three: the top line, the midline a letter's
+ * body reaches, and the baseline it sits on. Grid rulings return nothing —
+ * their geometry is two pitches and a renderer, not a list of offsets.
+ */
+export function ruleLines(rule: Rule): RuleLine[] {
+  const ruling = rulingOf(rule);
+  const pitch = rulePitch(rule);
+  if (pitch <= 0 || ruling.grid) return [];
+  if (!ruling.handwriting) return [{ at: pitch, role: "line", dashed: false }];
+
+  const writing = rule.descender
+    ? Math.round(pitch * (1 - DESCENDER_SHARE))
+    : pitch;
+  const midline = rule.midline ?? "dashed";
+  return [
+    { at: 0, role: "top", dashed: false },
+    ...(midline === "none"
+      ? []
+      : [
+          {
+            at: Math.round(writing / 2),
+            role: "mid" as const,
+            dashed: midline === "dashed",
+          },
+        ]),
+    { at: writing, role: "base", dashed: false },
+  ];
+}

--- a/src/engine/sheets/spec.ts
+++ b/src/engine/sheets/spec.ts
@@ -10,7 +10,7 @@
 import type { World } from "@/engine/worlds";
 
 import type { Sheet, SheetConfig } from "./types";
-import { DEFAULT_PAPER } from "./paper";
+import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "./paper";
 
 /**
  * Which world a sheet prints in — stated, not assumed, exactly as
@@ -73,6 +73,7 @@ export const UNKNOWN_SHEET: SheetSpec = {
     // Everything that lands here came from outside this build — a shared URL,
     // a saved sheet — so the field the type promises may simply not be there.
     paper: config.paper ?? DEFAULT_PAPER,
+    fontPt: config.fontPt ?? DEFAULT_FONT_PT,
     header: {
       title: "Sheet unavailable",
       instructions: "This kind of sheet isn't made any more.",

--- a/src/engine/sheets/spec.ts
+++ b/src/engine/sheets/spec.ts
@@ -1,0 +1,87 @@
+/**
+ * What every family of sheets has to be able to say about itself.
+ *
+ * The same shape of answer `DeckSpec` gives the race loop, for the same reason:
+ * the parts of a worksheet that generalise — paper, rulings, capacity, the
+ * header, the footer, the print stylesheet — can't decide what a problem is,
+ * what its answer is, or how to say in one line what the sheet contains. Those
+ * three judgements belong to the family, and this is where it states them.
+ */
+import type { World } from "@/engine/worlds";
+
+import type { Sheet, SheetConfig } from "./types";
+import { DEFAULT_PAPER } from "./paper";
+
+/**
+ * Which world a sheet prints in — stated, not assumed, exactly as
+ * `DeckSpec.world` is.
+ *
+ * It is `line`, the site's non-game chrome, until the Print Shop's own `paper`
+ * world lands with its colours and its place on the map (§9). The engine never
+ * interprets the value, so that is a one-line change here and a block of CSS
+ * there — which is the whole point of keeping worlds opaque to the model.
+ */
+export const SHEET_WORLD: World = "line";
+
+/** Printed small at the foot of every sheet: free traffic, and true (§16). */
+export const SHEET_URL = "schoolskills.app";
+export const SHEET_CREDIT = "Free printables and learning games";
+
+/**
+ * `C` is the family's own config, and the registry in index.ts is what ties it
+ * back to the union: a spec is only ever handed the config whose `kind` looked
+ * it up. Declaring `build` and `describe` as methods rather than as arrow
+ * properties is load-bearing — TypeScript checks method parameters
+ * bivariantly, which is what lets a `SheetSpec<LinedConfig>` sit in a registry
+ * of `SheetSpec<SheetConfig>` without a cast at every entry. Rewrite either as
+ * `build: (config: C, seed: number) => Sheet` and the registry stops
+ * compiling.
+ */
+export type SheetSpec<C extends SheetConfig = SheetConfig> = {
+  /** Matches `SheetConfig.kind`, so a saved sheet finds its way back here. */
+  id: string;
+  label: string;
+  world: World;
+  /** Build the sheet. Deterministic in (config, seed) — see §7. */
+  build(config: C, seed: number): Sheet;
+  /**
+   * The same sheet with the answers filled in. Not optional on any family: an
+   * answer key is the single most expected feature of a worksheet site and the
+   * most common thing done badly, and a family that can't produce one has no
+   * business generating problems.
+   */
+  key(sheet: Sheet): Sheet;
+  /** One line for the catalog, and for the record of what was printed. */
+  describe(config: C): string;
+};
+
+/**
+ * Stands in for a sheet family that isn't in the registry.
+ *
+ * Saved sheets outlive the families they were made on, the same way sessions
+ * outlive their decks: a config from a URL somebody bookmarked in March must
+ * still open in June after its family was renamed. So this returns a page that
+ * prints, and says plainly why there is nothing on it, rather than throwing
+ * inside a build that would otherwise have shipped a catalog.
+ */
+export const UNKNOWN_SHEET: SheetSpec = {
+  id: "unknown",
+  label: "Retired sheet",
+  world: SHEET_WORLD,
+  build: (config, seed) => ({
+    // The one place a config is treated as untrusted rather than as its type.
+    // Everything that lands here came from outside this build — a shared URL,
+    // a saved sheet — so the field the type promises may simply not be there.
+    paper: config.paper ?? DEFAULT_PAPER,
+    header: {
+      title: "Sheet unavailable",
+      instructions: "This kind of sheet isn't made any more.",
+      fields: [],
+    },
+    blocks: [],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  }),
+  key: (sheet) => sheet,
+  describe: () => "A sheet this build no longer makes",
+};

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -8,9 +8,9 @@
  * the same build function run in a unit test, in the build-time render of a
  * catalog page, and in the live builder (docs/printables.md §2).
  *
- * Answers are on the sheet from the moment it is built. The answer key is the
- * same `Sheet` with `answers: true`, not a second build from the same seed, so
- * a key can't drift from the sheet it belongs to.
+ * Answers are on the sheet from the moment it is built. A key prints the
+ * answers the build already computed — `answers: true` and nothing else — so
+ * however a key is obtained it can't disagree with the sheet it belongs to.
  */
 
 /* ── Units ────────────────────────────────────────────────────────────────
@@ -234,6 +234,14 @@ export type SheetFooter = {
 
 export type Sheet = {
   paper: Paper;
+  /**
+   * Body type size, in points rather than `Mil` — a font size on paper is
+   * quoted in points by everyone who has ever set one, and it is the one number
+   * here a renderer hands straight to CSS (`--sheet-pt`, §4). It travels on the
+   * sheet because a `Sheet` is the whole hand-off: a renderer holding one has
+   * to be able to set the type without also being given the config.
+   */
+  fontPt: number;
   header: SheetHeader;
   /**
    * The flow, in order. A sheet is one document that may print over more than

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -1,0 +1,287 @@
+/**
+ * A worksheet, as plain data.
+ *
+ * `Sheet` is to the print shop what `Card` is to the race: the engine decides
+ * what goes on the page and returns it as values, and the view's only job is to
+ * turn that into elements. Nothing here knows what a `<div>` is, nothing here
+ * measures anything, and every length is already resolved — which is what lets
+ * the same build function run in a unit test, in the build-time render of a
+ * catalog page, and in the live builder (docs/printables.md §2).
+ *
+ * Answers are on the sheet from the moment it is built. The answer key is the
+ * same `Sheet` with `answers: true`, not a second build from the same seed, so
+ * a key can't drift from the sheet it belongs to.
+ */
+
+/* ── Units ────────────────────────────────────────────────────────────────
+   Every length on a sheet is a whole number of thousandths of an inch.
+
+   One integer unit for the whole subtree, because a ⅝-inch rule is ⅝ of an
+   inch or it is wrong (§4), and a child taught to write between two lines
+   notices before an adult does. A thousandth of an inch is 25 microns — finer
+   than any home printer resolves — and it lands close enough to an inch, a
+   point (13.889) and a millimetre (39.37) that the rounding never reaches
+   paper. The rest of the app sizes in `rem` × `--ui-scale`; a sheet must not,
+   and this type is the reminder.                                            */
+
+export type Mil = number;
+
+/* ── Paper ─────────────────────────────────────────────────────────────── */
+
+export type PaperSize = "letter" | "a4" | "legal";
+
+export type Orientation = "portrait" | "landscape";
+
+/**
+ * Margins are named, not free numbers.
+ *
+ * A sheet that runs off the bottom of the page is worse than no sheet, so the
+ * capacity arithmetic in layout.ts has to hold for every margin a parent can
+ * choose — which is a set worth being able to enumerate in a test.
+ */
+export type MarginSize = "none" | "narrow" | "normal" | "wide";
+
+export type Paper = {
+  size: PaperSize;
+  orientation: Orientation;
+  margin: MarginSize;
+};
+
+/* ── Ruling ────────────────────────────────────────────────────────────── */
+
+/**
+ * The ruling systems of §5, as ids. The geometry behind each — pitch, where
+ * the lines sit inside the repeat, where the margin line goes — is in paper.ts.
+ */
+export type RuleStyle =
+  | "blank"
+  /** Handwriting rules, named by the repeat every teacher already says aloud. */
+  | "hand-1"
+  | "hand-3-4"
+  | "hand-5-8"
+  | "hand-1-2"
+  | "hand-3-8"
+  /** Notebook rules: one line per repeat, and a margin line on the first two. */
+  | "wide"
+  | "college"
+  | "narrow"
+  /** Rules that repeat across the page as well as down it. */
+  | "graph"
+  | "dot"
+  | "isometric";
+
+/** Dashed is the usual; solid is for the youngest, none for the oldest. */
+export type Midline = "dashed" | "solid" | "none";
+
+export type Rule = {
+  style: RuleStyle;
+  /** Handwriting only. Defaults to dashed, which is what schools print. */
+  midline?: Midline;
+  /**
+   * Handwriting only. Room below the baseline for the tail of a `g`, taken out
+   * of the repeat rather than added to it — the pitch is what it says it is.
+   */
+  descender?: boolean;
+  /**
+   * Graph, dot and isometric only: the square, or the triangle's side, when it
+   * isn't the ¼-inch default. See `GRID_PITCHES` in paper.ts.
+   */
+  pitch?: Mil;
+};
+
+/* ── Blocks ────────────────────────────────────────────────────────────── */
+
+/**
+ * How a letterform is drawn on a tracing row — §6, all five from one ordinary
+ * font. `none` is the empty space at the end of a trace → copy → write row,
+ * where the child is on their own.
+ */
+export type TraceStyle =
+  "solid" | "dim" | "hollow" | "dotted" | "dashed" | "none";
+
+export type Problem = {
+  /** How it reads on the sheet: "7 × 8 =". */
+  prompt: string;
+  /**
+   * Text even when it's a number — "56", not 56 — for the same reason
+   * `Card.answer` is. A worksheet's answers are printed, not compared.
+   */
+  answer: string;
+  /**
+   * Which fact this exercises, in the vocabulary the race already uses
+   * ("7:8"). Optional, and the whole of what makes "print the facts they keep
+   * missing" (§14) possible: the record book hands over fact ids and a family
+   * turns them into problems without either side learning the other's shape.
+   */
+  factId?: string;
+  /** Blank height under the problem for working out. Absent means none. */
+  workspace?: Mil;
+};
+
+export type TraceRow = {
+  text: string;
+  /**
+   * One entry per repeat across the row, left to right. `["solid", "dotted",
+   * "dotted", "none"]` is the trace → copy → write progression on one line.
+   */
+  repeats: TraceStyle[];
+};
+
+export type GridSpec = {
+  kind: "graph" | "chart" | "coordinate";
+  columns: number;
+  rows: number;
+  /** The square. */
+  cell: Mil;
+  /** What's printed in the squares, row-major. Empty for a blank grid. */
+  cells?: string[];
+  /** Coordinate planes only: where the axes cross, counted in squares. */
+  origin?: { column: number; row: number };
+};
+
+export type Blank = {
+  /** `_` marks each gap, the same convention `Card.clue` already uses. */
+  text: string;
+  /** What belongs in the gaps, in order. */
+  answers: string[];
+};
+
+export type Choice = {
+  prompt: string;
+  options: string[];
+  /** Index into `options`. */
+  answer: number;
+};
+
+export type ClockFace = {
+  hour: number;
+  minute: number;
+  /** Hands drawn (read the time) or left off (draw them). */
+  hands: boolean;
+  label?: string;
+};
+
+/** A shape to measure, name or shade. Points are in mil, within its own box. */
+export type Figure = {
+  shape: "rectangle" | "triangle" | "circle" | "polygon";
+  points: Array<{ x: Mil; y: Mil }>;
+  /** Side labels, in the order the points are given. */
+  labels?: string[];
+};
+
+export type Block =
+  | { kind: "problems"; columns: number; items: Problem[] }
+  | { kind: "rules"; rule: Rule; lines: number }
+  | { kind: "trace"; rule: Rule; rows: TraceRow[] }
+  | { kind: "copywork"; text: string; rule: Rule; mode: TraceStyle }
+  | { kind: "grid"; grid: GridSpec }
+  | {
+      kind: "wordsearch";
+      letters: string[][];
+      find: string[];
+      /** Where each word was placed, for the key. `dx`/`dy` are per step. */
+      solution?: Array<{
+        word: string;
+        column: number;
+        row: number;
+        dx: number;
+        dy: number;
+      }>;
+    }
+  | {
+      kind: "matching";
+      left: string[];
+      right: string[];
+      /** `answer[i]` is the index in `right` that `left[i]` pairs with. */
+      answer: number[];
+    }
+  | { kind: "blanks"; sentences: Blank[] }
+  | { kind: "choice"; questions: Choice[] }
+  | { kind: "clock"; faces: ClockFace[] }
+  | { kind: "shapes"; figures: Figure[] }
+  /** Where to cut, for cards and bookmarks. */
+  | { kind: "cutline" }
+  | { kind: "spacer"; height: Mil };
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+/**
+ * A blank the child fills in by hand.
+ *
+ * Printed empty, always. A child's name is the one field every worksheet on
+ * earth asks for and the one thing this site refuses to hold (§1), so it is a
+ * ruled line on paper and never a value in the config.
+ */
+export type HeaderField = "name" | "date" | "class";
+
+export type SheetHeader = {
+  title: string;
+  instructions?: string;
+  fields: HeaderField[];
+  /** The "___ / 20" box. Absent when there is nothing to mark. */
+  score?: { outOf: number };
+};
+
+export type SheetFooter = {
+  credit: string;
+  /** Short, and pointing back at the game the sheet came from (§16). */
+  url?: string;
+  /** Printed small, so the same sheet can be had again next week (§7). */
+  seed: number;
+  /** "Answer key", or a source credit the sheet's content requires. */
+  note?: string;
+};
+
+export type Sheet = {
+  paper: Paper;
+  header: SheetHeader;
+  /**
+   * The flow, in order. A sheet is one document that may print over more than
+   * one page; keeping a block inside a page is the family's job, using the
+   * capacity arithmetic in layout.ts, and breaking between them is the print
+   * stylesheet's.
+   */
+  blocks: Block[];
+  footer: SheetFooter;
+  /**
+   * Print the answers that are already in the blocks.
+   *
+   * This is the whole of the answer-key mechanism. `SheetSpec.key` flips it,
+   * every renderer reads it, and because the answers were computed when the
+   * sheet was built there is no second generation to disagree with the first.
+   */
+  answers: boolean;
+};
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+/** What every sheet config carries, whatever family it belongs to. */
+export type SheetOptions = {
+  paper: Paper;
+  /**
+   * Body type size in points, not `rem`. Larger type is a first-class option
+   * here rather than a zoom hack (§17), and points are what a font size means
+   * on paper.
+   */
+  fontPt: number;
+  /** Overrides the family's own title. */
+  title?: string;
+  instructions?: string;
+  fields: HeaderField[];
+};
+
+/**
+ * A page with nothing on it but the header and the footer.
+ *
+ * Not one of the sheet families in §11 — it generates no problems and has no
+ * answers. It is the spine's own sheet: the page the builder opens on, the one
+ * a retired sheet type falls back to, and the smallest thing that proves the
+ * front door routes, builds and keys.
+ */
+export type BlankConfig = SheetOptions & { kind: "blank" };
+
+/**
+ * Anything a saved sheet can hold. Narrow on `kind` — and only in index.ts,
+ * which is the one module that knows the whole union.
+ */
+export type SheetConfig = BlankConfig;


### PR DESCRIPTION
Closes #45. Epic: #76 (PRINT01).

## What this is

`src/engine/sheets/` describes a worksheet the way `src/engine/decks/` describes a deck: values in, values out, no framework anywhere near it. The same three functions build a sheet in a unit test, on a prerendered catalog page and inside the builder island, because none of them can tell which one they are in.

Types and arithmetic only — no renderers, no CSS, no pages, no sheet families.

## Why it is shaped this way

**One integer unit.** Every length is a whole number of thousandths of an inch. The rest of the app sizes in `rem` × `--ui-scale`, and a worksheet must not — a ⅝-inch rule is ⅝ of an inch or it is wrong, and a child taught to write between two lines finds the error before an adult does. A mil is 25 microns, finer than a home printer resolves, and sits close enough to the inch, the point and the millimetre that rounding never reaches paper.

**Capacity is arithmetic, not measurement.** `layout.ts` computes how much fits from geometry alone, because a build-time page has no DOM to ask. A problem cell therefore has a declared size rather than a measured one — a real constraint on every family to come, and the right one.

**Answers are on the sheet from the moment it is built.** The key is the same `Sheet` with `answers: true`, not a second generation from the same seed, so a key cannot disagree with the sheet it belongs to.

**The union is narrowed exactly once**, at the registry lookup in `index.ts`. A spec is keyed by the same string its config carries as `kind`, so looking one up *is* the narrowing — there is no `if (isLined)` chain to keep in step. `sheetSpec(kind)` never throws, for the reason `deckSpec(mode)` doesn't: a config from a URL bookmarked in March has to open in June after its family was renamed, so an unknown kind returns `UNKNOWN_SHEET` and prints a page that says so.

## Files

| File | What it holds |
| --- | --- |
| `types.ts` | `Sheet`, `Block`, `Paper`, `Rule`, the `SheetConfig` union |
| `spec.ts` | `SheetSpec` — `id`, `label`, `world`, `build`, `key`, `describe` (`key` required, not optional) |
| `index.ts` | the front door; the only place `SheetConfig` is narrowed; `sheetSpec(kind)` |
| `paper.ts` | Letter / A4 / Legal geometry and every ruling in `docs/printables.md` §5, in mils |
| `layout.ts` | page capacity from geometry alone — no DOM, no measurement |
| `blank.ts` | the one registered kind: a blank page, the smallest thing that proves the front door routes, builds and keys |

## Tests

- A ⅝" rule set is 0.625in apart on Letter **and** A4, at every supported margin.
- `buildSheet(config, seed)` called twice with the same arguments is deeply equal.
- Capacity never returns a row that doesn't fit, at any stock, margin or orientation.
- Registry lookups survive a `SHEETS["toString"]`-style key — every lookup asks for an own property, so an inherited `Object.prototype` member can't masquerade as a registered kind.

## Validation

`type-check`, `lint`, `test:unit` (230 passing), `build` (still static, 21 pages) and the browser smoke test all pass locally. `mulberry32` in `src/engine/random.ts` is the RNG; no second one was added.

## Notes

The `paper` world lands with PRINT03; until then `SHEET_WORLD` is one constant here for it to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
