### PR TITLE
A sheet becomes ink

### DIFF
--- a/src/components/sheet/Ruling.tsx
+++ b/src/components/sheet/Ruling.tsx
@@ -1,0 +1,220 @@
+/**
+ * A ruling, as strokes.
+ *
+ * Every ruled thing on a sheet goes through here: lined paper, the band a
+ * tracing row sits on, the ground under a line of copywork. It returns a `<g>`
+ * rather than an `<svg>` on purpose — a trace row draws its letterforms into
+ * the same coordinate system as the rules they sit on, and two elements can't
+ * share one.
+ *
+ * **Strokes, never a background.** The obvious implementation of ruled paper is
+ * `repeating-linear-gradient`, which `worlds.css` already uses for the jungle's
+ * terrain. Browsers drop `background-image` when printing unless the reader has
+ * ticked "Background graphics", and most readers haven't — so a sheet built
+ * that way prints blank and looks perfect on screen, which is the worst kind of
+ * bug this feature can have. SVG strokes are foreground paint: they always
+ * print, they print at the printer's resolution rather than the screen's, and
+ * a dashed midline is one attribute rather than a second gradient (§5).
+ *
+ * Coordinates are mil, matching the viewBox its caller sets up.
+ */
+import { ruledLines, type Box } from "@/engine/sheets/layout";
+import { gridPitch, rulePitch, rulingOf } from "@/engine/sheets/paper";
+import type { Mil, Rule } from "@/engine/sheets/types";
+
+import { DASH_MIDLINE, HAIRLINE, RULE } from "./units";
+
+/** How tall `sets` repeats of a ruling stand. Zero for blank paper. */
+export function ruledHeight(rule: Rule, sets: number): Mil {
+  return Math.max(0, sets) * rulePitch(rule);
+}
+
+type Props = {
+  rule: Rule;
+  /** Where the block sits on the paper. `x` places the margin line. */
+  box: Box;
+  /** How many repeats to draw. */
+  sets: number;
+};
+
+export function Ruling({ rule, box, sets }: Props) {
+  const ruling = rulingOf(rule);
+  if (sets <= 0 || rulePitch(rule) <= 0) return null;
+  return ruling.grid ? (
+    <GridRuling rule={rule} box={box} sets={sets} />
+  ) : (
+    <LinedRuling rule={rule} box={box} sets={sets} />
+  );
+}
+
+/**
+ * Handwriting and notebook rules: horizontal strokes down the page.
+ *
+ * The y positions come from the engine rather than from a loop here, because
+ * where the lines sit inside a repeat is geometry (`ruleLines`) and how many
+ * repeats fit is arithmetic (`ruledLines`) — both of which a unit test can
+ * check without a browser, and neither of which a renderer should be deciding.
+ */
+function LinedRuling({ rule, box, sets }: Props) {
+  const height = ruledHeight(rule, sets);
+  const lines = ruledLines({ x: 0, y: 0, width: box.width, height }, rule);
+  const ruling = rulingOf(rule);
+
+  // 1.25in from the edge of the paper, so it lands in the same place as the
+  // one on a notebook the child already owns. Black rather than the printed
+  // red, because the default sheet is black on white and nobody should pay
+  // for a colour cartridge to get lined paper.
+  const margin =
+    ruling.marginLine === undefined ? null : ruling.marginLine - box.x;
+  const showMargin = margin !== null && margin > 0 && margin < box.width;
+
+  return (
+    <g className="sheet__ruling">
+      {lines.map((line) => (
+        <line
+          key={`${line.y}-${line.role}`}
+          className={`sheet__rule sheet__rule--${line.role}`}
+          x1={0}
+          x2={box.width}
+          y1={line.y}
+          y2={line.y}
+          strokeWidth={RULE}
+          strokeDasharray={line.dashed ? DASH_MIDLINE : undefined}
+        />
+      ))}
+      {showMargin && (
+        <line
+          className="sheet__rule sheet__rule--margin"
+          x1={margin}
+          x2={margin}
+          y1={0}
+          y2={height}
+          strokeWidth={RULE}
+        />
+      )}
+    </g>
+  );
+}
+
+/**
+ * Graph, dot and isometric: a ruling that repeats across the page as well as
+ * down it.
+ *
+ * The dot grid is drawn as dashed lines rather than as a few thousand
+ * `<circle>` elements — a zero-length dash with a round cap *is* a dot, which
+ * is the same trick CSS's `dotted` border plays. One `<line>` per row instead
+ * of one element per intersection, and the two print identically.
+ */
+function GridRuling({ rule, box, sets }: Props) {
+  const down = rulePitch(rule);
+  const across = gridPitch(rule);
+  const height = ruledHeight(rule, sets);
+  if (across <= 0) return null;
+
+  if (rule.style === "isometric") {
+    return <Isometric width={box.width} rows={sets} row={down} side={across} />;
+  }
+
+  const rows = range(sets + 1, (row) => row * down);
+  const columns = range(Math.floor(box.width / across) + 1, (i) => i * across);
+  const dotted = rule.style === "dot";
+  return (
+    <g className="sheet__ruling sheet__ruling--grid">
+      {rows.map((y) => (
+        <line
+          key={`r${y}`}
+          className="sheet__rule sheet__rule--grid"
+          x1={0}
+          x2={box.width}
+          y1={y}
+          y2={y}
+          strokeWidth={dotted ? HAIRLINE * 2 : HAIRLINE}
+          strokeLinecap={dotted ? "round" : undefined}
+          strokeDasharray={dotted ? `0 ${across}` : undefined}
+        />
+      ))}
+      {!dotted &&
+        columns.map((x) => (
+          <line
+            key={`c${x}`}
+            className="sheet__rule sheet__rule--grid"
+            x1={x}
+            x2={x}
+            y1={0}
+            y2={height}
+            strokeWidth={HAIRLINE}
+          />
+        ))}
+    </g>
+  );
+}
+
+/**
+ * Equilateral triangles: three families of strokes at 0° and ±60°.
+ *
+ * The diagonals run off both sides of the box by half a side per row, which is
+ * why they start left of zero — an `<svg>` clips to its own viewport, so the
+ * overhang costs nothing and the grid reaches the edges instead of stopping
+ * short of them.
+ */
+function Isometric({
+  width,
+  rows,
+  row,
+  side,
+}: {
+  width: Mil;
+  /** Triangle rows. */
+  rows: number;
+  /** The height of one row — a triangle's altitude, already in `rulePitch`. */
+  row: Mil;
+  /** The triangle's side, which is the pitch across the page. */
+  side: Mil;
+}) {
+  const height = rows * row;
+  const run = Math.round((rows * side) / 2);
+  const starts = range(Math.floor((width + 2 * run) / side) + 1, (i) =>
+    Math.round(i * side - run),
+  );
+
+  return (
+    <g className="sheet__ruling sheet__ruling--grid">
+      {range(rows + 1, (index) => index * row).map((y) => (
+        <line
+          key={`h${y}`}
+          className="sheet__rule sheet__rule--grid"
+          x1={0}
+          x2={width}
+          y1={y}
+          y2={y}
+          strokeWidth={HAIRLINE}
+        />
+      ))}
+      {starts.map((x) => (
+        <g key={`d${x}`}>
+          <line
+            className="sheet__rule sheet__rule--grid"
+            x1={x}
+            x2={x + run}
+            y1={0}
+            y2={height}
+            strokeWidth={HAIRLINE}
+          />
+          <line
+            className="sheet__rule sheet__rule--grid"
+            x1={x}
+            x2={x - run}
+            y1={0}
+            y2={height}
+            strokeWidth={HAIRLINE}
+          />
+        </g>
+      ))}
+    </g>
+  );
+}
+
+/** `n` values from an index. Saves a hand-rolled loop in four places. */
+function range<T>(n: number, at: (index: number) => T): T[] {
+  return Array.from({ length: Math.max(0, n) }, (_, index) => at(index));
+}

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -1,0 +1,353 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_PAPER } from "@/engine/sheets/paper";
+import type { Block, Sheet } from "@/engine/sheets/types";
+
+import { SheetView } from "./Sheet";
+
+/**
+ * The properties a printable sheet lives or dies by.
+ *
+ * Three of them can't be seen by looking at a screen, which is why they are
+ * tested rather than reviewed:
+ *
+ * **It prints.** Browsers drop background paint unless the reader has ticked
+ * "Background graphics", so a ruling drawn with `repeating-linear-gradient`
+ * looks perfect in a preview and comes out of the printer blank. Only strokes
+ * and borders are foreground.
+ *
+ * **It ships no JavaScript.** That is the whole SEO argument (§2), and it holds
+ * only while every renderer is prop-driven — the moment one needs a hook, the
+ * catalog page needs `client:*` and the page becomes an app.
+ *
+ * **No advertising is inside the printable region** (§10). A slot beside a
+ * sheet is fine; a slot inside one prints.
+ */
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/* ── Fixtures ──────────────────────────────────────────────────────────────
+   One block of every kind in the union, so a renderer that throws on a shape
+   the engine can legally produce fails here rather than on a catalog page.  */
+
+const EVERY_BLOCK: Block[] = [
+  {
+    kind: "problems",
+    columns: 3,
+    items: [
+      { prompt: "7 × 8 =", answer: "56", factId: "7:8" },
+      { prompt: "6 × 9 =", answer: "54", workspace: 500 },
+    ],
+  },
+  { kind: "rules", rule: { style: "hand-5-8", descender: true }, lines: 6 },
+  { kind: "rules", rule: { style: "college" }, lines: 4 },
+  { kind: "rules", rule: { style: "graph" }, lines: 8 },
+  { kind: "rules", rule: { style: "dot" }, lines: 8 },
+  { kind: "rules", rule: { style: "isometric" }, lines: 8 },
+  { kind: "rules", rule: { style: "blank" }, lines: 4 },
+  {
+    kind: "trace",
+    rule: { style: "hand-1", midline: "dashed" },
+    rows: [{ text: "cat", repeats: ["solid", "dotted", "dashed", "none"] }],
+  },
+  {
+    kind: "copywork",
+    text: "The quick brown fox\njumps over the lazy dog",
+    rule: { style: "hand-1-2" },
+    mode: "dim",
+  },
+  {
+    kind: "grid",
+    grid: {
+      kind: "coordinate",
+      columns: 4,
+      rows: 4,
+      cell: 250,
+      cells: ["1", "2", "", "4"],
+      origin: { column: 2, row: 2 },
+    },
+  },
+  {
+    kind: "wordsearch",
+    letters: [
+      ["c", "a", "t"],
+      ["x", "y", "z"],
+      ["d", "o", "g"],
+    ],
+    find: ["cat", "dog"],
+    solution: [{ word: "cat", column: 0, row: 0, dx: 1, dy: 0 }],
+  },
+  {
+    kind: "matching",
+    left: ["one", "two"],
+    right: ["uno", "dos"],
+    answer: [0, 1],
+  },
+  {
+    kind: "blanks",
+    sentences: [{ text: "The __ sat on the __.", answers: ["cat", "mat"] }],
+  },
+  {
+    kind: "choice",
+    questions: [
+      { prompt: "How many legs?", options: ["two", "four"], answer: 1 },
+    ],
+  },
+  {
+    kind: "clock",
+    faces: [
+      { hour: 3, minute: 20, hands: true, label: "A" },
+      { hour: 9, minute: 45, hands: false },
+    ],
+  },
+  {
+    kind: "shapes",
+    figures: [
+      {
+        shape: "rectangle",
+        points: [
+          { x: 0, y: 0 },
+          { x: 800, y: 0 },
+          { x: 800, y: 500 },
+          { x: 0, y: 500 },
+        ],
+        labels: ["8 cm", "5 cm"],
+      },
+      {
+        shape: "circle",
+        points: [
+          { x: 400, y: 400 },
+          { x: 700, y: 400 },
+        ],
+      },
+    ],
+  },
+  { kind: "cutline" },
+  { kind: "spacer", height: 1200 },
+];
+
+const sheet = (over: Partial<Sheet> = {}): Sheet => ({
+  paper: DEFAULT_PAPER,
+  fontPt: 12,
+  header: {
+    title: "Times tables",
+    instructions: "Work down each column.",
+    fields: ["name", "date"],
+    score: { outOf: 20 },
+  },
+  blocks: EVERY_BLOCK,
+  footer: {
+    credit: "Free printables and learning games",
+    url: "schoolskills.app",
+    seed: 4242,
+  },
+  answers: false,
+  ...over,
+});
+
+const render = (value: Sheet = sheet()) =>
+  renderToStaticMarkup(<SheetView sheet={value} />);
+
+/** Every file under `dir` whose name ends in one of `endings`. */
+function filesUnder(dir: string, endings: string[]): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return filesUnder(path, endings);
+    return endings.some((end) => entry.name.endsWith(end)) ? [path] : [];
+  });
+}
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+/* ── The blocks ────────────────────────────────────────────────────────── */
+
+describe("rendering a sheet", () => {
+  it("draws every kind of block the engine can produce", () => {
+    const html = render();
+    for (const block of EVERY_BLOCK) {
+      expect(() =>
+        renderToStaticMarkup(<SheetView sheet={sheet({ blocks: [block] })} />),
+      ).not.toThrow();
+    }
+    expect(html).toContain('class="sheet"');
+    expect(html).toContain("Times tables");
+    expect(html).toContain("schoolskills.app");
+    expect(html).toContain("#4242");
+  });
+
+  it("keeps the problems as real text, not as a picture of text", () => {
+    // Half of §2: the problems on a multiplication sheet are content a crawler
+    // reads and a parent can select. A canvas would rank for nothing.
+    expect(render()).toContain("7 × 8 =");
+  });
+
+  it("prints the name line blank", () => {
+    // §1. There is nowhere in a config for a child's name, and this is the
+    // component that would otherwise be the place it leaked out.
+    const html = render();
+    expect(html).toContain("Name");
+    expect(html).toContain("sheet__field-rule");
+  });
+
+  it("prints the answers only when the sheet says so", () => {
+    expect(render()).not.toContain(">56<");
+    const key = render(sheet({ answers: true }));
+    expect(key).toContain(">56<");
+    expect(key).toContain('data-answers="true"');
+  });
+
+  it("sizes the page in inches, from the paper the sheet was built on", () => {
+    expect(render()).toContain("--sheet-w:8.5in");
+    const a4 = render(
+      sheet({
+        paper: { size: "a4", orientation: "landscape", margin: "narrow" },
+      }),
+    );
+    // A4 landscape is 11.693in × 8.268in, and it has to say so in `@page` —
+    // print is the whole output path, so a page box that disagrees with the
+    // sheet on it prints scaled or across two pages (§10).
+    expect(a4).toContain("--sheet-w:11.693in");
+    expect(a4).toContain("@page{size:11.693in 8.268in;margin:0}");
+  });
+});
+
+/* ── It has to survive the printer ─────────────────────────────────────── */
+
+describe("ruled blocks", () => {
+  it("draws rules as <svg> <line>, never as a background image", () => {
+    const html = render(
+      sheet({ blocks: [{ kind: "rules", rule: { style: "wide" }, lines: 5 }] }),
+    );
+    expect(html).toContain("<svg");
+    expect(html).toContain("<line");
+    expect(html).not.toContain("repeating-linear-gradient");
+    expect(html).not.toContain("background");
+  });
+
+  it("draws a dot grid with lines too, rather than a thousand circles", () => {
+    // A zero-length dash with a round cap is a dot. One <line> per row instead
+    // of one element per intersection, and the two print identically.
+    const html = render(
+      sheet({ blocks: [{ kind: "rules", rule: { style: "dot" }, lines: 20 }] }),
+    );
+    expect(html).toContain('stroke-dasharray="0 250"');
+    expect(html).not.toContain("<circle");
+  });
+
+  it("never reaches for a gradient anywhere in the sheet's own styles", () => {
+    // The obvious implementation, and the one that prints blank.
+    for (const file of ["sheet.css", "print.css"]) {
+      expect(read(join(ROOT, "src/styles", file))).not.toContain(
+        "repeating-linear-gradient",
+      );
+    }
+  });
+});
+
+/* ── Print isolation (§20) ─────────────────────────────────────────────── */
+
+describe("print isolation", () => {
+  it("never puts an ad inside a sheet", () => {
+    expect(render()).not.toMatch(/class="[^"]*\bad\b[^"]*"/);
+  });
+
+  it("has no renderer that could put one there", () => {
+    // The rendered markup only proves it for the blocks this fixture holds.
+    // The source proves it for every sheet anybody builds later.
+    for (const file of filesUnder(HERE, [".tsx", ".ts"])) {
+      if (file.endsWith(".test.tsx")) continue;
+      expect(read(file)).not.toMatch(/AdSlot|adsbygoogle|"ad[ "]/);
+    }
+  });
+
+  it("hides the site, the ad slots and the builder's controls when printing", () => {
+    const css = read(join(ROOT, "src/styles/print.css"));
+    const print = css.slice(css.indexOf("@media print"));
+    for (const hidden of [".mast", ".foot", ".skip", ".ad", ".no-print"]) {
+      expect(print).toContain(hidden);
+    }
+    expect(css).toMatch(/@page\s*\{[^}]*size:/);
+    expect(css).toMatch(/@page\s*\{[^}]*margin:\s*0/);
+  });
+
+  it("breaks pages where a reader would expect it to", () => {
+    const css = read(join(ROOT, "src/styles/sheet.css"));
+    expect(css).toContain("break-after: page");
+    expect(css).toContain("break-inside: avoid");
+  });
+
+  it("takes the sheet out of the app's scale, rather than inheriting it", () => {
+    // §4: a ⅝ rule is ⅝ of an inch or it is wrong. `--ui-scale` grows every
+    // size on the site with the player's age, and paper must not do that.
+    const css = read(join(ROOT, "src/styles/sheet.css"));
+    const rule = css.slice(css.indexOf(".sheet {"), css.indexOf("}"));
+    expect(rule).toContain("--ui-scale: 1");
+  });
+});
+
+/* ── Zero JavaScript ───────────────────────────────────────────────────── */
+
+describe("the zero-JavaScript property", () => {
+  it("renders to markup with nothing to run in it", () => {
+    const html = render();
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("astro-island");
+    // A handler attribute is the tell that a renderer wanted to be an app.
+    expect(html).not.toMatch(/\son[a-z]+="/);
+  });
+
+  it("has no renderer that would need hydrating", () => {
+    // The issue's own note: if a renderer needs a hook, it belongs in the
+    // builder, not here. A hook is also exactly what forces `client:*` onto a
+    // catalog page, which is what would cost the section its SEO argument.
+    for (const file of filesUnder(HERE, [".tsx", ".ts"])) {
+      if (file.endsWith(".test.tsx")) continue;
+      expect(read(file)).not.toMatch(
+        /\buse(State|Effect|Ref|Reducer|Context|Memo|Callback|Id|SyncExternalStore)\b/,
+      );
+      expect(read(file)).not.toContain("react-dom/client");
+    }
+  });
+
+  it("is never mounted with a client directive by a page", () => {
+    const pages = filesUnder(join(ROOT, "src/pages"), [".astro"]).concat(
+      filesUnder(join(ROOT, "src/layouts"), [".astro"]),
+    );
+    for (const page of pages) {
+      const source = read(page);
+      if (!source.includes("components/sheet")) continue;
+      expect(source).not.toMatch(/<Sheet[A-Za-z]*[^>]*\sclient:/);
+    }
+  });
+
+  /*
+   * The same property, against the built output.
+   *
+   * Two things would show up in `dist/` if a sheet were ever hydrated: an
+   * `<astro-island>` naming the renderer, and the renderer's own class names
+   * inside a JavaScript chunk. Neither is there while every mount is
+   * directive-free — which is the point, and is why this passes before the
+   * first catalog page exists and keeps passing after PRINT03 adds one.
+   */
+  it("ships no sheet renderer in the built JavaScript", () => {
+    const dist = join(ROOT, "dist");
+    if (!existsSync(dist)) return; // `npm run build` hasn't run yet.
+
+    for (const script of filesUnder(join(dist, "_astro"), [".js"])) {
+      expect(read(script)).not.toContain("sheet__glyph");
+      expect(read(script)).not.toContain("sheet__blocks");
+    }
+    for (const page of filesUnder(dist, [".html"])) {
+      const html = read(page);
+      if (!/class="[^"]*\bsheet\b/.test(html)) continue;
+      expect(html).not.toContain("astro-island");
+    }
+  });
+});

--- a/src/components/sheet/Sheet.tsx
+++ b/src/components/sheet/Sheet.tsx
@@ -1,0 +1,94 @@
+/**
+ * A `Sheet`, as HTML.
+ *
+ * This is the component the whole Print Shop rests on. A sheet is real
+ * elements laid out in real inches — not a canvas, not a PDF blob, not an image
+ * — and everything good about the feature falls out of that one decision (§2):
+ * the catalog pages ship zero JavaScript, the problems on a multiplication
+ * sheet are text a search engine can read, the page is selectable and
+ * accessible at any zoom, and it works offline through the existing service
+ * worker with nothing added.
+ *
+ * **It takes a `Sheet` and nothing else.** No context, no service, no storage,
+ * no state. That is what lets the same component render at build time on a
+ * prerendered catalog page and at runtime inside the builder — exactly the
+ * trick `App.tsx` already pulls by mounting twice — and it is why the zero-JS
+ * property is structural rather than a rule someone has to remember. A renderer
+ * with nothing to hydrate needs no `client:*` directive; if one of these ever
+ * needs a hook, the hook belongs in the builder around it, not in here.
+ *
+ * The stylesheets travel with the component rather than with a layout, so a
+ * page that renders a sheet cannot forget to print it properly.
+ */
+import { contentBox } from "@/engine/sheets/layout";
+import { marginOf, pageSize } from "@/engine/sheets/paper";
+import type { Paper, Sheet } from "@/engine/sheets/types";
+import type { CSSProperties } from "react";
+
+import "@/styles/sheet.css";
+import "@/styles/print.css";
+
+import { BlockView } from "./blocks";
+import type { SheetMetrics } from "./metrics";
+import { SheetFoot } from "./SheetFoot";
+import { SheetHead } from "./SheetHead";
+import { inch, pt } from "./units";
+
+export function SheetView({ sheet }: { sheet: Sheet }) {
+  const page = pageSize(sheet.paper);
+  const metrics: SheetMetrics = {
+    box: contentBox(sheet.paper),
+    fontPt: sheet.fontPt,
+    answers: sheet.answers,
+  };
+
+  return (
+    <article
+      className="sheet"
+      // Not a class, because a key is the same sheet in a different state
+      // rather than a different kind of sheet — and a stylesheet that wants to
+      // mark up the answers can reach it either way.
+      data-answers={sheet.answers ? "true" : undefined}
+      style={
+        {
+          "--sheet-w": inch(page.width),
+          "--sheet-h": inch(page.height),
+          "--sheet-margin": inch(marginOf(sheet.paper)),
+          "--sheet-pt": pt(sheet.fontPt),
+        } as CSSProperties
+      }
+    >
+      <PageSize paper={sheet.paper} />
+      <SheetHead header={sheet.header} />
+      <div className="sheet__blocks">
+        {/* Indexed keys: a block has no identity of its own, the list is
+            rebuilt whole on every change of config, and nothing in it is
+            stateful — there is nothing for a stable key to preserve. */}
+        {sheet.blocks.map((block, index) => (
+          <BlockView key={index} block={block} metrics={metrics} />
+        ))}
+      </div>
+      <SheetFoot footer={sheet.footer} />
+    </article>
+  );
+}
+
+/**
+ * `@page` for a sheet that isn't on the default stock.
+ *
+ * `print.css` sets Letter portrait with no margin, which is what most of this
+ * audience prints on. `@page` is a document rule with no way to scope it to a
+ * class, so the only way a sheet can state its own stock is to emit one — and
+ * getting this wrong is not a cosmetic bug: print is the whole of the output
+ * path here (§10), so a sheet whose paper and page size disagree is one that
+ * prints across two pages or gets scaled down to fit, and there is no PDF to
+ * fall back on.
+ *
+ * A `<style>` element, not a script. It costs nothing at run time and keeps the
+ * page free of JavaScript.
+ */
+function PageSize({ paper }: { paper: Paper }) {
+  if (paper.size === "letter" && paper.orientation === "portrait") return null;
+  const { width, height } = pageSize(paper);
+  return <style>{`@page{size:${inch(width)} ${inch(height)};margin:0}`}</style>;
+}

--- a/src/components/sheet/SheetFoot.tsx
+++ b/src/components/sheet/SheetFoot.tsx
@@ -1,0 +1,22 @@
+import type { SheetFooter } from "@/engine/sheets/types";
+
+/**
+ * The bottom of the sheet: who made it, where to go next, and which sheet this
+ * is.
+ *
+ * The seed is printed small on purpose. A parent who wants *this* sheet again
+ * next week — not another one like it — can have it, because the seed is the
+ * whole of what generated it (§7). The URL is plain text rather than a link:
+ * it exists to be read off paper and typed, and a link on a catalog page that
+ * points at the site the page is on earns nothing.
+ */
+export function SheetFoot({ footer }: { footer: SheetFooter }) {
+  return (
+    <footer className="sheet__foot">
+      <span className="sheet__credit">{footer.credit}</span>
+      {footer.note && <span className="sheet__note">{footer.note}</span>}
+      {footer.url && <span className="sheet__link">{footer.url}</span>}
+      <span className="sheet__seed">#{footer.seed}</span>
+    </footer>
+  );
+}

--- a/src/components/sheet/SheetHead.tsx
+++ b/src/components/sheet/SheetHead.tsx
@@ -1,0 +1,53 @@
+import type { HeaderField, SheetHeader } from "@/engine/sheets/types";
+
+/** What each blank is called on paper. */
+const FIELD: Record<HeaderField, string> = {
+  name: "Name",
+  date: "Date",
+  class: "Class",
+};
+
+/**
+ * The top of the sheet: what it is, what to do, and the lines a child fills in.
+ *
+ * **The name line is printed blank, always.** It is the one field every
+ * worksheet on earth asks for and the one thing this site refuses to hold: a
+ * `HeaderField` is a marker rather than a value, so there is nowhere in a
+ * config for a child's name to be typed and nothing in a shared URL for it to
+ * leak through (§1). A pencil fills it in.
+ *
+ * The title is an `<h2>`. A catalog page is a page *about* a worksheet with the
+ * worksheet on it, so its `<h1>` is the page's — and the same component has to
+ * be droppable into the builder's preview, where there is no page heading at
+ * all. Neither mount gets to be wrong about the outline.
+ */
+export function SheetHead({ header }: { header: SheetHeader }) {
+  const hasLine = header.fields.length > 0 || header.score !== undefined;
+
+  return (
+    <header className="sheet__head">
+      {header.title && <h2 className="sheet__title">{header.title}</h2>}
+
+      {hasLine && (
+        <div className="sheet__fields">
+          {header.fields.map((field) => (
+            <span className="sheet__field" key={field}>
+              <span className="sheet__field-name">{FIELD[field]}</span>
+              <span className="sheet__field-rule" />
+            </span>
+          ))}
+          {header.score && (
+            <span className="sheet__score">
+              <span className="sheet__field-rule sheet__field-rule--short" />
+              <span className="sheet__field-name">/ {header.score.outOf}</span>
+            </span>
+          )}
+        </div>
+      )}
+
+      {header.instructions && (
+        <p className="sheet__instructions">{header.instructions}</p>
+      )}
+    </header>
+  );
+}

--- a/src/components/sheet/Traced.tsx
+++ b/src/components/sheet/Traced.tsx
@@ -1,0 +1,151 @@
+/**
+ * Letterforms to trace, without a tracing font.
+ *
+ * Dotted and dim letters are the point of a handwriting sheet, and every
+ * commercial tracing font is licensed per seat. None is needed: SVG `<text>`
+ * can be stroked instead of filled, and a dash pattern applies **along the
+ * glyph outline** — so one ordinary font gives all five appearances in §6, the
+ * dash pitch is a number rather than a purchase, and the same face the rest of
+ * the sheet is set in is the one the child traces.
+ *
+ * Fill and opacity are CSS, because neither scales. Stroke width and dash
+ * pattern are attributes in mil, because both do — see `units.ts`.
+ */
+import { ruledLines } from "@/engine/sheets/layout";
+import { rulePitch } from "@/engine/sheets/paper";
+import type { Mil, Rule, TraceStyle } from "@/engine/sheets/types";
+
+import { Ruling } from "./Ruling";
+import { DASH_DASHED, DASH_DOTTED, inch, RULE } from "./units";
+import type { SheetMetrics } from "./metrics";
+
+/** The three styles that are an outline rather than a filled shape. */
+const OUTLINED: TraceStyle[] = ["hollow", "dotted", "dashed"];
+
+const DASHES: Partial<Record<TraceStyle, string>> = {
+  dotted: DASH_DOTTED,
+  dashed: DASH_DASHED,
+};
+
+export function Glyph({
+  text,
+  x,
+  y,
+  size,
+  style,
+}: {
+  text: string;
+  x: Mil;
+  /** The baseline the letters sit on. */
+  y: Mil;
+  size: Mil;
+  style: TraceStyle;
+}) {
+  // The empty space at the end of a trace → copy → write row, where the child
+  // is on their own. Nothing is drawn, and the space is still reserved.
+  if (style === "none" || text === "") return null;
+
+  const outlined = OUTLINED.includes(style);
+  return (
+    <text
+      className={`sheet__glyph sheet__glyph--${style}`}
+      x={x}
+      y={y}
+      fontSize={size}
+      strokeWidth={outlined ? RULE : undefined}
+      strokeDasharray={DASHES[style]}
+      strokeLinecap={style === "dotted" ? "round" : undefined}
+    >
+      {text}
+    </text>
+  );
+}
+
+export type TracedCell = { text: string; style: TraceStyle };
+
+/**
+ * One repeat of a ruling with letterforms written onto it.
+ *
+ * Both blocks that trace anything are this: a tracing row is several cells
+ * across one repeat, and a line of copywork is one cell across one repeat.
+ *
+ * The type size is derived from the ruling rather than from the sheet's body
+ * size, because on a handwriting sheet the ruling *is* the type size — a ⅝
+ * rule with a midline is asking for letters whose bodies reach that midline.
+ * `WRITING_TO_EM` is the em size that puts a capital's height at one writing
+ * space — the inverse of a face's cap-height ratio, near enough for the site's
+ * own Nunito. Phase 3 replaces the guesswork with the Playwrite Guides family,
+ * which draws its own guidelines (§6).
+ */
+const WRITING_TO_EM = 1.35;
+
+/**
+ * A *declared* average advance width, as a share of the em.
+ *
+ * The same bargain as a problem cell in `layout.ts`: state what a character
+ * will take rather than measure what it took, because there is no DOM to ask
+ * at build time (§4). It is only used to keep letters inside their cell — a
+ * family that sized its row properly never reaches it, and one that asked for
+ * six repeats of a long word on a ⅝ rule gets small letters instead of letters
+ * that run off the paper.
+ */
+const ADVANCE_PER_EM = 0.55;
+
+export function TracedRow({
+  rule,
+  metrics,
+  cells,
+}: {
+  rule: Rule;
+  metrics: SheetMetrics;
+  cells: TracedCell[];
+}) {
+  const pitch = rulePitch(rule);
+  const width = metrics.box.width;
+  const lines = ruledLines({ x: 0, y: 0, width, height: pitch }, rule);
+
+  // Where the letters sit, and how big they are. A handwriting rule states
+  // both; a notebook rule states only the line, so the body size fills what is
+  // left above it.
+  const baseline = lines.find((line) => line.role === "base")?.y ?? pitch;
+  const top = lines.find((line) => line.role === "top")?.y ?? 0;
+  const cell = cells.length > 0 ? Math.floor(width / cells.length) : width;
+  const longest = cells.reduce(
+    (most, one) => Math.max(most, one.text.length),
+    0,
+  );
+  const size = Math.max(
+    1,
+    Math.min(
+      Math.round((baseline - top) * WRITING_TO_EM),
+      longest > 0 ? Math.floor(cell / (longest * ADVANCE_PER_EM)) : Infinity,
+    ),
+  );
+
+  // Every cell in a row carries the same word — that is what a tracing row is
+  // — so the row is announced once rather than four times over.
+  const said = cells.find((entry) => entry.text !== "")?.text;
+
+  return (
+    <svg
+      className="sheet__ink"
+      width={inch(width)}
+      height={inch(pitch)}
+      viewBox={`0 0 ${width} ${pitch}`}
+      role="img"
+      aria-label={said ?? "A line to write on"}
+    >
+      <Ruling rule={rule} box={metrics.box} sets={1} />
+      {cells.map((entry, index) => (
+        <Glyph
+          key={`${index}-${entry.text}`}
+          text={entry.text}
+          x={index * cell}
+          y={baseline}
+          size={size}
+          style={entry.style}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/src/components/sheet/blocks/Blanks.tsx
+++ b/src/components/sheet/blocks/Blanks.tsx
@@ -1,0 +1,44 @@
+import type { BlockProps } from "./block";
+
+/**
+ * Sentences with something missing.
+ *
+ * `_` marks each gap, the same convention `Card.clue` already uses, so a run of
+ * underscores of any length is one blank. The gap is a ruled span rather than
+ * the underscores themselves: underscores set in a proportional face are a
+ * ragged line whose length depends on how many the generator happened to
+ * write, and a child writing in one needs the same room whatever the answer is.
+ *
+ * On the key the answer is printed in the gap and the rule stays under it,
+ * which is how a marked sheet reads.
+ */
+export function Blanks({ block, metrics }: BlockProps<"blanks">) {
+  return (
+    <ol className="sheet__blanks">
+      {block.sentences.map((sentence, index) => {
+        // n gaps split the sentence into n + 1 segments, so segment i is
+        // followed by gap i — and the last segment is followed by nothing.
+        const segments = sentence.text.split(/_+/);
+        return (
+          <li className="sheet__sentence" key={`${index}-${sentence.text}`}>
+            <span className="sheet__number">{index + 1}.</span>
+            {segments.map((segment, gap) => (
+              <span key={gap}>
+                {segment}
+                {gap < segments.length - 1 && (
+                  <span
+                    className={`sheet__slot${
+                      metrics.answers ? " sheet__slot--answered" : ""
+                    }`}
+                  >
+                    {metrics.answers ? (sentence.answers[gap] ?? "") : ""}
+                  </span>
+                )}
+              </span>
+            ))}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/components/sheet/blocks/Choice.tsx
+++ b/src/components/sheet/blocks/Choice.tsx
@@ -1,0 +1,43 @@
+import type { BlockProps } from "./block";
+
+/** A, B, C … and then numbers, so a long list never runs out of labels. */
+const label = (index: number): string =>
+  index < 26 ? String.fromCharCode(65 + index) : String(index + 1);
+
+/**
+ * Multiple choice.
+ *
+ * The correct option is marked on the key by a rule under it, not by a filled
+ * or tinted box. Ink-saving is a feature rather than an accident (§5) — and a
+ * background is the one kind of mark a browser drops when printing, so a key
+ * that used one would print identical to the sheet it answers.
+ */
+export function Choice({ block, metrics }: BlockProps<"choice">) {
+  return (
+    <ol className="sheet__questions">
+      {block.questions.map((question, index) => (
+        <li className="sheet__question" key={`${index}-${question.prompt}`}>
+          <p className="sheet__ask">
+            <span className="sheet__number">{index + 1}.</span>
+            {question.prompt}
+          </p>
+          <ol className="sheet__options">
+            {question.options.map((option, choice) => (
+              <li
+                className={`sheet__option${
+                  metrics.answers && choice === question.answer
+                    ? " sheet__option--answer"
+                    : ""
+                }`}
+                key={`${choice}-${option}`}
+              >
+                <span className="sheet__mark">{label(choice)}</span>
+                {option}
+              </li>
+            ))}
+          </ol>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/components/sheet/blocks/Clock.tsx
+++ b/src/components/sheet/blocks/Clock.tsx
@@ -1,0 +1,122 @@
+import { inches } from "@/engine/sheets/paper";
+import type { ClockFace, Mil } from "@/engine/sheets/types";
+
+import { HAIRLINE, HEAVY, RULE, inch } from "../units";
+import type { BlockProps } from "./block";
+
+/* The dial, in mil. One and a half inches is the size a clock face is printed
+   at on a worksheet: big enough for a child to draw a minute hand accurately,
+   small enough that six of them fit across a page. */
+const FACE = inches(1.5);
+const CENTRE = FACE / 2;
+const DIAL = Math.round(FACE * 0.46);
+const TICK = Math.round(DIAL * 0.88);
+const NUMERAL = Math.round(DIAL * 0.74);
+const HOUR_HAND = Math.round(DIAL * 0.52);
+const MINUTE_HAND = Math.round(DIAL * 0.8);
+
+/** Where a point sits on the dial, measured clockwise from twelve. */
+function at(degrees: number, radius: Mil): { x: number; y: number } {
+  const radians = (degrees * Math.PI) / 180;
+  return {
+    x: Math.round(CENTRE + radius * Math.sin(radians)),
+    y: Math.round(CENTRE - radius * Math.cos(radians)),
+  };
+}
+
+/**
+ * Analog dials.
+ *
+ * One block covers both halves of telling the time: `hands: true` is a face to
+ * read, `hands: false` is a face to draw. On the key the hands appear either
+ * way — a sheet asking a child to draw twenty past three is answered by the
+ * face with the hands on it.
+ */
+export function Clock({ block, metrics }: BlockProps<"clock">) {
+  return (
+    <div className="sheet__faces">
+      {block.faces.map((face, index) => (
+        <figure className="sheet__face" key={`${index}-${face.label ?? ""}`}>
+          <Dial face={face} hands={face.hands || metrics.answers} />
+          {face.label && (
+            <figcaption className="sheet__caption">{face.label}</figcaption>
+          )}
+        </figure>
+      ))}
+    </div>
+  );
+}
+
+function Dial({ face, hands }: { face: ClockFace; hands: boolean }) {
+  const minute = face.minute * 6;
+  const hour = ((face.hour % 12) + face.minute / 60) * 30;
+  const time = `${face.hour}:${String(face.minute).padStart(2, "0")}`;
+
+  return (
+    <svg
+      className="sheet__ink"
+      width={inch(FACE)}
+      height={inch(FACE)}
+      viewBox={`0 0 ${FACE} ${FACE}`}
+      role="img"
+      aria-label={hands ? `A clock showing ${time}` : "A clock with no hands"}
+    >
+      <circle
+        className="sheet__dial"
+        cx={CENTRE}
+        cy={CENTRE}
+        r={DIAL}
+        strokeWidth={RULE}
+      />
+      {Array.from({ length: 12 }, (_, index) => {
+        const outer = at(index * 30, DIAL);
+        const inner = at(index * 30, TICK);
+        const numeral = at(index * 30, NUMERAL);
+        return (
+          <g key={index}>
+            <line
+              className="sheet__rule"
+              x1={inner.x}
+              y1={inner.y}
+              x2={outer.x}
+              y2={outer.y}
+              strokeWidth={HAIRLINE}
+            />
+            <text
+              className="sheet__cell"
+              x={numeral.x}
+              y={numeral.y}
+              fontSize={Math.round(DIAL * 0.3)}
+              textAnchor="middle"
+              dominantBaseline="central"
+            >
+              {index === 0 ? 12 : index}
+            </text>
+          </g>
+        );
+      })}
+      {hands && (
+        <g className="sheet__hands">
+          <line
+            className="sheet__rule"
+            x1={CENTRE}
+            y1={CENTRE}
+            x2={at(hour, HOUR_HAND).x}
+            y2={at(hour, HOUR_HAND).y}
+            strokeWidth={HEAVY}
+            strokeLinecap="round"
+          />
+          <line
+            className="sheet__rule"
+            x1={CENTRE}
+            y1={CENTRE}
+            x2={at(minute, MINUTE_HAND).x}
+            y2={at(minute, MINUTE_HAND).y}
+            strokeWidth={RULE}
+            strokeLinecap="round"
+          />
+        </g>
+      )}
+    </svg>
+  );
+}

--- a/src/components/sheet/blocks/Copywork.tsx
+++ b/src/components/sheet/blocks/Copywork.tsx
@@ -1,0 +1,29 @@
+import { TracedRow } from "../Traced";
+import type { BlockProps } from "./block";
+
+/**
+ * A passage on ruled lines, in one of the five trace styles.
+ *
+ * **Where it breaks is the family's decision, not this component's.** There is
+ * no measurement in the view — that is the declared-size bargain `layout.ts` is
+ * built on (§4) — so one line of `text` is one repeat of the ruling, and a
+ * family that wants a verse across four lines puts three newlines in it. It
+ * also means a Scripture passage is stored and rendered exactly as it was
+ * given, punctuation and all, which the WEB's one licence condition requires
+ * (§12).
+ */
+export function Copywork({ block, metrics }: BlockProps<"copywork">) {
+  return (
+    <div className="sheet__block">
+      {block.text.split("\n").map((line, index) => (
+        <div className="sheet__row" key={`${index}-${line}`}>
+          <TracedRow
+            rule={block.rule}
+            metrics={metrics}
+            cells={[{ text: line, style: block.mode }]}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/sheet/blocks/Cutline.tsx
+++ b/src/components/sheet/blocks/Cutline.tsx
@@ -1,6 +1,6 @@
 import { inches } from "@/engine/sheets/paper";
 
-import { DASH_CUT, HAIRLINE, inch } from "../units";
+import { DASH_CUT, HEAVY, inch } from "../units";
 import type { BlockProps } from "./block";
 
 /** Enough room either side that the line reads as an instruction, not a rule. */
@@ -12,6 +12,10 @@ const HEIGHT = inches(0.24);
  * A dashed stroke rather than a dashed CSS border for the same reason the
  * rulings are strokes: this one has to survive the print pipeline, and a child
  * with scissors is following it exactly.
+ *
+ * `HEAVY` for the same reason — a cut line is read before it is used, and it
+ * has to be the one line on the page nobody mistakes for a rule to write on.
+ * That is the weight `units.ts` names cut lines under.
  */
 export function Cutline({ metrics }: BlockProps<"cutline">) {
   const width = metrics.box.width;
@@ -30,7 +34,7 @@ export function Cutline({ metrics }: BlockProps<"cutline">) {
         x2={width}
         y1={HEIGHT / 2}
         y2={HEIGHT / 2}
-        strokeWidth={HAIRLINE}
+        strokeWidth={HEAVY}
         strokeDasharray={DASH_CUT}
       />
     </svg>

--- a/src/components/sheet/blocks/Cutline.tsx
+++ b/src/components/sheet/blocks/Cutline.tsx
@@ -1,0 +1,38 @@
+import { inches } from "@/engine/sheets/paper";
+
+import { DASH_CUT, HAIRLINE, inch } from "../units";
+import type { BlockProps } from "./block";
+
+/** Enough room either side that the line reads as an instruction, not a rule. */
+const HEIGHT = inches(0.24);
+
+/**
+ * Where to cut, for cards and bookmarks.
+ *
+ * A dashed stroke rather than a dashed CSS border for the same reason the
+ * rulings are strokes: this one has to survive the print pipeline, and a child
+ * with scissors is following it exactly.
+ */
+export function Cutline({ metrics }: BlockProps<"cutline">) {
+  const width = metrics.box.width;
+  return (
+    <svg
+      className="sheet__ink sheet__cut"
+      width={inch(width)}
+      height={inch(HEIGHT)}
+      viewBox={`0 0 ${width} ${HEIGHT}`}
+      role="img"
+      aria-label="Cut along this line"
+    >
+      <line
+        className="sheet__rule sheet__rule--cut"
+        x1={0}
+        x2={width}
+        y1={HEIGHT / 2}
+        y2={HEIGHT / 2}
+        strokeWidth={HAIRLINE}
+        strokeDasharray={DASH_CUT}
+      />
+    </svg>
+  );
+}

--- a/src/components/sheet/blocks/Grid.tsx
+++ b/src/components/sheet/blocks/Grid.tsx
@@ -13,9 +13,20 @@ const CELL_TO_EM = 0.5;
  * squares — a hundred chart is a grid with a hundred cells filled in and a
  * multiplication grid is the same shape with an axis.
  */
-export function Grid({ block }: BlockProps<"grid">) {
-  const { columns, rows, cell, cells, origin, kind } = block.grid;
-  if (columns <= 0 || rows <= 0 || cell <= 0) return null;
+export function Grid({ block, metrics }: BlockProps<"grid">) {
+  const { columns, rows, cells, origin, kind } = block.grid;
+  if (columns <= 0 || rows <= 0 || block.grid.cell <= 0) return null;
+
+  // Clamped to what the content box actually holds. A grid wider than the box
+  // is not cut off — `.sheet__ink { max-width: 100% }` rescales it — so a
+  // declared quarter-inch square would print as something else, silently and
+  // invisibly in the preview. Squares that measure what they say they measure
+  // is the whole point of §4, so shrink the square rather than the drawing.
+  const cell = Math.min(
+    block.grid.cell,
+    Math.floor(metrics.box.width / columns),
+  );
+  if (cell <= 0) return null;
 
   const width = columns * cell;
   const height = rows * cell;
@@ -27,9 +38,15 @@ export function Grid({ block }: BlockProps<"grid">) {
       width={inch(width)}
       height={inch(height)}
       viewBox={`0 0 ${width} ${height}`}
-      role="img"
-      aria-label={`${columns} by ${rows} ${kind} grid`}
     >
+      {/* A `<title>` rather than `role="img"` + `aria-label`: a hundred chart
+          carries a hundred numbers in `<text>`, and `role="img"` would collapse
+          all of them into this one sentence. The convention in this codebase is
+          that `role="img"` is for a drawing whose label restates everything
+          inside it (see `Ring` in ui/kit.tsx) — a numbered grid is the opposite
+          case, so name it and leave its contents readable. */}
+      <title>{`${columns} by ${rows} ${kind} grid`}</title>
+
       {count(columns + 1).map((column) => (
         <line
           key={`c${column}`}

--- a/src/components/sheet/blocks/Grid.tsx
+++ b/src/components/sheet/blocks/Grid.tsx
@@ -1,0 +1,102 @@
+import { HAIRLINE, HEAVY, inch } from "../units";
+import type { BlockProps } from "./block";
+
+/** Numerals inside a square, at about half its height. */
+const CELL_TO_EM = 0.5;
+
+/**
+ * A grid of squares: graph paper inside a box, a hundred chart, a coordinate
+ * plane.
+ *
+ * Distinct from the `rules` block, which rules the *page*. This one has a
+ * declared number of columns and rows and may have something printed in the
+ * squares — a hundred chart is a grid with a hundred cells filled in and a
+ * multiplication grid is the same shape with an axis.
+ */
+export function Grid({ block }: BlockProps<"grid">) {
+  const { columns, rows, cell, cells, origin, kind } = block.grid;
+  if (columns <= 0 || rows <= 0 || cell <= 0) return null;
+
+  const width = columns * cell;
+  const height = rows * cell;
+  const size = Math.round(cell * CELL_TO_EM);
+
+  return (
+    <svg
+      className="sheet__ink"
+      width={inch(width)}
+      height={inch(height)}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={`${columns} by ${rows} ${kind} grid`}
+    >
+      {count(columns + 1).map((column) => (
+        <line
+          key={`c${column}`}
+          className="sheet__rule sheet__rule--grid"
+          x1={column * cell}
+          x2={column * cell}
+          y1={0}
+          y2={height}
+          strokeWidth={HAIRLINE}
+        />
+      ))}
+      {count(rows + 1).map((row) => (
+        <line
+          key={`r${row}`}
+          className="sheet__rule sheet__rule--grid"
+          x1={0}
+          x2={width}
+          y1={row * cell}
+          y2={row * cell}
+          strokeWidth={HAIRLINE}
+        />
+      ))}
+
+      {/* A coordinate plane is the same grid with two heavier strokes through
+          it. Where they cross is counted in squares, so the axes land on the
+          ruling rather than near it. */}
+      {kind === "coordinate" && origin && (
+        <g className="sheet__axes">
+          <line
+            x1={0}
+            x2={width}
+            y1={origin.row * cell}
+            y2={origin.row * cell}
+            className="sheet__rule sheet__rule--axis"
+            strokeWidth={HEAVY}
+          />
+          <line
+            x1={origin.column * cell}
+            x2={origin.column * cell}
+            y1={0}
+            y2={height}
+            className="sheet__rule sheet__rule--axis"
+            strokeWidth={HEAVY}
+          />
+        </g>
+      )}
+
+      {cells?.map((text, index) =>
+        text === "" ? null : (
+          <text
+            key={`${index}-${text}`}
+            className="sheet__cell"
+            x={((index % columns) + 0.5) * cell}
+            y={(Math.floor(index / columns) + 0.5) * cell}
+            fontSize={size}
+            textAnchor="middle"
+            dominantBaseline="central"
+          >
+            {text}
+          </text>
+        ),
+      )}
+    </svg>
+  );
+}
+
+/** `0 … n − 1`. */
+function count(n: number): number[] {
+  return Array.from({ length: Math.max(0, n) }, (_, index) => index);
+}

--- a/src/components/sheet/blocks/Matching.tsx
+++ b/src/components/sheet/blocks/Matching.tsx
@@ -1,0 +1,98 @@
+import { points } from "@/engine/sheets/paper";
+
+import { HAIRLINE, inch } from "../units";
+import type { BlockProps } from "./block";
+
+/** A row is two lines of type tall: room to draw between, and to write in. */
+const ROW_TO_EM = 2.4;
+/** Big enough for a five-year-old with a pencil to aim a line at. */
+const DOT = points(1.6);
+/** How far in from each edge the dots sit, as a share of the block width. */
+const LEFT_DOT = 0.44;
+const RIGHT_DOT = 0.56;
+
+/**
+ * Two columns to join with a pencil.
+ *
+ * The dots are what the child aims at, so they are drawn rather than typed —
+ * a middle dot in a font sits at a height that depends on the face. On the key
+ * the pairing is a stroke from dot to dot, which is what a marked matching
+ * exercise looks like and what a parent checks against.
+ */
+export function Matching({ block, metrics }: BlockProps<"matching">) {
+  const rows = Math.max(block.left.length, block.right.length);
+  if (rows === 0) return null;
+
+  const width = metrics.box.width;
+  const size = points(metrics.fontPt);
+  const row = Math.round(size * ROW_TO_EM);
+  const height = rows * row;
+  const leftX = Math.round(width * LEFT_DOT);
+  const rightX = Math.round(width * RIGHT_DOT);
+  const middle = (index: number) => Math.round((index + 0.5) * row);
+
+  return (
+    <svg
+      className="sheet__ink"
+      width={inch(width)}
+      height={inch(height)}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label="Join each item on the left to its pair on the right"
+    >
+      {block.left.map((text, index) => (
+        <g key={`l${index}-${text}`}>
+          <text
+            className="sheet__cell sheet__cell--start"
+            x={0}
+            y={middle(index)}
+            fontSize={size}
+            dominantBaseline="central"
+          >
+            {text}
+          </text>
+          <circle
+            className="sheet__dot"
+            cx={leftX}
+            cy={middle(index)}
+            r={DOT}
+          />
+        </g>
+      ))}
+
+      {block.right.map((text, index) => (
+        <g key={`r${index}-${text}`}>
+          <circle
+            className="sheet__dot"
+            cx={rightX}
+            cy={middle(index)}
+            r={DOT}
+          />
+          <text
+            className="sheet__cell sheet__cell--end"
+            x={width}
+            y={middle(index)}
+            fontSize={size}
+            textAnchor="end"
+            dominantBaseline="central"
+          >
+            {text}
+          </text>
+        </g>
+      ))}
+
+      {metrics.answers &&
+        block.answer.map((right, left) => (
+          <line
+            key={`a${left}-${right}`}
+            className="sheet__rule sheet__rule--joined"
+            x1={leftX}
+            y1={middle(left)}
+            x2={rightX}
+            y2={middle(right)}
+            strokeWidth={HAIRLINE}
+          />
+        ))}
+    </svg>
+  );
+}

--- a/src/components/sheet/blocks/Matching.tsx
+++ b/src/components/sheet/blocks/Matching.tsx
@@ -37,9 +37,12 @@ export function Matching({ block, metrics }: BlockProps<"matching">) {
       width={inch(width)}
       height={inch(height)}
       viewBox={`0 0 ${width} ${height}`}
-      role="img"
-      aria-label="Join each item on the left to its pair on the right"
     >
+      {/* Named with a `<title>`, not `role="img"`. Both columns of words live
+          in `<text>` inside this `<svg>`, and `role="img"` would replace the
+          whole exercise with this one instruction. */}
+      <title>Join each item on the left to its pair on the right</title>
+
       {block.left.map((text, index) => (
         <g key={`l${index}-${text}`}>
           <text

--- a/src/components/sheet/blocks/Problems.tsx
+++ b/src/components/sheet/blocks/Problems.tsx
@@ -1,0 +1,52 @@
+import type { CSSProperties } from "react";
+
+import { inch } from "../units";
+import type { BlockProps } from "./block";
+
+/**
+ * Numbered problems in columns.
+ *
+ * Real text in a real list, not a drawing — which is the half of §2 that the
+ * SVG blocks can't do: the problems on a multiplication sheet are content a
+ * search engine reads, a screen reader announces and a parent can select and
+ * copy. It is also the block that decides whether a print preview is right the
+ * first time, so `.sheet__problem` carries `break-inside: avoid` (§10).
+ *
+ * The answer prints when the sheet says so and is blank when it doesn't. Both
+ * come from the same build, so a key cannot disagree with its sheet (§7).
+ */
+export function Problems({ block, metrics }: BlockProps<"problems">) {
+  const columns = Math.max(1, Math.floor(block.columns));
+
+  return (
+    <ol
+      className="sheet__problems"
+      style={{ "--sheet-columns": columns } as CSSProperties}
+    >
+      {block.items.map((problem, index) => (
+        <li className="sheet__problem" key={`${index}-${problem.prompt}`}>
+          {/* The number is written out rather than left to a list marker:
+              `base.css` strips markers site-wide, and a numbered problem a
+              child is told to "do 4, 7 and 12 of" has to carry its number as
+              text anyway. */}
+          <span className="sheet__number">{index + 1}.</span>
+          <span className="sheet__prompt">{problem.prompt}</span>
+          <span
+            className={`sheet__slot${
+              metrics.answers ? " sheet__slot--answered" : ""
+            }`}
+          >
+            {metrics.answers ? problem.answer : ""}
+          </span>
+          {problem.workspace !== undefined && (
+            <span
+              className="sheet__workspace"
+              style={{ height: inch(problem.workspace) }}
+              aria-hidden="true"
+            />
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/components/sheet/blocks/Rules.tsx
+++ b/src/components/sheet/blocks/Rules.tsx
@@ -1,0 +1,30 @@
+import { Ruling, ruledHeight } from "../Ruling";
+import { inch } from "../units";
+import type { BlockProps } from "./block";
+
+/**
+ * Ruled paper: `lines` repeats of a ruling and nothing written on them.
+ *
+ * The whole of "printable wide ruled paper", which is a top-tier query in its
+ * own right (§18) — and the block every other ruled thing on a sheet is built
+ * out of.
+ */
+export function Rules({ block, metrics }: BlockProps<"rules">) {
+  const width = metrics.box.width;
+  const height = ruledHeight(block.rule, block.lines);
+  // Blank paper is a ruling with no pitch. It draws nothing, which is correct
+  // and is not the same thing as drawing a zero-height box.
+  if (height <= 0) return null;
+
+  return (
+    <svg
+      className="sheet__ink"
+      width={inch(width)}
+      height={inch(height)}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden="true"
+    >
+      <Ruling rule={block.rule} box={metrics.box} sets={block.lines} />
+    </svg>
+  );
+}

--- a/src/components/sheet/blocks/Shapes.tsx
+++ b/src/components/sheet/blocks/Shapes.tsx
@@ -1,0 +1,205 @@
+import { points } from "@/engine/sheets/paper";
+import type { Figure, Mil } from "@/engine/sheets/types";
+
+import { HAIRLINE, RULE, inch } from "../units";
+import type { BlockProps } from "./block";
+
+/**
+ * Room around a figure for its labels, in ems of the sheet's own body size —
+ * a label sits half its own width past the edge it names, so the margin has to
+ * grow with the type or `6 cm` loses its `m` off the side of the box.
+ */
+const PAD_TO_EM = 2.2;
+
+/**
+ * Figures to measure, name or shade.
+ *
+ * Each one is drawn in its own coordinate space — the engine gives points in
+ * mil within the figure's own box — so a row of shapes is a row of small
+ * `<svg>` elements rather than one large one with the arithmetic to place them.
+ * That is also what lets a figure keep its shape when the row wraps.
+ */
+export function Shapes({ block, metrics }: BlockProps<"shapes">) {
+  return (
+    <div className="sheet__figures">
+      {block.figures.map((figure, index) => (
+        <Drawn
+          key={index}
+          figure={figure}
+          size={points(metrics.fontPt)}
+          index={index}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Drawn({
+  figure,
+  size,
+  index,
+}: {
+  figure: Figure;
+  size: Mil;
+  index: number;
+}) {
+  const corners = figure.points;
+  if (corners.length === 0) return null;
+
+  // The box is measured from the drawing rather than from the points: a circle
+  // reaches a radius past its centre in every direction, so sizing it by its
+  // two points alone clips the bottom half off.
+  const box = boundsOf(figure);
+  const pad = Math.round(size * PAD_TO_EM);
+  const width = box.maxX - box.minX + pad * 2;
+  const height = box.maxY - box.minY + pad * 2;
+  const shift = (point: Point): Point => ({
+    x: point.x - box.minX + pad,
+    y: point.y - box.minY + pad,
+  });
+
+  return (
+    <svg
+      className="sheet__ink sheet__figure"
+      width={inch(width)}
+      height={inch(height)}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={`Figure ${index + 1}: a ${figure.shape}`}
+    >
+      {figure.shape === "circle" ? (
+        <Circle points={corners.map(shift)} />
+      ) : (
+        <polygon
+          className="sheet__shape"
+          strokeWidth={RULE}
+          points={corners
+            .map(shift)
+            .map((point) => `${point.x},${point.y}`)
+            .join(" ")}
+        />
+      )}
+
+      {/* A side label sits just outside the midpoint of the edge that starts
+          at the point of the same index — which is why `labels` is documented
+          as being in the order the points are given. Outside, because a `6 cm`
+          printed on top of the line it measures is a line a child then has to
+          read through. */}
+      {figure.labels?.map((text, edge) => {
+        const from = corners[edge];
+        const to = corners[(edge + 1) % corners.length];
+        if (!from || !to) return null;
+        const middle = shift(
+          away(
+            {
+              x: Math.round((from.x + to.x) / 2),
+              y: Math.round((from.y + to.y) / 2),
+            },
+            centreOf(corners),
+            Math.round(size * 0.75),
+          ),
+        );
+        return (
+          <text
+            key={`${edge}-${text}`}
+            className="sheet__cell"
+            x={middle.x}
+            y={middle.y}
+            fontSize={size}
+            textAnchor="middle"
+            dominantBaseline="central"
+          >
+            {text}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}
+
+type Point = { x: Mil; y: Mil };
+
+/** How far a figure actually reaches, which is not always where its points are. */
+function boundsOf(figure: Figure): {
+  minX: Mil;
+  minY: Mil;
+  maxX: Mil;
+  maxY: Mil;
+} {
+  const corners =
+    figure.shape === "circle" ? circleCorners(figure.points) : figure.points;
+  return {
+    minX: Math.min(...corners.map((point) => point.x)),
+    minY: Math.min(...corners.map((point) => point.y)),
+    maxX: Math.max(...corners.map((point) => point.x)),
+    maxY: Math.max(...corners.map((point) => point.y)),
+  };
+}
+
+/** The corners of the square a circle is inscribed in. */
+function circleCorners([centre, edge]: Point[]): Point[] {
+  if (!centre) return [];
+  const radius = radiusOf(centre, edge);
+  return [
+    { x: centre.x - radius, y: centre.y - radius },
+    { x: centre.x + radius, y: centre.y + radius },
+  ];
+}
+
+const radiusOf = (centre: Point, edge?: Point): Mil =>
+  edge ? Math.round(Math.hypot(edge.x - centre.x, edge.y - centre.y)) : 0;
+
+/** The average of a figure's corners — near enough its middle to push away from. */
+function centreOf(corners: Point[]): Point {
+  const total = corners.reduce(
+    (sum, point) => ({ x: sum.x + point.x, y: sum.y + point.y }),
+    { x: 0, y: 0 },
+  );
+  return {
+    x: Math.round(total.x / corners.length),
+    y: Math.round(total.y / corners.length),
+  };
+}
+
+/** `point`, moved `by` further from `centre`. */
+function away(point: Point, centre: Point, by: Mil): Point {
+  const dx = point.x - centre.x;
+  const dy = point.y - centre.y;
+  const span = Math.hypot(dx, dy);
+  if (span === 0) return point;
+  return {
+    x: Math.round(point.x + (dx / span) * by),
+    y: Math.round(point.y + (dy / span) * by),
+  };
+}
+
+/**
+ * A circle is two points: where its centre is, and one point on it. Storing a
+ * radius separately would let a figure disagree with itself, and every other
+ * shape in the union is already a list of points.
+ */
+function Circle({ points: [centre, edge] }: { points: Point[] }) {
+  if (!centre) return null;
+  const radius = radiusOf(centre, edge);
+  return (
+    <>
+      <circle
+        className="sheet__shape"
+        cx={centre.x}
+        cy={centre.y}
+        r={radius}
+        strokeWidth={RULE}
+      />
+      {edge && (
+        <line
+          className="sheet__rule"
+          x1={centre.x}
+          y1={centre.y}
+          x2={edge.x}
+          y2={edge.y}
+          strokeWidth={HAIRLINE}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/sheet/blocks/Shapes.tsx
+++ b/src/components/sheet/blocks/Shapes.tsx
@@ -64,9 +64,12 @@ function Drawn({
       width={inch(width)}
       height={inch(height)}
       viewBox={`0 0 ${width} ${height}`}
-      role="img"
-      aria-label={`Figure ${index + 1}: a ${figure.shape}`}
     >
+      {/* A `<title>` rather than `role="img"`: the side labels below are the
+          measurements the question is about, and `role="img"` would hide
+          "8 cm" behind "a rectangle". */}
+      <title>{`Figure ${index + 1}: a ${figure.shape}`}</title>
+
       {figure.shape === "circle" ? (
         <Circle points={corners.map(shift)} />
       ) : (

--- a/src/components/sheet/blocks/Spacer.tsx
+++ b/src/components/sheet/blocks/Spacer.tsx
@@ -1,0 +1,19 @@
+import { inch } from "../units";
+import type { BlockProps } from "./block";
+
+/**
+ * Reserved space with nothing in it.
+ *
+ * The one block whose whole content is its height — a page a child writes a
+ * story on is a title, a name line and one of these. It is `aria-hidden`
+ * because there is nothing there to announce; the blank is the point.
+ */
+export function Spacer({ block }: BlockProps<"spacer">) {
+  return (
+    <div
+      className="sheet__spacer"
+      style={{ height: inch(block.height) }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/sheet/blocks/Trace.tsx
+++ b/src/components/sheet/blocks/Trace.tsx
@@ -1,0 +1,26 @@
+import { TracedRow } from "../Traced";
+import type { BlockProps } from "./block";
+
+/**
+ * Tracing rows: the same word several times across one ruled repeat, each in
+ * its own style.
+ *
+ * `["solid", "dotted", "dotted", "none"]` is trace → copy → write on one line,
+ * which is the progression a handwriting sheet exists to walk a child through.
+ * The row decides its own styles; this only draws them.
+ */
+export function Trace({ block, metrics }: BlockProps<"trace">) {
+  return (
+    <div className="sheet__block">
+      {block.rows.map((row, index) => (
+        <div className="sheet__row" key={`${index}-${row.text}`}>
+          <TracedRow
+            rule={block.rule}
+            metrics={metrics}
+            cells={row.repeats.map((style) => ({ text: row.text, style }))}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/sheet/blocks/WordSearch.tsx
+++ b/src/components/sheet/blocks/WordSearch.tsx
@@ -1,0 +1,84 @@
+import { inches } from "@/engine/sheets/paper";
+
+import { HEAVY, inch } from "../units";
+import type { BlockProps } from "./block";
+
+/**
+ * A letter big enough for a five-year-old to find and small enough that a
+ * ten-by-ten puzzle doesn't take the whole page.
+ */
+const MAX_CELL = inches(0.34);
+const CELL_TO_EM = 0.62;
+
+/**
+ * A word search: a letter grid, the words to find, and — on the key — a stroke
+ * through each one.
+ *
+ * The letters are `<text>` rather than a table so the solution can be drawn
+ * over them in the same coordinate system. They are still selectable, readable
+ * text; an `<svg>` is not an image unless it contains one.
+ */
+export function WordSearch({ block, metrics }: BlockProps<"wordsearch">) {
+  const rows = block.letters.length;
+  const columns = block.letters.reduce(
+    (most, row) => Math.max(most, row.length),
+    0,
+  );
+  if (rows === 0 || columns === 0) return null;
+
+  const cell = Math.min(MAX_CELL, Math.floor(metrics.box.width / columns));
+  const width = columns * cell;
+  const height = rows * cell;
+  const centre = (index: number) => (index + 0.5) * cell;
+
+  return (
+    <div className="sheet__block">
+      <svg
+        className="sheet__ink"
+        width={inch(width)}
+        height={inch(height)}
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label={`Word search, ${columns} by ${rows}`}
+      >
+        {block.letters.flatMap((row, y) =>
+          row.map((letter, x) => (
+            <text
+              key={`${x}-${y}`}
+              className="sheet__cell"
+              x={centre(x)}
+              y={centre(y)}
+              fontSize={Math.round(cell * CELL_TO_EM)}
+              textAnchor="middle"
+              dominantBaseline="central"
+            >
+              {letter}
+            </text>
+          )),
+        )}
+
+        {/* The key. A capsule around the word rather than a highlight, because
+            a filled shape is a background and backgrounds don't print (§5). */}
+        {metrics.answers &&
+          block.solution?.map((found) => (
+            <line
+              key={found.word}
+              className="sheet__found"
+              x1={centre(found.column)}
+              y1={centre(found.row)}
+              x2={centre(found.column + found.dx * (found.word.length - 1))}
+              y2={centre(found.row + found.dy * (found.word.length - 1))}
+              strokeWidth={HEAVY}
+              strokeLinecap="round"
+            />
+          ))}
+      </svg>
+
+      <ul className="sheet__words">
+        {block.find.map((word) => (
+          <li key={word}>{word}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/sheet/blocks/block.ts
+++ b/src/components/sheet/blocks/block.ts
@@ -1,0 +1,20 @@
+/**
+ * What every block renderer is handed.
+ *
+ * One renderer per `Block` kind, each taking its own member of the union and
+ * the page metrics — no context, no service, no storage, and nothing it could
+ * ask a question of. That is what lets the same component render at build time
+ * on a catalog page and at runtime in the builder without knowing which one it
+ * is in (§2), and it is why the zero-JavaScript property holds by construction
+ * rather than by discipline.
+ */
+import type { Block } from "@/engine/sheets/types";
+
+import type { SheetMetrics } from "../metrics";
+
+export type BlockOf<K extends Block["kind"]> = Extract<Block, { kind: K }>;
+
+export type BlockProps<K extends Block["kind"]> = {
+  block: BlockOf<K>;
+  metrics: SheetMetrics;
+};

--- a/src/components/sheet/blocks/index.tsx
+++ b/src/components/sheet/blocks/index.tsx
@@ -1,0 +1,66 @@
+/**
+ * The one place a `Block` is narrowed.
+ *
+ * The mirror of `sheetSpec(kind)` in the engine: a block is keyed by the same
+ * string its renderer is registered under, so the switch below *is* the
+ * narrowing and there is no second place that has to keep in step with the
+ * union. Add a kind to `Block` and TypeScript fails here until it is drawn.
+ *
+ * Every arm is a prop-driven component that imports no service and no storage,
+ * which is what the zero-JavaScript property in §2 rests on — a renderer with
+ * nothing to hydrate needs no `client:*` directive, so a catalog page ships the
+ * markup and nothing else.
+ */
+import type { Block } from "@/engine/sheets/types";
+
+import type { SheetMetrics } from "../metrics";
+import { Blanks } from "./Blanks";
+import { Choice } from "./Choice";
+import { Clock } from "./Clock";
+import { Copywork } from "./Copywork";
+import { Cutline } from "./Cutline";
+import { Grid } from "./Grid";
+import { Matching } from "./Matching";
+import { Problems } from "./Problems";
+import { Rules } from "./Rules";
+import { Shapes } from "./Shapes";
+import { Spacer } from "./Spacer";
+import { Trace } from "./Trace";
+import { WordSearch } from "./WordSearch";
+
+export function BlockView({
+  block,
+  metrics,
+}: {
+  block: Block;
+  metrics: SheetMetrics;
+}) {
+  switch (block.kind) {
+    case "problems":
+      return <Problems block={block} metrics={metrics} />;
+    case "rules":
+      return <Rules block={block} metrics={metrics} />;
+    case "trace":
+      return <Trace block={block} metrics={metrics} />;
+    case "copywork":
+      return <Copywork block={block} metrics={metrics} />;
+    case "grid":
+      return <Grid block={block} metrics={metrics} />;
+    case "wordsearch":
+      return <WordSearch block={block} metrics={metrics} />;
+    case "matching":
+      return <Matching block={block} metrics={metrics} />;
+    case "blanks":
+      return <Blanks block={block} metrics={metrics} />;
+    case "choice":
+      return <Choice block={block} metrics={metrics} />;
+    case "clock":
+      return <Clock block={block} metrics={metrics} />;
+    case "shapes":
+      return <Shapes block={block} metrics={metrics} />;
+    case "cutline":
+      return <Cutline block={block} metrics={metrics} />;
+    case "spacer":
+      return <Spacer block={block} metrics={metrics} />;
+  }
+}

--- a/src/components/sheet/metrics.ts
+++ b/src/components/sheet/metrics.ts
@@ -1,0 +1,24 @@
+/**
+ * What a block renderer is allowed to know about the page it is on.
+ *
+ * A block is handed this and its own data, and nothing else. It is deliberately
+ * three facts rather than the whole `Sheet`: a renderer that could read the
+ * header would start deciding things the family already decided, and the
+ * declared-size bargain in `layout.ts` only holds while the view honours a
+ * layout instead of discovering one.
+ */
+import type { Box } from "@/engine/sheets/layout";
+
+export type SheetMetrics = {
+  /**
+   * The printable box, in mil, measured from the paper's top-left corner —
+   * `contentBox(sheet.paper)`. `x` is load-bearing as well as `width`: a
+   * notebook rule's margin line is 1.25in from the edge of the *paper*, not
+   * from the edge of the block, so a ruling has to know how far in it starts.
+   */
+  box: Box;
+  /** The sheet's body size, in points. Sets the type inside an `<svg>`. */
+  fontPt: number;
+  /** Print the answers that were computed when the sheet was built. */
+  answers: boolean;
+};

--- a/src/components/sheet/units.ts
+++ b/src/components/sheet/units.ts
@@ -1,0 +1,54 @@
+/**
+ * Mil on the sheet, CSS on the page.
+ *
+ * The engine hands every length over as `Mil` — a whole thousandth of an inch
+ * (see `src/engine/sheets/types.ts`). Two things then need it in a form a
+ * browser understands, and they want different forms:
+ *
+ * **The box model wants inches.** `0.625in` is what a ⅝ rule is, and inches
+ * survive the print pipeline unchanged where `rem` would not.
+ *
+ * **Every `<svg>` on a sheet is a mil viewBox**, so inside one, user units
+ * *are* mil and no conversion happens at all. That is why the ink weights
+ * below are `Mil` and are set as attributes rather than in CSS: a
+ * `stroke-width: 0.75pt` declaration inside a viewBox scaled from mil to
+ * inches is resolved in CSS pixels and then multiplied by the viewBox
+ * transform, which turns three quarters of a point into about a thousandth of
+ * one — a line that vanishes on paper while looking fine on screen. Colour and
+ * font family don't scale, so those stay in the stylesheet where they belong.
+ */
+import { inches, points, toInches } from "@/engine/sheets/paper";
+import type { Mil } from "@/engine/sheets/types";
+
+/** A length for CSS. Inches, because that is what paper is measured in. */
+export const inch = (mil: Mil): string => `${toInches(mil)}in`;
+
+/** A type size for CSS. Points, because that is what a type size is. */
+export const pt = (size: number): string => `${size}pt`;
+
+/* ── Ink ───────────────────────────────────────────────────────────────────
+   Three weights and nothing else. A worksheet printed thirty pages a week is
+   paid for in toner (§5), so the default sheet is black on white with no fills
+   and the only thing that varies is how heavy a line is.                    */
+
+/** Boxes, gaps, the faint half of a grid. */
+export const HAIRLINE: Mil = points(0.5);
+/** Rule lines, glyph outlines, everything a child writes on. */
+export const RULE: Mil = points(0.75);
+/** Axes, cut lines, the outside of a box — anything read before it's used. */
+export const HEAVY: Mil = points(1.25);
+
+/* ── Dashes ────────────────────────────────────────────────────────────────
+   `stroke-dasharray` in mil, for the same reason the weights are. Each pair is
+   ink-then-gap, and each is tuned to what it marks rather than shared: a
+   handwriting midline is a broken line a child ignores, a dotted letterform is
+   a path they trace over, and a cut line is an instruction.                 */
+
+/** The dashed midline of a handwriting rule — the usual (§5). */
+export const DASH_MIDLINE = `${inches(0.09)} ${inches(0.07)}`;
+/** A dotted letterform: round caps on a near-zero dash make actual dots (§6). */
+export const DASH_DOTTED = `${points(0.5)} ${points(3)}`;
+/** A dashed letterform — the same trick, longer strokes. */
+export const DASH_DASHED = `${points(4)} ${points(3)}`;
+/** Cut here. Long enough to read as scissors rather than as a faint rule. */
+export const DASH_CUT = `${inches(0.12)} ${inches(0.08)}`;

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -1,0 +1,80 @@
+/* ── What happens when somebody presses ⌘P ──────────────────────────────────
+   Print only. There is no PDF library here and there never will be: it would
+   cost ~600KB and a second rendering path that drifts from the first, and the
+   browser's own "Save as PDF" is already the download path (§10, decided).
+
+   That makes the print dialog the *whole* of the output. Everything in this
+   file is therefore load-bearing rather than cosmetic — a masthead that
+   survives onto paper is a masthead a parent pays for in toner, and a page box
+   that disagrees with the sheet on it prints across two pages or gets silently
+   scaled to fit.
+
+   This file is imported by the sheet renderer rather than by a layout, so it
+   lands on exactly the pages that have a sheet on them. That matters for the
+   `@page` rule below: zeroing the margin on a page that is an article rather
+   than a worksheet would print its text to the edge of the paper.           */
+
+/* Letter portrait, no margin — the sheet owns its own geometry, so screen and
+   paper agree exactly. A sheet on any other stock emits its own `@page` (see
+   `PageSize` in Sheet.tsx); `@page` cannot be scoped to a class, so that is
+   the only way one can say so. */
+@page {
+  size: 8.5in 11in;
+  margin: 0;
+}
+
+@media print {
+  /*
+   * Everything that is the site rather than the sheet: the masthead, the site
+   * footer, the skip link, the ad slots, and every builder control.
+   *
+   * `.no-print` is the contract for that last one. The builder (§14) is a
+   * print bar, an option panel and a preview frame around a sheet, and none of
+   * it is paper — so each of those carries the class rather than this file
+   * naming components that don't exist yet.
+   *
+   * The ad slots are the important entry. They must never sit inside the
+   * printable region in the first place — `src/components/sheet/` renders no
+   * `.ad` and a test holds it to that — and this is the second line of
+   * defence, for a slot placed beside a sheet by a page around it.
+   */
+  .mast,
+  .foot,
+  .skip,
+  .ad,
+  .no-print {
+    display: none !important;
+  }
+
+  /*
+   * The world's ground, and the dark ink ramp that goes with it. Both are
+   * background paint, which most browsers drop when printing anyway — but
+   * "most" is not "all", and a reader who has ticked "Background graphics" to
+   * get a photo out of some other site should not get a black page here.
+   */
+  html,
+  body {
+    background: #fff !important;
+    background-image: none !important;
+    color: #000;
+  }
+
+  /*
+   * `min-height` has to go. On screen it is what makes a short sheet still
+   * look like a page; in print the page box already supplies the height, and
+   * an element exactly as tall as the paper it is on rounds up often enough to
+   * push a blank second page out of the printer.
+   */
+  .sheet {
+    min-height: 0;
+    margin: 0;
+    box-shadow: none;
+  }
+
+  /* Belt and braces with `break-after` in sheet.css: some engines honour one
+     and not the other, and a variant sharing a page with the sheet before it
+     is the single most visible way this can go wrong. */
+  .sheet + .sheet {
+    break-before: page;
+  }
+}

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -10,9 +10,18 @@
    scaled to fit.
 
    This file is imported by the sheet renderer rather than by a layout, so it
-   lands on exactly the pages that have a sheet on them. That matters for the
-   `@page` rule below: zeroing the margin on a page that is an article rather
-   than a worksheet would print its text to the edge of the paper.           */
+   lands on exactly the pages that have a sheet on them, and nowhere else. That
+   is what the `@page` rule below needs: a page with no sheet on it — the about
+   page, a privacy policy — keeps the browser's default margin and prints its
+   prose inside the paper rather than off the edge of it.
+
+   It buys no more than that. `@page` cannot be scoped to a class, so on a page
+   that is *both* — the catalog pages of §8 are an h1, two or three paragraphs
+   and then a sheet — the zeroed margin applies to the prose as well. Open for
+   PRINT03, when those routes are built: either the prose is `display: none`
+   under `@media print` (printing a catalog page means printing the sheet on
+   it), or the article gets its own print padding to stand in for the page
+   margin this rule takes away. It cannot be solved here.                    */
 
 /* Letter portrait, no margin — the sheet owns its own geometry, so screen and
    paper agree exactly. A sheet on any other stock emits its own `@page` (see

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -38,6 +38,12 @@
   --sheet-margin: 0.5in;
   --sheet-pt: 12pt;
 
+  /* Set here rather than inherited from `base.css`: width plus padding only
+     add up to the paper size under `border-box`, and under the initial
+     `content-box` an 8.5in sheet is 9.5in wide and every print silently scales
+     or clips. Same reason as the font fallbacks below — this file has to hold
+     on a page that never loaded the rest of the app's CSS. */
+  box-sizing: border-box;
   width: var(--sheet-w);
   min-height: var(--sheet-h);
   padding: var(--sheet-margin);

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -1,0 +1,335 @@
+/* ── The sheet's own geometry ───────────────────────────────────────────────
+   A worksheet is HTML laid out in real inches (docs/printables.md §2), and
+   this is the file where that stops being a claim.
+
+   ── Why nothing here is in `rem` ────────────────────────────────────────────
+   The rest of the app sizes everything in `rem × --ui-scale`, so a five-year-
+   old's screen is physically bigger than a ten-year-old's. A worksheet must not
+   do that. A ⅝-inch handwriting rule is ⅝ of an inch or it is wrong, and a
+   child who has been taught to write between two lines notices before an adult
+   does. So the subtree opts out — `--ui-scale: 1` below is set, not inherited —
+   and every length in here is an inch, a point, or an em of a size that was
+   itself set in points.
+
+   ── One name collision, recorded rather than worked around ──────────────────
+   `screens.css` already has a `.sheet`: the modal panel behind the player
+   editor and the quit confirmation. The two never meet today — that one arrives
+   with `index.css` on the game islands, this one with the renderer that uses it
+   — but `/printables/make` will be an island that loads both, and on that day
+   an 8.5in-wide `position: fixed` modal is what happens. The builder story
+   renames one of them; this note is here so it is a decision rather than a
+   surprise.
+
+   ── The ink ────────────────────────────────────────────────────────────────
+   Black on white with no fills, by default and on purpose. A parent printing
+   thirty pages a week is paying for this in toner, so ink-saving is a feature
+   rather than an accident (§5) — and it composes with the fact that browsers
+   drop background paint when printing anyway. Everything a child writes on is
+   a stroke or a border, both of which are foreground and always print.       */
+
+.sheet {
+  --ui-scale: 1;
+
+  /* Overwritten inline by the renderer from the sheet's own `paper`. The
+     defaults are Letter portrait at half-inch margins, which is what most of
+     this audience prints on. */
+  --sheet-w: 8.5in;
+  --sheet-h: 11in;
+  --sheet-margin: 0.5in;
+  --sheet-pt: 12pt;
+
+  width: var(--sheet-w);
+  min-height: var(--sheet-h);
+  padding: var(--sheet-margin);
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  /* The fallbacks are not decoration: this stylesheet arrives with the
+     renderer, so it has to stand up on a page that never loaded tokens.css. */
+  font-family: var(--font-body, system-ui, sans-serif);
+  font-size: var(--sheet-pt);
+  line-height: 1.35;
+  color: #000;
+  background: #fff;
+
+  /* Consecutive sheets — variants A/B/C, or a sheet and its answer key — are
+     one page each. The last one doesn't push a blank page after itself. */
+  break-after: page;
+}
+
+.sheet:last-of-type {
+  break-after: auto;
+}
+
+/* On screen the sheet is white paper floating on the world's own ground, which
+   is how every layout tool on earth presents a page and is also just true. */
+@media screen {
+  .sheet {
+    box-shadow: 0 24px 60px -30px rgb(0 0 0 / 90%);
+  }
+}
+
+/* ── Chrome ─────────────────────────────────────────────────────────────── */
+
+.sheet__head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.09in;
+  margin-bottom: 0.16in;
+}
+
+.sheet__title {
+  font-family: var(--font-display, system-ui, sans-serif);
+  font-size: 1.7em;
+  font-weight: 400;
+  line-height: 1.05;
+}
+
+.sheet__fields {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.06in 0.28in;
+  font-size: 0.82em;
+}
+
+.sheet__field,
+.sheet__score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.06in;
+}
+
+.sheet__score {
+  margin-left: auto;
+}
+
+/* A border, not a row of underscores: underscores set in a proportional face
+   are a ragged line whose length depends on how many the generator wrote, and
+   a child needs the same room whatever they are writing. */
+.sheet__field-rule {
+  display: inline-block;
+  width: 2.1in;
+  border-bottom: 0.75pt solid currentcolor;
+}
+
+.sheet__field-rule--short {
+  width: 0.7in;
+}
+
+.sheet__instructions {
+  font-size: 0.9em;
+}
+
+.sheet__blocks {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.14in;
+}
+
+.sheet__block {
+  display: flex;
+  flex-direction: column;
+}
+
+.sheet__foot {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.04in 0.16in;
+  margin-top: 0.18in;
+  padding-top: 0.05in;
+  border-top: 0.5pt solid currentcolor;
+  font-size: 0.62em;
+}
+
+.sheet__seed {
+  margin-left: auto;
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+/* Every list on a sheet numbers itself in `<span class="sheet__number">`
+   rather than with a marker: `base.css` strips markers site-wide and this
+   file has to hold on a page that never loaded it, a problem a child is told
+   to "do 4, 7 and 12 of" needs its number as selectable text anyway, and a
+   marker outside the box is a marker outside the margin. */
+.sheet__problems,
+.sheet__blanks,
+.sheet__questions,
+.sheet__options,
+.sheet__words {
+  list-style: none;
+  padding-left: 0;
+}
+
+/* ── Ink ────────────────────────────────────────────────────────────────────
+   Colour and font family only. Stroke widths and dash patterns are attributes
+   in mil, set by the renderer — see src/components/sheet/units.ts for why a
+   `stroke-width` declared here would come out about a thousandth of the size
+   it says.                                                                  */
+
+.sheet__ink {
+  display: block;
+  max-width: 100%;
+  font-family: var(--font-body, system-ui, sans-serif);
+}
+
+.sheet__rule,
+.sheet__dial,
+.sheet__shape {
+  stroke: currentcolor;
+  fill: none;
+}
+
+.sheet__cell,
+.sheet__dot {
+  fill: currentcolor;
+  stroke: none;
+}
+
+/* The solution stroke on a word search. Lighter than the letters it crosses,
+   so the key is still readable underneath it. */
+.sheet__found {
+  stroke: currentcolor;
+  fill: none;
+  opacity: 45%;
+}
+
+.sheet__cell--start {
+  text-anchor: start;
+}
+
+.sheet__cell--end {
+  text-anchor: end;
+}
+
+/* ── Letterforms, from an ordinary font (§6) ─────────────────────────────── */
+
+.sheet__glyph--solid {
+  fill: currentcolor;
+  stroke: none;
+}
+
+.sheet__glyph--dim {
+  fill: currentcolor;
+  stroke: none;
+  opacity: 28%;
+}
+
+.sheet__glyph--hollow,
+.sheet__glyph--dotted,
+.sheet__glyph--dashed {
+  fill: none;
+  stroke: currentcolor;
+}
+
+/* ── Problems ───────────────────────────────────────────────────────────────
+   `break-inside: avoid` here and on every other row-shaped thing below is not
+   a nicety. Print is the whole of the output path (§10), so the preview has to
+   be right the first time — a problem split across two pages is a problem a
+   child can't answer, and there is no PDF to fall back on.                   */
+
+.sheet__problems {
+  display: grid;
+  grid-template-columns: repeat(var(--sheet-columns, 2), minmax(0, 1fr));
+  gap: 0.2in 0.3in;
+}
+
+.sheet__problem,
+.sheet__row,
+.sheet__sentence,
+.sheet__question,
+.sheet__face,
+.sheet__figure {
+  break-inside: avoid;
+}
+
+.sheet__problem {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.06in;
+}
+
+.sheet__number,
+.sheet__mark {
+  font-variant-numeric: tabular-nums;
+  margin-right: 0.06in;
+}
+
+.sheet__mark {
+  font-weight: 700;
+  margin-right: 0.05in;
+}
+
+/* Where the answer goes: a ruled slot when the sheet is blank, the answer
+   itself on the key. Same element either way, so the two can't drift apart. */
+.sheet__slot {
+  display: inline-block;
+  min-width: 0.8in;
+  border-bottom: 0.75pt solid currentcolor;
+  text-align: center;
+}
+
+.sheet__slot--answered {
+  font-weight: 700;
+}
+
+.sheet__workspace {
+  display: block;
+  flex: 1 0 100%;
+}
+
+/* ── The rest of the blocks ─────────────────────────────────────────────── */
+
+.sheet__blanks,
+.sheet__questions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.16in;
+}
+
+.sheet__sentence,
+.sheet__ask {
+  display: block;
+}
+
+.sheet__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.06in 0.3in;
+  padding-left: 0.3in;
+}
+
+/* A rule under the right answer, never a tint behind it — see the ink note. */
+.sheet__option--answer {
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.sheet__words {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.06in 0.28in;
+  margin-top: 0.12in;
+  font-size: 0.9em;
+}
+
+.sheet__faces,
+.sheet__figures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.24in;
+}
+
+.sheet__face {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.04in;
+}
+
+.sheet__caption {
+  font-size: 0.8em;
+}


### PR DESCRIPTION
Closes #46. Epic code **PRINT02** — design in `docs/printables.md`.

## What this adds

`src/components/sheet/` turns a `Sheet` into HTML, and `src/styles/sheet.css` +
`src/styles/print.css` make that HTML come out of a printer looking the way it
looks on screen. No sheet families and no routes — this renders whatever PRINT01
hands it.

## Why it is shaped this way

**A renderer takes a `Sheet` and nothing else.** No context, no service, no
storage, no state. That is what lets the same component render at build time on a
prerendered catalog page and at run time inside the builder — the trick
`App.tsx` already pulls by mounting twice. It also makes the zero-JavaScript
property structural rather than a rule to remember: a component with nothing to
hydrate needs no `client:*`, so a page that renders one ships markup and stops.

**Strokes, never a background.** Browsers drop `background-image` when printing
unless the reader has ticked "Background graphics", and most haven't — so the
obvious `repeating-linear-gradient` ruling is the worst bug this feature can
have: perfect in the preview, blank out of the printer. Every rule, glyph
outline, axis and cut line is an SVG stroke or a border. The dot grid is drawn
with `<line>` too, since a zero-length dash with a round cap *is* a dot: one
element per row instead of fifteen hundred per page.

**One unit, and where it stops.** Every `<svg>` on a sheet is a mil viewBox, so
lengths from the engine need no conversion inside one. Stroke widths and dash
patterns are therefore attributes rather than CSS — a `stroke-width: 0.75pt` in
a stylesheet is resolved in CSS pixels and then multiplied by the viewBox
transform, turning three quarters of a point into about a thousandth of one.
Colour and font family don't scale, so those stay in CSS.

**Nothing here measures anything.** `layout.ts` says how much fits and the view
draws it. The two places that would have wanted a ruler — how wide a traced word
is, how much room a figure's label takes — take a declared ratio instead, and
both exist only to keep ink inside the paper when a family asks for more than
fits.

`sheet.css` neutralises `--ui-scale` inside `.sheet` and sizes in inches and
points, because a ⅝ rule is ⅝ of an inch or it is wrong. It also sets its own
`box-sizing`, since width plus padding only add up to the paper size under
`border-box` and this stylesheet arrives with the renderer — on a page that
never loaded `base.css`, an 8.5in sheet was 9.5in wide. `print.css` hides the
masthead, footer, skip link, ad slots and anything marked `.no-print`, and sets
`@page`; a sheet on anything but Letter portrait emits its own, since `@page`
cannot be scoped to a class. `break-inside: avoid` sits on every row-shaped
thing and `break-after: page` between sheets — print is the whole output path
and there is no PDF to fall back on.

## Accessibility

`Matching`, `Grid` and `Shapes` are named with `<title>` rather than
`role="img"`. All three carry the text the exercise is about — two columns of
words, a hundred chart's numbers, a figure's "8 cm" — and `role="img"` replaced
every one of them with a single sentence. `role="img"` stays where the label
genuinely restates the drawing: a clock face, a cut line, a letter soup.

## Tests

Cover the three properties you cannot see by looking at a screen: no `.ad` is
ever a descendant of `.sheet` (in the markup and in every renderer's source), no
renderer holds a hook or would need hydrating, and no ruling is a gradient. Two
were mutation-checked by breaking the code they guard.

Zero-JS verified against `dist/`: no `astro-island`, no sheet class name in any
built chunk, and the stylesheets inlined into the page head because they are
imported by the renderer rather than by a layout.

## Recorded, not worked around

`screens.css` already has a `.sheet` — the modal panel. The two stylesheets
never meet today, but `/printables/make` will load both; the note in `sheet.css`
makes that a decision for the builder story instead of a surprise. Likewise
`@page` cannot be kept off the prose of a catalog page, so that is an open
question for the routes story rather than a claim that isn't true.

## Validation

`type-check`, `lint`, `test:unit` (247 passed), `build` (static, 21 pages) and
the browser smoke test all pass locally. Every renderer is under the 300-line
cap — enforced by lint, with no allowlist entries added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
