### PR TITLE
Sums that can be marked

### DIFF
--- a/src/components/sheet/NumberLine.tsx
+++ b/src/components/sheet/NumberLine.tsx
@@ -11,34 +11,38 @@
  * happens here is the scaling from the numbers on the line to the mil the
  * viewBox counts in.
  */
-import { NUMBER_LINE_HEIGHT, ticks } from "@/engine/sheets/numberline";
+import {
+  LABEL_SIZE,
+  LINE_INSET,
+  NUMBER_LINE_HEIGHT,
+  ticks,
+} from "@/engine/sheets/numberline";
 import type { NumberLine } from "@/engine/sheets/types";
 
 import { RULE, inch } from "./units";
 
 /**
- * Room at each end for the outermost label, which is centred on its tick and
- * would otherwise be cut in half by the edge of the drawing. Enough for three
- * digits at the size below.
+ * The inset at each end and the size of a label come from the engine, not from
+ * here: they are two of the three numbers it chose the tick spacing with, and
+ * a second copy of either would be a line whose labels overlap on paper while
+ * the engine's own test says they cannot.
  */
-const INSET = 140;
 
 /** The axis, and how far the ticks stand out either side of it. */
 const AXIS = 120;
 const TICK = 32;
 
-/** The labels: their baseline, and the size they are set at (about 9pt). */
+/** The labels' baseline. */
 const LABEL = 290;
-const LABEL_SIZE = 125;
 
 export function NumberLineView({ line }: { line: NumberLine }) {
   const marks = ticks(line);
   const span = line.to - line.from;
   if (marks.length < 2 || span <= 0 || line.width <= 0) return null;
 
-  const usable = Math.max(0, line.width - INSET * 2);
+  const usable = Math.max(0, line.width - LINE_INSET * 2);
   const at = (value: number) =>
-    Math.round(INSET + ((value - line.from) / span) * usable);
+    Math.round(LINE_INSET + ((value - line.from) / span) * usable);
 
   return (
     <svg
@@ -54,8 +58,8 @@ export function NumberLineView({ line }: { line: NumberLine }) {
 
       <line
         className="sheet__rule sheet__rule--axis"
-        x1={INSET}
-        x2={line.width - INSET}
+        x1={LINE_INSET}
+        x2={line.width - LINE_INSET}
         y1={AXIS}
         y2={AXIS}
         strokeWidth={RULE}

--- a/src/components/sheet/NumberLine.tsx
+++ b/src/components/sheet/NumberLine.tsx
@@ -1,0 +1,86 @@
+/**
+ * A number line, as strokes.
+ *
+ * Drawn under a problem so a child can count along it, which is how addition
+ * starts before it is a fact: 6 + 3 is six hops and then three more. Strokes
+ * rather than a background for the same reason every ruled thing on a sheet is
+ * (§5) — browsers drop background paint when printing, and a counting aid that
+ * comes out of the printer blank is worse than none.
+ *
+ * Where the ticks go is the engine's answer, not this component's. All that
+ * happens here is the scaling from the numbers on the line to the mil the
+ * viewBox counts in.
+ */
+import { NUMBER_LINE_HEIGHT, ticks } from "@/engine/sheets/numberline";
+import type { NumberLine } from "@/engine/sheets/types";
+
+import { RULE, inch } from "./units";
+
+/**
+ * Room at each end for the outermost label, which is centred on its tick and
+ * would otherwise be cut in half by the edge of the drawing. Enough for three
+ * digits at the size below.
+ */
+const INSET = 140;
+
+/** The axis, and how far the ticks stand out either side of it. */
+const AXIS = 120;
+const TICK = 32;
+
+/** The labels: their baseline, and the size they are set at (about 9pt). */
+const LABEL = 290;
+const LABEL_SIZE = 125;
+
+export function NumberLineView({ line }: { line: NumberLine }) {
+  const marks = ticks(line);
+  const span = line.to - line.from;
+  if (marks.length < 2 || span <= 0 || line.width <= 0) return null;
+
+  const usable = Math.max(0, line.width - INSET * 2);
+  const at = (value: number) =>
+    Math.round(INSET + ((value - line.from) / span) * usable);
+
+  return (
+    <svg
+      className="sheet__ink sheet__number-line"
+      width={inch(line.width)}
+      height={inch(NUMBER_LINE_HEIGHT)}
+      viewBox={`0 0 ${line.width} ${NUMBER_LINE_HEIGHT}`}
+    >
+      {/* Named rather than `role="img"` + `aria-label`, the same call `Grid`
+          makes: the numbers along it are readable content, and collapsing
+          them into one sentence would throw them away. */}
+      <title>{`Number line from ${line.from} to ${line.to}`}</title>
+
+      <line
+        className="sheet__rule sheet__rule--axis"
+        x1={INSET}
+        x2={line.width - INSET}
+        y1={AXIS}
+        y2={AXIS}
+        strokeWidth={RULE}
+      />
+      {marks.map((value) => (
+        <g key={value}>
+          <line
+            className="sheet__rule"
+            x1={at(value)}
+            x2={at(value)}
+            y1={AXIS - TICK}
+            y2={AXIS + TICK}
+            strokeWidth={RULE}
+          />
+          <text
+            className="sheet__tick"
+            x={at(value)}
+            y={LABEL}
+            fontSize={LABEL_SIZE}
+            textAnchor="middle"
+          >
+            {value}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -5,8 +5,16 @@ import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { answerKey, buildSheet } from "@/engine/sheets";
+import { ticks } from "@/engine/sheets/numberline";
 import { DEFAULT_PAPER } from "@/engine/sheets/paper";
-import type { Block, Paper, Sheet } from "@/engine/sheets/types";
+import type {
+  ArithmeticConfig,
+  Block,
+  Paper,
+  Problem,
+  Sheet,
+} from "@/engine/sheets/types";
 
 import { SheetView } from "./Sheet";
 
@@ -278,6 +286,167 @@ describe("rendering a sheet", () => {
       "7.268",
       7268,
     );
+  });
+});
+
+/* ── The answer key, as a parent receives it ───────────────────────────────
+   The engine's suite proves the answers are right and stops at the edge of the
+   markup — "the renderer's rule, stated here as the engine's half of it". This
+   is the other half, and it is the half a parent actually holds: a key whose
+   answers are correct and printed into a blank built for one of them is still
+   a bad sheet. The sheets below are built through the real family rather than
+   hand-written, so a shape the engine starts producing is a shape these see. */
+
+const arithmetic = (
+  over: Partial<ArithmeticConfig> = {},
+): ArithmeticConfig => ({
+  kind: "arithmetic",
+  paper: DEFAULT_PAPER,
+  fontPt: 12,
+  fields: ["name"],
+  operation: "add",
+  style: "standard",
+  form: "horizontal",
+  range: { min: 1, max: 20 },
+  count: 6,
+  columns: 2,
+  regrouping: "either",
+  ...over,
+});
+
+const SEED = 7;
+
+const blank = (over: Partial<ArithmeticConfig> = {}) =>
+  render(buildSheet(arithmetic(over), SEED) as Sheet);
+const keyed = (over: Partial<ArithmeticConfig> = {}) =>
+  render(answerKey(arithmetic(over), SEED) as Sheet);
+
+/** The problems of a built sheet, narrowed out of the block union. */
+function itemsOf(over: Partial<ArithmeticConfig> = {}): Problem[] {
+  const block = buildSheet(arithmetic(over), SEED).blocks[0];
+  if (block.kind !== "problems") throw new Error(`got ${block.kind}`);
+  return block.items;
+}
+
+/** The markup of each problem, one string per `<li>`. */
+const problems = (html: string): string[] =>
+  html.split('<li class="sheet__problem"').slice(1);
+
+const count = (html: string, needle: string): number =>
+  html.split(needle).length - 1;
+
+describe("a rendered arithmetic sheet", () => {
+  /** Every shape the family prints, as the renderer sees them. */
+  const SHAPES: Array<Partial<ArithmeticConfig>> = [
+    {},
+    { style: "missing" },
+    { form: "vertical" },
+    { style: "fact-family", count: 4 },
+    { numberLine: true },
+    { workspace: true },
+  ];
+
+  it("gives every problem exactly one place to write the answer", () => {
+    // The rule `Problems.tsx` is built around, and the one a sheet is unusable
+    // without: a child handed a ruled blank *and* four ruled lines has been
+    // asked the same question twice and does not know which one counts.
+    for (const shape of SHAPES) {
+      for (const html of [blank(shape), keyed(shape)]) {
+        const items = problems(html);
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+          const places =
+            count(item, 'class="sheet__slot') +
+            count(item, 'class="sheet__total') +
+            count(item, 'class="sheet__answers"');
+          expect(places, `${JSON.stringify(shape)}: ${item}`).toBe(1);
+        }
+      }
+    }
+  });
+
+  it("splices a missing number into the sentence, not onto the end of it", () => {
+    const [item] = problems(keyed({ style: "missing" }));
+    const prompt = item.indexOf('<span class="sheet__prompt">');
+    const slot = item.indexOf('<span class="sheet__slot');
+    expect(prompt).toBeGreaterThanOrEqual(0);
+    expect(slot).toBeGreaterThan(prompt);
+    // Nothing closes the prompt before the slot opens, which is the whole
+    // difference between "7 + _ = 15" and "7 + _ = 15 ____".
+    expect(item.slice(prompt, slot)).not.toContain("</span>");
+    // And the ordinary shape does put it after — otherwise the check above
+    // would pass on markup that had lost the distinction entirely.
+    const [plain] = problems(keyed());
+    expect(
+      plain.slice(
+        plain.indexOf('<span class="sheet__prompt">'),
+        plain.indexOf('<span class="sheet__slot'),
+      ),
+    ).toContain("</span>");
+  });
+
+  it("stacks a column sum with its sign and rules the total", () => {
+    const [item] = problems(keyed({ form: "vertical" }));
+    expect(count(item, 'class="sheet__addend"')).toBe(2);
+    expect(item).toContain('class="sheet__operator"');
+    expect(item).toMatch(/class="sheet__total sheet__total--answered">\d+</);
+  });
+
+  it("draws a number line under every problem, ticks and labels included", () => {
+    const items = itemsOf({ numberLine: true });
+    const line = items[0].line;
+    if (!line) throw new Error("no number line was built");
+
+    const html = blank({ numberLine: true });
+    expect(count(html, 'class="sheet__ink sheet__number-line"')).toBe(
+      items.length,
+    );
+    expect(count(html, 'class="sheet__tick"')).toBe(
+      ticks(line).length * items.length,
+    );
+  });
+
+  it("rules a line for each of a fact family's four sentences", () => {
+    const family = { style: "fact-family" as const, count: 4 };
+    const written = itemsOf(family).flatMap((problem) => problem.answers ?? []);
+    expect(written.length).toBe(16);
+
+    const sheet = blank(family);
+    expect(count(sheet, 'class="sheet__answer-line"')).toBe(written.length);
+    // Each line carries a share of the height the family reserved, so the row
+    // is as tall as the layout arithmetic said it was.
+    expect(sheet).toContain("height:0.25in");
+
+    const key = keyed(family);
+    for (const sentence of written) {
+      expect(sheet).not.toContain(sentence);
+      expect(key).toContain(sentence);
+    }
+  });
+
+  it("prints nothing in any answer place until the sheet is a key", () => {
+    // Read off the answer places themselves rather than by hunting the answer
+    // strings in the page: "15" is the answer to one problem and half the
+    // prompt of another, and a test that searched for it would fail on a sheet
+    // that was perfectly blank.
+    const PLACES = [
+      /<span class="sheet__slot"[^>]*>(.*?)<\/span>/g,
+      /<span class="sheet__total"[^>]*>(.*?)<\/span>/g,
+      /<span class="sheet__answer-line"[^>]*>(.*?)<\/span>/g,
+    ];
+    for (const shape of SHAPES) {
+      const html = blank(shape);
+      const where = JSON.stringify(shape);
+      expect(html, where).not.toContain("--answered");
+      let found = 0;
+      for (const place of PLACES) {
+        for (const [, inside] of html.matchAll(place)) {
+          expect(inside, where).toBe("");
+          found += 1;
+        }
+      }
+      expect(found, where).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -43,6 +43,16 @@ const EVERY_BLOCK: Block[] = [
     items: [
       { prompt: "7 × 8 =", answer: "56", factId: "7:8" },
       { prompt: "6 × 9 =", answer: "54", workspace: 500 },
+      // The three shapes a problem takes: written along a line, written with
+      // the gap inside the sentence, and stacked in columns.
+      { prompt: "7 + _ = 15", answer: "8", factId: "7:8" },
+      {
+        prompt: "",
+        operands: ["47", "28"],
+        operator: "+",
+        answer: "75",
+        line: { from: 0, to: 20, step: 2, width: 2400 },
+      },
     ],
   },
   { kind: "rules", rule: { style: "hand-5-8", descender: true }, lines: 6 },

--- a/src/components/sheet/blocks/Problems.tsx
+++ b/src/components/sheet/blocks/Problems.tsx
@@ -1,5 +1,8 @@
 import type { CSSProperties } from "react";
 
+import type { Problem } from "@/engine/sheets/types";
+
+import { NumberLineView } from "../NumberLine";
 import { inch } from "../units";
 import type { BlockProps } from "./block";
 
@@ -14,6 +17,12 @@ import type { BlockProps } from "./block";
  *
  * The answer prints when the sheet says so and is blank when it doesn't. Both
  * come from the same build, so a key cannot disagree with its sheet (§7).
+ *
+ * **This is the shared primitive.** Every maths family prints through it
+ * rather than adding a block of its own, so the three shapes below are the
+ * three shapes an arithmetic problem takes and not three families' worth of
+ * markup: written along a line, written along a line with the gap inside it,
+ * or stacked in columns the way a sum is worked.
  */
 export function Problems({ block, metrics }: BlockProps<"problems">) {
   const columns = Math.max(1, Math.floor(block.columns));
@@ -30,14 +39,12 @@ export function Problems({ block, metrics }: BlockProps<"problems">) {
               child is told to "do 4, 7 and 12 of" has to carry its number as
               text anyway. */}
           <span className="sheet__number">{index + 1}.</span>
-          <span className="sheet__prompt">{problem.prompt}</span>
-          <span
-            className={`sheet__slot${
-              metrics.answers ? " sheet__slot--answered" : ""
-            }`}
-          >
-            {metrics.answers ? problem.answer : ""}
-          </span>
+          {problem.operands ? (
+            <Stacked problem={problem} answers={metrics.answers} />
+          ) : (
+            <Written problem={problem} answers={metrics.answers} />
+          )}
+          {problem.line && <NumberLineView line={problem.line} />}
           {problem.workspace !== undefined && (
             <span
               className="sheet__workspace"
@@ -48,5 +55,72 @@ export function Problems({ block, metrics }: BlockProps<"problems">) {
         </li>
       ))}
     </ol>
+  );
+}
+
+type Part = { problem: Problem; answers: boolean };
+
+/**
+ * A problem written along a line, with the answer wherever the prompt says.
+ *
+ * A single `_` in the prompt marks a gap inside the sentence — "7 + _ = 15" —
+ * and everything else takes a ruled slot at the end. One rule, so a problem
+ * can only ever have one place to write the answer: a missing-number sheet
+ * that also drew a slot on the end would be a sheet a child answers twice.
+ */
+function Written({ problem, answers }: Part) {
+  const gap = problem.prompt.indexOf("_");
+  if (gap < 0) {
+    return (
+      <>
+        <span className="sheet__prompt">{problem.prompt}</span>
+        <Slot answer={problem.answer} answers={answers} />
+      </>
+    );
+  }
+  return (
+    <span className="sheet__prompt">
+      {problem.prompt.slice(0, gap)}
+      <Slot answer={problem.answer} answers={answers} />
+      {problem.prompt.slice(gap + 1)}
+    </span>
+  );
+}
+
+/**
+ * The same sum, stacked: the numbers right-aligned under one another, the sign
+ * against the last of them, and a rule with the answer under it.
+ *
+ * Column form is not a style choice — it is how carrying is taught, and a
+ * child who has been shown to line the units up notices when they aren't. The
+ * digits sit in `tabular-nums` for that reason and no other.
+ */
+function Stacked({ problem, answers }: Part) {
+  const operands = problem.operands ?? [];
+  return (
+    <span className="sheet__column">
+      {operands.map((operand, index) => (
+        <span className="sheet__addend" key={`${index}-${operand}`}>
+          <span className="sheet__operator">
+            {index === operands.length - 1 ? problem.operator : ""}
+          </span>
+          <span>{operand}</span>
+        </span>
+      ))}
+      <span
+        className={`sheet__total${answers ? " sheet__total--answered" : ""}`}
+      >
+        {answers ? problem.answer : ""}
+      </span>
+    </span>
+  );
+}
+
+/** Where the answer goes: a ruled blank, or the answer the build computed. */
+function Slot({ answer, answers }: { answer: string; answers: boolean }) {
+  return (
+    <span className={`sheet__slot${answers ? " sheet__slot--answered" : ""}`}>
+      {answers ? answer : ""}
+    </span>
   );
 }

--- a/src/components/sheet/blocks/Problems.tsx
+++ b/src/components/sheet/blocks/Problems.tsx
@@ -19,10 +19,11 @@ import type { BlockProps } from "./block";
  * come from the same build, so a key cannot disagree with its sheet (§7).
  *
  * **This is the shared primitive.** Every maths family prints through it
- * rather than adding a block of its own, so the three shapes below are the
- * three shapes an arithmetic problem takes and not three families' worth of
- * markup: written along a line, written along a line with the gap inside it,
- * or stacked in columns the way a sum is worked.
+ * rather than adding a block of its own, so the shapes below are the shapes an
+ * arithmetic problem takes and not several families' worth of markup: written
+ * along a line, written along a line with the gap inside it, stacked in columns
+ * the way a sum is worked, or answered on ruled lines underneath when the
+ * answer is more than one sentence.
  */
 export function Problems({ block, metrics }: BlockProps<"problems">) {
   const columns = Math.max(1, Math.floor(block.columns));
@@ -45,13 +46,7 @@ export function Problems({ block, metrics }: BlockProps<"problems">) {
             <Written problem={problem} answers={metrics.answers} />
           )}
           {problem.line && <NumberLineView line={problem.line} />}
-          {problem.workspace !== undefined && (
-            <span
-              className="sheet__workspace"
-              style={{ height: inch(problem.workspace) }}
-              aria-hidden="true"
-            />
-          )}
+          <Below problem={problem} answers={metrics.answers} />
         </li>
       ))}
     </ol>
@@ -60,29 +55,82 @@ export function Problems({ block, metrics }: BlockProps<"problems">) {
 
 type Part = { problem: Problem; answers: boolean };
 
+/** Whether the answer is written on ruled lines under the problem. */
+const ruled = (problem: Problem): boolean => (problem.answers?.length ?? 0) > 0;
+
 /**
  * A problem written along a line, with the answer wherever the prompt says.
  *
  * A single `_` in the prompt marks a gap inside the sentence — "7 + _ = 15" —
- * and everything else takes a ruled slot at the end. One rule, so a problem
- * can only ever have one place to write the answer: a missing-number sheet
- * that also drew a slot on the end would be a sheet a child answers twice.
+ * and everything else takes a ruled slot at the end, unless the answer is
+ * already going on the lines below. One rule, so a problem can only ever have
+ * one place to write the answer: a missing-number sheet that also drew a slot
+ * on the end, or a fact family that drew one beside its four ruled lines, is a
+ * sheet a child answers twice.
  */
 function Written({ problem, answers }: Part) {
   const gap = problem.prompt.indexOf("_");
-  if (gap < 0) {
+  if (gap >= 0) {
     return (
-      <>
-        <span className="sheet__prompt">{problem.prompt}</span>
+      <span className="sheet__prompt">
+        {problem.prompt.slice(0, gap)}
         <Slot answer={problem.answer} answers={answers} />
-      </>
+        {problem.prompt.slice(gap + 1)}
+      </span>
     );
   }
   return (
-    <span className="sheet__prompt">
-      {problem.prompt.slice(0, gap)}
-      <Slot answer={problem.answer} answers={answers} />
-      {problem.prompt.slice(gap + 1)}
+    <>
+      <span className="sheet__prompt">{problem.prompt}</span>
+      {!ruled(problem) && <Slot answer={problem.answer} answers={answers} />}
+    </>
+  );
+}
+
+/**
+ * What sits under the problem: the lines its answer is written on, or blank
+ * paper to work the answer out in — never both, because they are the same
+ * paper. A problem whose answer is a list has already had its answer place
+ * counted, and `workspace` is the height those lines share.
+ */
+function Below({ problem, answers }: Part) {
+  if (ruled(problem)) return <Ruled problem={problem} answers={answers} />;
+  if (problem.workspace === undefined) return null;
+  return (
+    <span
+      className="sheet__workspace"
+      style={{ height: inch(problem.workspace) }}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * More than one answer to write, one ruled line each.
+ *
+ * A fact family asks for four number sentences, and the lines are where they
+ * go on both halves of the build: a rule to write on when the sheet is blank,
+ * the sentence itself when it is a key. They divide the height the family
+ * reserved rather than adding to it, which is what keeps the row as tall as
+ * the layout arithmetic declared — see `.sheet__answer-line` in sheet.css for
+ * the other half of that, which is why the sentences may not wrap.
+ */
+function Ruled({ problem, answers }: Part) {
+  const lines = problem.answers ?? [];
+  const height = problem.workspace
+    ? inch(problem.workspace / lines.length)
+    : undefined;
+  return (
+    <span className="sheet__answers">
+      {lines.map((line, index) => (
+        <span
+          className={`sheet__answer-line${answers ? " sheet__answer-line--answered" : ""}`}
+          key={`${index}-${line}`}
+          style={height ? { height } : undefined}
+        >
+          {answers ? line : ""}
+        </span>
+      ))}
     </span>
   );
 }

--- a/src/engine/sheets/chrome.ts
+++ b/src/engine/sheets/chrome.ts
@@ -1,0 +1,133 @@
+/**
+ * What the header and footer take out of the page.
+ *
+ * Declared, not measured — the bargain `blockBox` is built on (§4) — and
+ * rounded up, because the two errors are not symmetrical. Reserving a tenth of
+ * an inch too much costs one rule line at the bottom of the page. Reserving too
+ * little pushes that line onto a second sheet of paper, and print is the whole
+ * of the output path here: there is no PDF to notice it in first.
+ *
+ * It lives on its own rather than inside a family because every family asks the
+ * same question and the answer is delicate: the numbers below trail sheet.css,
+ * which sets the header's rows in ems of the body size and its gaps in inches.
+ * A second copy of them would be a second thing to keep in step with a
+ * stylesheet, and the failure would be silent — a sheet that looks right on
+ * screen and prints a blank second page.
+ *
+ * So: a title is 1.7em over a 1.05 line-height, a field line 0.82em over 1.35,
+ * an instruction 0.9em, and the footer 0.62em above a rule with 0.18in of air
+ * over it.
+ */
+import type { Mil, SheetOptions } from "./types";
+
+import { blockBox, contentBox, type Box } from "./layout";
+import { inches, points } from "./paper";
+
+const HEAD_ROWS = { title: 1.9, fields: 1.2, instructions: 1.3 } as const;
+const FOOT_ROW = 0.9;
+
+/** The gap sheet.css puts between the header's rows. */
+const HEAD_GAP = inches(0.09);
+/** And under the header itself, whatever is in it. */
+const HEAD_MARGIN = inches(0.16);
+/** The footer's rule, its padding, and the air above it. */
+const FOOT_MARGIN = inches(0.23);
+
+/* The name line is not always one row. `.sheet__fields` is a wrapping flex
+   row, so how many rows it takes is a question about the width of the page —
+   three fields ("name", "date", "class" are all legal) measure more than a
+   Letter content width and land on two. A row that was not reserved for is a
+   rule line below the bottom margin, which is a second sheet of paper. */
+
+/** One field: `.sheet__field-rule` at 2.1in, plus its label and their gap. */
+const FIELD_WIDTH = inches(2.5);
+/** The score box is the same row and a third of the width: 0.7in and "/ 20". */
+const SCORE_WIDTH = inches(1.4);
+/** `.sheet__fields` sets 0.06in between rows and 0.28in between fields. */
+const FIELD_GAP = inches(0.28);
+const FIELD_ROW_GAP = inches(0.06);
+
+/** A height quoted in ems of the body size, in the unit the page is in. */
+const em = (fontPt: number, rows: number): Mil => points(fontPt * rows);
+
+/**
+ * How many rows the name line wraps onto, packed the way a flex row packs.
+ *
+ * Greedy, item by item, because that is what `flex-wrap` does — and because
+ * the items are not all the same width once a score box joins them. Counting
+ * the score as another 2.5in field instead would push a name-date-score header
+ * onto a second row it does not use, and on ⅝ paper a row is a line to write
+ * on.
+ */
+function fieldRows(options: SheetOptions, score: boolean): number {
+  const widths = [
+    ...options.fields.map(() => FIELD_WIDTH),
+    ...(score ? [SCORE_WIDTH] : []),
+  ];
+  if (widths.length === 0) return 0;
+
+  const limit = contentBox(options.paper).width;
+  let rows = 1;
+  let used = 0;
+  for (const width of widths) {
+    const next = used === 0 ? width : used + FIELD_GAP + width;
+    // A page too narrow for one whole field still prints one per row rather
+    // than looping forever — `used > 0` is what makes the wrap terminate.
+    if (next > limit && used > 0) {
+      rows += 1;
+      used = width;
+    } else {
+      used = next;
+    }
+  }
+  return rows;
+}
+
+/**
+ * How much of the page the header and footer will use.
+ *
+ * Counted from what the header actually holds rather than from a constant: a
+ * sheet of lined paper with a name line and no title has an inch more writing
+ * space than one with both, and on ⅝ paper an inch is two more lines to write
+ * on. A family that reserved for the worst case would throw them away.
+ */
+export function chromeHeight(
+  options: SheetOptions,
+  /**
+   * Whether the header carries a "___ / 20" box. The one part of the chrome a
+   * family decides rather than a parent: a sheet is marked out of the number
+   * of problems it ended up with, which is known after the build.
+   */
+  score = false,
+): { header: Mil; footer: Mil } {
+  const fields = fieldRows(options, score);
+  const rows = [
+    options.title ? HEAD_ROWS.title : 0,
+    HEAD_ROWS.fields * fields,
+    options.instructions ? HEAD_ROWS.instructions : 0,
+  ].filter((row) => row > 0);
+
+  return {
+    // The margin is there even when the header is empty — SheetHead renders
+    // the element either way, and an empty flex column still takes its gap.
+    header:
+      HEAD_MARGIN +
+      rows.reduce((total, row) => total + em(options.fontPt, row), 0) +
+      HEAD_GAP * Math.max(0, rows.length - 1) +
+      FIELD_ROW_GAP * Math.max(0, fields - 1),
+    footer: FOOT_MARGIN + em(options.fontPt, FOOT_ROW),
+  };
+}
+
+/**
+ * What is left for the blocks: the page, less its margins, less the chrome.
+ *
+ * Exported because it is the reservation itself, and the reservation is the
+ * only thing a test can hold `chromeHeight` to. Checking a family's blocks
+ * against the *content* box instead cannot fail — capacity is floored against
+ * this box, which is the content box minus a non-negative number, so any
+ * chrome at all satisfies it, including none.
+ */
+export function sheetBlockBox(options: SheetOptions, score = false): Box {
+  return blockBox(options.paper, chromeHeight(options, score));
+}

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -16,12 +16,14 @@
 import type { Sheet, SheetConfig } from "./types";
 
 import { BLANK_SHEET } from "./blank";
+import { ARITHMETIC_SHEET } from "./maths/arithmetic";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
 import { PAPER_SHEET } from "./templates/paper";
 
 const SHEETS: Record<string, SheetSpec> = {
   [BLANK_SHEET.id]: BLANK_SHEET,
   [PAPER_SHEET.id]: PAPER_SHEET,
+  [ARITHMETIC_SHEET.id]: ARITHMETIC_SHEET,
 };
 
 /**

--- a/src/engine/sheets/maths/arithmetic.test.ts
+++ b/src/engine/sheets/maths/arithmetic.test.ts
@@ -1,0 +1,545 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { inches } from "../paper";
+import type {
+  ArithmeticConfig,
+  MarginSize,
+  Paper,
+  PaperSize,
+  Problem,
+} from "../types";
+
+import { ARITHMETIC_SHEET, GAP, arithmeticLayout } from "./arithmetic";
+
+/**
+ * The first generated family, and the one that sets the bar.
+ *
+ * A sheet of lined paper is right if it measures what it says. A sheet of sums
+ * is right only if every answer on the key is right, so the whole of this file
+ * is arranged around one rule:
+ *
+ * **Nothing here checks the generator against the generator.** Every answer is
+ * verified from the *printed* problem — the string a child reads — by a path
+ * the family does not use: addition by counting, subtraction by its inverse,
+ * and carrying by the digit-sum identity. A test that re-ran `a + b` would
+ * pass on a family that had `+` wrong, which is the one bug a worksheet site
+ * cannot ship.
+ */
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const config = (over: Partial<ArithmeticConfig> = {}): ArithmeticConfig => ({
+  kind: "arithmetic",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  operation: "add",
+  style: "standard",
+  form: "horizontal",
+  range: { min: 1, max: 20 },
+  count: 20,
+  columns: 2,
+  regrouping: "either",
+  ...over,
+});
+
+/**
+ * Every shape the family can print, which is every acceptance criterion of the
+ * story: both layouts, both operations and the two together, regrouping on,
+ * off and either, missing numbers, fact families, number lines and workspace.
+ * The sweeps below run over all of it rather than over the default.
+ */
+const EVERY_SHAPE: Array<Partial<ArithmeticConfig>> = [
+  {},
+  { form: "vertical" },
+  { operation: "subtract" },
+  { operation: "subtract", form: "vertical" },
+  { operation: "both" },
+  { regrouping: "never" },
+  { regrouping: "always" },
+  { operation: "subtract", regrouping: "never" },
+  { operation: "subtract", regrouping: "always" },
+  { style: "missing" },
+  { style: "missing", operation: "subtract" },
+  { style: "fact-family", count: 8 },
+  {
+    operation: "both",
+    numberLine: true,
+    range: { min: 0, max: 10 },
+    count: 10,
+  },
+  { workspace: true, count: 12 },
+  { operation: "subtract", negatives: true },
+  { range: { min: 10, max: 99 }, regrouping: "always", count: 12 },
+  { range: { min: 100, max: 999 }, form: "vertical", count: 9, columns: 3 },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** The one block an arithmetic sheet has, narrowed for the reader. */
+function problemsOf(over: Partial<ArithmeticConfig>, seed: number): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+/* ── Reading a sheet the way a child does ──────────────────────────────────
+   Everything below works from the printed problem — the prompt, or the stack
+   of numbers in column form — and never from the config that produced it. If
+   the family printed one thing and computed another, these are what notice. */
+
+/**
+ * The problem, written out in full with its answer put where it belongs.
+ *
+ * Four shapes reduce to one sentence: a sum with a slot on the end, a sum with
+ * the gap inside it, a stack of numbers in column form, and a fact family,
+ * which is four sentences rather than one.
+ */
+function sentences(problem: Problem): string[] {
+  if (problem.operands) {
+    const stack = problem.operands.join(` ${problem.operator} `);
+    return [`${stack} = ${problem.answer}`];
+  }
+  if (problem.prompt.includes("_")) {
+    return [problem.prompt.replace("_", problem.answer)];
+  }
+  if (problem.prompt.trimEnd().endsWith("=")) {
+    return [`${problem.prompt} ${problem.answer}`];
+  }
+  // A fact family: the prompt is three numbers, the answer is the four
+  // sentences they make.
+  return problem.answer.split(", ");
+}
+
+type Statement = { left: number; sign: string; right: number; result: number };
+
+/** A written sentence, taken apart. Rejects anything that isn't one. */
+function read(sentence: string): Statement {
+  const match = /^(-?\d+) ([+−]) (-?\d+) = (-?\d+)$/.exec(sentence.trim());
+  if (!match) throw new Error(`not a number sentence: "${sentence}"`);
+  return {
+    left: Number(match[1]),
+    sign: match[2],
+    right: Number(match[3]),
+    result: Number(match[4]),
+  };
+}
+
+/**
+ * Addition, by counting — the point of the whole file.
+ *
+ * `a + b` is what the family computes, so a test that used it would agree with
+ * the family however wrong the family was. Counting up one at a time is the
+ * other definition of addition, and it is the one a child uses on the number
+ * line these sheets print.
+ */
+function countUp(from: number, by: number): number {
+  let total = from;
+  for (let step = 0; step < by; step += 1) total += 1;
+  return total;
+}
+
+/** Whether a written sentence is true, established by counting. */
+function holds(sentence: string): boolean {
+  const { left, sign, right, result } = read(sentence);
+  // Subtraction is checked through its inverse: `a − b = c` is true exactly
+  // when counting up from `c` by `b` arrives at `a`.
+  return sign === "+"
+    ? countUp(left, right) === result
+    : countUp(result, right) === left;
+}
+
+const digitSum = (value: number): number =>
+  Math.abs(value)
+    .toString()
+    .split("")
+    .reduce((total, digit) => total + Number(digit), 0);
+
+/**
+ * Whether a sentence regroups — carries, or borrows — established by an
+ * identity rather than by the family's own column loop.
+ *
+ * Adding without carrying preserves digit sums, and every carry costs exactly
+ * nine of them: 34 + 25 = 59 keeps 7 + 7 = 14, while 38 + 25 = 63 turns
+ * 11 + 7 into 9. So "the digit sums agree" and "no column carried" are the
+ * same statement reached from opposite directions. Subtraction is the same
+ * fact read backwards: `a − b = c` borrows exactly when `c + b` carries.
+ */
+function regroups(sentence: string): boolean {
+  const { left, sign, right, result } = read(sentence);
+  return sign === "+"
+    ? digitSum(left) + digitSum(right) !== digitSum(result)
+    : digitSum(result) + digitSum(right) !== digitSum(left);
+}
+
+/** The two numbers the sum is made of, read off the sentence as printed. */
+function operandsOf(sentence: string): [number, number] {
+  const { left, right } = read(sentence);
+  return [left, right];
+}
+
+/** What makes two problems the same problem, worked out from the page. */
+function factOf(sentence: string): string {
+  const { left, sign, right } = read(sentence);
+  return sign === "+"
+    ? `+:${Math.min(left, right)}:${Math.max(left, right)}`
+    : `−:${left}:${right}`;
+}
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the arithmetic family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("arithmetic")).toBe(ARITHMETIC_SHEET);
+    expect(sheetSpec("arithmetic").label).toBe("Addition and subtraction");
+  });
+
+  it("names what it prints, in the terms a parent chose it by", () => {
+    expect(describeSheet(config())).toBe("Addition to 20");
+    expect(describeSheet(config({ form: "vertical" }))).toBe(
+      "Addition to 20 — in columns",
+    );
+    expect(
+      describeSheet(
+        config({
+          operation: "subtract",
+          regrouping: "never",
+          form: "vertical",
+        }),
+      ),
+    ).toBe("Subtraction to 20 — in columns — no regrouping");
+    expect(
+      describeSheet(config({ style: "missing", regrouping: "always" })),
+    ).toBe("Addition to 20 — missing number — with regrouping");
+    expect(describeSheet(config({ style: "fact-family" }))).toBe(
+      "Fact families to 20",
+    );
+    expect(describeSheet(config({ operation: "both", numberLine: true }))).toBe(
+      "Addition and subtraction to 20 — with a number line",
+    );
+  });
+
+  it("gives the sheet a title and a score box it can be marked against", () => {
+    const sheet = buildSheet(config(), 3);
+    const block = sheet.blocks[0];
+    expect(sheet.header.title).toBe("Addition to 20");
+    expect(sheet.header.instructions).toBe("Work out each answer.");
+    // Out of what is on the page, not out of what was asked for: a sheet that
+    // says "/ 20" over eighteen problems is wrong twice.
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("is right on every problem of every sheet this family can print", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        expect(problems.length).toBeGreaterThan(0);
+        for (const problem of problems) {
+          for (const sentence of sentences(problem)) {
+            expect(holds(sentence), `${JSON.stringify(shape)}: ${sentence}`) //
+              .toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    // The key is not built again from the seed — it is the build, told to
+    // print what it already worked out. So the problems on the two are the
+    // same objects, and a key cannot disagree with the sheet it belongs to.
+    for (const shape of EVERY_SHAPE) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+
+  it("gives a fact family its four sentences, and only its own numbers", () => {
+    for (const problem of problemsOf({ style: "fact-family", count: 8 }, 3)) {
+      const written = sentences(problem);
+      expect(written.length).toBe(4);
+      // Two sums and two differences, all four true.
+      expect(written.filter((line) => read(line).sign === "+").length).toBe(2);
+      expect(written.every(holds)).toBe(true);
+      // And built from the three numbers the prompt gives, with nothing
+      // brought in from outside them.
+      const family = new Set(problem.prompt.split(", "));
+      for (const line of written) {
+        for (const number of line.split(/[^\d]+/).filter(Boolean)) {
+          expect(family.has(number)).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("puts the answer where the problem left the gap", () => {
+    // A missing-number problem has exactly one blank, and it is inside the
+    // sentence rather than after it — the renderer's rule, stated here as the
+    // engine's half of it.
+    for (const problem of problemsOf({ style: "missing" }, 2)) {
+      expect(problem.prompt.split("_").length - 1).toBe(1);
+      expect(holds(problem.prompt.replace("_", problem.answer))).toBe(true);
+    }
+  });
+});
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  it("never puts a number outside the range a parent asked for", () => {
+    const RANGES = [
+      { min: 0, max: 5 },
+      { min: 1, max: 20 },
+      { min: 10, max: 99 },
+      { min: 100, max: 999 },
+    ];
+    for (const range of RANGES) {
+      for (const shape of EVERY_SHAPE) {
+        for (const problem of problemsOf({ ...shape, range }, 9)) {
+          // The first sentence is the sum itself; a fact family's other three
+          // are that sum turned round, and its total is allowed past the top
+          // of the range for the same reason every carried sum is.
+          for (const value of operandsOf(sentences(problem)[0])) {
+            expect(value).toBeGreaterThanOrEqual(range.min);
+            expect(value).toBeLessThanOrEqual(range.max);
+          }
+        }
+      }
+    }
+  });
+
+  it("never dips below zero unless it was asked to", () => {
+    for (const shape of EVERY_SHAPE.filter((shape) => !shape.negatives)) {
+      for (const seed of SEEDS) {
+        for (const problem of problemsOf(shape, seed)) {
+          for (const sentence of sentences(problem)) {
+            expect(read(sentence).result).toBeGreaterThanOrEqual(0);
+          }
+        }
+      }
+    }
+  });
+
+  it("does dip below zero when it was — or the switch is decoration", () => {
+    const below = problemsOf({ operation: "subtract", negatives: true }, 4)
+      .flatMap(sentences)
+      .filter((sentence) => read(sentence).result < 0);
+    expect(below.length).toBeGreaterThan(0);
+    expect(below.every(holds)).toBe(true);
+  });
+
+  it("asks the same question twice on no sheet at all", () => {
+    // Folded, because 3 + 5 and 5 + 3 are one sum — and independent of which
+    // side a missing-number problem blanks out, because "7 + _ = 15" and
+    // "_ + 8 = 15" are one fact in two hats.
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        const facts = problems.map((problem) => factOf(sentences(problem)[0]));
+        expect(new Set(facts).size).toBe(problems.length);
+      }
+    }
+  });
+
+  it("carries on every problem, or on none, when it is told to", () => {
+    for (const range of [
+      { min: 1, max: 20 },
+      { min: 10, max: 99 },
+    ]) {
+      for (const operation of ["add", "subtract", "both"] as const) {
+        for (const [regrouping, want] of [
+          ["always", true],
+          ["never", false],
+        ] as const) {
+          const problems = problemsOf(
+            { operation, regrouping, range, count: 12 },
+            6,
+          );
+          expect(problems.length).toBeGreaterThan(0);
+          for (const problem of problems) {
+            const sentence = sentences(problem)[0];
+            expect(regroups(sentence), `${regrouping}: ${sentence}`).toBe(want);
+          }
+        }
+      }
+    }
+  });
+
+  it("prints nothing rather than something wrong when the ask is impossible", () => {
+    // Nothing between 1 and 3 carries. A generator that kept drawing would
+    // either hang or print a sum that does not regroup on a sheet that says it
+    // does; an empty sheet is the honest answer, and the builder's job to
+    // prevent (PRINT13).
+    const problems = problemsOf(
+      { range: { min: 1, max: 3 }, regrouping: "always" },
+      1,
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it("prints the whole small pool rather than repeating itself", () => {
+    // Twenty different sums from 1 to 3 without regrouping is six sums, and
+    // six is what a parent should get.
+    const problems = problemsOf(
+      { range: { min: 1, max: 3 }, regrouping: "never", count: 20 },
+      1,
+    );
+    expect(problems.length).toBe(6);
+    expect(new Set(problems.map((p) => p.prompt)).size).toBe(6);
+  });
+});
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("carries the seed into the footer, so the same sheet can be had again", () => {
+    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
+  });
+
+  /** The problems of `seed`, `seed + 1` and `seed + 2`, pairwise. */
+  function variants(shape: Partial<ArithmeticConfig>, seed: number) {
+    // Compared as sentences rather than as prompts, because a column-form
+    // problem has no prompt — the stack is the prompt.
+    const [a, b, c] = [0, 1, 2].map((offset) =>
+      problemsOf(shape, seed + offset).map((problem) => sentences(problem)[0]),
+    );
+    return [
+      [a, b],
+      [a, c],
+      [b, c],
+    ];
+  }
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    // Three consecutive seeds are the whole of "a different sheet, same
+    // settings" and of variants for a class (§7). Some overlap is inevitable
+    // — the variants are drawn from one pool, and a narrow ask has a narrow
+    // pool — so what is asserted is that a third of each variant is new,
+    // whatever the config. Three sheets that were nearly the same sheet would
+    // make the feature a lie.
+    for (const shape of EVERY_SHAPE) {
+      for (const [one, other] of variants(shape, 100)) {
+        expect(one).not.toEqual(other);
+        const shared = one.filter((sum) => other.includes(sum)).length;
+        expect(shared, JSON.stringify(shape)).toBeLessThan(
+          (one.length * 2) / 3,
+        );
+      }
+    }
+  });
+
+  it("shares almost nothing between variants of an ordinary sheet", () => {
+    // The bound above has to hold for a config whose pool is barely bigger
+    // than the sheet. This is the sheet a parent actually prints: twenty sums
+    // inside twenty, where two variants have no business having much in
+    // common at all.
+    for (const [one, other] of variants({}, 100)) {
+      const shared = one.filter((sum) => other.includes(sum)).length;
+      expect(shared).toBeLessThanOrEqual(2);
+    }
+  });
+});
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    // The failure is silent on screen and obvious on paper: one row too many
+    // is a second sheet out of the printer with two sums on it, and print is
+    // the whole of the output path (§10).
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row } = arithmeticLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used = rows * row + Math.max(0, rows - 1) * GAP.y;
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("does not throw the page away either", () => {
+    // The half a capacity check cannot see: a family that printed four
+    // problems on a Letter page would satisfy every assertion above.
+    const { box, row, perPage } = arithmeticLayout(config());
+    expect(perPage).toBeGreaterThanOrEqual(20);
+    // One more row would not have fitted, which is what makes the reservation
+    // testable in both directions.
+    const rows = perPage / arithmeticLayout(config()).columns;
+    expect((rows + 1) * row + rows * GAP.y).toBeGreaterThan(box.height);
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ count: 12 }, 1).length).toBe(12);
+    expect(problemsOf({ count: 0 }, 1).length).toBe(0);
+    for (const columns of [1, 2, 3, 4]) {
+      const block = buildSheet(config({ columns }), 1).blocks[0];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+  });
+
+  it("sizes the number line to the column it sits in", () => {
+    // Declared, not measured (§4): the family already worked out how wide a
+    // column is to decide how many fit, and a second answer discovered in the
+    // browser would be a second answer.
+    for (const columns of [1, 2, 3]) {
+      const over = { columns, numberLine: true, range: { min: 0, max: 10 } };
+      const [problem] = problemsOf(over, 2);
+      expect(problem.line?.width).toBe(arithmeticLayout(config(over)).cell);
+      // Zero is on it, and so is every result the config can reach.
+      expect(problem.line?.from).toBe(0);
+      expect(problem.line?.to).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it("gives a fact family room to write four sentences in", () => {
+    for (const problem of problemsOf({ style: "fact-family", count: 6 }, 1)) {
+      expect(problem.workspace).toBeGreaterThanOrEqual(inches(1));
+    }
+  });
+});

--- a/src/engine/sheets/maths/arithmetic.test.ts
+++ b/src/engine/sheets/maths/arithmetic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { LINE_INSET, labelRoom, ticks } from "../numberline";
 import { inches } from "../paper";
 import type {
   ArithmeticConfig,
@@ -70,6 +71,9 @@ const EVERY_SHAPE: Array<Partial<ArithmeticConfig>> = [
   { style: "missing" },
   { style: "missing", operation: "subtract" },
   { style: "fact-family", count: 8 },
+  // A family with the number-line switch on, which it ignores: the combination
+  // is legal, and the layout and the build have to agree that it draws none.
+  { style: "fact-family", numberLine: true, count: 8 },
   {
     operation: "both",
     numberLine: true,
@@ -83,6 +87,9 @@ const EVERY_SHAPE: Array<Partial<ArithmeticConfig>> = [
 ];
 
 const SEEDS = [0, 1, 2, 7, 4242];
+
+/** Every column count the family will lay out — `MAX_COLUMNS` is six. */
+const COLUMN_COUNTS = [1, 2, 3, 4, 5, 6];
 
 /** The one block an arithmetic sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<ArithmeticConfig>, seed: number): Problem[] {
@@ -105,6 +112,9 @@ function problemsOf(over: Partial<ArithmeticConfig>, seed: number): Problem[] {
  * which is four sentences rather than one.
  */
 function sentences(problem: Problem): string[] {
+  // A fact family: the prompt is three numbers, and the answer is the four
+  // sentences they make, each written on a ruled line of its own.
+  if (problem.answers) return problem.answers;
   if (problem.operands) {
     const stack = problem.operands.join(` ${problem.operator} `);
     return [`${stack} = ${problem.answer}`];
@@ -112,12 +122,7 @@ function sentences(problem: Problem): string[] {
   if (problem.prompt.includes("_")) {
     return [problem.prompt.replace("_", problem.answer)];
   }
-  if (problem.prompt.trimEnd().endsWith("=")) {
-    return [`${problem.prompt} ${problem.answer}`];
-  }
-  // A fact family: the prompt is three numbers, the answer is the four
-  // sentences they make.
-  return problem.answer.split(", ");
+  return [`${problem.prompt} ${problem.answer}`];
 }
 
 type Statement = { left: number; sign: string; right: number; result: number };
@@ -282,6 +287,11 @@ describe("the answer key", () => {
     for (const problem of problemsOf({ style: "fact-family", count: 8 }, 3)) {
       const written = sentences(problem);
       expect(written.length).toBe(4);
+      // Carried as a list, which is what makes the sheet rule four lines for
+      // it. Four sentences smuggled through the one-answer field would print a
+      // slot the size of one of them, and a key four times too long for it.
+      expect(problem.answers).toEqual(written);
+      expect(problem.prompt).not.toContain("_");
       // Two sums and two differences, all four true.
       expect(written.filter((line) => read(line).sign === "+").length).toBe(2);
       expect(written.every(holds)).toBe(true);
@@ -431,6 +441,48 @@ describe("(config, seed)", () => {
     expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
   });
 
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    // Building twice in one process only proves the draw is a function of
+    // `(config, seed)`. The promise the footer makes is bigger than that: the
+    // seed is printed on the paper so a parent can have the same sheet again
+    // next week, across a deploy — the same durability constraint `configKey`
+    // is under for saved runs.
+    //
+    // Nothing else in this file would notice a refactor that moved where the
+    // draw consumes `rand()` — the `slot` draw taken whatever the style, or
+    // the `operation` draw taken only when both are asked for. Every seed a
+    // parent had already printed would quietly start producing a different
+    // sheet. These two lists make that a decision somebody has to take rather
+    // than one they can trip over: if they change, the change was deliberate.
+    expect(
+      problemsOf({ count: 6 }, 4242).map((p) => [p.prompt, p.answer]),
+    ).toEqual([
+      ["11 + 6 =", "17"],
+      ["11 + 14 =", "25"],
+      ["6 + 9 =", "15"],
+      ["12 + 15 =", "27"],
+      ["13 + 20 =", "33"],
+      ["16 + 18 =", "34"],
+    ]);
+
+    expect(
+      problemsOf({ style: "fact-family", count: 3 }, 7).map((p) => [
+        p.prompt,
+        p.answers,
+      ]),
+    ).toEqual([
+      ["1, 2, 3", ["1 + 2 = 3", "2 + 1 = 3", "3 − 1 = 2", "3 − 2 = 1"]],
+      [
+        "14, 11, 25",
+        ["14 + 11 = 25", "11 + 14 = 25", "25 − 14 = 11", "25 − 11 = 14"],
+      ],
+      [
+        "10, 5, 15",
+        ["10 + 5 = 15", "5 + 10 = 15", "15 − 10 = 5", "15 − 5 = 10"],
+      ],
+    ]);
+  });
+
   /** The problems of `seed`, `seed + 1` and `seed + 2`, pairwise. */
   function variants(shape: Partial<ArithmeticConfig>, seed: number) {
     // Compared as sentences rather than as prompts, because a column-form
@@ -527,7 +579,7 @@ describe("how much fits", () => {
     // Declared, not measured (§4): the family already worked out how wide a
     // column is to decide how many fit, and a second answer discovered in the
     // browser would be a second answer.
-    for (const columns of [1, 2, 3]) {
+    for (const columns of COLUMN_COUNTS) {
       const over = { columns, numberLine: true, range: { min: 0, max: 10 } };
       const [problem] = problemsOf(over, 2);
       expect(problem.line?.width).toBe(arithmeticLayout(config(over)).cell);
@@ -537,9 +589,58 @@ describe("how much fits", () => {
     }
   });
 
+  it("spaces its labels so they can be read in the narrowest column", () => {
+    // `columns` is a setting a parent picks and six of them is legal, which
+    // leaves a number line about an inch of paper. A tick spacing chosen from
+    // a fixed budget rather than from the width would put nine two-digit
+    // labels across that inch — unreadable paper for a legal config, printed,
+    // with nothing on screen to warn about it first.
+    for (const columns of COLUMN_COUNTS) {
+      for (const range of [
+        { min: 0, max: 10 },
+        { min: 0, max: 20 },
+        { min: 1, max: 20 },
+      ]) {
+        const over = { columns, numberLine: true, range, count: 6 };
+        const [problem] = problemsOf(over, 2);
+        const line = problem.line;
+        if (!line) throw new Error(`no line at ${columns} columns`);
+
+        const marks = ticks(line);
+        expect(marks.length).toBeGreaterThanOrEqual(2);
+        const pitch = (line.width - LINE_INSET * 2) / (marks.length - 1);
+        expect(
+          pitch,
+          `${columns} columns, ${JSON.stringify(range)}: ${marks.join(" ")}`,
+        ).toBeGreaterThanOrEqual(labelRoom(marks));
+      }
+    }
+  });
+
   it("gives a fact family room to write four sentences in", () => {
     for (const problem of problemsOf({ style: "fact-family", count: 6 }, 1)) {
       expect(problem.workspace).toBeGreaterThanOrEqual(inches(1));
+      // The room is shared out between the four lines rather than added under
+      // a slot, so the height reserved is the height rendered.
+      expect(problem.answers?.length).toBe(4);
     }
+  });
+
+  it("reserves room for a number line only where it draws one", () => {
+    // The layout reserves the height and the build attaches the line, and the
+    // two reading the config differently is the bug the whole "declared, not
+    // measured" design exists to exclude. A family asks for four sentences,
+    // not a line to count along, so `numberLine` may not cost it a row.
+    const family = { style: "fact-family", count: 8 } as const;
+    for (const problem of problemsOf({ ...family, numberLine: true }, 3)) {
+      expect(problem.line).toBeUndefined();
+    }
+    expect(arithmeticLayout(config({ ...family, numberLine: true }))).toEqual(
+      arithmeticLayout(config(family)),
+    );
+    // And it does cost one everywhere it is actually drawn.
+    expect(arithmeticLayout(config({ numberLine: true })).row).toBeGreaterThan(
+      arithmeticLayout(config()).row,
+    );
   });
 });

--- a/src/engine/sheets/maths/arithmetic.ts
+++ b/src/engine/sheets/maths/arithmetic.ts
@@ -56,8 +56,23 @@ const ROW_EMS = { horizontal: 1.7, vertical: 4.4 } as const;
 
 /** Blank space to work a sum out in, when the config asks for it. */
 const WORKSPACE = inches(0.55);
-/** A fact family is four sentences to write, so it always gets room for four. */
-const FAMILY_SPACE = inches(1);
+
+/** A fact family is four number sentences, and each one gets a line. */
+const FAMILY_LINES = 4;
+
+/**
+ * How tall one ruled line for a written answer is.
+ *
+ * A quarter of an inch is what a child writes on, and never less than the body
+ * type needs: at 18pt the type is a quarter inch on its own, and a key printed
+ * onto lines shorter than its own letters is a row taller than this reserved
+ * for — which is the last row of the page on a second sheet of paper.
+ */
+const answerLine = (fontPt: number): Mil =>
+  Math.max(inches(0.25), points(fontPt * 1.35));
+
+/** The room a fact family's four sentences take, lines and all. */
+const familySpace = (fontPt: number): Mil => FAMILY_LINES * answerLine(fontPt);
 
 /** More than six columns of sums is a page nobody can read. */
 const MAX_COLUMNS = 6;
@@ -232,18 +247,25 @@ function problemOf(
 
   if (config.style === "fact-family") {
     const { left, right, result } = sum;
+    // One list, printed two ways and built once, so the two cannot disagree:
+    // `answers` is what the sheet rules lines for and the key writes on them,
+    // `answer` the same sentences on one line for anything wanting a string.
+    const written = [
+      `${left} + ${right} = ${result}`,
+      `${right} + ${left} = ${result}`,
+      `${result} − ${left} = ${right}`,
+      `${result} − ${right} = ${left}`,
+    ];
     return {
       prompt: `${left}, ${right}, ${result}`,
-      answer: [
-        `${left} + ${right} = ${result}`,
-        `${right} + ${left} = ${result}`,
-        `${result} − ${left} = ${right}`,
-        `${result} − ${right} = ${left}`,
-      ].join(", "),
+      answer: written.join(", "),
+      answers: written,
       factId,
       ...extras,
-      // Four sentences to write, whatever the config said about workspace.
-      workspace: FAMILY_SPACE,
+      // Four sentences to write, whatever the config said about workspace —
+      // and this is the height those four lines share, not blank paper under
+      // a slot. `rowHeight` reserves exactly the same number.
+      workspace: familySpace(config.fontPt),
     };
   }
 
@@ -290,6 +312,23 @@ function problemOf(
 const clamp = (value: number, low: number, high: number): number =>
   Math.max(low, Math.min(high, Math.floor(value)));
 
+/**
+ * Whether this sheet prints a number line.
+ *
+ * One predicate with four readers — the row height reserves for it, the build
+ * attaches it, the instruction line tells a child to use it and the record line
+ * names it — because the two halves disagreeing is the exact bug the
+ * "declared, not measured" design exists to exclude: reserving for a line the
+ * build never emits throws two problems a page away, and the other way round is
+ * a row below the bottom margin.
+ *
+ * A fact family never gets one however the config asks. Its prompt is three
+ * numbers rather than a sum, so there is nothing on it to count along.
+ */
+function hasNumberLine(config: ArithmeticConfig): boolean {
+  return config.numberLine === true && config.style !== "fact-family";
+}
+
 /** How tall one problem stands, extras included. */
 function rowHeight(config: ArithmeticConfig): Mil {
   const stacked = config.style === "standard" && config.form === "vertical";
@@ -298,11 +337,11 @@ function rowHeight(config: ArithmeticConfig): Mil {
   );
   const workspace =
     config.style === "fact-family"
-      ? FAMILY_SPACE
+      ? familySpace(config.fontPt)
       : config.workspace
         ? WORKSPACE
         : 0;
-  return body + workspace + (config.numberLine ? NUMBER_LINE_HEIGHT : 0);
+  return body + workspace + (hasNumberLine(config) ? NUMBER_LINE_HEIGHT : 0);
 }
 
 /**
@@ -363,8 +402,10 @@ export function arithmeticProblems(
   while (problems.length < wanted && misses < MISS_BUDGET) {
     const sum = drawSum(config, rand);
     // Which side of a missing-number problem is blank. Drawn whatever the
-    // style, so that changing style does not reshuffle every other problem on
-    // a sheet built from the same seed.
+    // style, so that switching between standard, missing and column form does
+    // not reshuffle every other problem on a sheet built from the same seed. A
+    // fact family does reshuffle, because it skips the operation draw that
+    // `operation: "both"` takes — it is both operations by definition.
     const slot = rand() < 0.5 ? 0 : 1;
     const key = sum === null ? null : keyOf(sum, config.style);
     // Not what was asked for, or already on the page. Either way the budget
@@ -396,10 +437,9 @@ function sheetExtras(
   // The far end is the largest result the config can reach: two numbers from
   // the range added together, or — where nothing is added — the range itself.
   const top = config.operation === "subtract" ? max : max * 2;
-  const line =
-    config.numberLine && config.style !== "fact-family"
-      ? numberLine(config.negatives ? -max : 0, top, cell)
-      : undefined;
+  const line = hasNumberLine(config)
+    ? numberLine(config.negatives ? -max : 0, top, cell)
+    : undefined;
   return {
     ...(line ? { line } : {}),
     ...(config.workspace ? { workspace: WORKSPACE } : {}),
@@ -428,8 +468,7 @@ const INSTRUCTION: Record<ArithmeticStyle, string> = {
 };
 
 function instructionOf(config: ArithmeticConfig): string {
-  const line = config.numberLine && config.style !== "fact-family";
-  return line
+  return hasNumberLine(config)
     ? `${INSTRUCTION[config.style]} Use the number line to help.`
     : INSTRUCTION[config.style];
 }
@@ -472,9 +511,7 @@ export function describeArithmetic(config: ArithmeticConfig): string {
       : null,
     config.style === "missing" ? "missing number" : null,
     REGROUPING[config.regrouping],
-    config.numberLine && config.style !== "fact-family"
-      ? "with a number line"
-      : null,
+    hasNumberLine(config) ? "with a number line" : null,
   ]
     .filter((part): part is string => part !== null)
     .join(" — ");

--- a/src/engine/sheets/maths/arithmetic.ts
+++ b/src/engine/sheets/maths/arithmetic.ts
@@ -1,0 +1,523 @@
+/**
+ * Addition and subtraction.
+ *
+ * The first *generated* family, and the one that sets the bar for every maths
+ * family after it. Lined paper is correct if it measures what it says it
+ * measures; a page of sums is correct only if every answer on the key is right,
+ * every problem is inside the range a parent asked for, and no two problems on
+ * the page are the same problem. An answer key is the single most expected
+ * feature of a worksheet site and the most common thing done badly (§7), so the
+ * answers are computed once, when the problem is built, and the key only
+ * decides to print them.
+ *
+ * Everything on the page comes out of `(config, seed)` and nothing else. That
+ * one property is three features: the key is the same build, "another sheet
+ * like this one" is `seed + 1`, and variants A/B/C for a class are `seed`,
+ * `seed + 1` and `seed + 2` printed as consecutive pages.
+ *
+ * ── Why the problems are drawn rather than enumerated ──────────────────────
+ * The obvious generator lists every pair in the range, shuffles it and takes
+ * twenty. It is exact, and it allocates a million pairs for a sheet of
+ * three-digit sums — at build time, on every catalog page, three times over for
+ * the variants. So a problem is drawn, checked against what the config asked
+ * for, and rejected if it fails or repeats. The draw gives up after a run of
+ * rejections and prints what it has, which is the honest answer to "twenty
+ * different sums from 1 to 3": there are six, and six is what a parent should
+ * get rather than the same sum three times.
+ */
+import { arithmeticFactId } from "@/engine/decks/flashcards";
+import { mulberry32 } from "@/engine/random";
+
+import type {
+  ArithmeticConfig,
+  ArithmeticStyle,
+  Mil,
+  NumberLine,
+  Problem,
+  Regrouping,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import { columnWidth, fitAcross, type Box } from "../layout";
+import { NUMBER_LINE_HEIGHT, numberLine } from "../numberline";
+import { inches, points } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+
+/* ── What a problem takes on the page ─────────────────────────────────────
+   Declared, not measured (§4), and trailing sheet.css the same way chrome.ts
+   does: `.sheet__problems` sets a 0.2in gap down and 0.3in across, a problem
+   written along a line is one line of the body type with a little air round
+   it, and a column sum is the two numbers, the rule and the answer under it. */
+
+export const GAP = { x: inches(0.3), y: inches(0.2) };
+const ROW_EMS = { horizontal: 1.7, vertical: 4.4 } as const;
+
+/** Blank space to work a sum out in, when the config asks for it. */
+const WORKSPACE = inches(0.55);
+/** A fact family is four sentences to write, so it always gets room for four. */
+const FAMILY_SPACE = inches(1);
+
+/** More than six columns of sums is a page nobody can read. */
+const MAX_COLUMNS = 6;
+
+/**
+ * How many rejections in a row before the draw accepts it has run out.
+ *
+ * Generous, because a rejection is a few arithmetic operations and the cost of
+ * being wrong is a sheet that silently prints fifteen problems where sixteen
+ * were possible. It is a budget rather than a guarantee, which is fine: the
+ * draw is deterministic, so a config that stops short stops short every time
+ * rather than intermittently.
+ */
+const MISS_BUDGET = 500;
+
+const SIGN = { add: "+", subtract: "−" } as const;
+
+/* ── Regrouping ────────────────────────────────────────────────────────────
+   The switch between the week a child learns to add and the week they learn
+   to carry, so it is a property of the columns rather than of the result: 8 +
+   9 regroups and 80 + 9 does not, though both are additions inside twenty.  */
+
+/** Whether working `a + b` in columns carries out of any column. */
+export function carries(a: number, b: number): boolean {
+  let left = a;
+  let right = b;
+  while (left > 0 || right > 0) {
+    if ((left % 10) + (right % 10) >= 10) return true;
+    left = Math.floor(left / 10);
+    right = Math.floor(right / 10);
+  }
+  return false;
+}
+
+/**
+ * Whether working `top − bottom` in columns borrows from any column.
+ *
+ * The first column whose top digit is short of its bottom one settles it, so
+ * there is nothing to propagate: a borrow that a *previous* borrow caused can
+ * only happen in a column to the left of one that already answered true.
+ */
+export function borrows(top: number, bottom: number): boolean {
+  let left = top;
+  let right = bottom;
+  while (right > 0) {
+    if (left % 10 < right % 10) return true;
+    left = Math.floor(left / 10);
+    right = Math.floor(right / 10);
+  }
+  return false;
+}
+
+const allowed = (want: Regrouping, regrouped: boolean): boolean =>
+  want === "either" || (want === "always") === regrouped;
+
+/* ── Drawing a sum ─────────────────────────────────────────────────────── */
+
+/** One sum, as it will be printed: `left` op `right` makes `result`. */
+type Sum = {
+  operation: "add" | "subtract";
+  left: number;
+  right: number;
+  result: number;
+};
+
+const pick = (min: number, max: number, rand: () => number): number =>
+  min + Math.floor(rand() * (max - min + 1));
+
+/** The range, made safe to draw from whatever a saved config says. */
+function bounds(range: { min: number; max: number }): {
+  min: number;
+  max: number;
+} {
+  const min = Math.max(0, Math.floor(range.min));
+  return { min, max: Math.max(min, Math.floor(range.max)) };
+}
+
+/**
+ * One candidate sum, or `null` when what was drawn isn't what was asked for.
+ *
+ * Both numbers come from the range, which is the promise the config makes: a
+ * parent who says "to twenty" is saying what their child will see on the page,
+ * not what the answers add up to. A sum that runs past twenty is what carrying
+ * is for.
+ */
+function drawSum(config: ArithmeticConfig, rand: () => number): Sum | null {
+  const { min, max } = bounds(config.range);
+  // A fact family is both operations by definition — 3, 5 and 8 make two sums
+  // and two differences — so it is always drawn as an addition and turned
+  // round afterwards.
+  const operation =
+    config.style === "fact-family"
+      ? "add"
+      : config.operation === "both"
+        ? rand() < 0.5
+          ? "add"
+          : "subtract"
+        : config.operation;
+
+  const first = pick(min, max, rand);
+  const second = pick(min, max, rand);
+
+  if (operation === "add") {
+    // A doubles pair has no family: 4 + 4 = 8 turned round is 4 + 4 = 8, and
+    // the four sentences a family sheet asks for are two.
+    if (config.style === "fact-family" && first === second) return null;
+    return allowed(config.regrouping, carries(first, second))
+      ? { operation, left: first, right: second, result: first + second }
+      : null;
+  }
+
+  // Below zero is off unless asked for, so the pair is turned round rather
+  // than thrown away — rejecting half the draws would halve the pool for no
+  // gain, and a child subtracting inside twenty writes the larger first.
+  const top = config.negatives ? first : Math.max(first, second);
+  const bottom = config.negatives ? second : Math.min(first, second);
+  const sum: Sum = {
+    operation,
+    left: top,
+    right: bottom,
+    result: top - bottom,
+  };
+
+  // A negative difference has no column arithmetic to speak of — nobody
+  // borrows their way from 3 − 8 — so it is only ever drawn when regrouping is
+  // left open. Asking for "always borrows" and being handed 3 − 8 would answer
+  // a question the parent did not ask.
+  if (sum.result < 0) return config.regrouping === "either" ? sum : null;
+  return allowed(config.regrouping, borrows(top, bottom)) ? sum : null;
+}
+
+/**
+ * What makes two problems the same problem.
+ *
+ * Addition folds — 3 + 5 and 5 + 3 are one sum, and a child who finds both on
+ * a page has been given nineteen problems and a joke — while subtraction does
+ * not. Which slot is blank is not part of it either: "7 + _ = 15" and
+ * "_ + 8 = 15" are one fact wearing two hats, and a child spots that faster
+ * than the adult who printed it does.
+ */
+function keyOf(sum: Sum, style: ArithmeticStyle): string {
+  const low = Math.min(sum.left, sum.right);
+  const high = Math.max(sum.left, sum.right);
+  if (style === "fact-family") return `family:${low}:${high}`;
+  const pair =
+    sum.operation === "add" ? `${low}:${high}` : `${sum.left}:${sum.right}`;
+  return `${sum.operation}:${pair}`;
+}
+
+/* ── Turning a sum into a problem ──────────────────────────────────────── */
+
+/**
+ * The race's own vocabulary for a fact, so a sheet printed from the record
+ * book's trouble facts (§14) names the same things the race does. Addition is
+ * its two addends; a subtraction is the number taken away and what is left,
+ * which is how `decks/flashcards.ts` builds the pair it asks about.
+ */
+function factOf(sum: Sum): string {
+  return sum.operation === "add"
+    ? arithmeticFactId(sum.left, sum.right)
+    : arithmeticFactId(sum.right, sum.result);
+}
+
+function problemOf(
+  sum: Sum,
+  config: ArithmeticConfig,
+  slot: number,
+  extras: { line?: NumberLine; workspace?: Mil },
+): Problem {
+  const sign = SIGN[sum.operation];
+  const factId = factOf(sum);
+
+  if (config.style === "fact-family") {
+    const { left, right, result } = sum;
+    return {
+      prompt: `${left}, ${right}, ${result}`,
+      answer: [
+        `${left} + ${right} = ${result}`,
+        `${right} + ${left} = ${result}`,
+        `${result} − ${left} = ${right}`,
+        `${result} − ${right} = ${left}`,
+      ].join(", "),
+      factId,
+      ...extras,
+      // Four sentences to write, whatever the config said about workspace.
+      workspace: FAMILY_SPACE,
+    };
+  }
+
+  if (config.style === "missing") {
+    // A missing number in column form is a blank where a number should be and
+    // the answer already written under the rule — two gaps, one to fill in,
+    // and a child who fills in the wrong one was not wrong. So it reads along
+    // the line whatever `form` says.
+    const prompt =
+      slot === 0
+        ? `_ ${sign} ${sum.right} = ${sum.result}`
+        : `${sum.left} ${sign} _ = ${sum.result}`;
+    return {
+      prompt,
+      answer: String(slot === 0 ? sum.left : sum.right),
+      factId,
+      ...extras,
+    };
+  }
+
+  if (config.form === "vertical") {
+    return {
+      // Empty, because the stack is the prompt. There is no second copy of the
+      // sum written along a line for the two to disagree about.
+      prompt: "",
+      operands: [String(sum.left), String(sum.right)],
+      operator: sign,
+      answer: String(sum.result),
+      factId,
+      ...extras,
+    };
+  }
+
+  return {
+    prompt: `${sum.left} ${sign} ${sum.right} =`,
+    answer: String(sum.result),
+    factId,
+    ...extras,
+  };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/** How tall one problem stands, extras included. */
+function rowHeight(config: ArithmeticConfig): Mil {
+  const stacked = config.style === "standard" && config.form === "vertical";
+  const body = points(
+    config.fontPt * (stacked ? ROW_EMS.vertical : ROW_EMS.horizontal),
+  );
+  const workspace =
+    config.style === "fact-family"
+      ? FAMILY_SPACE
+      : config.workspace
+        ? WORKSPACE
+        : 0;
+  return body + workspace + (config.numberLine ? NUMBER_LINE_HEIGHT : 0);
+}
+
+/**
+ * How many problems the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic, not measurement, so `npm run test:unit` can answer "did it fit?"
+ * without a browser — and so the same answer serves the catalog page built at
+ * build time and the builder's preview (§4).
+ */
+export function arithmeticLayout(config: ArithmeticConfig): {
+  box: Box;
+  columns: number;
+  /** The width of one column of problems. */
+  cell: Mil;
+  /** How tall one problem stands, extras included. */
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of
+  // them. Reserving for a config with no title and then printing the family's
+  // own is a last row of problems below the bottom margin — invisible on
+  // screen, and a second sheet out of the printer.
+  const box = sheetBlockBox(headerOf(config), true);
+  const columns = clamp(config.columns, 1, MAX_COLUMNS);
+  const row = rowHeight(config);
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, GAP.y),
+  };
+}
+
+/**
+ * Every problem on the sheet, in the order they are printed.
+ *
+ * Exported because it is the whole of what a test has to check, and checking
+ * it through the `Sheet` means unwrapping a block union to reach it.
+ */
+export function arithmeticProblems(
+  config: ArithmeticConfig,
+  seed: number,
+): Problem[] {
+  const { cell, perPage } = arithmeticLayout(config);
+  // The count is a request, not a promise. Print is the whole of the output
+  // path (§10), so a count that overruns is a second sheet out of the printer
+  // with two problems on it — worse than printing the ones that fit.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  const seen = new Set<string>();
+  const problems: Problem[] = [];
+  const extras = sheetExtras(config, cell);
+
+  let misses = 0;
+  while (problems.length < wanted && misses < MISS_BUDGET) {
+    const sum = drawSum(config, rand);
+    // Which side of a missing-number problem is blank. Drawn whatever the
+    // style, so that changing style does not reshuffle every other problem on
+    // a sheet built from the same seed.
+    const slot = rand() < 0.5 ? 0 : 1;
+    const key = sum === null ? null : keyOf(sum, config.style);
+    // Not what was asked for, or already on the page. Either way the budget
+    // ticks down, and a pool that has run out ends the draw rather than
+    // repeating itself.
+    if (sum === null || key === null || seen.has(key)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(key);
+    problems.push(problemOf(sum, config, slot, extras));
+    misses = 0;
+  }
+  return problems;
+}
+
+/**
+ * What every problem on this sheet carries besides its own numbers.
+ *
+ * One number line for the whole page rather than one per problem: a child
+ * reads the scale once and uses it twenty times. It spans zero to the largest
+ * result the config can produce, so no problem falls off the end of it.
+ */
+function sheetExtras(
+  config: ArithmeticConfig,
+  cell: Mil,
+): { line?: NumberLine; workspace?: Mil } {
+  const { max } = bounds(config.range);
+  // The far end is the largest result the config can reach: two numbers from
+  // the range added together, or — where nothing is added — the range itself.
+  const top = config.operation === "subtract" ? max : max * 2;
+  const line =
+    config.numberLine && config.style !== "fact-family"
+      ? numberLine(config.negatives ? -max : 0, top, cell)
+      : undefined;
+  return {
+    ...(line ? { line } : {}),
+    ...(config.workspace ? { workspace: WORKSPACE } : {}),
+  };
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const OPERATION_NAME = {
+  add: "Addition",
+  subtract: "Subtraction",
+  both: "Addition and subtraction",
+} as const;
+
+/** "Addition to 20" — the phrase a parent says, and the one they search. */
+function titleOf(config: ArithmeticConfig): string {
+  const { max } = bounds(config.range);
+  if (config.style === "fact-family") return `Fact families to ${max}`;
+  return `${OPERATION_NAME[config.operation]} to ${max}`;
+}
+
+const INSTRUCTION: Record<ArithmeticStyle, string> = {
+  standard: "Work out each answer.",
+  missing: "Write the missing number in each blank.",
+  "fact-family": "Write the four number sentences each family makes.",
+};
+
+function instructionOf(config: ArithmeticConfig): string {
+  const line = config.numberLine && config.style !== "fact-family";
+  return line
+    ? `${INSTRUCTION[config.style]} Use the number line to help.`
+    : INSTRUCTION[config.style];
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: ArithmeticConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions: config.instructions ?? instructionOf(config),
+  };
+}
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * The two things a shop's label leaves off are the two that decide whether a
+ * sheet matches the lesson: whether it carries, and whether the sum is written
+ * along a line or worked in columns.
+ */
+export function describeArithmetic(config: ArithmeticConfig): string {
+  const REGROUPING: Record<Regrouping, string | null> = {
+    either: null,
+    never: "no regrouping",
+    always: "with regrouping",
+  };
+  return [
+    titleOf(config),
+    config.style === "standard" && config.form === "vertical"
+      ? "in columns"
+      : null,
+    config.style === "missing" ? "missing number" : null,
+    REGROUPING[config.regrouping],
+    config.numberLine && config.style !== "fact-family"
+      ? "with a number line"
+      : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" — ");
+}
+
+export function buildArithmeticSheet(
+  config: ArithmeticConfig,
+  seed: number,
+): Sheet {
+  const items = arithmeticProblems(config, seed);
+  const { columns } = arithmeticLayout(config);
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Marked out of what is actually on the page, not out of what was asked
+      // for: a sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf: items.length },
+    },
+    blocks: [{ kind: "problems", columns, items }],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const ARITHMETIC_SHEET: SheetSpec<ArithmeticConfig> = {
+  id: "arithmetic",
+  label: "Addition and subtraction",
+  world: SHEET_WORLD,
+  build: buildArithmeticSheet,
+  // The whole of the answer-key mechanism: the answers were computed when each
+  // problem was built, so a key prints what is already there rather than
+  // generating it a second time and risking a different answer to the same
+  // question.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeArithmetic,
+};

--- a/src/engine/sheets/numberline.ts
+++ b/src/engine/sheets/numberline.ts
@@ -18,22 +18,89 @@ import { inches } from "./paper";
 export const NUMBER_LINE_HEIGHT: Mil = inches(0.34);
 
 /**
+ * Room at each end for the outermost label, which is centred on its tick and
+ * would otherwise be cut in half by the edge of the drawing. Enough for three
+ * digits at the size below.
+ *
+ * Here rather than in the renderer that draws it, because the spacing chosen
+ * below is chosen against the width that is left once both ends are paid for.
+ * A second copy of this number in the view would be a line whose labels
+ * overlap in exactly the cases the arithmetic here said they would not.
+ */
+export const LINE_INSET: Mil = 140;
+
+/** The size a tick label is set at — about 9pt. */
+export const LABEL_SIZE: Mil = 125;
+
+/**
+ * How wide a digit is at `LABEL_SIZE`.
+ *
+ * A little over half the size it is set at, which is what a digit measures in
+ * every face a browser would pick for this. Not exact — the engine has no font
+ * to ask — and it does not need to be: it is the input to "will these two
+ * labels touch?", and the answer is only ever used to step down to the next
+ * spacing a child would count in.
+ */
+const DIGIT = 0.62;
+
+/**
  * The spacings a line is allowed to count in.
  *
  * Ones, twos, fives and the tens above them — the intervals a child already
  * counts in. Nothing here is a spacing nobody would say out loud: a line
  * marked every seven is arithmetic homework of its own.
  */
-const STEPS = [1, 2, 5, 10, 20, 25, 50, 100];
+const STEPS = [1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000];
 
 /**
- * The most ticks a line carries before its labels touch.
+ * How much room the labels on a line need, tick to tick.
  *
- * Twelve two-digit labels across a three-inch column is about a quarter of an
- * inch each, which is legible at the small type a tick label is set in. More
- * than that and the line stops being something to count along.
+ * The widest label, plus a digit's worth of air: labels are centred on their
+ * ticks, so two of them exactly one label apart are two labels touching. The
+ * widest is measured rather than assumed, because a line that runs to 100 to
+ * cover a range of 20 is a three-digit label on a two-digit sheet.
+ *
+ * Exported because it is the readability promise itself, and the only thing a
+ * test can hold the spacing below to.
  */
-const MAX_TICKS = 12;
+export function labelRoom(marks: number[]): Mil {
+  const widest = marks.reduce(
+    (most, value) => Math.max(most, String(value).length),
+    1,
+  );
+  return Math.ceil((widest + 1) * LABEL_SIZE * DIGIT);
+}
+
+/** Whether a line's labels have the room `labelRoom` says they need. */
+function fits(line: NumberLine): boolean {
+  const marks = ticks(line);
+  if (marks.length < 2) return false;
+  const usable = Math.max(0, line.width - LINE_INSET * 2);
+  return usable / (marks.length - 1) >= labelRoom(marks);
+}
+
+/**
+ * A line at one candidate spacing, covering `low` to `high` in `least` steps
+ * at the fewest.
+ */
+function lineAt(
+  low: number,
+  high: number,
+  width: Mil,
+  step: number,
+  least: number,
+): NumberLine {
+  const from = Math.min(0, Math.floor(low / step) * step);
+  return {
+    from,
+    to: Math.max(from + step * least, up(high, step)),
+    step,
+    width,
+  };
+}
+
+/** A line is worth counting along at five steps; below that it is two ticks. */
+const WANTED_STEPS = 5;
 
 /**
  * A number line covering everything between `low` and `high`.
@@ -42,15 +109,24 @@ const MAX_TICKS = 12;
  * scale once and then uses it twenty times, and twenty lines drawn at twenty
  * different scales is twenty things to read. Zero is always on it, because
  * that is where counting starts.
+ *
+ * The spacing is chosen against the `width` the line is actually drawn in, and
+ * that is the whole of why `width` is a parameter rather than something the
+ * caller stamps on afterwards. `columns` is a setting a parent picks and six of
+ * them is legal, which leaves a line an inch of paper — nine two-digit labels
+ * across an inch is unreadable, and print is the whole of the output path, so
+ * there is no screen it looks wrong on first.
  */
 export function numberLine(low: number, high: number, width: Mil): NumberLine {
-  const span = Math.max(1, Math.max(0, high) - Math.min(0, low));
-  const step =
-    STEPS.find((by) => span / by <= MAX_TICKS) ?? STEPS[STEPS.length - 1];
-  const from = Math.min(0, Math.floor(low / step) * step);
-  // At least five steps, so a line for single digits is still a line rather
-  // than a pair of ticks with the answer between them.
-  return { from, to: Math.max(from + step * 5, up(high, step)), step, width };
+  // Five steps if they fit, and if they don't, fewer ticks further apart: a
+  // short line a child can read beats a long one whose numbers run together.
+  for (const least of [WANTED_STEPS, 1]) {
+    const step = STEPS.find((by) => fits(lineAt(low, high, width, by, least)));
+    if (step !== undefined) return lineAt(low, high, width, step, least);
+  }
+  // Nothing fits, which means the column is too narrow for the numbers on it
+  // whatever is done. The coarsest spacing is the fewest labels there are.
+  return lineAt(low, high, width, STEPS[STEPS.length - 1], 1);
 }
 
 /** Every labelled value on a line, left to right. */

--- a/src/engine/sheets/numberline.ts
+++ b/src/engine/sheets/numberline.ts
@@ -1,0 +1,63 @@
+/**
+ * A line to count along.
+ *
+ * The first thing a child adds with, before they add: 6 + 3 is six hops and
+ * then three more. So it is a drawing aid attached to a problem rather than a
+ * block of its own — the problem-grid block is the shared primitive every
+ * maths family reuses, and a line under a sum is part of the sum.
+ *
+ * Where the ticks go is arithmetic, so it lives here and not in the renderer,
+ * for the same reason `ruleLines` does: a spacing that a browser worked out is
+ * a spacing no test can check.
+ */
+import type { Mil, NumberLine } from "./types";
+
+import { inches } from "./paper";
+
+/** The axis, its ticks, and the labels under them. */
+export const NUMBER_LINE_HEIGHT: Mil = inches(0.34);
+
+/**
+ * The spacings a line is allowed to count in.
+ *
+ * Ones, twos, fives and the tens above them — the intervals a child already
+ * counts in. Nothing here is a spacing nobody would say out loud: a line
+ * marked every seven is arithmetic homework of its own.
+ */
+const STEPS = [1, 2, 5, 10, 20, 25, 50, 100];
+
+/**
+ * The most ticks a line carries before its labels touch.
+ *
+ * Twelve two-digit labels across a three-inch column is about a quarter of an
+ * inch each, which is legible at the small type a tick label is set in. More
+ * than that and the line stops being something to count along.
+ */
+const MAX_TICKS = 12;
+
+/**
+ * A number line covering everything between `low` and `high`.
+ *
+ * One line for the whole sheet rather than one per problem: a child reads the
+ * scale once and then uses it twenty times, and twenty lines drawn at twenty
+ * different scales is twenty things to read. Zero is always on it, because
+ * that is where counting starts.
+ */
+export function numberLine(low: number, high: number, width: Mil): NumberLine {
+  const span = Math.max(1, Math.max(0, high) - Math.min(0, low));
+  const step =
+    STEPS.find((by) => span / by <= MAX_TICKS) ?? STEPS[STEPS.length - 1];
+  const from = Math.min(0, Math.floor(low / step) * step);
+  // At least five steps, so a line for single digits is still a line rather
+  // than a pair of ticks with the answer between them.
+  return { from, to: Math.max(from + step * 5, up(high, step)), step, width };
+}
+
+/** Every labelled value on a line, left to right. */
+export function ticks(line: NumberLine): number[] {
+  if (line.step <= 0 || line.to <= line.from) return [];
+  const count = Math.floor((line.to - line.from) / line.step) + 1;
+  return Array.from({ length: count }, (_, i) => line.from + i * line.step);
+}
+
+const up = (value: number, step: number) => Math.ceil(value / step) * step;

--- a/src/engine/sheets/templates/paper.test.ts
+++ b/src/engine/sheets/templates/paper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { sheetBlockBox } from "../chrome";
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
 import { contentBox, ruledLines } from "../layout";
 import { RULINGS, inches, rulePitch } from "../paper";
@@ -12,7 +13,7 @@ import type {
   RuleStyle,
 } from "../types";
 
-import { PAPER_SHEET, paperBlockBox } from "./paper";
+import { PAPER_SHEET } from "./paper";
 
 /**
  * The family the geometry is proved on.
@@ -118,7 +119,7 @@ describe("what a ruler would find", () => {
     // Measured against the *block* box, which is the only box that can fail.
     // The content box cannot: `ruleCapacity` floors against a height that is
     // already the content box minus the chrome, so a family that reserved
-    // nothing at all would still satisfy it, and deleting `chrome()` would
+    // nothing at all would still satisfy it, and deleting `chromeHeight()` would
     // leave this test green while every sheet overran its footer.
     for (const size of SIZES) {
       for (const margin of MARGINS) {
@@ -127,7 +128,7 @@ describe("what a ruler would find", () => {
           const over = { paper: paper({ size, margin }), rule };
           const lines = rulesOf(over).lines;
           const pitch = rulePitch(rule);
-          const box = paperBlockBox(config(over));
+          const box = sheetBlockBox(config(over));
 
           expect(lines * pitch).toBeLessThanOrEqual(box.height);
           // ...and one more would not have fitted, which is what makes the
@@ -145,7 +146,7 @@ describe("what a ruler would find", () => {
     // on ⅝ paper a child notices. Name and date, no title, no instructions —
     // the sheet the catalog actually ships — spends under an inch on chrome.
     const bare = config();
-    const spare = contentBox(bare.paper).height - paperBlockBox(bare).height;
+    const spare = contentBox(bare.paper).height - sheetBlockBox(bare).height;
     expect(spare).toBeGreaterThan(0);
     expect(spare).toBeLessThan(inches(0.8));
   });
@@ -159,7 +160,7 @@ describe("what a ruler would find", () => {
     // passes two; reachable from `buildSheet` today and from the builder next.
     const two = config();
     const three = config({ fields: ["name", "date", "class"] });
-    expect(paperBlockBox(three).height).toBeLessThan(paperBlockBox(two).height);
+    expect(sheetBlockBox(three).height).toBeLessThan(sheetBlockBox(two).height);
 
     // The sheet pays for the row by losing a line, rather than by overrunning.
     const rule: Rule = { style: "narrow" };

--- a/src/engine/sheets/templates/paper.ts
+++ b/src/engine/sheets/templates/paper.ts
@@ -16,111 +16,18 @@
  * chrome leaves, and the renderer draws that many. Nothing measures anything,
  * which is what lets this run at build time on a catalog page (§4).
  */
-import type { Mil, PaperConfig, Sheet } from "../types";
+import type { PaperConfig, Sheet } from "../types";
 
-import {
-  blockBox,
-  contentBox,
-  fitAcross,
-  ruleCapacity,
-  type Box,
-} from "../layout";
-import { inches, points, rulingOf } from "../paper";
+import { sheetBlockBox } from "../chrome";
+import { ruleCapacity } from "../layout";
+import { rulingOf } from "../paper";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
 
-/* ── What the chrome takes out of the page ────────────────────────────────
-   Declared, not measured — the bargain `blockBox` is built on (§4) — and
-   rounded up, because the two errors are not symmetrical. Reserving a tenth of
-   an inch too much costs one rule line at the bottom of the page. Reserving
-   too little pushes that line onto a second sheet of paper, and print is the
-   whole of the output path here: there is no PDF to notice it in first.
-
-   The numbers trail sheet.css, which sets the header's rows in ems of the body
-   size and its gaps in inches. So these are too: a title is 1.7em over a 1.05
-   line-height, a field line 0.82em over 1.35, an instruction 0.9em, and the
-   footer 0.62em above a rule with 0.18in of air over it.                    */
-
-const HEAD_ROWS = { title: 1.9, fields: 1.2, instructions: 1.3 } as const;
-const FOOT_ROW = 0.9;
-
-/** The gap sheet.css puts between the header's rows. */
-const HEAD_GAP = inches(0.09);
-/** And under the header itself, whatever is in it. */
-const HEAD_MARGIN = inches(0.16);
-/** The footer's rule, its padding, and the air above it. */
-const FOOT_MARGIN = inches(0.23);
-
-/* The name line is not always one row. `.sheet__fields` is a wrapping flex
-   row, so how many rows it takes is a question about the width of the page —
-   three fields ("name", "date", "class" are all legal) measure more than a
-   Letter content width and land on two. A row that was not reserved for is a
-   rule line below the bottom margin, which is a second sheet of paper. */
-
-/** One field: `.sheet__field-rule` at 2.1in, plus its label and their gap. */
-const FIELD_WIDTH = inches(2.5);
-/** `.sheet__fields` sets 0.06in between rows and 0.28in between fields. */
-const FIELD_GAP = inches(0.28);
-const FIELD_ROW_GAP = inches(0.06);
-
-/** A height quoted in ems of the body size, in the unit the page is in. */
-const em = (fontPt: number, rows: number): Mil => points(fontPt * rows);
-
-/** How many rows the name line wraps onto, given the width it has to fill. */
-function fieldRows(config: PaperConfig): number {
-  if (config.fields.length === 0) return 0;
-  const across = fitAcross(
-    contentBox(config.paper).width,
-    FIELD_WIDTH,
-    FIELD_GAP,
-  );
-  // A page too narrow for one whole field still prints one per row rather
-  // than dividing by zero — and the rules then get whatever is left.
-  return Math.ceil(config.fields.length / Math.max(1, across));
-}
-
-/**
- * How much of the page the header and footer will use.
- *
- * Counted from what the header actually holds rather than from a constant: a
- * sheet of lined paper with a name line and no title has an inch more writing
- * space than one with both, and on ⅝ paper an inch is two more lines to write
- * on. A family that reserved for the worst case would throw them away.
- */
-function chrome(config: PaperConfig): { header: Mil; footer: Mil } {
-  const fields = fieldRows(config);
-  const rows = [
-    config.title ? HEAD_ROWS.title : 0,
-    HEAD_ROWS.fields * fields,
-    config.instructions ? HEAD_ROWS.instructions : 0,
-  ].filter((row) => row > 0);
-
-  return {
-    // The margin is there even when the header is empty — SheetHead renders
-    // the element either way, and an empty flex column still takes its gap.
-    header:
-      HEAD_MARGIN +
-      rows.reduce((total, row) => total + em(config.fontPt, row), 0) +
-      HEAD_GAP * Math.max(0, rows.length - 1) +
-      FIELD_ROW_GAP * Math.max(0, fields - 1),
-    footer: FOOT_MARGIN + em(config.fontPt, FOOT_ROW),
-  };
-}
-
-/**
- * What is left for the ruling: the page, less its margins, less the chrome.
- *
- * Exported because it is the reservation itself, and the reservation is the
- * only thing a test can hold `chrome` to. Checking the rules against the
- * *content* box instead cannot fail — `ruleCapacity` floors against this box,
- * which is the content box minus a non-negative number, so any chrome at all
- * satisfies it, including none.
- */
-export function paperBlockBox(config: PaperConfig): Box {
-  return blockBox(config.paper, chrome(config));
-}
-
 export function buildPaperSheet(config: PaperConfig, seed: number): Sheet {
-  const box = paperBlockBox(config);
+  // Whatever the header and footer leave. The reservation is shared with every
+  // other family (chrome.ts) rather than counted again here, because it trails
+  // sheet.css and a second copy of it would drift silently.
+  const box = sheetBlockBox(config);
 
   return {
     paper: config.paper,

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -99,8 +99,34 @@ export type Rule = {
 export type TraceStyle =
   "solid" | "dim" | "hollow" | "dotted" | "dashed" | "none";
 
+/**
+ * A line to count along, under a problem.
+ *
+ * Two numbers and a tick spacing, which is all a number line is. The width is
+ * declared here rather than measured by the renderer, for the same reason a
+ * problem cell's is (§4): the family already worked out how wide a column is
+ * to decide how many fit, and a second answer discovered in the browser is a
+ * second answer.
+ */
+export type NumberLine = {
+  from: number;
+  to: number;
+  /** A tick every `step`, each one labelled. */
+  step: number;
+  /** How wide it is drawn. */
+  width: Mil;
+};
+
 export type Problem = {
-  /** How it reads on the sheet: "7 × 8 =". */
+  /**
+   * How it reads on the sheet: "7 × 8 =".
+   *
+   * A single `_` marks where the answer goes when it belongs inside the
+   * sentence rather than after it — "7 + _ = 15" — the same convention
+   * `Blank.text` uses. A prompt with no gap gets a ruled slot at the end, so
+   * every problem has exactly one place for an answer and the two forms can't
+   * both apply. Empty when `operands` says the problem is drawn in columns.
+   */
   prompt: string;
   /**
    * Text even when it's a number — "56", not 56 — for the same reason
@@ -108,12 +134,26 @@ export type Problem = {
    */
   answer: string;
   /**
+   * Column form: the numbers stacked top to bottom, right-aligned under one
+   * another with `operator` against the last of them and a rule under the lot.
+   *
+   * Absent for the problems that read across a line, which is most of them.
+   * There is no second field saying which form a problem is in, because a
+   * renderer stacks exactly when there is a stack to draw — a flag beside the
+   * data is a flag that can disagree with it.
+   */
+  operands?: string[];
+  /** The sign printed beside the stack: "+" or "−". Column form only. */
+  operator?: string;
+  /**
    * Which fact this exercises, in the vocabulary the race already uses
    * ("7:8"). Optional, and the whole of what makes "print the facts they keep
    * missing" (§14) possible: the record book hands over fact ids and a family
    * turns them into problems without either side learning the other's shape.
    */
   factId?: string;
+  /** A number line under the problem, to count along. */
+  line?: NumberLine;
   /** Blank height under the problem for working out. Absent means none. */
   workspace?: Mil;
 };
@@ -301,8 +341,63 @@ export type BlankConfig = SheetOptions & { kind: "blank" };
  */
 export type PaperConfig = SheetOptions & { kind: "paper"; rule: Rule };
 
+/* ── Arithmetic ────────────────────────────────────────────────────────────
+   The first *generated* family: the one where a sheet is not a shape to write
+   on but a set of problems that have right answers, and where a wrong answer
+   key is worse than no sheet at all.                                        */
+
+/** Which sums are on the page. `both` shuffles the two together. */
+export type ArithmeticOperation = "add" | "subtract" | "both";
+
+/**
+ * What the problem asks for.
+ *
+ * `standard` gives both numbers and asks for the result; `missing` gives the
+ * result and one number and asks for the other, which is the same fact
+ * approached from the far side; `fact-family` gives the three numbers of a
+ * family and asks for the four sentences they make.
+ */
+export type ArithmeticStyle = "standard" | "missing" | "fact-family";
+
+/** Written across the line, or stacked in columns the way a sum is worked. */
+export type ArithmeticForm = "horizontal" | "vertical";
+
+/**
+ * Whether a column may carry or borrow.
+ *
+ * The single most-asked-for switch on an arithmetic worksheet, because it is
+ * the line between the week a child learns to add and the week they learn to
+ * carry. `either` is the default: whatever the numbers happen to do.
+ */
+export type Regrouping = "either" | "never" | "always";
+
+export type ArithmeticConfig = SheetOptions & {
+  kind: "arithmetic";
+  operation: ArithmeticOperation;
+  style: ArithmeticStyle;
+  form: ArithmeticForm;
+  /**
+   * Where both numbers in a problem come from, ends included.
+   *
+   * The numbers a child *sees*, not the answers they reach: "addition to 20"
+   * with a range of 0–20 puts two numbers up to twenty on the page, and their
+   * sum may run past it. That is what carrying is.
+   */
+  range: { min: number; max: number };
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  regrouping: Regrouping;
+  /** Whether a subtraction may go below zero. Off unless asked for. */
+  negatives?: boolean;
+  /** A number line under every problem, to count along. */
+  numberLine?: boolean;
+  /** Blank space under every problem, to work in. */
+  workspace?: boolean;
+};
+
 /**
  * Anything a saved sheet can hold. Narrow on `kind` — and only in index.ts,
  * which is the one module that knows the whole union.
  */
-export type SheetConfig = BlankConfig | PaperConfig;
+export type SheetConfig = BlankConfig | PaperConfig | ArithmeticConfig;

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -134,6 +134,22 @@ export type Problem = {
    */
   answer: string;
   /**
+   * The answer as more than one thing to write, one ruled line each — a fact
+   * family's four number sentences.
+   *
+   * When it is here it *is* the answer place: the prompt prints no slot on the
+   * end, and `workspace` becomes the height those lines share rather than
+   * blank paper beneath them. A single slot instead would be a blank the size
+   * of one sentence on the sheet and four sentences crammed into it on the key,
+   * which wraps — and a row taller than the layout reserved is the last row of
+   * the page printed on a second sheet.
+   *
+   * `answer` carries the same list joined onto one line, for anything that
+   * wants the answer as a string. Both are built from one array where the
+   * problem is made, so there is no second answer to disagree with the first.
+   */
+  answers?: string[];
+  /**
    * Column form: the numbers stacked top to bottom, right-aligned under one
    * another with `operator` against the last of them and a rule under the lot.
    *

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -217,7 +217,8 @@
 }
 
 .sheet__cell,
-.sheet__dot {
+.sheet__dot,
+.sheet__tick {
   fill: currentcolor;
   stroke: none;
 }
@@ -306,11 +307,45 @@
   text-align: center;
 }
 
-.sheet__slot--answered {
+/* An answer, wherever it is written: in the slot at the end of a sum, in the
+   gap inside one, or under the rule of a column. One weight in one place, so
+   a key reads the same however the problem was set. */
+.sheet__slot--answered,
+.sheet__total--answered {
   font-weight: 700;
 }
 
-.sheet__workspace {
+/* ── Column form ────────────────────────────────────────────────────────────
+   The same sum stacked, which is how carrying is taught. `tabular-nums` is not
+   a nicety here: a child shown to line the units up under the units will line
+   them up, and a proportional face puts a 1 half a column left of where a 4
+   goes. The rule under the sum is a border on the answer's own box, so it is
+   exactly as wide as the sum it belongs to whatever the numbers are.        */
+
+.sheet__column {
+  display: inline-flex;
+  flex-direction: column;
+  min-width: 0.85in;
+  font-variant-numeric: tabular-nums;
+}
+
+.sheet__addend {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.14in;
+}
+
+.sheet__total {
+  border-top: 0.75pt solid currentcolor;
+  padding-top: 0.03in;
+  min-height: 1.2em;
+  text-align: right;
+}
+
+/* A number line and a workspace are both a full row of their own under the
+   problem they belong to, rather than something beside it. */
+.sheet__workspace,
+.sheet__number-line {
   display: block;
   flex: 1 0 100%;
 }

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -350,6 +350,33 @@
   flex: 1 0 100%;
 }
 
+/* ── Answers written out ────────────────────────────────────────────────────
+   A fact family asks for four number sentences, so it gets four lines to write
+   them on rather than one slot the size of one of them. These lines *are* the
+   answer place — the prompt above prints no slot — and they divide the height
+   the family reserved between them, which is why `nowrap` is load-bearing and
+   not a nicety: a sentence that wrapped would make the row taller than the
+   layout arithmetic declared, and the bottom row of the page would come out of
+   the printer on a second sheet.                                            */
+
+.sheet__answers {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 100%;
+}
+
+.sheet__answer-line {
+  display: flex;
+  align-items: flex-end;
+  overflow: hidden;
+  white-space: nowrap;
+  border-bottom: 0.75pt solid currentcolor;
+}
+
+.sheet__answer-line--answered {
+  font-weight: 700;
+}
+
 /* ── The rest of the blocks ─────────────────────────────────────────────── */
 
 .sheet__blanks,


### PR DESCRIPTION
Closes #49 (PRINT05).

The first sheet family with right answers on it. Lined paper is correct if it
measures what it says; a page of sums is correct only if the key is, so the
whole story is arranged around proving that.

## What changed

`src/engine/sheets/maths/arithmetic.ts` is the family: addition and subtraction,
written along the line or stacked in columns, with and without regrouping,
missing numbers, fact families, and a number line to count along. Ranges,
problem count and columns are config.

It prints through the problem-grid block from PRINT02 rather than adding one of
its own, so `Problem` grows three optional fields — a stack, a sign and a line —
and the renderer stacks exactly when there is a stack to draw. There is no flag
beside the data that could disagree with it.

Problems are **drawn and rejected rather than enumerated**. Listing every pair in
a three-digit range allocates a million of them at build time, three times over
for the variants. A draw that runs out of pool prints what it has, which is the
honest answer to "twenty different sums from 1 to 3" — there are six.

Header reservation moves out of the paper family into `src/engine/sheets/chrome.ts`,
because this family asks the same delicate question and a second copy of numbers
that trail `sheet.css` would drift silently. That move found a bug worth
recording: a generated family names its own sheet, so reserving against
`config.title` — usually absent — under-reserved by a title's worth and put the
last row of problems below the bottom margin.

## Why the tests look the way they do

The tests never check the generator against the generator. Every answer is
verified from the *printed* problem by a path the family does not use: addition
by counting up one at a time, subtraction through its inverse, and carrying by
the digit-sum identity (a carry costs exactly nine). Bounds, duplicates,
capacity at every stock and margin, and variants A/B/C from `seed`, `seed+1` and
`seed+2` are swept over every shape the family can print. Mutating the sum, the
carry test, the range or the dedupe each fails at least one test.

Two golden lists pin determinism *across processes*, not just within one. The
seed is printed on the paper so a parent can have the same sheet again next
week, across a deploy — without those, a refactor that moved where the draw
consumes `rand()` would quietly change every seed already printed.

## Review fixes in the second commit

Three of them are the same shape of bug: a sheet whose declared layout and
printed markup disagree, which is the one class of failure a static print
pipeline has no way to notice — there is no PDF between the build and the paper.

- **Fact families had no shape to be printed in.** The prompt is three numbers
  with no gap, so the renderer took the append-a-slot branch and drew a ruled
  blank *and* the inch of workspace meant for four sentences — a sheet a child
  answers twice. A problem may now carry `answers`, and that list *is* the answer
  place: four ruled lines dividing the height the family already reserved, no
  slot on the prompt, `white-space: nowrap` to keep the row the height the
  arithmetic declared. `answer` is that list joined onto one line, built from it,
  so the two cannot disagree.
- **`numberLine()` ignored the width it was drawn in.** Spacing came from a fixed
  budget of twelve ticks, so `{numberLine: true, columns: 6, range: 0-20}`
  printed nine two-digit labels across 0.72in, physically overlapping. The budget
  now comes from the width, and five steps yields to fewer ticks further apart
  when the column is too narrow.
- **`rowHeight()` reserved number-line height for fact families**, which never get
  one — two problems a page thrown away, from two functions reading the same
  config differently. There is one `hasNumberLine` predicate now, with four
  readers.
- **The renderer's half of the key had no assertions.** What a parent receives is
  the *rendered* key; it is now tested against a sheet built through the real
  family — exactly one answer place per problem, a missing number spliced inside
  the sentence, a stacked sum's operands and ruled total, a number line's ticks
  and labels, and every answer place empty until the sheet is a key.

## Acceptance criteria

- [x] Horizontal and vertical layouts; with and without regrouping; missing addend; fact families; number-line support
- [x] Number ranges, problem count and columns are all config
- [x] `spec.key()` produces a correct answer key for every generated sheet
- [x] Answer-key tests verify each answer by an independent path, not the generator's own arithmetic
- [x] Bounds tests: no negative results unless enabled, no duplicates within a sheet, nothing outside the declared range
- [x] Variants A/B/C from `seed`, `seed+1`, `seed+2` produce genuinely different problem sets

Out of scope as stated on the issue: no catalog pages (PRINT10), no builder UI (PRINT13).

## Validation

`type-check`, `lint`, `test:unit` (301 passing), `build` (static, 45 pages) and
the browser smoke test all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
