### PR TITLE
A fourth world: The Print Shop, and a sitemap that says no properly

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import { WORLDS } from "./src/engine/worlds";
+import { pathOf, sitemapGuard } from "./scripts/sitemap-guard.mjs";
 
 /**
  * Static output, deliberately.
@@ -31,14 +32,23 @@ export default defineConfig({
        * contradiction Search Console reports back at you.
        *
        * Derived from WORLDS rather than written out, so a new world cannot
-       * be added to the map and quietly left in the sitemap — `href` on a
-       * world IS its game route.
+       * be added to the map and quietly left in the sitemap.
+       *
+       * Keyed on `island`, NOT on `href`. For the three game worlds those are
+       * the same string and the distinction looks academic; The Print Shop is
+       * where it stops being academic, because its `href` is a catalog of
+       * prerendered worksheets that has to be indexed and its island is a
+       * builder that must not be. Filtering on `href` would have removed the
+       * catalog silently. sitemapGuard below fails the build if it ever does.
        */
       filter: (page) => {
-        const path = new URL(page).pathname.replace(/\/$/, "");
-        return !WORLDS.some((world) => world.href === path);
+        const path = pathOf(page);
+        return !WORLDS.some((world) => world.island === path);
       },
     }),
+    // After the sitemap integration, deliberately: it reads what that one
+    // wrote. See scripts/sitemap-guard.mjs.
+    sitemapGuard(WORLDS),
   ],
   // Emit `/about/index.html` rather than `/about.html` so CloudFront can serve
   // clean URLs from S3 without a rewrite function.

--- a/scripts/post-deploy-smoke.sh
+++ b/scripts/post-deploy-smoke.sh
@@ -170,23 +170,26 @@ else
   echo "  ✓ ${pagecount} pages listed in the sitemap"
 fi
 
-# --- the game routes ---------------------------------------------------------
+# --- the island routes -------------------------------------------------------
 #
 # Deliberately NOT in the sitemap: each is a `client:only` island whose
 # prerendered body is two words, so they carry `noindex` and are filtered out
 # in astro.config.mjs. That is correct for search and it silently removed them
 # from the loop above, which discovers pages FROM the sitemap — leaving the
-# three most important URLs on the site unchecked after a deploy.
+# routes a child actually plays on unchecked after a deploy.
+#
+# Not all of them are games: the paper world's island is a worksheet builder,
+# and it is excluded for the same reason and needs the same check.
 #
 # So they are named here. A new world means a new line here as well as an entry
 # in src/engine/worlds.ts; there is no way to derive one from the other in a
 # script that only has an origin to talk to.
-echo "Game routes (noindex, so not in the sitemap):"
-for path in /flash-cards/ /spelling/play/ /typing/; do
+echo "Island routes (noindex, so not in the sitemap):"
+for path in /flash-cards/ /spelling/play/ /typing/ /printables/make/; do
   try "${path}" "200" status "${BASE}${path}"
-  # The noindex is the point of excluding them, so it is worth asserting: a
-  # game route that lost its robots tag would start competing with the content
-  # page written to rank for exactly that query.
+  # The noindex is the point of excluding them, so it is worth asserting: an
+  # island route that lost its robots tag would start competing with the
+  # content page written to rank for exactly that query.
   try "${path} is noindex" "yes" \
     body_contains "${BASE}${path}" 'name="robots" content="noindex'
 done

--- a/scripts/sitemap-guard.mjs
+++ b/scripts/sitemap-guard.mjs
@@ -1,0 +1,135 @@
+// @ts-check
+import { readFile } from "node:fs/promises";
+
+/**
+ * The build-time check that the sitemap still says what the map says.
+ *
+ * `astro.config.mjs` filters routes out of the sitemap from the world
+ * registry, which is the right way round — a new world can't be added to the
+ * map and quietly left in. But a filter is silent by construction: it can only
+ * ever remove, and the failure mode that matters is removing too much. The
+ * Print Shop is the case that made this necessary. Its front door is a catalog
+ * of prerendered worksheets, the largest crawlable surface on the site; a
+ * filter keyed on `href` rather than on `island` would have deleted every one
+ * of those URLs from the sitemap with nothing failing and no test catching it
+ * (docs/printables.md §8).
+ *
+ * So the same registry is read twice, from opposite ends: once to decide what
+ * to leave out, and once — here, against the file that actually shipped — to
+ * assert that what's left is what was meant. A build that gets it wrong fails
+ * rather than deploying.
+ */
+
+/**
+ * An absolute URL as the path a `WorldInfo` would have written: no origin, no
+ * trailing slash.
+ *
+ * Shared with the sitemap filter in astro.config.mjs rather than written out
+ * twice, because the two have to agree exactly. One of them deciding that
+ * `/printables/make/` and `/printables/make` are different strings is a bug
+ * neither would report.
+ *
+ * @param {string} loc
+ * @returns {string}
+ */
+export const pathOf = (loc) => new URL(loc).pathname.replace(/\/$/, "");
+
+/**
+ * Pathnames in a sitemap, in the form the world registry writes them.
+ *
+ * @param {string} xml
+ * @returns {Set<string>}
+ */
+export function locations(xml) {
+  return new Set(
+    [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => pathOf(m[1])),
+  );
+}
+
+/**
+ * Every way the shipped sitemap and the world registry can disagree, as lines
+ * a human can act on. An empty array is the passing case.
+ *
+ * Two rules, and they are opposites of each other:
+ *
+ *   · An island is `noindex` (see Base.astro), so submitting it is telling
+ *     Google to crawl a page we've asked it to ignore — a contradiction
+ *     Search Console reports back at you.
+ *   · A world's crawlable pages — its front door where that differs from the
+ *     island, and its guide where it has one — exist to be found. Missing
+ *     from the sitemap is the failure nobody notices, because the site still
+ *     builds, still deploys and still looks right.
+ *
+ * @param {string} xml
+ * @param {import("../src/engine/worlds").WorldInfo[]} worlds
+ * @returns {string[]}
+ */
+export function auditSitemap(xml, worlds) {
+  const found = locations(xml);
+  const problems = [];
+
+  for (const world of worlds) {
+    if (found.has(world.island)) {
+      problems.push(
+        `${world.island} is in the sitemap, but it is ${world.name}'s island and carries noindex.`,
+      );
+    }
+    const crawlable = [
+      ...(world.href === world.island ? [] : [world.href]),
+      ...(world.guide ? [world.guide.href] : []),
+    ];
+    for (const href of crawlable) {
+      if (!found.has(href)) {
+        problems.push(
+          `${href} is missing from the sitemap — it is ${world.name}'s crawlable front door and is meant to be indexed.`,
+        );
+      }
+    }
+  }
+
+  return problems;
+}
+
+/**
+ * Wired into `astro.config.mjs` AFTER the sitemap integration, which is
+ * load-bearing: Astro runs `astro:build:done` hooks in the order integrations
+ * are registered, and there is nothing to read until @astrojs/sitemap has
+ * written it.
+ *
+ * @param {import("../src/engine/worlds").WorldInfo[]} worlds
+ * @returns {import("astro").AstroIntegration}
+ */
+export function sitemapGuard(worlds) {
+  return {
+    name: "sitemap-guard",
+    hooks: {
+      "astro:build:done": async ({ dir, logger }) => {
+        const file = new URL("sitemap-0.xml", dir);
+        let xml;
+        try {
+          xml = await readFile(file, "utf8");
+        } catch {
+          throw new Error(
+            `No sitemap at ${file.pathname}. @astrojs/sitemap did not write one, so this build would ship with nothing submitted to search engines at all.`,
+          );
+        }
+
+        const problems = auditSitemap(xml, worlds);
+        if (problems.length > 0) {
+          throw new Error(
+            [
+              "The sitemap and the world registry disagree:",
+              ...problems.map((line) => `  · ${line}`),
+              "",
+              "Both are derived from src/engine/worlds.ts — see the `island` field there, and the filter in astro.config.mjs.",
+            ].join("\n"),
+          );
+        }
+
+        logger.info(
+          `sitemap checked — ${locations(xml).size} URLs, no noindex routes among them`,
+        );
+      },
+    },
+  };
+}

--- a/scripts/sitemap-guard.test.mjs
+++ b/scripts/sitemap-guard.test.mjs
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { WORLDS } from "../src/engine/worlds";
+import { auditSitemap, locations } from "./sitemap-guard.mjs";
+
+/**
+ * The guard itself is the thing most at risk of rotting into a no-op — a check
+ * that always passes is indistinguishable from a check that works, right up
+ * until the day it was supposed to fire. So this suite makes it fire.
+ *
+ * The build-time half lives in scripts/sitemap-guard.mjs and runs against the
+ * file that actually shipped; this half proves that what it reads it also
+ * judges correctly.
+ */
+
+const sitemap = (...paths) =>
+  `<?xml version="1.0" encoding="UTF-8"?><urlset>${paths
+    .map((path) => `<loc>https://schoolskills.app${path}</loc>`)
+    .join("")}</urlset>`;
+
+/** Everything the registry says must be crawlable, and nothing it doesn't. */
+const healthy = sitemap(
+  "/",
+  ...WORLDS.flatMap((world) => [
+    ...(world.href === world.island ? [] : [`${world.href}/`]),
+    ...(world.guide ? [`${world.guide.href}/`] : []),
+  ]),
+);
+
+describe("reading a sitemap", () => {
+  it("compares like an href, not like a URL", () => {
+    // Astro writes absolute URLs with a trailing slash; a world's href has
+    // neither. Comparing the two raw is the bug this normalisation prevents.
+    expect(locations(sitemap("/printables/", "/spelling/"))).toEqual(
+      new Set(["/printables", "/spelling"]),
+    );
+  });
+});
+
+describe("auditing it against the world registry", () => {
+  it("passes the sitemap the site is meant to ship", () => {
+    expect(auditSitemap(healthy, WORLDS)).toEqual([]);
+  });
+
+  it("fails when a world's island is submitted", () => {
+    // Every island carries `noindex`. Listing one is asking Google to crawl a
+    // page we have told it to ignore.
+    const problems = auditSitemap(
+      sitemap(...[...locations(healthy)], "/printables/make/"),
+      WORLDS,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("/printables/make");
+  });
+
+  it("fails when a world's crawlable front door is missing", () => {
+    // The Print Shop's catalog is the case this whole guard exists for: it
+    // vanishes from the sitemap without breaking the build, the deploy, or the
+    // look of a single page.
+    const problems = auditSitemap(
+      sitemap(...[...locations(healthy)].filter((p) => p !== "/printables")),
+      WORLDS,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("/printables");
+  });
+
+  it("fails when a world's guide is missing", () => {
+    const problems = auditSitemap(
+      sitemap(...[...locations(healthy)].filter((p) => p !== "/spelling")),
+      WORLDS,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("/spelling");
+  });
+
+  it("expects nothing crawlable of a world whose front door IS its island", () => {
+    // /flash-cards is both, and correctly absent from the sitemap. A rule that
+    // treated every `href` as crawlable would demand it back and fail here.
+    expect([...locations(healthy)]).not.toContain("/flash-cards");
+    expect(auditSitemap(healthy, WORLDS)).toEqual([]);
+  });
+});

--- a/src/components/site/WorldMap.astro
+++ b/src/components/site/WorldMap.astro
@@ -33,16 +33,25 @@ const BADGES: Partial<Record<World, string>> = {
       <path d="M12 3v18M4.2 7.5l15.6 9M19.8 7.5l-15.6 9"/>
       <path d="M12 7.4 9.7 5.2M12 7.4l2.3-2.2M12 16.6l-2.3 2.2M12 16.6l2.3 2.2"/>
     </svg>`,
+  // Crop marks round a registration target: what a press puts on a sheet, and
+  // the same mark the paper world's own ground is drawn out of.
+  paper: `<svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true" fill="none"
+      stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+      <path d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4"/>
+      <circle cx="12" cy="12" r="3.6"/>
+      <path d="M12 6.8v10.4M6.8 12h10.4" stroke-width="1.2" opacity=".55"/>
+    </svg>`,
 };
 ---
 
 <section class="map" aria-labelledby="map-head">
-  <h2 class="h2" id="map-head">Three worlds, and no locked doors</h2>
+  <h2 class="h2" id="map-head">Four worlds, and no locked doors</h2>
   <p class="h2__sub">
-    Each world is one subject and one thing to get good at. Start anywhere, stop
-    anywhere, and switch mid-week &mdash; nothing has to be finished before
-    anything else opens, and the same player carries their records between all
-    three.
+    Three are games, one subject each and one thing to get good at. Start
+    anywhere, stop anywhere, and switch mid-week &mdash; nothing has to be
+    finished before anything else opens, and the same player carries their
+    records between all three. The fourth is The Print Shop, which makes paper
+    rather than points, and is a stop for you rather than for them.
   </p>
 
   {

--- a/src/engine/sheets/spec.ts
+++ b/src/engine/sheets/spec.ts
@@ -16,12 +16,13 @@ import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "./paper";
  * Which world a sheet prints in — stated, not assumed, exactly as
  * `DeckSpec.world` is.
  *
- * It is `line`, the site's non-game chrome, until the Print Shop's own `paper`
- * world lands with its colours and its place on the map (§9). The engine never
- * interprets the value, so that is a one-line change here and a block of CSS
- * there — which is the whole point of keeping worlds opaque to the model.
+ * It was `line` while the Print Shop had no colours of its own; now that
+ * `paper` exists it is `paper`, and that was the one-line change the note here
+ * promised. Nothing else in the engine moved, because the engine never
+ * interprets the value — a world id is an opaque string to the model, and
+ * everything the change means is a block of CSS in worlds.css (§9).
  */
-export const SHEET_WORLD: World = "line";
+export const SHEET_WORLD: World = "paper";
 
 /** Printed small at the foot of every sheet: free traffic, and true (§16). */
 export const SHEET_URL = "schoolskills.app";

--- a/src/engine/worlds.ts
+++ b/src/engine/worlds.ts
@@ -2,10 +2,10 @@
  * The worlds, as data.
  *
  * A world is a subject with a look: The Grid is multiplication, Word Jungle is
- * spelling, Frost Keys is typing. The whole site is one game and these are its
- * levels, so this file is the registry both halves read from — the content
- * pages build the map out of it, and the game asks a deck which world it's
- * played in (see `DeckSpec.world`).
+ * spelling, Frost Keys is typing, The Print Shop is paper. The whole site is
+ * one game and these are its levels, so this file is the registry both halves
+ * read from — the content pages build the map out of it, and the game asks a
+ * deck which world it's played in (see `DeckSpec.world`).
  *
  * It lives in the engine because "what worlds exist" is product knowledge, the
  * same kind of thing as the Dolch lists in decks/wordlists.ts. The engine never
@@ -17,7 +17,8 @@
  * browser chrome can't read a custom property. Keep them in step.
  */
 
-export type World = "map" | "grid" | "jungle" | "ice" | "line" | "empty";
+export type World =
+  "map" | "grid" | "jungle" | "ice" | "paper" | "line" | "empty";
 
 /** Matches `--ink-900` for each world, so the browser chrome joins the page. */
 export const THEME_COLOUR: Record<World, string> = {
@@ -25,6 +26,7 @@ export const THEME_COLOUR: Record<World, string> = {
   grid: "#0a0c16",
   jungle: "#08160f",
   ice: "#06121e",
+  paper: "#131211",
   line: "#0c0e12",
   empty: "#0c0e12",
 };
@@ -35,14 +37,37 @@ export type WorldInfo = {
   name: string;
   /** What it actually teaches, in the words a parent would search for. */
   subject: string;
-  /** One line, written for the child who has to pick. */
+  /**
+   * One line, written for the child who has to pick.
+   *
+   * Except The Print Shop's, which is written for the parent — a worksheet is
+   * not a level and a card that pretended otherwise would be selling a child
+   * something they can't use. Same for its `subject`, `blurb`, `levels` and
+   * `ages`: the map is a child's screen with one grown-up's stop on it, and
+   * saying so plainly is cheaper than the disappointment.
+   */
   tagline: string;
   /** What a parent needs to know before handing over the tablet. */
   blurb: string;
   /** For the hop-between-worlds control in a game's top bar. */
   icon: string;
-  /** Where the world starts — the game, not a page about it. */
+  /** Where the world starts, and where the map and the masthead point. */
   href: string;
+  /**
+   * The mounted app — a `client:only` island whose prerendered body is two
+   * words. It carries `noindex` (see Base.astro) and astro.config.mjs keeps it
+   * out of the sitemap, so THIS field, not `href`, is what "the route search
+   * engines must never be handed" means.
+   *
+   * For the three game worlds it is `href`, because the game is the front
+   * door. The Print Shop is the exception that made the field necessary: its
+   * front door is a catalog of prerendered worksheets — the largest crawlable
+   * surface on the site, and one that must be in the sitemap — while its
+   * builder at /printables/make must not be. Deriving the exclusion from
+   * `href` instead would have deleted the catalog from the sitemap silently,
+   * with nothing failing (docs/printables.md §8).
+   */
+  island: string;
   /**
    * The crawlable page about this world, where one exists.
    *
@@ -60,11 +85,12 @@ export type WorldInfo = {
 };
 
 /**
- * The worlds you can actually play, in the order they appear on the map.
+ * The worlds that exist, in the order they appear on the map.
  *
  * Order is difficulty-ish rather than fixed: nothing is gated, and a six-year
  * old who wants to start in the jungle should be allowed to. Non-linear is the
- * point — see the note on the map itself.
+ * point — see the note on the map itself. The Print Shop is last because it is
+ * the one you don't play.
  */
 export const WORLDS: WorldInfo[] = [
   {
@@ -76,6 +102,7 @@ export const WORLDS: WorldInfo[] = [
       "Multiplication, division, addition and subtraction as timed cards. Race the clock, a ghost of your own best run, or a sibling's. Facts that come out slow get their own practice deck.",
     icon: "🔢",
     href: "/flash-cards",
+    island: "/flash-cards",
     levels: "12 tables",
     ages: "Ages 5–12",
   },
@@ -88,6 +115,7 @@ export const WORLDS: WorldInfo[] = [
       'The Dolch sight words, graded by age. Each one is read aloud in a sentence and typed from memory, so "their" and "there" are telling apart rather than guessing. Paste in this week\'s spellings and they become a deck like any other.',
     icon: "🔤",
     href: "/spelling/play",
+    island: "/spelling/play",
     guide: { href: "/spelling", label: "What sight words are" },
     levels: "6 word lists",
     ages: "Ages 4–9",
@@ -101,8 +129,32 @@ export const WORLDS: WorldInfo[] = [
       "Start with eight keys under eight fingers and work up to real punctuation. Every word is a split, so a rival's pace is something you feel word by word instead of reading at the end.",
     icon: "⌨️",
     href: "/typing",
+    island: "/typing",
     levels: "4 levels",
     ages: "Ages 5–12",
+  },
+  /*
+   * The one stop on the map that isn't a game, and the copy says so in the
+   * first four words rather than burying it. A child who taps this card should
+   * be able to tell within a line that it belongs to whoever bought the
+   * printer — anything cleverer would be a bait-and-switch on the audience
+   * this site is most careful with.
+   *
+   * `href` is the catalog and `island` is the builder; see the field docs
+   * above for why those have to be different here and nowhere else.
+   */
+  {
+    id: "paper",
+    name: "The Print Shop",
+    subject: "Worksheets to print",
+    tagline: "For the grown-up. Pick a sheet, tune it, print it.",
+    blurb:
+      "Times tables, handwriting rules, spelling lists and Scripture copywork, as paper you can hand over. Sheets print straight from the browser with an answer key — no download, no account, and nothing about your child in the file.",
+    icon: "🖨️",
+    href: "/printables",
+    island: "/printables/make",
+    levels: "Paper, not levels",
+    ages: "Pre-K to Y8",
   },
 ];
 

--- a/src/layouts/Content.astro
+++ b/src/layouts/Content.astro
@@ -22,9 +22,20 @@ interface Props {
   jsonLd?: Record<string, unknown>;
   /** Which world this page is in. Drives every colour on it. */
   world: World;
+  /**
+   * Keep this page out of search results. See Base.astro for what that means
+   * and what it costs.
+   *
+   * Rare here, and it should stay rare — a content page that isn't worth
+   * indexing usually isn't worth writing. The Print Shop's builder is the
+   * exception that needs it: it is an island, like a game, but unlike a game
+   * it lives behind the site's own chrome, because the print stylesheet hides
+   * the masthead and footer rather than the page having to do without them.
+   */
+  noindex?: boolean;
 }
 
-const { title, description, image, jsonLd, world } = Astro.props;
+const { title, description, image, jsonLd, world, noindex } = Astro.props;
 
 // Line world and Empty world have no scenery, so their pages tighten the
 // measure and drop the display type a size. See content.css.
@@ -37,6 +48,7 @@ const pause = world === "line" || world === "empty";
   image={image}
   jsonLd={jsonLd}
   world={world}
+  noindex={noindex}
 >
   <SiteHeader world={world} />
   <main id="main" class:list={["page", { "page--pause": pause }]}>

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -1,0 +1,119 @@
+---
+import Content from "@/layouts/Content.astro";
+
+/**
+ * The Print Shop's front door.
+ *
+ * A world's `href` normally points at the game, and the page ABOUT the world
+ * is a second link. Here it is the other way round: this page is the world,
+ * and the island at /printables/make is the second link. That inversion is the
+ * whole reason `WorldInfo.island` exists — a catalog of prerendered worksheets
+ * is the largest crawlable surface this site will ever have, and the sitemap
+ * filter used to be keyed on the field that would have deleted it.
+ *
+ * It stays a page of prose until the sheet families land (PRINT04 onwards),
+ * because a catalog page here is meant to BE the worksheet — real prerendered
+ * HTML a parent can print without touching anything — and a shelf of
+ * placeholder links to sheets that don't exist is the thin-content pattern
+ * Base.astro's `noindex` block already argues against.
+ */
+const title = "Free printable worksheets — The Print Shop | School Skills";
+const description =
+  "Practice sheets you can print at home, free and without an account. Every sheet is an ordinary web page, so printing it needs no download, no reader and no sign-up — and nothing about your child goes into the file.";
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "The Print Shop",
+    description,
+    url: "https://schoolskills.app/printables",
+    isAccessibleForFree: true,
+    inLanguage: "en",
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Worksheets to print
+    </p>
+    <h1 class="hero__title">Paper, when the screen has had enough</h1>
+    <p class="hero__lead">
+      The one corner of School Skills built for the grown-up. Pick a sheet, set
+      it how you want it, and print it &mdash; free, with an answer key, and
+      with your child&rsquo;s name left blank for them to fill in by hand.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">A worksheet here is a web page</h2>
+    <div class="prose">
+      <p>
+        Not a PDF, not a picture of a worksheet, and nothing to download. A
+        sheet is real text and real lines laid out in real inches, so printing
+        one is <em>File &rarr; Print</em> on the page you are already looking at.
+        If you want to keep a copy, choose <em>Save as PDF</em> in the print dialog
+        and your browser writes one for you.
+      </p>
+      <p>
+        That is worth a paragraph because of what it rules out. No reader to
+        install, no email address for the download, no watermark, no file that
+        turns out to be the first page of twelve. It also means a sheet is real
+        text: it reflows on a phone if you are only checking what is on it, it
+        can be read aloud by a screen reader, and a printer renders the lines at
+        the printer&rsquo;s own resolution rather than at the screen&rsquo;s.
+      </p>
+    </div>
+  </section>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">What the press is being set for</h2>
+      <p class="h2__sub">
+        The Print Shop is opening a family at a time, and this page lists what
+        exists rather than what is planned. Right now that is the shop itself
+        &mdash; the paper, the rulings and the print path &mdash; with the first
+        sheets next.
+      </p>
+      <div class="prose">
+        <p>
+          The order it opens in: lined, graph and handwriting paper in every
+          ruling, then the maths sheets with their answer keys, then handwriting
+          and copywork &mdash; passages from the public domain, Scripture among
+          them &mdash; then spelling, phonics, and the charts, certificates and
+          planners that are simply blank forms.
+        </p>
+        <p>
+          The one it is really being built for comes with the sheet builder:
+          printing <strong>exactly the facts a child keeps missing</strong>. The
+          record book on this site already knows which those are, because it
+          watched them get typed. No other worksheet site can know that, and it
+          is the reason this section exists rather than being one more page of
+          printables.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Your child&rsquo;s name is not in the file</h2>
+    <div class="prose">
+      <p>
+        The <em>Name:</em> line every worksheet on earth asks for is printed blank
+        here and filled in with a pencil. Nothing is uploaded to make a sheet, no
+        account is needed to print one, and a sheet you share with another family
+        carries the settings you chose and nothing else. The same promise as the games,
+        and for the same reason &mdash; see{" "}
+        <a href="/privacy">what we don&rsquo;t collect</a>.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/">Back to the map</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/make.astro
+++ b/src/pages/printables/make.astro
@@ -1,0 +1,46 @@
+---
+import Content from "@/layouts/Content.astro";
+
+/**
+ * The sheet builder's route, reserved and wired before the builder exists.
+ *
+ * It is `WorldInfo.island` for the paper world, which is what keeps it out of
+ * the sitemap, and it carries `noindex` for the reason every island does: what
+ * will render here is a `client:only` app, and a near-empty page submitted to
+ * search is a thin-content signal against the whole domain. Both halves of
+ * that have to be true from the first build rather than from the build the app
+ * lands in — a route that is indexed for a month and then hidden is worse than
+ * one that was never offered.
+ *
+ * Content rather than Base, unlike the games. A race must never have site
+ * chrome over it; the builder is the opposite case, because `print.css` hides
+ * the masthead, the footer and everything marked `.no-print` when a sheet goes
+ * to paper. So the builder can keep the site around it and lose it at exactly
+ * the moment it would cost somebody toner.
+ */
+---
+
+<Content
+  title="Build a sheet — The Print Shop | School Skills"
+  description="The sheet builder: choose a family, set the options, and print."
+  world="paper"
+  noindex
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      The bench
+    </p>
+    <h1 class="hero__title">The press isn&rsquo;t installed yet</h1>
+    <p class="hero__lead">
+      This is where a sheet gets built: pick a family, set the ruling, the type
+      size and how many problems fit, and watch the page change as you do it. It
+      is being made now, and nothing in The Print Shop will wait on it &mdash; a
+      sheet there is a page that prints as it stands, and the bench only changes
+      what is on one.
+    </p>
+    <div class="hero__actions">
+      <a class="cta" href="/printables">Go to The Print Shop</a>
+    </div>
+  </header>
+</Content>

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -138,6 +138,9 @@
 .mast__link[data-world="ice"] {
   --dot: var(--w-ice);
 }
+.mast__link[data-world="paper"] {
+  --dot: var(--w-paper);
+}
 
 .mast__play {
   flex: none;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3,8 +3,10 @@
    game there is one exit door in the top bar and nothing else — a nav bar over
    a race is a nav bar in a child's way.
 
-   It reads as a HUD rather than a website header: a flag, three worlds colour-
-   coded to match the map, and one button that plays. The flag's pennant takes
+   It reads as a HUD rather than a website header: a flag, a dot per world
+   colour-coded to match the map, and one button that plays. The header renders
+   one link per entry in the world registry, so the row grows with it rather
+   than with anything written down here. The flag's pennant takes
    the current world's accent, so walking from the jungle to the glacier
    recolours the thing you navigate by. That is the only ornament in here. */
 

--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -68,18 +68,22 @@
 .map__node[data-world="ice"] {
   --node: var(--w-ice);
 }
+.map__node[data-world="paper"] {
+  --node: var(--w-paper);
+}
 
 @media (width >= 62rem) {
   .map__route {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
     padding-left: 0;
     padding-top: var(--node-top);
   }
 
   .map__route::before {
-    /* Between the first and last node centre — a sixth in from each edge. */
-    left: 16.6%;
-    right: 16.6%;
+    /* Between the first and last node centre — half a column in from each
+       edge, so this moves with the column count above. */
+    left: 12.5%;
+    right: 12.5%;
     top: var(--path-y);
     bottom: auto;
     width: auto;
@@ -186,10 +190,15 @@
   color: var(--chalk-dim);
 }
 
+/* The viewport step is 2.6vw rather than the 3.4vw three columns could afford:
+   a fourth column takes a quarter off every card, and at the narrow end of the
+   four-across range a display face sized for a third of the row breaks "Word
+   Jungle" across two lines. Both ends of the clamp are unchanged, so a phone
+   and a wide desktop see exactly what they saw before. */
 .world__name {
   font-family: var(--font-display);
   font-weight: 400;
-  font-size: clamp(1.6rem, 3.4vw, 2.1rem);
+  font-size: clamp(1.6rem, 2.6vw, 2.1rem);
   line-height: 1;
   letter-spacing: 0.005em;
 }

--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -74,16 +74,20 @@
 
 @media (width >= 62rem) {
   .map__route {
-    grid-template-columns: repeat(4, 1fr);
+    /* The column count, written once. The dashed path below has to stop at the
+       centre of the first and last node, which is half a column in from each
+       edge — a number only derivable from this one. A fifth world changes this
+       line and nothing else. */
+    --map-cols: 4;
+    grid-template-columns: repeat(var(--map-cols), 1fr);
     padding-left: 0;
     padding-top: var(--node-top);
   }
 
   .map__route::before {
-    /* Between the first and last node centre — half a column in from each
-       edge, so this moves with the column count above. */
-    left: 12.5%;
-    right: 12.5%;
+    /* Between the first and last node centre: half a column in from each edge. */
+    left: calc(100% / var(--map-cols) / 2);
+    right: calc(100% / var(--map-cols) / 2);
     top: var(--path-y);
     bottom: auto;
     width: auto;

--- a/src/styles/worlds.css
+++ b/src/styles/worlds.css
@@ -15,7 +15,7 @@
 
    The blocks are scoped to `[data-world]` rather than `:root[data-world]` so
    the same declarations can dress a single element. That is what lets the
-   overworld map show three worlds at once: each card carries `data-world` and
+   overworld map show every world at once: each card carries `data-world` and
    is therefore built out of that world's ink, accent and ground, on a page
    standing somewhere else entirely.
 
@@ -29,6 +29,12 @@
              on, the same way graph paper is the substrate of a times table.
      ice     Typing. Speed reads as gliding, so: a glacier, frost cracks, and
              keycap-shaped slabs underfoot.
+     paper   Worksheets. The only world here that isn't outdoors — a press
+             room: warm graphite instead of the cold blues of grid and ice,
+             blueprint cyan to press, and registration marks on non-photo blue
+             for ground. The sheet is white paper floating on that, which is
+             how every layout tool on earth presents a page and is also just
+             true.
      map     The overworld. Not a world — the screen you pick one from. Dusk,
              stars and contour lines, like a map left open on a table.
      line    The pause menu: privacy and terms. Ruled paper, one grey, no
@@ -43,7 +49,7 @@
    `world="…"`. Nothing else needs to know it exists.                       */
 
 /* ── Every world's signature colour, readable from inside any of them ──────
-   The map shows three worlds at once and the masthead shows all of them from
+   The map shows all the worlds at once and so does the masthead, from
    wherever you're standing, so these can't live inside a world block — by
    definition only one of those is ever in scope. Keep them in step with the
    `--accent`/`--go` of the matching world below; they're the same colour seen
@@ -52,6 +58,10 @@
   --w-grid: #c8ff41;
   --w-jungle: #ffb545;
   --w-ice: #7fe8ff;
+  /* The Print Shop's `--go`, not its `--accent`: its accent is a blueprint
+     cyan, and two cyan dots in a nav of four would undo the whole point of
+     the code. Paper white is the one signature no other world can claim. */
+  --w-paper: #f4efe4;
 }
 
 /* ── grid · space, and the default ─────────────────────────────────────────
@@ -222,6 +232,73 @@
       transparent 70%
     );
   --terrain-size: 100% 100%, 100% 100%, 100% 56px, 64px 100%, 100% 100%;
+}
+
+/* ── paper · worksheets to print ─────────────────────────────────────────── */
+[data-world="paper"] {
+  --ink-950: #0b0a09;
+  --ink-900: #131211;
+  --ink-850: #1a1816;
+  --ink-800: #22201d;
+  --ink-700: #2f2b26;
+  --ink-600: #3f3a33;
+  --ink-500: #574f45;
+
+  --chalk: #f6f2ea;
+  --chalk-soft: #cdc4b6;
+  --chalk-dim: #918879;
+
+  --accent: #4fb8d8;
+  --accent-ink: #04171e;
+  /* Press this, and it is a sheet of paper. Every other world's `--go` is a
+     colour; this one is the thing the world makes. */
+  --go: #f4efe4;
+  --go-ink: #17140f;
+
+  /* Non-photo blue, the one line on a page a press deliberately can't see. */
+  --grid-line: rgb(126 206 232 / 7%);
+  --grid-line-strong: rgb(126 206 232 / 11%);
+  --hairline: rgb(246 242 234 / 12%);
+  --world-glow: rgb(79 184 216 / 11%);
+
+  /* A registration target and its crosshair, a second target further down,
+     and a non-photo blue grid under both. The ticks are radial gradients with
+     one tiny radius rather than lines, because a `--terrain` layer has no
+     background-position of its own — the position has to live in the gradient
+     (the same trick the grid world's stars use). */
+  --terrain:
+    radial-gradient(
+      circle 6px at 58px 66px,
+      transparent 0 4px,
+      rgb(126 206 232 / 34%) 4px 5px,
+      transparent 5px
+    ),
+    radial-gradient(
+      0.6px 9px at 58px 66px,
+      rgb(126 206 232 / 34%),
+      transparent 100%
+    ),
+    radial-gradient(
+      9px 0.6px at 58px 66px,
+      rgb(126 206 232 / 34%),
+      transparent 100%
+    ),
+    radial-gradient(
+      circle 5px at 232px 178px,
+      transparent 0 3.4px,
+      rgb(244 239 228 / 20%) 3.4px 4.2px,
+      transparent 4.2px
+    ),
+    linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px),
+    radial-gradient(
+      ellipse 110% 50% at 50% -8%,
+      rgb(79 184 216 / 12%),
+      transparent 70%
+    );
+  --terrain-size:
+    300px 240px, 300px 240px, 300px 240px, 300px 240px, 22px 22px, 22px 22px,
+    100% 100%;
 }
 
 /* ── map · the overworld ─────────────────────────────────────────────────── */


### PR DESCRIPTION
Closes #47

## What

The Print Shop becomes a real world. `paper` joins the `World` union, gets its own eleven custom properties, a card on the map, and links in the masthead and footer — so printables read as part of School Skills rather than as a tool bolted to the side of it.

The world is the usual three things: `paper` in the union with `THEME_COLOUR` kept in step, a `[data-world="paper"]` block in `src/styles/worlds.css`, and an entry in `WORLDS`. **The telemetry five are untouched.** The biome is the only one that isn't outdoors — warm graphite, blueprint cyan to press, registration marks on non-photo blue for ground.

The map card's copy is written for a parent and says so in its first four words. The map is a child's screen with one grown-up's stop on it, and pretending a worksheet is a level would be a bait-and-switch on exactly the audience this site is careful with. The heading above the cards no longer says "Three worlds".

## Why the sitemap changed

The landmine from `docs/printables.md` §8. `astro.config.mjs` excluded every `WORLDS[].href` from the sitemap, on the reasoning that a world's href **is** its noindex game route. That reasoning stops holding here: the Print Shop's front door is a catalog of prerendered worksheets that has to be indexed, and its builder is what must not be. Filtering on `href` would have deleted the catalog from the sitemap silently, with nothing failing.

So `WorldInfo` grows an explicit `island` — equal to `href` for the three game worlds — and the filter keys on that instead.

That fixes the bug and leaves the class of bug intact, so the build now asserts the outcome rather than the mechanism. `scripts/sitemap-guard.mjs` runs after the sitemap integration, reads the XML that actually shipped, and fails the build if a world's island is in it or a world's crawlable front door is missing. Reverting the filter to `href` fails with both problems named — which is how it was tested. `scripts/sitemap-guard.test.mjs` covers the auditor itself, because a check that can only pass is indistinguishable from one that works.

## Routes

- `/printables` — real prose, indexable, present in `sitemap-0.xml`. PRINT04 fills it out with the sheets.
- `/printables/make` — the builder's route reserved, carrying `noindex` from its first build rather than from the build the app lands in, and absent from the sitemap.

`/printables/make` renders through `Content.astro` rather than `Base.astro`. Unlike a game, which must never have chrome over it, the builder keeps the site around it and loses it in `print.css` at the moment it would otherwise cost somebody toner.

`SHEET_WORLD` moves from `line` to `paper` — the one-line change PRINT01 left a note promising.

## Also in here

- The post-deploy smoke walks the fourth island. `/printables/make/` carries `noindex`, which is exactly why the sitemap-driven page walk cannot see it; the loop that names such routes was missing the new one.
- Two comments stop lying. The masthead comment still counted three worlds when the header has always rendered one link per registry entry. The map's dashed path claimed it moved with the column count and did not — `--map-cols` now makes that true, so a fifth world is one number.
- The URL→path normalisation that the sitemap filter and the guard both need is one exported `pathOf` rather than the same regex written twice in two files that have to agree exactly.

## Out of scope

No sheet families, no builder — the world and its wiring only.

## Validation

`type-check`, `lint`, `test:unit` (253 passing), `build`, and the browser smoke test all pass locally. Verified in the built output: `/printables/` is in `sitemap-0.xml`, `/printables/make/` is absent and serves `<meta name="robots" content="noindex, follow">`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
