### PR TITLE
The Print Shop opens with paper

### DIFF
--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -6,7 +6,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_PAPER } from "@/engine/sheets/paper";
-import type { Block, Sheet } from "@/engine/sheets/types";
+import type { Block, Paper, Sheet } from "@/engine/sheets/types";
 
 import { SheetView } from "./Sheet";
 
@@ -166,6 +166,18 @@ function filesUnder(dir: string, endings: string[]): string[] {
 
 const read = (path: string) => readFileSync(path, "utf8");
 
+/**
+ * The landmarks a page puts around a sheet: its sections, its page header, and
+ * any full-width wrap that is not the sheet's own frame. Everything nested
+ * inside one of these goes wherever it goes, so these are the elements the
+ * `.no-print` contract is actually about.
+ */
+function landmarks(source: string): Array<[string, string]> {
+  return [...source.matchAll(/<(section|header|div)\s[^>]*class="([^"]*)"/g)]
+    .filter(([, tag, classes]) => tag !== "div" || /\bwrap\b/.test(classes))
+    .map(([, tag, classes]) => [tag, classes] as [string, string]);
+}
+
 /* ── The blocks ────────────────────────────────────────────────────────── */
 
 describe("rendering a sheet", () => {
@@ -215,6 +227,47 @@ describe("rendering a sheet", () => {
     // sheet on it prints scaled or across two pages (§10).
     expect(a4).toContain("--sheet-w:11.693in");
     expect(a4).toContain("@page{size:11.693in 8.268in;margin:0}");
+  });
+
+  it("draws rules in mil inside a box measured in inches, so ⅝ prints as ⅝", () => {
+    // The whole physical-measurement claim rests on one correspondence, and it
+    // lives in three attributes of one element: the <svg> is sized in inches
+    // while its viewBox counts mil, so one user unit is a thousandth of an
+    // inch and a 625-unit gap comes off the printer at ⅝. Put the viewBox in
+    // inches, or drop the width and height, and every other test in this file
+    // stays green while every printed rule is a thousand times the wrong size
+    // — the one bug this feature cannot afford, and the one a screen never
+    // shows. The engine's own tests stop short of it: they never render.
+    const LINES = 14;
+    const ruled: Block = {
+      kind: "rules",
+      rule: { style: "hand-5-8", descender: true },
+      lines: LINES,
+    };
+
+    const measure = (paper: Paper, inches: string, mil: number) => {
+      const html = render(sheet({ paper, blocks: [ruled] }));
+      expect(html).toContain(
+        `<svg class="sheet__ink" width="${inches}in" height="8.75in" viewBox="0 0 ${mil} 8750"`,
+      );
+
+      const tops = [...html.matchAll(/sheet__rule--top"[^>]*y1="(\d+)"/g)].map(
+        (line) => Number(line[1]),
+      );
+      expect(tops.length).toBe(LINES);
+      for (let i = 1; i < tops.length; i++) {
+        expect(tops[i] - tops[i - 1]).toBe(625);
+      }
+    };
+
+    // 8.5in less two half-inch margins, and 14 × ⅝ of an inch down the page.
+    measure(DEFAULT_PAPER, "7.5", 7500);
+    // The same ruling on the second stock: 210mm less the same margins.
+    measure(
+      { size: "a4", orientation: "portrait", margin: "normal" },
+      "7.268",
+      7268,
+    );
   });
 });
 
@@ -275,6 +328,29 @@ describe("print isolation", () => {
     }
     expect(css).toMatch(/@page\s*\{[^}]*size:/);
     expect(css).toMatch(/@page\s*\{[^}]*margin:\s*0/);
+  });
+
+  it("keeps everything that is not the sheet off the paper", () => {
+    // print.css zeroes the `@page` margin on every page that renders a sheet,
+    // because the sheet owns its own geometry. On a catalog page — an h1, some
+    // prose, and then the paper — the only thing stopping the article printing
+    // off the edge is that every section of it carries `.no-print`. print.css
+    // records that as the settled decision; this is what holds a page to it. A
+    // section added later without the class prints an article with no page
+    // margin, silently, and "⌘P with no interaction produces usable paper"
+    // stops being true with nothing failing.
+    const pages = filesUnder(join(ROOT, "src/pages"), [".astro"]).filter(
+      (page) => read(page).includes("components/sheet"),
+    );
+    expect(pages.length).toBeGreaterThan(0);
+
+    for (const page of pages) {
+      for (const [tag, classes] of landmarks(read(page))) {
+        expect(classes, `<${tag} class="${classes}"> in ${page}`).toMatch(
+          /\bno-print\b/,
+        );
+      }
+    }
   });
 
   it("breaks pages where a reader would expect it to", () => {

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -17,9 +17,11 @@ import type { Sheet, SheetConfig } from "./types";
 
 import { BLANK_SHEET } from "./blank";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
+import { PAPER_SHEET } from "./templates/paper";
 
 const SHEETS: Record<string, SheetSpec> = {
   [BLANK_SHEET.id]: BLANK_SHEET,
+  [PAPER_SHEET.id]: PAPER_SHEET,
 };
 
 /**

--- a/src/engine/sheets/templates/paper.test.ts
+++ b/src/engine/sheets/templates/paper.test.ts
@@ -12,7 +12,7 @@ import type {
   RuleStyle,
 } from "../types";
 
-import { PAPER_SHEET } from "./paper";
+import { PAPER_SHEET, paperBlockBox } from "./paper";
 
 /**
  * The family the geometry is proved on.
@@ -114,31 +114,58 @@ describe("what a ruler would find", () => {
   it("never rules past the bottom of the paper, whatever it is printed on", () => {
     // The failure this exists to catch is silent on screen and obvious on
     // paper: one rule too many is a second sheet out of the printer.
+    //
+    // Measured against the *block* box, which is the only box that can fail.
+    // The content box cannot: `ruleCapacity` floors against a height that is
+    // already the content box minus the chrome, so a family that reserved
+    // nothing at all would still satisfy it, and deleting `chrome()` would
+    // leave this test green while every sheet overran its footer.
     for (const size of SIZES) {
       for (const margin of MARGINS) {
         for (const style of RULED) {
           const rule: Rule = { style };
-          const block = rulesOf({ paper: paper({ size, margin }), rule });
-          const height = block.lines * rulePitch(rule);
-          expect(height).toBeLessThanOrEqual(
-            contentBox(paper({ size, margin })).height,
-          );
+          const over = { paper: paper({ size, margin }), rule };
+          const lines = rulesOf(over).lines;
+          const pitch = rulePitch(rule);
+          const box = paperBlockBox(config(over));
+
+          expect(lines * pitch).toBeLessThanOrEqual(box.height);
+          // ...and one more would not have fitted, which is what makes the
+          // reservation testable in both directions.
+          expect((lines + 1) * pitch).toBeGreaterThan(box.height);
         }
       }
     }
   });
 
   it("does not throw the page away either", () => {
-    // The other half of the same property. What is left over has to be the
-    // header, the footer and less than one more repeat — a family that
-    // reserved for the worst case would cost every sheet two lines to write
-    // on, which on ⅝ paper a child notices.
-    for (const style of RULED) {
-      const rule: Rule = { style };
-      const block = rulesOf({ rule });
-      const spare = contentBox(paper()).height - block.lines * rulePitch(rule);
-      expect(spare).toBeLessThan(rulePitch(rule) + inches(0.8));
-    }
+    // The half the block box cannot see: what the chrome took in the first
+    // place. A family that reserved for the worst case would satisfy every
+    // assertion above and still cost each sheet two lines to write on, which
+    // on ⅝ paper a child notices. Name and date, no title, no instructions —
+    // the sheet the catalog actually ships — spends under an inch on chrome.
+    const bare = config();
+    const spare = contentBox(bare.paper).height - paperBlockBox(bare).height;
+    expect(spare).toBeGreaterThan(0);
+    expect(spare).toBeLessThan(inches(0.8));
+  });
+
+  it("reserves a second row when the name line wraps onto one", () => {
+    // `HEAD_ROWS.fields` is charged per row, not per line. Three fields are
+    // all legal in `HeaderField` and measure more than a Letter content width
+    // between them, so they wrap — and a wrap that was not reserved for puts
+    // the last rule below the bottom margin and a blank second page out of
+    // the printer. Not reachable from the shipped catalog, which always
+    // passes two; reachable from `buildSheet` today and from the builder next.
+    const two = config();
+    const three = config({ fields: ["name", "date", "class"] });
+    expect(paperBlockBox(three).height).toBeLessThan(paperBlockBox(two).height);
+
+    // The sheet pays for the row by losing a line, rather than by overrunning.
+    const rule: Rule = { style: "narrow" };
+    expect(rulesOf({ fields: ["name", "date", "class"], rule }).lines).toBe(
+      rulesOf({ rule }).lines - 1,
+    );
   });
 
   it("gives a sheet with no title the lines the title would have taken", () => {

--- a/src/engine/sheets/templates/paper.test.ts
+++ b/src/engine/sheets/templates/paper.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { contentBox, ruledLines } from "../layout";
+import { RULINGS, inches, rulePitch } from "../paper";
+import type {
+  MarginSize,
+  Paper,
+  PaperConfig,
+  PaperSize,
+  Rule,
+  RuleStyle,
+} from "../types";
+
+import { PAPER_SHEET } from "./paper";
+
+/**
+ * The family the geometry is proved on.
+ *
+ * A sheet of lined paper is nothing but its ruling, so there is nowhere for a
+ * rule that is a thousandth out to hide — which is why the story that ships it
+ * is the one that asks for a ruler on a real printer. These are the half of
+ * that check a machine can do: that the arithmetic says ⅝ of an inch, on both
+ * stocks and at every margin, and that the last rule is on the page.
+ */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const config = (over: Partial<PaperConfig> = {}): PaperConfig => ({
+  kind: "paper",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  rule: { style: "wide" },
+  ...over,
+});
+
+/** The one block a paper sheet has, narrowed for the reader. */
+function rulesOf(over: Partial<PaperConfig> = {}) {
+  const block = buildSheet(config(over), 0).blocks[0];
+  if (block.kind !== "rules")
+    throw new Error(`expected rules, got ${block.kind}`);
+  return block;
+}
+
+/** Every ruling in §5, which is every ruling there is. */
+const STYLES = Object.keys(RULINGS) as RuleStyle[];
+const RULED = STYLES.filter((style) => RULINGS[style].pitch > 0);
+
+const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+describe("the paper family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("paper")).toBe(PAPER_SHEET);
+    expect(sheetSpec("paper").label).toBe("Lined and graph paper");
+  });
+
+  it("rules a sheet in every ruling of §5", () => {
+    for (const style of RULED) {
+      const block = rulesOf({ rule: { style } });
+      expect(block.rule.style).toBe(style);
+      expect(block.lines).toBeGreaterThan(0);
+    }
+  });
+
+  it("draws nothing on blank paper, rather than a zero-height box", () => {
+    // Blank is a ruling with no pitch. Nought repeats is the honest answer.
+    expect(rulesOf({ rule: { style: "blank" } }).lines).toBe(0);
+  });
+
+  it("is a pure function of its config, like every other family", () => {
+    for (const seed of [0, 1, 4242]) {
+      expect(buildSheet(config(), seed)).toEqual(buildSheet(config(), seed));
+    }
+  });
+
+  it("has nothing to answer, so its key is the sheet itself", () => {
+    // Paper is supposed to be empty (§11). A key that differed from the sheet
+    // would be inventing something to have been right about.
+    expect(answerKey(config(), 0)).toEqual(buildSheet(config(), 0));
+  });
+});
+
+/* ── The geometry, which is the whole point ────────────────────────────── */
+
+describe("what a ruler would find", () => {
+  it("puts a ⅝ rule ⅝ of an inch from the next one, on Letter and on A4", () => {
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        const rule: Rule = { style: "hand-5-8", descender: true };
+        const block = rulesOf({ paper: paper({ size, margin }), rule });
+        const box = contentBox(paper({ size, margin }));
+        const tops = ruledLines(
+          { ...box, height: block.lines * rulePitch(rule) },
+          rule,
+        )
+          .filter((line) => line.role === "top")
+          .map((line) => line.y);
+
+        expect(tops.length).toBe(block.lines);
+        for (let i = 1; i < tops.length; i++) {
+          expect(tops[i] - tops[i - 1]).toBe(inches(0.625));
+        }
+      }
+    }
+  });
+
+  it("never rules past the bottom of the paper, whatever it is printed on", () => {
+    // The failure this exists to catch is silent on screen and obvious on
+    // paper: one rule too many is a second sheet out of the printer.
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const style of RULED) {
+          const rule: Rule = { style };
+          const block = rulesOf({ paper: paper({ size, margin }), rule });
+          const height = block.lines * rulePitch(rule);
+          expect(height).toBeLessThanOrEqual(
+            contentBox(paper({ size, margin })).height,
+          );
+        }
+      }
+    }
+  });
+
+  it("does not throw the page away either", () => {
+    // The other half of the same property. What is left over has to be the
+    // header, the footer and less than one more repeat — a family that
+    // reserved for the worst case would cost every sheet two lines to write
+    // on, which on ⅝ paper a child notices.
+    for (const style of RULED) {
+      const rule: Rule = { style };
+      const block = rulesOf({ rule });
+      const spare = contentBox(paper()).height - block.lines * rulePitch(rule);
+      expect(spare).toBeLessThan(rulePitch(rule) + inches(0.8));
+    }
+  });
+
+  it("gives a sheet with no title the lines the title would have taken", () => {
+    // Chrome is counted from what the header holds, not from a constant.
+    const bare = rulesOf({ rule: { style: "hand-5-8" } });
+    const titled = rulesOf({
+      rule: { style: "hand-5-8" },
+      title: "Spelling practice",
+      instructions: "Write each word three times.",
+    });
+    expect(bare.lines).toBeGreaterThan(titled.lines);
+  });
+});
+
+/* ── The two choices a handwriting rule offers (§5) ────────────────────── */
+
+describe("handwriting rules", () => {
+  const hand = (over: Partial<Rule>) =>
+    rulesOf({ rule: { style: "hand-5-8", ...over } }).rule;
+
+  it("carries the midline the config asked for, all three of them", () => {
+    expect(hand({}).midline).toBeUndefined(); // dashed, the default schools print
+    expect(hand({ midline: "solid" }).midline).toBe("solid");
+    expect(hand({ midline: "none" }).midline).toBe("none");
+  });
+
+  it("takes the descender space out of the repeat, not out of the pitch", () => {
+    // The toggle is the difference between a sheet a child can write a `g` on
+    // and one they can't — but ⅝ paper stays ⅝ paper either way, or every
+    // ruling would silently reprice itself when the box was ticked.
+    const rule: Rule = { style: "hand-5-8", descender: true };
+    const withTail = rulesOf({ rule });
+    const without = rulesOf({ rule: { style: "hand-5-8" } });
+    expect(withTail.rule.descender).toBe(true);
+    expect(without.rule.descender).toBeUndefined();
+    expect(withTail.lines).toBe(without.lines);
+  });
+
+  it("names the midline and the tail space, because a shop's label doesn't", () => {
+    expect(describeSheet(config({ rule: { style: "wide" } }))).toBe(
+      "Wide ruled paper",
+    );
+    expect(
+      describeSheet(config({ rule: { style: "hand-5-8", descender: true } })),
+    ).toBe('Handwriting ⅝" paper — dashed midline — room for descenders');
+    expect(
+      describeSheet(config({ rule: { style: "hand-3-8", midline: "none" } })),
+    ).toBe('Handwriting ⅜" paper — no midline — no descender space');
+  });
+});

--- a/src/engine/sheets/templates/paper.ts
+++ b/src/engine/sheets/templates/paper.ts
@@ -18,7 +18,13 @@
  */
 import type { Mil, PaperConfig, Sheet } from "../types";
 
-import { blockBox, ruleCapacity } from "../layout";
+import {
+  blockBox,
+  contentBox,
+  fitAcross,
+  ruleCapacity,
+  type Box,
+} from "../layout";
 import { inches, points, rulingOf } from "../paper";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
 
@@ -44,8 +50,33 @@ const HEAD_MARGIN = inches(0.16);
 /** The footer's rule, its padding, and the air above it. */
 const FOOT_MARGIN = inches(0.23);
 
+/* The name line is not always one row. `.sheet__fields` is a wrapping flex
+   row, so how many rows it takes is a question about the width of the page —
+   three fields ("name", "date", "class" are all legal) measure more than a
+   Letter content width and land on two. A row that was not reserved for is a
+   rule line below the bottom margin, which is a second sheet of paper. */
+
+/** One field: `.sheet__field-rule` at 2.1in, plus its label and their gap. */
+const FIELD_WIDTH = inches(2.5);
+/** `.sheet__fields` sets 0.06in between rows and 0.28in between fields. */
+const FIELD_GAP = inches(0.28);
+const FIELD_ROW_GAP = inches(0.06);
+
 /** A height quoted in ems of the body size, in the unit the page is in. */
 const em = (fontPt: number, rows: number): Mil => points(fontPt * rows);
+
+/** How many rows the name line wraps onto, given the width it has to fill. */
+function fieldRows(config: PaperConfig): number {
+  if (config.fields.length === 0) return 0;
+  const across = fitAcross(
+    contentBox(config.paper).width,
+    FIELD_WIDTH,
+    FIELD_GAP,
+  );
+  // A page too narrow for one whole field still prints one per row rather
+  // than dividing by zero — and the rules then get whatever is left.
+  return Math.ceil(config.fields.length / Math.max(1, across));
+}
 
 /**
  * How much of the page the header and footer will use.
@@ -56,9 +87,10 @@ const em = (fontPt: number, rows: number): Mil => points(fontPt * rows);
  * on. A family that reserved for the worst case would throw them away.
  */
 function chrome(config: PaperConfig): { header: Mil; footer: Mil } {
+  const fields = fieldRows(config);
   const rows = [
     config.title ? HEAD_ROWS.title : 0,
-    config.fields.length > 0 ? HEAD_ROWS.fields : 0,
+    HEAD_ROWS.fields * fields,
     config.instructions ? HEAD_ROWS.instructions : 0,
   ].filter((row) => row > 0);
 
@@ -68,13 +100,27 @@ function chrome(config: PaperConfig): { header: Mil; footer: Mil } {
     header:
       HEAD_MARGIN +
       rows.reduce((total, row) => total + em(config.fontPt, row), 0) +
-      HEAD_GAP * Math.max(0, rows.length - 1),
+      HEAD_GAP * Math.max(0, rows.length - 1) +
+      FIELD_ROW_GAP * Math.max(0, fields - 1),
     footer: FOOT_MARGIN + em(config.fontPt, FOOT_ROW),
   };
 }
 
+/**
+ * What is left for the ruling: the page, less its margins, less the chrome.
+ *
+ * Exported because it is the reservation itself, and the reservation is the
+ * only thing a test can hold `chrome` to. Checking the rules against the
+ * *content* box instead cannot fail — `ruleCapacity` floors against this box,
+ * which is the content box minus a non-negative number, so any chrome at all
+ * satisfies it, including none.
+ */
+export function paperBlockBox(config: PaperConfig): Box {
+  return blockBox(config.paper, chrome(config));
+}
+
 export function buildPaperSheet(config: PaperConfig, seed: number): Sheet {
-  const box = blockBox(config.paper, chrome(config));
+  const box = paperBlockBox(config);
 
   return {
     paper: config.paper,

--- a/src/engine/sheets/templates/paper.ts
+++ b/src/engine/sheets/templates/paper.ts
@@ -1,0 +1,131 @@
+/**
+ * Paper you print because it is empty.
+ *
+ * Lined, ruled, graph, dot and isometric — every ruling in §5, as sheets. It is
+ * the "templates" tier of §11 rather than a generator: genuinely useful,
+ * completely honest, and supposed to be blank. There are no problems on it, so
+ * there is nothing to answer and nothing to seed.
+ *
+ * It is also the family the geometry is proved on. A sheet with something
+ * written on it can hide a rule that is a thousandth out; a sheet that is
+ * nothing *but* the rules cannot. If a ⅝ rule measures ⅝ of an inch under a
+ * ruler here, it measures ⅝ of an inch everywhere, because every other family
+ * asks `layout.ts` the same question this one does.
+ *
+ * One block, always: `ruleCapacity` says how many repeats fit in what the
+ * chrome leaves, and the renderer draws that many. Nothing measures anything,
+ * which is what lets this run at build time on a catalog page (§4).
+ */
+import type { Mil, PaperConfig, Sheet } from "../types";
+
+import { blockBox, ruleCapacity } from "../layout";
+import { inches, points, rulingOf } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+
+/* ── What the chrome takes out of the page ────────────────────────────────
+   Declared, not measured — the bargain `blockBox` is built on (§4) — and
+   rounded up, because the two errors are not symmetrical. Reserving a tenth of
+   an inch too much costs one rule line at the bottom of the page. Reserving
+   too little pushes that line onto a second sheet of paper, and print is the
+   whole of the output path here: there is no PDF to notice it in first.
+
+   The numbers trail sheet.css, which sets the header's rows in ems of the body
+   size and its gaps in inches. So these are too: a title is 1.7em over a 1.05
+   line-height, a field line 0.82em over 1.35, an instruction 0.9em, and the
+   footer 0.62em above a rule with 0.18in of air over it.                    */
+
+const HEAD_ROWS = { title: 1.9, fields: 1.2, instructions: 1.3 } as const;
+const FOOT_ROW = 0.9;
+
+/** The gap sheet.css puts between the header's rows. */
+const HEAD_GAP = inches(0.09);
+/** And under the header itself, whatever is in it. */
+const HEAD_MARGIN = inches(0.16);
+/** The footer's rule, its padding, and the air above it. */
+const FOOT_MARGIN = inches(0.23);
+
+/** A height quoted in ems of the body size, in the unit the page is in. */
+const em = (fontPt: number, rows: number): Mil => points(fontPt * rows);
+
+/**
+ * How much of the page the header and footer will use.
+ *
+ * Counted from what the header actually holds rather than from a constant: a
+ * sheet of lined paper with a name line and no title has an inch more writing
+ * space than one with both, and on ⅝ paper an inch is two more lines to write
+ * on. A family that reserved for the worst case would throw them away.
+ */
+function chrome(config: PaperConfig): { header: Mil; footer: Mil } {
+  const rows = [
+    config.title ? HEAD_ROWS.title : 0,
+    config.fields.length > 0 ? HEAD_ROWS.fields : 0,
+    config.instructions ? HEAD_ROWS.instructions : 0,
+  ].filter((row) => row > 0);
+
+  return {
+    // The margin is there even when the header is empty — SheetHead renders
+    // the element either way, and an empty flex column still takes its gap.
+    header:
+      HEAD_MARGIN +
+      rows.reduce((total, row) => total + em(config.fontPt, row), 0) +
+      HEAD_GAP * Math.max(0, rows.length - 1),
+    footer: FOOT_MARGIN + em(config.fontPt, FOOT_ROW),
+  };
+}
+
+export function buildPaperSheet(config: PaperConfig, seed: number): Sheet {
+  const box = blockBox(config.paper, chrome(config));
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: config.title ?? "",
+      instructions: config.instructions,
+      fields: config.fields,
+    },
+    // As many repeats of the ruling as fit, and not one more. `ruleCapacity`
+    // floors, so the last rule is inside the margin rather than on it.
+    blocks: [
+      {
+        kind: "rules",
+        rule: config.rule,
+        lines: ruleCapacity(box.height, config.rule),
+      },
+    ],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+/**
+ * One line naming the paper, in the words a teacher says out loud.
+ *
+ * A handwriting rule says more than its size, because the two things a parent
+ * chooses between are exactly the two a shop's label leaves off: whether the
+ * midline is there to write between, and whether a `g` has anywhere to go.
+ */
+export function describePaper(config: PaperConfig): string {
+  const ruling = rulingOf(config.rule);
+  const paper = `${ruling.label} paper`;
+  if (!ruling.handwriting) return paper;
+
+  const midline = config.rule.midline ?? "dashed";
+  return [
+    paper,
+    midline === "none" ? "no midline" : `${midline} midline`,
+    config.rule.descender ? "room for descenders" : "no descender space",
+  ].join(" — ");
+}
+
+export const PAPER_SHEET: SheetSpec<PaperConfig> = {
+  id: "paper",
+  label: "Lined and graph paper",
+  world: SHEET_WORLD,
+  build: buildPaperSheet,
+  // Blank paper is the answer. Returned as-is rather than with `answers: true`,
+  // for the reason the blank page is: a key indistinguishable from its sheet
+  // should also be identical to it.
+  key: (sheet) => sheet,
+  describe: describePaper,
+};

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -289,7 +289,20 @@ export type SheetOptions = {
 export type BlankConfig = SheetOptions & { kind: "blank" };
 
 /**
+ * Lined, ruled, graph, dot and isometric paper — a ruling and nothing written
+ * on it.
+ *
+ * The first real family (§11's "templates" tier), and the smallest one that
+ * proves the geometry end to end: there is nothing here but the ruling, so a ⅝
+ * rule that comes off the printer at anything other than ⅝ of an inch has
+ * nowhere to hide. It carries no options of its own beyond `rule`, because
+ * `Rule` already says everything there is to say about a ruling — which size,
+ * which midline, whether there is room for a `g`.
+ */
+export type PaperConfig = SheetOptions & { kind: "paper"; rule: Rule };
+
+/**
  * Anything a saved sheet can hold. Narrow on `kind` — and only in index.ts,
  * which is the one module that knows the whole union.
  */
-export type SheetConfig = BlankConfig;
+export type SheetConfig = BlankConfig | PaperConfig;

--- a/src/pages/printables/[...slug].astro
+++ b/src/pages/printables/[...slug].astro
@@ -150,8 +150,8 @@ const siblings = shelf();
   <section class="band band--tight wrap no-print">
     <h2 class="h2">Every ruling</h2>
     <p class="h2__sub">
-      Eleven sheets, each one a page like this one. Nothing is locked and
-      nothing needs an account.
+      {PAPER_SHEETS.length} sheets, each one a page like this one. Nothing is locked
+      and nothing needs an account.
     </p>
     {
       siblings.map((group) => (

--- a/src/pages/printables/[...slug].astro
+++ b/src/pages/printables/[...slug].astro
@@ -1,0 +1,181 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { buildSheet } from "@/engine/sheets";
+import {
+  PAPER_SHEETS,
+  STOCKS,
+  paperConfig,
+  pathFor,
+  shelf,
+  type PaperSheet,
+  type Stock,
+} from "./_catalog";
+
+/**
+ * One prerendered sheet of paper per ruling — and the page is the sheet.
+ *
+ * This is the shape every catalog page in §8 takes, and the first one built.
+ * A parent arriving from a search for "printable wide ruled paper" gets real
+ * prose answering the query, the paper itself directly under it as HTML, and
+ * nothing to click: ⌘P produces usable paper because the sheet IS the page,
+ * not a download link on it.
+ *
+ * **No client directive on `SheetView`, ever.** `@astrojs/react` renders a
+ * component with no `client:*` to HTML at build time, so these pages ship zero
+ * JavaScript — which is the whole SEO argument of §2 and the reason a sheet is
+ * HTML rather than a canvas or a PDF. Sheet.test.tsx holds every page in this
+ * directory to it, against the source and against `dist/`.
+ *
+ * **Everything that is not the sheet carries `.no-print`.** print.css records
+ * this as the open question the routes story had to settle: `@page` cannot be
+ * scoped to a class, so on a page that is both prose and paper the zeroed page
+ * margin applies to the prose as well and it would print off the edge. Hiding
+ * the prose is the right way round rather than merely the easy one — printing
+ * this page means printing the sheet on it, and a parent who wanted the
+ * article would not be reaching for the printer.
+ *
+ * Two stocks, two routes. A sheet is only correct on the paper it was measured
+ * for, and `@page` is a document rule, so Letter and A4 cannot share a page —
+ * see `_catalog.ts` for the whole of that reasoning.
+ */
+
+type Props = { sheet: PaperSheet; stock: Stock };
+
+export function getStaticPaths() {
+  return PAPER_SHEETS.flatMap((sheet) =>
+    STOCKS.map((stock) => ({
+      params: { slug: pathFor(sheet, stock) },
+      props: { sheet, stock },
+    })),
+  );
+}
+
+const { sheet, stock } = Astro.props;
+
+const a4 = stock.id === "a4";
+const printed = buildSheet(paperConfig(sheet, stock.id), 0);
+const other = STOCKS.find((candidate) => candidate.id !== stock.id)!;
+
+const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
+const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
+const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const url = `https://schoolskills.app/printables/${pathFor(sheet, stock)}`;
+
+const siblings = shelf();
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    name: heading,
+    description,
+    url,
+    learningResourceType: "Printable",
+    educationalUse: "Practice",
+    teaches: sheet.teaches,
+    typicalAgeRange: sheet.ages,
+    isAccessibleForFree: true,
+    inLanguage: "en",
+  }}
+>
+  <header class="hero wrap no-print">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      {stock.label} &middot; {stock.size}
+    </p>
+    <h1 class="hero__title">{heading}</h1>
+    <p class="hero__lead">{sheet.lead}</p>
+    <p class="aside">
+      The sheet below <strong>is</strong> the printout. Press{" "}
+      <strong>&#8984;P</strong> &mdash; <strong>Ctrl+P</strong> on Windows &mdash;
+      and everything but the paper disappears. Nothing here needs choosing first.
+      To keep a copy instead, pick <em>Save as PDF</em> in the print dialog and your
+      browser writes one.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  {
+    /*
+      The sheet, outside `.wrap` deliberately. A wrap adds an inline padding
+      that print.css cannot take back off, and a sheet printed a centimetre in
+      from where it says it is has the wrong geometry everywhere at once.
+    */
+  }
+  <div class="sheet-frame">
+    <SheetView sheet={printed} />
+  </div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">What is on this sheet</h2>
+    <div class="prose">
+      {sheet.notes.map((note) => <p>{note}</p>)}
+      <p>
+        The rules are drawn as real strokes at real sizes &mdash; not a picture
+        of lines, and not a background tint. That matters more than it sounds:
+        browsers drop background graphics when printing unless the reader has
+        gone looking for the setting, so ruled paper made the obvious way looks
+        perfect on screen and comes out of the printer blank. Put a ruler on
+        this one. It is the size it says it is.
+      </p>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Printing it on {other.label}</h2>
+    <div class="prose">
+      <p>
+        This sheet is set for {stock.label} &mdash; {stock.size}. Paper size is
+        not a preference here: sent to a printer loaded with something else, the
+        browser shrinks the page to fit, and a ruling that has been shrunk is no
+        longer the size it was chosen for. So there is a second copy of this
+        sheet, ruled identically and measured for {other.label}.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href={`/printables/${pathFor(sheet, other)}`}>
+        The {other.label} version
+      </a>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Every ruling</h2>
+    <p class="h2__sub">
+      Eleven sheets, each one a page like this one. Nothing is locked and
+      nothing needs an account.
+    </p>
+    {
+      siblings.map((group) => (
+        <>
+          <h3 class="h2 h2--next">{group.label}</h3>
+          <p class="h2__sub">{group.blurb}</p>
+          <nav class="stones" aria-label={group.label}>
+            {group.sheets.map((candidate) => (
+              <a
+                class="stone"
+                href={`/printables/${pathFor(candidate, stock)}`}
+                aria-current={
+                  candidate.slug === sheet.slug ? "page" : undefined
+                }
+              >
+                {candidate.short}
+              </a>
+            ))}
+          </nav>
+        </>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/_catalog.ts
+++ b/src/pages/printables/_catalog.ts
@@ -94,7 +94,7 @@ export const PAPER_SHEETS: PaperSheet[] = [
     keyword: "Free printable college ruled paper",
     summary:
       "College ruled paper: rules 9/32 of an inch apart, with the same 1¼-inch margin line.",
-    lead: "The narrower of the two notebook rules — nine thirty-seconds of an inch — with the same margin line as wide ruled and about four more lines on the page.",
+    lead: "The narrower of the two notebook rules — nine thirty-seconds of an inch — with the same margin line as wide ruled and about six more lines on the page.",
     notes: [
       "College ruled is what secondary-school and university notebooks are printed at, and what a teacher usually means by “lined paper” from around Year 6 upwards. More words to a page is the whole of the difference.",
       "If handwriting is still growing into the line, print the wide ruled sheet instead. Narrow rules do not make writing neater; they make a child write smaller than they can control, which is the opposite of the thing being practised.",

--- a/src/pages/printables/_catalog.ts
+++ b/src/pages/printables/_catalog.ts
@@ -1,0 +1,329 @@
+/**
+ * The paper the Print Shop has set, and the words that go round it.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data two
+ * pages share — `[...slug].astro`, which prerenders one sheet per entry, and
+ * `index.astro`, which lists them — rather than a route of its own.
+ *
+ * **The slugs are curated; the sheets are generated.** §8 is explicit about
+ * why: twelve times-table pages work because there are twelve of them and each
+ * has something true on it, and five thousand permutations of a config is a
+ * doorway-page farm. So the engine can rule paper any way §5 describes, and
+ * this file names the eleven a parent actually searches for, each with a note
+ * that is true of that ruling and no other. The rest arrive with the builder,
+ * which is where choosing belongs.
+ *
+ * Every entry is printed on both stocks. A sheet is only correct on the paper
+ * it was measured for — a Letter sheet sent to an A4 printer is scaled to fit,
+ * and a scaled ⅝ rule is not a ⅝ rule — and `@page` is a document rule, so the
+ * two cannot share a page. Hence a route each.
+ */
+import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
+import type { PaperConfig, PaperSize, Rule } from "@/engine/sheets/types";
+
+/** How the hub groups the shelf. Three shapes of paper, not three subjects. */
+export type PaperGroup = "notebook" | "handwriting" | "grid";
+
+export type PaperSheet = {
+  /** The route under /printables, and the head term it is written to answer. */
+  slug: string;
+  /** How it is listed on the hub. */
+  name: string;
+  /** How it is labelled in the row of every ruling. A few characters. */
+  short: string;
+  /** The page's `<h1>`. */
+  heading: string;
+  /** The query this page exists to answer, in the words a parent types. */
+  keyword: string;
+  /** One sentence of what the paper is. Used in the description and the hub. */
+  summary: string;
+  /** The lead paragraph: the geometry, stated plainly. */
+  lead: string;
+  /** Two things that are true of this ruling and not of the one beside it. */
+  notes: string[];
+  /** For the `LearningResource` block. */
+  teaches: string;
+  ages: string;
+  group: PaperGroup;
+  rule: Rule;
+};
+
+export type Stock = {
+  id: PaperSize;
+  label: string;
+  /** The dimensions, said the way that stock's users say them. */
+  size: string;
+  /** The path segment under the slug. Empty for the default. */
+  path: string;
+};
+
+/**
+ * Letter first because most of the audience is American, and A4 second because
+ * the rest of it is not — a sheet whose last rule falls off the bottom of the
+ * page is worse than no sheet at all (§4).
+ */
+export const STOCKS: Stock[] = [
+  { id: "letter", label: "US Letter", size: "8.5 × 11 inches", path: "" },
+  { id: "a4", label: "A4", size: "210 × 297 mm", path: "a4" },
+];
+
+export const PAPER_SHEETS: PaperSheet[] = [
+  {
+    slug: "lined-paper",
+    name: "Lined paper — wide ruled",
+    short: "Wide ruled",
+    heading: "Lined paper, wide ruled",
+    keyword: "Free printable lined paper, wide ruled",
+    summary:
+      "Wide ruled lined paper: rules 11/32 of an inch apart, with a margin line an inch and a quarter from the edge.",
+    lead: "The paper a school notebook is printed on. Rules eleven thirty-seconds of an inch apart, and a margin line an inch and a quarter in from the left, exactly where the pad has it.",
+    notes: [
+      "Wide ruled is the default in American classrooms up to about eleven, and it is the one to print if you are not sure which you were asked for. The sixteenth of an inch it has over college ruled is the difference between handwriting that fits between the lines and handwriting that is squeezed into them.",
+      "The margin line is not decoration — it is where the date, the question number and a teacher's tick go. Keeping it at the same 1¼ inches as a notebook means a page printed here and a page torn out of the pad sit in the same folder without looking like two different things.",
+    ],
+    teaches: "Handwriting and note taking",
+    ages: "Ages 6–11",
+    group: "notebook",
+    rule: { style: "wide" },
+  },
+  {
+    slug: "college-ruled-paper",
+    name: "College ruled paper",
+    short: "College ruled",
+    heading: "College ruled paper",
+    keyword: "Free printable college ruled paper",
+    summary:
+      "College ruled paper: rules 9/32 of an inch apart, with the same 1¼-inch margin line.",
+    lead: "The narrower of the two notebook rules — nine thirty-seconds of an inch — with the same margin line as wide ruled and about four more lines on the page.",
+    notes: [
+      "College ruled is what secondary-school and university notebooks are printed at, and what a teacher usually means by “lined paper” from around Year 6 upwards. More words to a page is the whole of the difference.",
+      "If handwriting is still growing into the line, print the wide ruled sheet instead. Narrow rules do not make writing neater; they make a child write smaller than they can control, which is the opposite of the thing being practised.",
+    ],
+    teaches: "Note taking",
+    ages: "Ages 11+",
+    group: "notebook",
+    rule: { style: "college" },
+  },
+  {
+    slug: "narrow-ruled-paper",
+    name: "Narrow ruled paper",
+    short: "Narrow ruled",
+    heading: "Narrow ruled paper",
+    keyword: "Free printable narrow ruled paper",
+    summary:
+      "Narrow ruled paper: quarter-inch rules, and no margin line at all.",
+    lead: "A quarter of an inch between the rules and no margin line — the tightest of the notebook rules, and the most words on a page.",
+    notes: [
+      "Narrow ruled is a fair-copy paper rather than a practice one: lists, indexes, a page of notes meant to be kept. Very little classroom writing is set at this size.",
+      "No margin line, deliberately. At a quarter of an inch there is not much page left to give away, and this is the ruling people print when they want all of it.",
+    ],
+    teaches: "Note taking",
+    ages: "Ages 12+",
+    group: "notebook",
+    rule: { style: "narrow" },
+  },
+  {
+    slug: "handwriting-paper",
+    name: "Handwriting paper — ⅝ inch",
+    short: "⅝ inch",
+    heading: "Handwriting paper, ⅝ inch",
+    keyword: "Free printable handwriting paper, ⅝ inch",
+    summary:
+      "Handwriting paper ruled at ⅝ of an inch: top line, dashed midline, baseline, and room below for descenders.",
+    lead: "Three lines to a set — a top line to reach, a dashed midline for the body of a letter, and a baseline to sit on — repeating every ⅝ of an inch, with the space below it that a g, a y and a p need.",
+    notes: [
+      "⅝ is the commonest primary size and the one a school most often means by “handwriting paper”. It is where most children are by the middle of Year 1 and where they stay for a year or two.",
+      "The midline is dashed rather than solid on purpose. A solid line invites a child to write on it; a dashed one tells them how tall an x is and then gets out of the way, which is the step between copying a letter and writing one.",
+    ],
+    teaches: "Handwriting",
+    ages: "Ages 6–8",
+    group: "handwriting",
+    rule: { style: "hand-5-8", midline: "dashed", descender: true },
+  },
+  {
+    slug: "kindergarten-writing-paper",
+    name: "Kindergarten writing paper — 1 inch",
+    short: "1 inch",
+    heading: "Kindergarten writing paper, 1 inch",
+    keyword: "Free printable kindergarten writing paper",
+    summary:
+      "Inch-high handwriting sets with a solid midline and room for descenders — the largest ruling there is.",
+    lead: "The biggest ruling on the shelf: a full inch from one set of lines to the next, with a solid midline through the middle of it and space underneath for the tail of a letter.",
+    notes: [
+      "A solid midline rather than a dashed one, because a four-year-old is aiming at a line rather than reading a hint. The dashes come later, and every other handwriting sheet here has them.",
+      "An inch looks enormous next to a notebook, and that is the point — a child whose fine motor control is still arriving writes large, and paper that asks them to write small teaches them that handwriting is something they are bad at.",
+    ],
+    teaches: "Letter formation",
+    ages: "Ages 4–6",
+    group: "handwriting",
+    rule: { style: "hand-1", midline: "solid", descender: true },
+  },
+  {
+    slug: "handwriting-paper-3-4-inch",
+    name: "Handwriting paper — ¾ inch",
+    short: "¾ inch",
+    heading: "Handwriting paper, ¾ inch",
+    keyword: "Free printable handwriting paper, ¾ inch",
+    summary:
+      "Handwriting paper ruled at ¾ of an inch: dashed midline, and room for descenders.",
+    lead: "Three quarters of an inch to a set, with a dashed midline and descender space — the step between inch-high kindergarten paper and the ⅝ most of Year 1 is written on.",
+    notes: [
+      "This is the size a lot of schools spend the first term of Year 1 on. It is worth printing a page of it before dropping to ⅝: if letters are still hitting the top line, the paper is not the problem yet.",
+      "Everything else about it matches the ⅝ sheet — same three lines, same dashed midline, same tail space — so moving down a size changes one thing at a time.",
+    ],
+    teaches: "Handwriting",
+    ages: "Ages 5–7",
+    group: "handwriting",
+    rule: { style: "hand-3-4", midline: "dashed", descender: true },
+  },
+  {
+    slug: "handwriting-paper-1-2-inch",
+    name: "Handwriting paper — ½ inch",
+    short: "½ inch",
+    heading: "Handwriting paper, ½ inch",
+    keyword: "Free printable handwriting paper, ½ inch",
+    summary:
+      "Handwriting paper ruled at half an inch: dashed midline, and room for descenders.",
+    lead: "Half an inch to a set, dashed midline, descender space — the ruling most of Years 2 and 3 write on once letters are formed and the work is getting longer.",
+    notes: [
+      "Half an inch is where handwriting paper stops being about forming letters and starts being about writing a paragraph without the page running out. Same three lines; less of a gap between them.",
+      "If a child is copying spellings or a short passage, this is usually the right size: small enough that a sentence fits on a line, large enough that the midline still means something.",
+    ],
+    teaches: "Handwriting",
+    ages: "Ages 7–9",
+    group: "handwriting",
+    rule: { style: "hand-1-2", midline: "dashed", descender: true },
+  },
+  {
+    slug: "handwriting-paper-3-8-inch",
+    name: "Handwriting paper — ⅜ inch",
+    short: "⅜ inch",
+    heading: "Handwriting paper, ⅜ inch",
+    keyword: "Free printable handwriting paper, ⅜ inch",
+    summary:
+      "Transitional handwriting paper at ⅜ of an inch: top line and baseline, no midline.",
+    lead: "Three eighths of an inch, with a top line and a baseline and nothing in between — the transitional ruling that gets a child from handwriting paper onto ordinary lined paper.",
+    notes: [
+      "No midline, deliberately. By this size a child knows how tall a letter is, and the sheet stops telling them; what is left is a pair of lines to keep the writing straight, which is all a notebook gives you.",
+      "It is the last ruling before wide ruled, and printing both together is a fair way to see whether someone is ready — the same sentence written on each, side by side.",
+    ],
+    teaches: "Handwriting",
+    ages: "Ages 8–10",
+    group: "handwriting",
+    rule: { style: "hand-3-8", midline: "none" },
+  },
+  {
+    slug: "graph-paper",
+    name: "Graph paper — ¼ inch",
+    short: "Graph",
+    heading: "Graph paper, ¼ inch",
+    keyword: "Free printable graph paper, ¼ inch squares",
+    summary: "Quarter-inch squared graph paper, ruled edge to edge.",
+    lead: "Quarter-inch squares, ruled in both directions across the whole writing area — the squared paper that maths homework is set on.",
+    notes: [
+      "Squared paper is worth printing for long multiplication and long division long before anyone plots a graph on it: one digit to a square is what keeps the columns lined up, and a column that drifts is most of what goes wrong in a long sum.",
+      "The lines are drawn as hairlines rather than as a printed background, so they come out of the printer as light as they look here and do not compete with a pencil.",
+    ],
+    teaches: "Arithmetic layout and graphing",
+    ages: "Ages 7+",
+    group: "grid",
+    rule: { style: "graph" },
+  },
+  {
+    slug: "dot-grid-paper",
+    name: "Dot grid paper",
+    short: "Dots",
+    heading: "Dot grid paper, ¼ inch",
+    keyword: "Free printable dot grid paper",
+    summary: "Quarter-inch dot grid — the squares implied rather than drawn.",
+    lead: "A quarter-inch grid with only the corners printed. The structure of squared paper without the lines through the middle of the work.",
+    notes: [
+      "Dots are the right paper for drawing shapes, arrays and number lines: there is something to measure against, but nothing crossing what has been drawn.",
+      "It is also the usual paper for bullet journals and hand-drawn plans, which is why a page of it is worth having in the printer tray whatever age is using it.",
+    ],
+    teaches: "Shapes, arrays and sketching",
+    ages: "Ages 7+",
+    group: "grid",
+    rule: { style: "dot" },
+  },
+  {
+    slug: "isometric-graph-paper",
+    name: "Isometric graph paper",
+    short: "Isometric",
+    heading: "Isometric graph paper, ¼ inch",
+    keyword: "Free printable isometric graph paper",
+    summary:
+      "Quarter-inch triangular grid at 30° — the paper three-dimensional drawing is done on.",
+    lead: "A triangular grid rather than a square one: three families of lines at sixty degrees to each other, a quarter of an inch to a side.",
+    notes: [
+      "Isometric paper is what cubes, nets and three-dimensional shapes are drawn on. The grid does the perspective, so a child can draw a solid that looks right without being taught to draw.",
+      "The rows are spaced by the height of the triangle rather than by its side, which is what makes the grid genuinely thirty degrees instead of a squashed approximation of it.",
+    ],
+    teaches: "Three-dimensional shapes and nets",
+    ages: "Ages 9+",
+    group: "grid",
+    rule: { style: "isometric" },
+  },
+];
+
+/** What each group is called on the hub, in the order they are listed. */
+export const GROUPS: Array<{ id: PaperGroup; label: string; blurb: string }> = [
+  {
+    id: "notebook",
+    label: "Lined paper",
+    blurb: "One rule to a line, the way a notebook is printed.",
+  },
+  {
+    id: "handwriting",
+    label: "Handwriting paper",
+    blurb:
+      "Three lines to a set, in the five sizes a primary school works through.",
+  },
+  {
+    id: "grid",
+    label: "Squares, dots and triangles",
+    blurb: "Paper that repeats across the page as well as down it.",
+  },
+];
+
+/** The route a sheet prints at, on a given stock. */
+export function pathFor(sheet: PaperSheet, stock: Stock): string {
+  return stock.path ? `${sheet.slug}/${stock.path}` : sheet.slug;
+}
+
+/**
+ * The shelf, grouped — the shape both the hub and a sheet page list it in.
+ *
+ * Written once because the two would otherwise have to be kept in step by
+ * hand, and the failure would be silent: a ruling added here and shown on one
+ * page but not the other still builds, still deploys, and still looks right.
+ */
+export function shelf(): Array<{
+  id: PaperGroup;
+  label: string;
+  blurb: string;
+  sheets: PaperSheet[];
+}> {
+  return GROUPS.map((group) => ({
+    ...group,
+    sheets: PAPER_SHEETS.filter((sheet) => sheet.group === group.id),
+  }));
+}
+
+/**
+ * The config the page builds its sheet from.
+ *
+ * No title on the paper: a page of lined paper with the word "Lined paper"
+ * printed at the top of it is a worse sheet of lined paper. What it does carry
+ * is the name and date line — printed blank, always, because that is the one
+ * field this site refuses to hold (§1).
+ */
+export function paperConfig(sheet: PaperSheet, size: PaperSize): PaperConfig {
+  return {
+    kind: "paper",
+    paper: { size, orientation: "portrait", margin: "normal" },
+    fontPt: DEFAULT_FONT_PT,
+    fields: ["name", "date"],
+    rule: sheet.rule,
+  };
+}

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { STOCKS, pathFor, shelf } from "./_catalog";
 
 /**
  * The Print Shop's front door.
@@ -11,15 +12,19 @@ import Content from "@/layouts/Content.astro";
  * is the largest crawlable surface this site will ever have, and the sitemap
  * filter used to be keyed on the field that would have deleted it.
  *
- * It stays a page of prose until the sheet families land (PRINT04 onwards),
- * because a catalog page here is meant to BE the worksheet — real prerendered
- * HTML a parent can print without touching anything — and a shelf of
- * placeholder links to sheets that don't exist is the thin-content pattern
- * Base.astro's `noindex` block already argues against.
+ * It lists what exists and nothing else. A shelf of links to sheets that
+ * haven't been built is the thin-content pattern Base.astro's `noindex` block
+ * already argues against, and a catalog page here is meant to BE the worksheet
+ * — real prerendered HTML a parent can print without touching anything. The
+ * first family fills it: every ruling in §5, on both stocks.
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
   "Practice sheets you can print at home, free and without an account. Every sheet is an ordinary web page, so printing it needs no download, no reader and no sign-up — and nothing about your child goes into the file.";
+
+/** Listed on the default stock; each sheet page carries the link to its twin. */
+const letter = STOCKS[0];
+const groups = shelf();
 ---
 
 <Content
@@ -43,12 +48,51 @@ const description =
     </p>
     <h1 class="hero__title">Paper, when the screen has had enough</h1>
     <p class="hero__lead">
-      The one corner of School Skills built for the grown-up. Pick a sheet, set
-      it how you want it, and print it &mdash; free, with an answer key, and
-      with your child&rsquo;s name left blank for them to fill in by hand.
+      The one corner of School Skills built for the grown-up. Open a sheet,
+      press print, and that is the whole of it &mdash; free, nothing to
+      download, and your child&rsquo;s name left blank for them to fill in by
+      hand.
     </p>
     <p class="hero__note">Free &middot; no account &middot; no download</p>
   </header>
+
+  {
+    /*
+      What exists, first — before the page explains itself. Somebody who
+      arrived looking for lined paper should be one link from lined paper,
+      and the argument for why a worksheet here is a web page reads better
+      after you have seen one than before.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">On the shelf now</h2>
+    <p class="h2__sub">
+      Paper, in every ruling. Each of these is a page that is itself the sheet
+      &mdash; open it, press print, and that is the whole of it. Every one comes
+      on both stocks, because a ruling shrunk to fit the paper in the tray is no
+      longer the ruling you chose.
+    </p>
+    {
+      groups.map((group) => (
+        <>
+          <h3 class="h2 h2--next">{group.label}</h3>
+          <p class="h2__sub">{group.blurb}</p>
+          <div class="prose">
+            <ul>
+              {group.sheets.map((sheet) => (
+                <li>
+                  <a href={`/printables/${pathFor(sheet, letter)}`}>
+                    {sheet.name}
+                  </a>{" "}
+                  &mdash; {sheet.summary}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      ))
+    }
+  </section>
 
   <section class="band band--tight wrap">
     <h2 class="h2">A worksheet here is a web page</h2>
@@ -76,17 +120,16 @@ const description =
       <h2 class="h2">What the press is being set for</h2>
       <p class="h2__sub">
         The Print Shop is opening a family at a time, and this page lists what
-        exists rather than what is planned. Right now that is the shop itself
-        &mdash; the paper, the rulings and the print path &mdash; with the first
-        sheets next.
+        exists rather than what is planned. Paper is open. What is on it is
+        next.
       </p>
       <div class="prose">
         <p>
-          The order it opens in: lined, graph and handwriting paper in every
-          ruling, then the maths sheets with their answer keys, then handwriting
-          and copywork &mdash; passages from the public domain, Scripture among
-          them &mdash; then spelling, phonics, and the charts, certificates and
-          planners that are simply blank forms.
+          The order it opens in: the paper above, then the maths sheets with
+          their answer keys, then handwriting and copywork &mdash; passages from
+          the public domain, Scripture among them &mdash; then spelling,
+          phonics, and the charts, certificates and planners that are simply
+          blank forms.
         </p>
         <p>
           The one it is really being built for comes with the sheet builder:

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -17,11 +17,17 @@
 
    It buys no more than that. `@page` cannot be scoped to a class, so on a page
    that is *both* — the catalog pages of §8 are an h1, two or three paragraphs
-   and then a sheet — the zeroed margin applies to the prose as well. Open for
-   PRINT03, when those routes are built: either the prose is `display: none`
-   under `@media print` (printing a catalog page means printing the sheet on
-   it), or the article gets its own print padding to stand in for the page
-   margin this rule takes away. It cannot be solved here.                    */
+   and then a sheet — the zeroed margin applies to the prose as well, which
+   would print the article off the edge of the paper.
+
+   **Settled by the catalog pages: the prose is hidden.** Every section of a
+   `/printables/*` page except the sheet carries `.no-print`, so ⌘P produces
+   the paper and only the paper. That is the right way round rather than the
+   convenient one — such a page IS the sheet (§8), a parent pressing print
+   wants the ruling rather than the article about it, and the alternative
+   (giving the article its own print padding to stand in for the page margin)
+   spends toner on a page nobody asked for. It also means the zeroed `@page`
+   never applies to anything but a sheet, which is what it was written for.  */
 
 /* Letter portrait, no margin — the sheet owns its own geometry, so screen and
    paper agree exactly. A sheet on any other stock emits its own `@page` (see

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -75,6 +75,34 @@
   }
 }
 
+/* ── The frame a sheet is looked at in ──────────────────────────────────────
+   A sheet is 8.5 inches wide and does not negotiate — that is the whole of
+   §4 — and 8.5 inches is wider than a phone. Left in the flow it makes the
+   document itself scroll sideways, which is the one layout failure a reader
+   can't work around.
+
+   So the page that shows a sheet puts it in this: the overflow belongs to the
+   frame, and a reader on a phone drags the paper rather than the article. It
+   lives here rather than in content.css because it arrives with the renderer,
+   the same as everything else in this file — the builder's preview will want
+   the identical frame and must not have to remember to ask for it.
+
+   Print takes it all back off. `overflow` on an ancestor of the page box is
+   another way to lose the bottom of a sheet, and the padding would offset the
+   very geometry the sheet exists to hold. */
+.sheet-frame {
+  overflow: auto;
+  padding-block: 1rem 2.5rem;
+  padding-inline: 1rem;
+}
+
+@media print {
+  .sheet-frame {
+    overflow: visible;
+    padding: 0;
+  }
+}
+
 /* ── Chrome ─────────────────────────────────────────────────────────────── */
 
 .sheet__head {


### PR DESCRIPTION
## What

The Print Shop's first sheet family. `templates/paper` rules lined, handwriting, graph, dot-grid and isometric paper, and eleven curated slugs × two paper stocks turn it into twenty-two prerendered pages under `/printables/`.

Closes #48.

## Why this shape

**The page is the printout.** A parent who lands on `/printables/lined-paper` from a search presses ⌘P and gets wide ruled paper — no builder, no options UI, nothing to click. That is the whole story, and it dictates the rest:

- Everything that is not the sheet carries `.no-print`. `@page` cannot be scoped to a class, so on a page that is both prose and paper, the zeroed page margin applies to the article too. Hiding the prose is the correct way round rather than the convenient one: such a page *is* the sheet, and someone reaching for the printer wants the ruling, not the piece about it. A test now enforces the contract instead of leaving it to memory — every section, header and wrap on a sheet page must carry the class.
- **Two stocks, two routes.** A sheet is only correct on the paper it was measured for; sent to a printer loaded with something else the browser shrinks the page, and a shrunk ⅝" rule is not a ⅝" rule. `@page` is a document rule, so Letter and A4 cannot share one — hence `/printables/lined-paper` and `/printables/lined-paper/a4`.
- **Eleven slugs, not a permutation farm.** Each names something a parent actually searches for and carries a note true of that ruling and no other.

**Geometry that can be wrong.** Capacity is `ruleCapacity` over what the chrome leaves, and the chrome is counted from what the header actually holds rather than from a constant — a page with a name line and no title is two more lines to write on at ⅝, which a child notices and an adult doesn't. The mil-to-inch correspondence the physical-measurement claim rests on is asserted directly: the `<svg>` is sized in inches, its viewBox counts mil, so a 625-unit gap prints at ⅝. Change either and the printed rule is off by a factor of a thousand while every other test stays green.

**The midline options are demonstrated, not described.** Kindergarten paper is ruled solid because a four-year-old is aiming at a line; ⅜" transitional paper has no midline at all; the five sizes between are dashed with descender room.

## Notes

- `.sheet-frame` lands in `sheet.css`, not `content.css` — a sheet is 8.5in wide and does not negotiate, which is wider than a phone, so the overflow belongs to a frame that arrives with the renderer. The builder's preview will want the identical one. Print takes it back off.
- `chrome()` previously charged the name line as one row however many fields it was given; three are legal but do not fit across a Letter page, and the row they wrapped onto was a rule line below the bottom margin — a blank second sheet. Rows are now counted from the width the fields have to fill.
- Two numbers derived instead of typed: the shelf count on a sheet page reads `PAPER_SHEETS.length`, and college ruled gives six more lines than wide ruled.

## Verification

`type-check`, `lint`, `test:unit` (268 passing), `build` (static, 45 pages, sitemap guard clean) and the browser smoke test all pass locally. Print output verified as PDF: one page, 612×792pt on Letter and 595×842pt on A4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
