### PR TITLE
PRINT06: multiplication and division worksheets

### DIFF
--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -217,6 +217,27 @@ function filesUnder(dir: string, endings: string[]): string[] {
 const read = (path: string) => readFileSync(path, "utf8");
 
 /**
+ * How far a rule holds its text off the right edge of its own box, as written.
+ *
+ * Compared as the source string rather than as a length, because that is all
+ * this can honestly claim without a browser: two rules that declare `0.06in`
+ * agree, and two that declare different things are a question for whoever
+ * changed one of them. Both the longhand and the three-value shorthand are
+ * read, since the two rules this compares are written each way.
+ */
+function rightInset(css: string, rule: string): string {
+  const block = css.slice(css.indexOf(rule));
+  const body = block.slice(0, block.indexOf("}"));
+  const longhand = /padding-right:\s*([^;]+);/.exec(body);
+  if (longhand) return longhand[1].trim();
+  const shorthand = /padding:\s*([^;]+);/.exec(body);
+  if (!shorthand) throw new Error(`${rule} declares no padding at all`);
+  // top | right-and-left | bottom, and the one-value form besides.
+  const parts = shorthand[1].trim().split(/\s+/);
+  return parts.length === 1 ? parts[0] : parts[1];
+}
+
+/**
  * The landmarks a page puts around a sheet: its sections, its page header, and
  * any full-width wrap that is not the sheet's own frame. Everything nested
  * inside one of these goes wherever it goes, so these are the elements the
@@ -625,6 +646,15 @@ describe("a rendered multiplication sheet", () => {
         "font-variant-numeric: tabular-nums",
       );
     }
+
+    // Tabular figures only line a quotient up with its dividend while the two
+    // boxes hold their digits the same distance off their shared right edge. A
+    // padding added to one and not the other slides the whole quotient across
+    // by a fraction of a digit — invisible in review, and the one thing the
+    // sheet exists to teach. Asserted rather than trusted.
+    expect(rightInset(css, ".sheet__quotient {")).toBe(
+      rightInset(css, ".sheet__dividend {"),
+    );
   });
 
   it("fills a multiplication grid in only on the key", () => {

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -11,6 +11,7 @@ import { DEFAULT_PAPER } from "@/engine/sheets/paper";
 import type {
   ArithmeticConfig,
   Block,
+  MultiplicationConfig,
   Paper,
   Problem,
   Sheet,
@@ -61,6 +62,23 @@ const EVERY_BLOCK: Block[] = [
         answer: "75",
         line: { from: 0, to: 20, step: 2, width: 2400 },
       },
+      // And the two long forms: a stack with its partial products between the
+      // rule and the total, and the division bracket, whose answer is written
+      // above the problem rather than under it.
+      {
+        prompt: "",
+        operands: ["347", "26"],
+        operator: "×",
+        working: ["2082", "6940"],
+        workspace: 500,
+        answer: "9022",
+      },
+      {
+        prompt: "",
+        bracket: { divisor: "4", dividend: "938" },
+        answer: "234 r 2",
+        workspace: 1500,
+      },
     ],
   },
   { kind: "rules", rule: { style: "hand-5-8", descender: true }, lines: 6 },
@@ -89,6 +107,20 @@ const EVERY_BLOCK: Block[] = [
       cell: 250,
       cells: ["1", "2", "", "4"],
       origin: { column: 2, row: 2 },
+    },
+  },
+  {
+    kind: "grid",
+    grid: {
+      kind: "chart",
+      columns: 3,
+      rows: 3,
+      cell: 250,
+      // A multiplication square: headers on the sheet from the start, products
+      // only on the key, and the two heavier rules that keep them apart.
+      cells: ["×", "2", "3", "4", "", "", "5", "", ""],
+      answers: ["", "", "", "", "8", "12", "", "10", "15"],
+      origin: { column: 1, row: 1 },
     },
   },
   {
@@ -449,6 +481,199 @@ describe("a rendered arithmetic sheet", () => {
     }
   });
 });
+
+/* ── The long forms, and the square ────────────────────────────────────────
+   The two sheets where the answer is not the only thing written down. The
+   engine's suite proves the partials and the quotients are right; this is
+   where they have to land in the right place on the paper, which is the whole
+   of what a long form teaches and the one thing no unit test of the engine can
+   see. Built through the real family, so a shape it starts producing is a
+   shape these see.                                                          */
+
+const multiplication = (
+  over: Partial<MultiplicationConfig> = {},
+): MultiplicationConfig => ({
+  kind: "multiplication",
+  paper: DEFAULT_PAPER,
+  fontPt: 12,
+  fields: ["name"],
+  operation: "multiply",
+  style: "standard",
+  form: "horizontal",
+  tables: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  factors: { min: 0, max: 12 },
+  count: 4,
+  columns: 2,
+  ...over,
+});
+
+const timesTable = (over: Partial<MultiplicationConfig> = {}) =>
+  render(buildSheet(multiplication(over), SEED) as Sheet);
+const timesKey = (over: Partial<MultiplicationConfig> = {}) =>
+  render(answerKey(multiplication(over), SEED) as Sheet);
+
+const LONG_MULTIPLICATION = {
+  style: "long",
+  digits: { into: 3, by: 2 },
+} as const;
+const LONG_DIVISION = {
+  style: "long",
+  operation: "divide",
+  digits: { into: 3, by: 1 },
+  remainders: true,
+} as const;
+
+describe("a rendered multiplication sheet", () => {
+  /** Every shape the family prints a problem in, as the renderer sees them. */
+  const SHAPES: Array<Partial<MultiplicationConfig>> = [
+    {},
+    { form: "vertical" },
+    { operation: "divide" },
+    { operation: "divide", form: "vertical" },
+    { style: "missing" },
+    LONG_MULTIPLICATION,
+    LONG_DIVISION,
+  ];
+
+  it("gives every problem exactly one place to write the answer", () => {
+    // The rule `Problems.tsx` is built around. A long multiplication's working
+    // lines are not one of them — they are working, and they are marked as
+    // working — so what is counted is the four places an *answer* goes.
+    for (const shape of SHAPES) {
+      for (const html of [timesTable(shape), timesKey(shape)]) {
+        const items = problems(html);
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+          const places =
+            count(item, 'class="sheet__slot') +
+            count(item, 'class="sheet__total') +
+            count(item, 'class="sheet__quotient') +
+            count(item, 'class="sheet__answers"');
+          expect(places, `${JSON.stringify(shape)}: ${item}`).toBe(1);
+        }
+      }
+    }
+  });
+
+  it("sets a long division in a bracket, with the answer on top of the bar", () => {
+    const [item] = problems(timesKey(LONG_DIVISION));
+    const divisor = item.indexOf('class="sheet__divisor"');
+    const quotient = item.indexOf('class="sheet__quotient');
+    const dividend = item.indexOf('class="sheet__dividend"');
+    // The divisor is outside the bracket, the quotient is written along the
+    // top of the bar, and the dividend is under it. In that order, because
+    // that is the order they are on paper and there is only one of it.
+    expect(divisor).toBeGreaterThanOrEqual(0);
+    expect(quotient).toBeGreaterThan(divisor);
+    expect(dividend).toBeGreaterThan(quotient);
+    expect(item).toMatch(
+      /class="sheet__quotient sheet__quotient--answered">\d+ r \d+</,
+    );
+    // And the blank sheet is the same drawing with nothing written on it.
+    expect(problems(timesTable(LONG_DIVISION))[0]).toContain(
+      '<span class="sheet__quotient"></span>',
+    );
+  });
+
+  it("rules the bracket rather than drawing it, so it always prints", () => {
+    // §5: browsers drop background paint, and a bracket that came out of the
+    // printer as three numbers in a row is not a long division.
+    const css = read(join(ROOT, "src/styles/sheet.css"));
+    const bracket = css.slice(css.indexOf(".sheet__dividend {"));
+    expect(bracket).toContain("border-top");
+    expect(bracket).toContain("border-left");
+  });
+
+  it("writes a long multiplication's partials between the rule and the total", () => {
+    const items = itemsOfMultiplication(LONG_MULTIPLICATION);
+    const partials = items.flatMap((problem) => problem.working ?? []);
+    expect(partials.length).toBe(items.length * 2);
+
+    const sheet = problems(timesTable(LONG_MULTIPLICATION));
+    for (const item of sheet) {
+      expect(count(item, 'class="sheet__work-line')).toBe(2);
+      // Inside the stack and above the total, which is where the algorithm
+      // puts them — under the sheet's own rule, not under the answer.
+      expect(item.indexOf('class="sheet__work"')).toBeLessThan(
+        item.indexOf('class="sheet__total'),
+      );
+      // Each line carries a share of the height the family reserved, so the
+      // row is as tall as the layout arithmetic said it was — and that height
+      // is spent once. Blank paper under the total *as well* would be a row
+      // twice as tall as the reservation, which is the bottom of the page on a
+      // second sheet.
+      expect(item).toContain("height:0.25in");
+      expect(count(item, 'class="sheet__workspace"')).toBe(0);
+    }
+    // Long division does take blank paper under the bracket, which is where a
+    // child works it: the two forms spend the same reservation differently.
+    for (const item of problems(timesTable(LONG_DIVISION))) {
+      expect(count(item, 'class="sheet__workspace"')).toBe(1);
+    }
+
+    const key = timesKey(LONG_MULTIPLICATION);
+    for (const partial of partials) expect(key).toContain(partial);
+  });
+
+  it("keeps the digits in their columns on both long forms", () => {
+    // The whole of what a long form teaches is which column a digit lands in,
+    // and a proportional face puts a 1 half a column left of where a 4 goes.
+    const css = read(join(ROOT, "src/styles/sheet.css"));
+    for (const rule of [".sheet__column {", ".sheet__bracket {"]) {
+      const block = css.slice(css.indexOf(rule));
+      expect(block.slice(0, block.indexOf("}"))).toContain(
+        "font-variant-numeric: tabular-nums",
+      );
+    }
+  });
+
+  it("fills a multiplication grid in only on the key", () => {
+    // The square a child fills in: headers from the start, products at the
+    // end, and the same build for both — `answers` flipped and nothing else.
+    const grid = { style: "grid" as const, tables: [2, 3] };
+    const sheet = timesTable(grid);
+    const key = timesKey(grid);
+    for (const header of [">×<", ">2<", ">3<"]) expect(sheet).toContain(header);
+    // Twelve times three and twelve times two, on the key and nowhere else.
+    expect(sheet).not.toContain(">36<");
+    expect(key).toContain(">36<");
+    expect(key).toContain(">24<");
+    expect(count(key, "sheet__cell--answered")).toBe(2 * 13);
+    expect(count(sheet, "sheet__cell--answered")).toBe(0);
+    // And the headers are ruled off from the answers, so a child does not read
+    // the row label as part of the sum.
+    expect(sheet).toContain('class="sheet__axes"');
+  });
+
+  it("prints nothing in any answer place until the sheet is a key", () => {
+    const PLACES = [
+      /<span class="sheet__slot"[^>]*>(.*?)<\/span>/g,
+      /<span class="sheet__total"[^>]*>(.*?)<\/span>/g,
+      /<span class="sheet__quotient"[^>]*>(.*?)<\/span>/g,
+      /<span class="sheet__work-line"[^>]*>(.*?)<\/span>/g,
+    ];
+    for (const shape of SHAPES) {
+      const html = timesTable(shape);
+      const where = JSON.stringify(shape);
+      expect(html, where).not.toContain("--answered");
+      let found = 0;
+      for (const place of PLACES) {
+        for (const [, inside] of html.matchAll(place)) {
+          expect(inside, where).toBe("");
+          found += 1;
+        }
+      }
+      expect(found, where).toBeGreaterThan(0);
+    }
+  });
+});
+
+/** The problems of a built multiplication sheet, narrowed out of the union. */
+function itemsOfMultiplication(over: Partial<MultiplicationConfig>): Problem[] {
+  const block = buildSheet(multiplication(over), SEED).blocks[0];
+  if (block.kind !== "problems") throw new Error(`got ${block.kind}`);
+  return block.items;
+}
 
 /* ── It has to survive the printer ─────────────────────────────────────── */
 

--- a/src/components/sheet/blocks/Grid.tsx
+++ b/src/components/sheet/blocks/Grid.tsx
@@ -14,7 +14,7 @@ const CELL_TO_EM = 0.5;
  * multiplication grid is the same shape with an axis.
  */
 export function Grid({ block, metrics }: BlockProps<"grid">) {
-  const { columns, rows, cells, origin, kind } = block.grid;
+  const { columns, rows, cells, answers, origin, kind } = block.grid;
   if (columns <= 0 || rows <= 0 || block.grid.cell <= 0) return null;
 
   // Clamped to what the content box actually holds. A grid wider than the box
@@ -70,10 +70,15 @@ export function Grid({ block, metrics }: BlockProps<"grid">) {
         />
       ))}
 
-      {/* A coordinate plane is the same grid with two heavier strokes through
-          it. Where they cross is counted in squares, so the axes land on the
-          ruling rather than near it. */}
-      {kind === "coordinate" && origin && (
+      {/* Two heavier strokes through the ruling, where the grid says they
+          cross — counted in squares, so they land on the ruling rather than
+          near it. A coordinate plane's axes are the first use; a multiplication
+          square's header rules are the second, and they are the same two lines
+          drawn from the same number. Gated on the origin rather than on the
+          kind, because a grid that named where they cross and then didn't get
+          them would be a grid whose data said one thing and whose ink said
+          another. */}
+      {origin && (
         <g className="sheet__axes">
           <line
             x1={0}
@@ -94,22 +99,60 @@ export function Grid({ block, metrics }: BlockProps<"grid">) {
         </g>
       )}
 
-      {cells?.map((text, index) =>
-        text === "" ? null : (
-          <text
-            key={`${index}-${text}`}
-            className="sheet__cell"
-            x={((index % columns) + 0.5) * cell}
-            y={(Math.floor(index / columns) + 0.5) * cell}
-            fontSize={size}
-            textAnchor="middle"
-            dominantBaseline="central"
-          >
-            {text}
-          </text>
-        ),
-      )}
+      {/* Two lists over the same squares: what is printed whatever the sheet
+          is, and what is printed only on a key. A multiplication square's
+          headers are the first and its hundred and forty-four products are the
+          second, so the blank grid and the wall chart are one build with
+          `answers` flipped — the same mechanism as every ruled slot. */}
+      {written(cells).map(([index, text]) => (
+        <Cell key={`c${index}`} {...{ index, text, columns, cell, size }} />
+      ))}
+      {metrics.answers &&
+        written(answers).map(([index, text]) => (
+          <Cell
+            key={`a${index}`}
+            answered
+            {...{ index, text, columns, cell, size }}
+          />
+        ))}
     </svg>
+  );
+}
+
+/** The squares of a list that have something in them, with their positions. */
+function written(cells: string[] | undefined): Array<[number, string]> {
+  return (cells ?? []).flatMap((text, index) =>
+    text === "" ? [] : [[index, text] as [number, string]],
+  );
+}
+
+/** One numeral in the middle of its square. */
+function Cell({
+  index,
+  text,
+  columns,
+  cell,
+  size,
+  answered = false,
+}: {
+  index: number;
+  text: string;
+  columns: number;
+  cell: number;
+  size: number;
+  answered?: boolean;
+}) {
+  return (
+    <text
+      className={`sheet__cell${answered ? " sheet__cell--answered" : ""}`}
+      x={((index % columns) + 0.5) * cell}
+      y={(Math.floor(index / columns) + 0.5) * cell}
+      fontSize={size}
+      textAnchor="middle"
+      dominantBaseline="central"
+    >
+      {text}
+    </text>
   );
 }
 

--- a/src/components/sheet/blocks/Problems.tsx
+++ b/src/components/sheet/blocks/Problems.tsx
@@ -22,8 +22,8 @@ import type { BlockProps } from "./block";
  * rather than adding a block of its own, so the shapes below are the shapes an
  * arithmetic problem takes and not several families' worth of markup: written
  * along a line, written along a line with the gap inside it, stacked in columns
- * the way a sum is worked, or answered on ruled lines underneath when the
- * answer is more than one sentence.
+ * the way a sum is worked, set inside a division bracket, or answered on ruled
+ * lines underneath when the answer is more than one sentence.
  */
 export function Problems({ block, metrics }: BlockProps<"problems">) {
   const columns = Math.max(1, Math.floor(block.columns));
@@ -40,7 +40,13 @@ export function Problems({ block, metrics }: BlockProps<"problems">) {
               child is told to "do 4, 7 and 12 of" has to carry its number as
               text anyway. */}
           <span className="sheet__number">{index + 1}.</span>
-          {problem.operands ? (
+          {/* Three drawings and one rule: a problem is set the way the data
+              says it is set. A stack when there is a stack, a bracket when
+              there is a bracket, and a sentence otherwise — no flag beside the
+              data for either of them to disagree with. */}
+          {problem.bracket ? (
+            <Bracket problem={problem} answers={metrics.answers} />
+          ) : problem.operands ? (
             <Stacked problem={problem} answers={metrics.answers} />
           ) : (
             <Written problem={problem} answers={metrics.answers} />
@@ -57,6 +63,10 @@ type Part = { problem: Problem; answers: boolean };
 
 /** Whether the answer is written on ruled lines under the problem. */
 const ruled = (problem: Problem): boolean => (problem.answers?.length ?? 0) > 0;
+
+/** Whether there is working to write between the problem and its answer. */
+const worked = (problem: Problem): boolean =>
+  (problem.working?.length ?? 0) > 0;
 
 /**
  * A problem written along a line, with the answer wherever the prompt says.
@@ -92,10 +102,14 @@ function Written({ problem, answers }: Part) {
  * paper to work the answer out in — never both, because they are the same
  * paper. A problem whose answer is a list has already had its answer place
  * counted, and `workspace` is the height those lines share.
+ *
+ * A long multiplication has spent it too. Its working goes *inside* the stack,
+ * between the rule and the total, because a partial product written anywhere
+ * else is the mistake the sheet exists to practise out of a child.
  */
 function Below({ problem, answers }: Part) {
   if (ruled(problem)) return <Ruled problem={problem} answers={answers} />;
-  if (problem.workspace === undefined) return null;
+  if (problem.workspace === undefined || worked(problem)) return null;
   return (
     <span
       className="sheet__workspace"
@@ -145,6 +159,7 @@ function Ruled({ problem, answers }: Part) {
  */
 function Stacked({ problem, answers }: Part) {
   const operands = problem.operands ?? [];
+  const working = problem.working ?? [];
   return (
     <span className="sheet__column">
       {operands.map((operand, index) => (
@@ -155,10 +170,62 @@ function Stacked({ problem, answers }: Part) {
           <span>{operand}</span>
         </span>
       ))}
+      {/* The partial products of a long multiplication: ruled lines under the
+          sum and above its total, which is where the algorithm puts them.
+          They divide the height the family reserved rather than adding to it —
+          see `.sheet__work-line` in sheet.css for the other half of that. */}
+      {worked(problem) && (
+        <span className="sheet__work">
+          {working.map((line, index) => (
+            <span
+              className={`sheet__work-line${answers ? " sheet__work-line--answered" : ""}`}
+              key={`${index}-${line}`}
+              style={
+                problem.workspace
+                  ? { height: inch(problem.workspace / working.length) }
+                  : undefined
+              }
+            >
+              {answers ? line : ""}
+            </span>
+          ))}
+        </span>
+      )}
       <span
         className={`sheet__total${answers ? " sheet__total--answered" : ""}`}
       >
         {answers ? problem.answer : ""}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * Long division, in the one shape it has ever been written in: the divisor
+ * outside the bracket, the dividend under the bar, and the quotient along the
+ * top of it.
+ *
+ * The bar and the upright are borders rather than a drawing, for the reason
+ * everything else on a sheet is (§5) — they are foreground paint and always
+ * print. The quotient is right-aligned over the dividend and not centred,
+ * because the two are aligned by place value: the last digit of a quotient
+ * always belongs over the last digit of the dividend, whatever either of them
+ * measures. That is the whole reason for `tabular-nums` here, and it is the
+ * same reason a column sum has it.
+ */
+function Bracket({ problem, answers }: Part) {
+  const bracket = problem.bracket;
+  if (!bracket) return null;
+  return (
+    <span className="sheet__bracket">
+      <span className="sheet__divisor">{bracket.divisor}</span>
+      <span className="sheet__house">
+        <span
+          className={`sheet__quotient${answers ? " sheet__quotient--answered" : ""}`}
+        >
+          {answers ? problem.answer : ""}
+        </span>
+        <span className="sheet__dividend">{bracket.dividend}</span>
       </span>
     </span>
   );

--- a/src/engine/random.ts
+++ b/src/engine/random.ts
@@ -14,6 +14,17 @@ export function mulberry32(seed: number) {
   };
 }
 
+/**
+ * A whole number from `min` to `max`, both ends included.
+ *
+ * Here rather than in the module that first wanted it because three of the
+ * sheet families draw numbers out of a declared range, and an off-by-one in a
+ * bound is a worksheet with a problem on it the parent excluded.
+ */
+export function between(min: number, max: number, rand: () => number): number {
+  return min + Math.floor(rand() * (max - min + 1));
+}
+
 export function shuffled<T>(items: readonly T[], rand: () => number): T[] {
   const out = items.slice();
   for (let i = out.length - 1; i > 0; i--) {

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -17,6 +17,7 @@ import type { Sheet, SheetConfig } from "./types";
 
 import { BLANK_SHEET } from "./blank";
 import { ARITHMETIC_SHEET } from "./maths/arithmetic";
+import { MULTIPLICATION_SHEET } from "./maths/multiplication";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
 import { PAPER_SHEET } from "./templates/paper";
 
@@ -24,6 +25,7 @@ const SHEETS: Record<string, SheetSpec> = {
   [BLANK_SHEET.id]: BLANK_SHEET,
   [PAPER_SHEET.id]: PAPER_SHEET,
   [ARITHMETIC_SHEET.id]: ARITHMETIC_SHEET,
+  [MULTIPLICATION_SHEET.id]: MULTIPLICATION_SHEET,
 };
 
 /**

--- a/src/engine/sheets/layout.ts
+++ b/src/engine/sheets/layout.ts
@@ -16,14 +16,45 @@
 import type { Mil, Paper, Rule } from "./types";
 
 import {
+  inches,
   marginOf,
   pageSize,
+  points,
   ruleLines,
   rulePitch,
   type RuleRole,
 } from "./paper";
 
 export type Box = { x: Mil; y: Mil; width: Mil; height: Mil };
+
+/**
+ * How tall one ruled line for a hand-written answer is.
+ *
+ * A quarter of an inch is what a child writes on, and never less than the body
+ * type needs: at 18pt the type is a quarter inch on its own, and a key printed
+ * onto lines shorter than its own letters is a row taller than was reserved for
+ * — which is the last row of the page on a second sheet of paper.
+ *
+ * Here rather than in the family that first needed it, because it is now the
+ * height of two different things a child writes on: a fact family's four number
+ * sentences, and the partial products of a long multiplication. A second copy
+ * of the number would be a second thing to keep in step with `.sheet__answer-
+ * line`, and the failure is silent — a sheet that looks right on screen and
+ * prints its bottom row on a second page.
+ */
+export const answerLine = (fontPt: number): Mil =>
+  Math.max(inches(0.25), points(fontPt * 1.35));
+
+/**
+ * The air between one problem and the next, down and across.
+ *
+ * `.sheet__problems` in sheet.css is the grid every maths family prints
+ * through, and this is its `gap` written in the unit the capacity arithmetic
+ * works in. Here rather than in a family for the same reason as the line above:
+ * two families now divide a page by it, and a copy that drifted from the
+ * stylesheet would be a row of problems below the bottom margin.
+ */
+export const PROBLEM_GAP = { x: inches(0.3), y: inches(0.2) };
 
 /** The paper minus its margins: everything a sheet is allowed to print in. */
 export function contentBox(paper: Paper): Box {

--- a/src/engine/sheets/maths/arithmetic.test.ts
+++ b/src/engine/sheets/maths/arithmetic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { PROBLEM_GAP } from "../layout";
 import { LINE_INSET, labelRoom, ticks } from "../numberline";
 import { inches } from "../paper";
 import type {
@@ -11,7 +12,7 @@ import type {
   Problem,
 } from "../types";
 
-import { ARITHMETIC_SHEET, GAP, arithmeticLayout } from "./arithmetic";
+import { ARITHMETIC_SHEET, arithmeticLayout } from "./arithmetic";
 
 /**
  * The first generated family, and the one that sets the bar.
@@ -545,7 +546,7 @@ describe("how much fits", () => {
             const problems = problemsOf({ ...over, count: 200 }, 8);
             const { box, columns, row } = arithmeticLayout(config(over));
             const rows = Math.ceil(problems.length / columns);
-            const used = rows * row + Math.max(0, rows - 1) * GAP.y;
+            const used = rows * row + Math.max(0, rows - 1) * PROBLEM_GAP.y;
             expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
               box.height,
             );
@@ -563,7 +564,7 @@ describe("how much fits", () => {
     // One more row would not have fitted, which is what makes the reservation
     // testable in both directions.
     const rows = perPage / arithmeticLayout(config()).columns;
-    expect((rows + 1) * row + rows * GAP.y).toBeGreaterThan(box.height);
+    expect((rows + 1) * row + rows * PROBLEM_GAP.y).toBeGreaterThan(box.height);
   });
 
   it("honours the count and the columns it was given", () => {

--- a/src/engine/sheets/maths/arithmetic.ts
+++ b/src/engine/sheets/maths/arithmetic.ts
@@ -26,7 +26,7 @@
  * get rather than the same sum three times.
  */
 import { arithmeticFactId } from "@/engine/decks/flashcards";
-import { mulberry32 } from "@/engine/random";
+import { between, mulberry32 } from "@/engine/random";
 
 import type {
   ArithmeticConfig,
@@ -40,18 +40,24 @@ import type {
 } from "../types";
 
 import { sheetBlockBox } from "../chrome";
-import { columnWidth, fitAcross, type Box } from "../layout";
+import {
+  PROBLEM_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
 import { NUMBER_LINE_HEIGHT, numberLine } from "../numberline";
 import { inches, points } from "../paper";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
 
 /* ── What a problem takes on the page ─────────────────────────────────────
    Declared, not measured (§4), and trailing sheet.css the same way chrome.ts
-   does: `.sheet__problems` sets a 0.2in gap down and 0.3in across, a problem
-   written along a line is one line of the body type with a little air round
-   it, and a column sum is the two numbers, the rule and the answer under it. */
+   does: a problem written along a line is one line of the body type with a
+   little air round it, and a column sum is the two numbers, the rule and the
+   answer under it. The gap between them belongs to the shared problem grid and
+   lives with the rest of its arithmetic, in layout.ts.                       */
 
-export const GAP = { x: inches(0.3), y: inches(0.2) };
 const ROW_EMS = { horizontal: 1.7, vertical: 4.4 } as const;
 
 /** Blank space to work a sum out in, when the config asks for it. */
@@ -59,17 +65,6 @@ const WORKSPACE = inches(0.55);
 
 /** A fact family is four number sentences, and each one gets a line. */
 const FAMILY_LINES = 4;
-
-/**
- * How tall one ruled line for a written answer is.
- *
- * A quarter of an inch is what a child writes on, and never less than the body
- * type needs: at 18pt the type is a quarter inch on its own, and a key printed
- * onto lines shorter than its own letters is a row taller than this reserved
- * for — which is the last row of the page on a second sheet of paper.
- */
-const answerLine = (fontPt: number): Mil =>
-  Math.max(inches(0.25), points(fontPt * 1.35));
 
 /** The room a fact family's four sentences take, lines and all. */
 const familySpace = (fontPt: number): Mil => FAMILY_LINES * answerLine(fontPt);
@@ -138,9 +133,6 @@ type Sum = {
   result: number;
 };
 
-const pick = (min: number, max: number, rand: () => number): number =>
-  min + Math.floor(rand() * (max - min + 1));
-
 /** The range, made safe to draw from whatever a saved config says. */
 function bounds(range: { min: number; max: number }): {
   min: number;
@@ -172,8 +164,8 @@ function drawSum(config: ArithmeticConfig, rand: () => number): Sum | null {
           : "subtract"
         : config.operation;
 
-  const first = pick(min, max, rand);
-  const second = pick(min, max, rand);
+  const first = between(min, max, rand);
+  const second = between(min, max, rand);
 
   if (operation === "add") {
     // A doubles pair has no family: 4 + 4 = 8 turned round is 4 + 4 = 8, and
@@ -371,9 +363,9 @@ export function arithmeticLayout(config: ArithmeticConfig): {
   return {
     box,
     columns,
-    cell: columnWidth(box, columns, GAP.x),
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
     row,
-    perPage: columns * fitAcross(box.height, row, GAP.y),
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
   };
 }
 

--- a/src/engine/sheets/maths/long.ts
+++ b/src/engine/sheets/maths/long.ts
@@ -1,0 +1,308 @@
+/**
+ * The long forms: long multiplication, and the division bracket.
+ *
+ * Every sheet before this one asked for an answer. These two ask for a
+ * *method*: the partial products written one under another and shifted a place
+ * each time, or the bring-down-and-subtract of long division. So the thing the
+ * page has to get right is not the answer — it is the room to work in and the
+ * columns to work in it, and both of those are declared here rather than
+ * discovered in a browser (§4).
+ *
+ * Which makes the two numbers that matter the digit counts. `into` is the
+ * number being worked on — the multiplicand, or the dividend — and `by` the one
+ * doing the working, the multiplier or the divisor. Everything else on the row
+ * follows from them: how many partial products there are to write, how many
+ * times a division brings a digit down, and therefore how tall the row stands.
+ *
+ * It lives beside `multiplication.ts` rather than inside it because it shares
+ * almost nothing with the fact styles: no tables, no factors, no folding of
+ * commutative pairs (347 × 26 and 26 × 347 are the same product and two
+ * different exercises), and a row height that comes from digits rather than
+ * from the body type alone.
+ */
+import { between } from "@/engine/random";
+
+import type { LongDigits, Mil, MultiplicationConfig, Problem } from "../types";
+
+import { answerLine } from "../layout";
+import { points } from "../paper";
+
+/**
+ * How many digits a long form may be asked for.
+ *
+ * Five into one is already past anything a primary child is set, and the cap
+ * is here so that a config from outside this build can't ask for a
+ * twenty-digit dividend and a row taller than the paper.
+ */
+const MAX_DIGITS = 5;
+
+/** Three-digit by two-digit: the long multiplication everybody means. */
+export const DEFAULT_DIGITS: LongDigits = { into: 3, by: 2 };
+
+/**
+ * The two shapes a problem worked on paper takes, in ems of the body type and
+ * trailing sheet.css the way every declared height here does.
+ *
+ * Exported because the fact styles print the same two drawings without any
+ * working in them — a column form times-table sheet is this stack and nothing
+ * else — and a second copy of either number would be a second thing to keep in
+ * step with `.sheet__column` and `.sheet__bracket`.
+ */
+export const STACK_EMS = 4.4;
+/* The bracket is two lines of body type, the bar between them and the padding
+   either side of it — which comes to a shade over three ems at every size the
+   sheet is set at, and is rounded up rather than down. Reserving a tenth of an
+   inch too much costs one problem at the bottom of the page; reserving too
+   little puts that problem on a second sheet of paper. */
+export const BRACKET_EMS = 3.1;
+
+/** The smallest and largest whole number with exactly this many digits. */
+function span(digits: number): { min: number; max: number } {
+  const places = Math.max(1, Math.min(MAX_DIGITS, Math.floor(digits) || 1));
+  return { min: places === 1 ? 1 : 10 ** (places - 1), max: 10 ** places - 1 };
+}
+
+/** The digit counts, made safe to draw from whatever a saved config says. */
+export function longDigits(config: MultiplicationConfig): LongDigits {
+  const asked = config.digits ?? DEFAULT_DIGITS;
+  const clamp = (value: number, low: number): number =>
+    Math.max(low, Math.min(MAX_DIGITS, Math.floor(value) || low));
+  return { into: clamp(asked.into, 1), by: clamp(asked.by, 1) };
+}
+
+/* ── What is drawn ─────────────────────────────────────────────────────── */
+
+export type LongMultiplication = {
+  operation: "multiply";
+  into: number;
+  by: number;
+  product: number;
+  /**
+   * One partial product per digit of the multiplier, units first — `347 × 26`
+   * is 2082 and then 6940, not 2082 and 694. The shift is part of the
+   * arithmetic rather than something the renderer does with padding, because a
+   * partial written in the wrong column is the entire mistake this sheet
+   * exists to practise out of a child.
+   *
+   * A zero digit keeps its row. The algorithm writes it, so the key shows it.
+   */
+  partials: number[];
+};
+
+export type LongDivision = {
+  operation: "divide";
+  divisor: number;
+  dividend: number;
+  quotient: number;
+  /** Zero unless the config asked for remainders, and never as large as the divisor. */
+  remainder: number;
+};
+
+export type LongForm = LongMultiplication | LongDivision;
+
+/**
+ * The multiplier and the divisor never come out as one.
+ *
+ * "Long multiplication by 1" and "long division by 1" are the same sheet with
+ * the answer already written on it, and a single-digit draw would produce them
+ * about a ninth of the time.
+ */
+const workingMin = (digits: number): number => Math.max(2, span(digits).min);
+
+/** The partial products of `into × by`, units place first. */
+function partialsOf(into: number, by: number): number[] {
+  const places = String(by).length;
+  return Array.from({ length: places }, (_, place) => {
+    const digit = Math.floor(by / 10 ** place) % 10;
+    return into * digit * 10 ** place;
+  });
+}
+
+/**
+ * One long multiplication, drawn from the digit counts the config asked for.
+ *
+ * Both numbers have exactly the number of digits requested, which is the whole
+ * of what "three-digit by two-digit" promises: a sheet that quietly slipped a
+ * two-digit multiplicand in is a sheet set at a level nobody chose.
+ */
+function drawMultiplication(
+  digits: LongDigits,
+  rand: () => number,
+): LongMultiplication {
+  const top = span(digits.into);
+  const bottom = span(digits.by);
+  const into = between(top.min, top.max, rand);
+  const by = between(workingMin(digits.by), bottom.max, rand);
+  return {
+    operation: "multiply",
+    into,
+    by,
+    product: into * by,
+    partials: partialsOf(into, by),
+  };
+}
+
+/**
+ * One long division, or `null` when the digit counts leave nothing to draw.
+ *
+ * Built from the answer outwards — divisor, remainder, quotient, and the
+ * dividend last — because that is the only order in which every one of the
+ * config's promises can be kept at once. Drawing a dividend first and dividing
+ * it would give a remainder nobody asked for and a quotient with no bound on
+ * it; this way the dividend lands inside its digit count by construction, and
+ * "without remainders" means the division comes out exactly rather than nearly.
+ *
+ * There is no division by zero here and there cannot be: a divisor is drawn
+ * from two upwards (§20).
+ */
+function drawDivision(
+  digits: LongDigits,
+  remainders: boolean,
+  rand: () => number,
+): LongDivision | null {
+  const divisor = between(workingMin(digits.by), span(digits.by).max, rand);
+  const remainder = remainders ? between(1, divisor - 1, rand) : 0;
+
+  // The quotient is whatever leaves the dividend with exactly `into` digits.
+  const { min, max } = span(digits.into);
+  const low = Math.max(1, Math.ceil((min - remainder) / divisor));
+  const high = Math.floor((max - remainder) / divisor);
+  // Nothing to draw: a two-digit divisor into a one-digit dividend is not a
+  // division, and an empty sheet is the honest answer to asking for one.
+  if (high < low) return null;
+
+  const quotient = between(low, high, rand);
+  return {
+    operation: "divide",
+    divisor,
+    dividend: divisor * quotient + remainder,
+    quotient,
+    remainder,
+  };
+}
+
+/** One long form of whichever kind the config asks for, or `null`. */
+export function drawLong(
+  config: MultiplicationConfig,
+  operation: "multiply" | "divide",
+  rand: () => number,
+): LongForm | null {
+  const digits = longDigits(config);
+  return operation === "multiply"
+    ? drawMultiplication(digits, rand)
+    : drawDivision(digits, config.remainders === true, rand);
+}
+
+/**
+ * What makes two long forms the same exercise.
+ *
+ * Multiplication does *not* fold here, though it folds everywhere else on a
+ * times-table sheet: 26 × 47 and 47 × 26 are one product and two different
+ * pieces of written work, with the partials in different places and a
+ * different number of them. Folding them would throw away half the pool of a
+ * sheet whose two digit counts are equal, to prevent a repetition that is not
+ * one.
+ */
+export function longKey(form: LongForm): string {
+  return form.operation === "multiply"
+    ? `×:${form.into}:${form.by}`
+    : `÷:${form.dividend}:${form.divisor}`;
+}
+
+/* ── What it takes on the page ─────────────────────────────────────────── */
+
+/**
+ * How many ruled lines of working a long division reserves.
+ *
+ * Two per digit of the quotient — the product you take away, and what is left
+ * of the dividend after you have. The quotient can be no longer than
+ * `into − by + 1` digits, which is a bound rather than a measurement and so
+ * can be computed before a single division has been drawn: the layout has to
+ * know how tall the row is before the row exists.
+ */
+export function divisionLines(digits: LongDigits): number {
+  return 2 * Math.max(1, digits.into - digits.by + 1);
+}
+
+/**
+ * How many partial products a long multiplication writes: one per digit of the
+ * multiplier, and none at all when there is only one of them — `347 × 6` is
+ * worked in the total line, and a row of blank rules over the answer would be
+ * a sheet asking a child to show working that does not exist.
+ */
+export function partialLines(digits: LongDigits): number {
+  return digits.by > 1 ? digits.by : 0;
+}
+
+/** How tall a long form of this shape stands, working space included. */
+export function longRow(config: MultiplicationConfig, fontPt: number): Mil {
+  const digits = longDigits(config);
+  const line = answerLine(fontPt);
+  const multiplication =
+    points(fontPt * STACK_EMS) + partialLines(digits) * line;
+  const division = points(fontPt * BRACKET_EMS) + divisionLines(digits) * line;
+  switch (config.operation) {
+    case "multiply":
+      return multiplication;
+    case "divide":
+      return division;
+    // A mixed sheet reserves for whichever is taller, because it prints both
+    // and the row height is one number for the whole grid of them.
+    default:
+      return Math.max(multiplication, division);
+  }
+}
+
+/**
+ * A drawn long form, as it will be printed.
+ *
+ * The two shapes are as different on paper as they are in a child's exercise
+ * book: a multiplication is the column stack the `arithmetic` family already
+ * prints, with ruled lines between the rule and the total for the partials; a
+ * division is the bracket, whose answer goes *above* the problem and whose
+ * working goes underneath it.
+ */
+export function longProblem(
+  form: LongForm,
+  config: MultiplicationConfig,
+): Problem {
+  const digits = longDigits(config);
+  const line = answerLine(config.fontPt);
+
+  if (form.operation === "multiply") {
+    // What the layout reserved, and what the draw produced. They are the same
+    // number by construction — a multiplier drawn inside its digit count has
+    // exactly that many digits — and the reservation is what decides whether
+    // the bottom row of the page comes out on a second sheet, so the count the
+    // page was measured for is the one that governs.
+    const lines = partialLines(digits);
+    return {
+      // Empty, because the stack is the prompt — the same bargain the column
+      // sums make. There is no second copy of the problem written along a line
+      // for the two to disagree about.
+      prompt: "",
+      operands: [String(form.into), String(form.by)],
+      operator: "×",
+      answer: String(form.product),
+      ...(lines > 0
+        ? {
+            working: form.partials.slice(0, lines).map(String),
+            workspace: lines * line,
+          }
+        : {}),
+    };
+  }
+
+  return {
+    prompt: "",
+    bracket: { divisor: String(form.divisor), dividend: String(form.dividend) },
+    // "234 r 2" — the way it is written on paper, and the way a child is asked
+    // to write it. A remainder of nothing is not written at all rather than
+    // written as "r 0", which is a different (and wrong) sentence.
+    answer:
+      form.remainder > 0
+        ? `${form.quotient} r ${form.remainder}`
+        : String(form.quotient),
+    workspace: divisionLines(digits) * line,
+  };
+}

--- a/src/engine/sheets/maths/multiplication.test.ts
+++ b/src/engine/sheets/maths/multiplication.test.ts
@@ -1,0 +1,852 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { PROBLEM_GAP } from "../layout";
+import type {
+  GridSpec,
+  MarginSize,
+  MultiplicationConfig,
+  Paper,
+  PaperSize,
+  Problem,
+} from "../types";
+
+import { divisionLines, longDigits, partialLines } from "./long";
+import {
+  MULTIPLICATION_SHEET,
+  multiplicationGrid,
+  multiplicationLayout,
+} from "./multiplication";
+
+/**
+ * Multiplication and division, held to the bar the arithmetic family set.
+ *
+ * **Nothing here checks the generator against the generator.** Every answer is
+ * verified from the *printed* problem — the string a child reads — by a path
+ * the family does not use:
+ *
+ * - a product is checked by **repeated addition**, which is the definition of
+ *   multiplication a child meets first and the one `×` is shorthand for;
+ * - a division is checked by **its inverse**, built out of that same repeated
+ *   addition: `a ÷ b = c r d` is true exactly when adding `b` to itself `c`
+ *   times and then `d` more arrives at `a`, with `d` short of `b`;
+ * - a partial product is checked by **shifting a string**, because the whole
+ *   of long multiplication is which column a number lands in and a test that
+ *   multiplied by a power of ten would agree with a family that had the shift
+ *   wrong;
+ * - a missing number is checked by **searching for every number that fits**,
+ *   which catches the two ways that question goes bad at once: an answer that
+ *   is wrong, and a blank that more than one answer would fill.
+ */
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+/** The tables a mixed sheet draws from: the wall chart, without its edges. */
+const TABLES = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+const config = (
+  over: Partial<MultiplicationConfig> = {},
+): MultiplicationConfig => ({
+  kind: "multiplication",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  operation: "multiply",
+  style: "standard",
+  form: "horizontal",
+  tables: TABLES,
+  factors: { min: 0, max: 12 },
+  count: 20,
+  columns: 2,
+  ...over,
+});
+
+/**
+ * Every shape of *problem* the family can print, which is every acceptance
+ * criterion of the story bar the grid: tables and mixed sets, both operations
+ * and the two together, written along a line and worked the way they are
+ * worked, missing numbers, and both long forms with and without remainders.
+ *
+ * The grid is not here because it has no problems — it is one block with a
+ * hundred and forty-four answers inside it — and it gets a section of its own.
+ */
+const EVERY_SHAPE: Array<Partial<MultiplicationConfig>> = [
+  {},
+  { form: "vertical" },
+  { operation: "divide" },
+  { operation: "divide", form: "vertical" },
+  { operation: "both" },
+  { operation: "both", form: "vertical" },
+  { style: "missing" },
+  { style: "missing", operation: "divide" },
+  { style: "missing", operation: "both" },
+  // One table rather than a mixed set — the difference between learning a
+  // table and being tested on all of them, and one array long.
+  { tables: [7], count: 6 },
+  { tables: [7], operation: "divide", count: 6 },
+  { tables: [7], operation: "both", count: 6 },
+  { workspace: true, count: 12 },
+  { factors: { min: 1, max: 9 }, tables: [3, 4], count: 10 },
+  // The long forms.
+  { style: "long", digits: { into: 3, by: 2 }, count: 6 },
+  { style: "long", digits: { into: 2, by: 1 }, count: 6 },
+  { style: "long", digits: { into: 4, by: 3 }, count: 4 },
+  { style: "long", operation: "divide", digits: { into: 3, by: 1 }, count: 6 },
+  { style: "long", operation: "divide", digits: { into: 3, by: 2 }, count: 6 },
+  {
+    style: "long",
+    operation: "divide",
+    digits: { into: 3, by: 1 },
+    remainders: true,
+    count: 6,
+  },
+  {
+    style: "long",
+    operation: "both",
+    digits: { into: 4, by: 2 },
+    remainders: true,
+    count: 4,
+  },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** Every column count the family will lay out — `MAX_COLUMNS` is six. */
+const COLUMN_COUNTS = [1, 2, 3, 4, 5, 6];
+
+/** The one block a fact or long-form sheet has, narrowed for the reader. */
+function problemsOf(
+  over: Partial<MultiplicationConfig>,
+  seed: number,
+): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+/* ── Reading a sheet the way a child does ──────────────────────────────────
+   Everything below works from the printed problem — the prompt, the stack of
+   numbers, or the bracket — and never from the config that produced it. If the
+   family printed one thing and computed another, these are what notice.     */
+
+/**
+ * Multiplication, by repeated addition — the point of the whole file.
+ *
+ * `a * b` is what the family computes, so a test that used it would agree with
+ * the family however wrong the family was. Adding `a` to itself `b` times is
+ * the other definition, and it is the one a child is taught first: four fives
+ * are five and five and five and five.
+ */
+function times(a: number, b: number): number {
+  let total = 0;
+  for (let step = 0; step < b; step += 1) total += a;
+  return total;
+}
+
+/** A number with `places` noughts stuck on the end, by string rather than sum. */
+function shifted(value: number, places: number): number {
+  return value === 0 ? 0 : Number(`${value}${"0".repeat(places)}`);
+}
+
+type Statement = {
+  left: number;
+  sign: string;
+  right: number;
+  result: number;
+  remainder: number;
+};
+
+/** A written sentence, taken apart. Rejects anything that isn't one. */
+function read(sentence: string): Statement {
+  const match = /^(\d+) ([×÷]) (\d+) = (\d+)(?: r (\d+))?$/.exec(
+    sentence.trim(),
+  );
+  if (!match) throw new Error(`not a number sentence: "${sentence}"`);
+  return {
+    left: Number(match[1]),
+    sign: match[2],
+    right: Number(match[3]),
+    result: Number(match[4]),
+    remainder: match[5] === undefined ? 0 : Number(match[5]),
+  };
+}
+
+/**
+ * Whether a written sentence is true.
+ *
+ * A division is checked through its inverse and never by dividing: `a ÷ b` is
+ * `c` with `d` left over exactly when `b` added to itself `c` times and then
+ * `d` more comes to `a`, and `d` is short of `b`. That last clause is what
+ * makes "56 ÷ 5 = 10 r 6" false, which is the shape a wrong long division
+ * takes far more often than a wrong quotient does.
+ */
+function holds(sentence: string): boolean {
+  const { left, sign, right, result, remainder } = read(sentence);
+  if (sign === "×") return times(left, right) === result && remainder === 0;
+  if (right === 0) return false;
+  return times(right, result) + remainder === left && remainder < right;
+}
+
+/**
+ * The problem, written out in full with its answer put where it belongs.
+ *
+ * Four shapes reduce to one sentence: a fact with a slot on the end, a fact
+ * with the gap inside it, a stack of numbers in column form, and the division
+ * bracket, whose answer is written above it rather than after it.
+ */
+function sentences(problem: Problem): string[] {
+  if (problem.bracket) {
+    const { dividend, divisor } = problem.bracket;
+    return [`${dividend} ÷ ${divisor} = ${problem.answer}`];
+  }
+  if (problem.operands) {
+    const stack = problem.operands.join(` ${problem.operator} `);
+    return [`${stack} = ${problem.answer}`];
+  }
+  if (problem.prompt.includes("_")) {
+    return [problem.prompt.replace("_", problem.answer)];
+  }
+  return [`${problem.prompt} ${problem.answer}`];
+}
+
+/** What makes two problems the same problem, worked out from the page. */
+function factOf(sentence: string): string {
+  const { left, sign, right } = read(sentence);
+  // Multiplication folds and division does not — `masteryKey` against
+  // `drillKey`, established here from the printed page rather than from the
+  // key the family happened to compute.
+  return sign === "×"
+    ? `×:${Math.min(left, right)}:${Math.max(left, right)}`
+    : `÷:${left}:${right}`;
+}
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the multiplication family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("multiplication")).toBe(MULTIPLICATION_SHEET);
+    expect(sheetSpec("multiplication").label).toBe(
+      "Multiplication and division",
+    );
+  });
+
+  it("names what it prints, in the terms a parent chose it by", () => {
+    expect(describeSheet(config())).toBe("Multiplication to 12");
+    expect(describeSheet(config({ tables: [7] }))).toBe("The 7 times table");
+    expect(describeSheet(config({ tables: [7], operation: "divide" }))).toBe(
+      "Dividing by 7",
+    );
+    expect(describeSheet(config({ tables: [7], operation: "both" }))).toBe(
+      "The 7 times table, both ways",
+    );
+    expect(describeSheet(config({ form: "vertical" }))).toBe(
+      "Multiplication to 12 — worked in columns",
+    );
+    expect(describeSheet(config({ style: "missing" }))).toBe(
+      "Multiplication to 12 — missing number",
+    );
+    expect(describeSheet(config({ style: "grid" }))).toBe(
+      "Multiplication grid to 12",
+    );
+    expect(
+      describeSheet(config({ style: "long", digits: { into: 3, by: 2 } })),
+    ).toBe("Long multiplication — 3-digit by 2-digit");
+    expect(
+      describeSheet(
+        config({
+          style: "long",
+          operation: "divide",
+          digits: { into: 4, by: 1 },
+          remainders: true,
+        }),
+      ),
+    ).toBe("Long division with remainders — 4-digit by 1-digit");
+  });
+
+  it("gives the sheet a title and a score box it can be marked against", () => {
+    const sheet = buildSheet(config({ tables: [7] }), 3);
+    const block = sheet.blocks[0];
+    expect(sheet.header.title).toBe("The 7 times table");
+    expect(sheet.header.instructions).toBe("Work out each answer.");
+    // Out of what is on the page, not out of what was asked for.
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+
+  it("tells a child what to do with a form they have not met before", () => {
+    expect(buildSheet(config({ style: "grid" }), 1).header.instructions).toBe(
+      "Write each product in the square where its row meets its column.",
+    );
+    expect(
+      buildSheet(
+        config({ style: "long", operation: "divide", remainders: true }),
+        1,
+      ).header.instructions,
+    ).toBe("Show your working. Write what is left over after an r.");
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("is right on every problem of every sheet this family can print", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+        for (const problem of problems) {
+          for (const sentence of sentences(problem)) {
+            expect(holds(sentence), `${JSON.stringify(shape)}: ${sentence}`) //
+              .toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    // The key is not built again from the seed — it is the build, told to
+    // print what it already worked out. So the blocks on the two are equal,
+    // and a key cannot disagree with the sheet it belongs to.
+    for (const shape of [...EVERY_SHAPE, { style: "grid" as const }]) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+
+  it("leaves exactly one number that would fit a missing-number blank", () => {
+    // Two failures caught by one search: an answer that is wrong, and a blank
+    // that more than one number would fill. "_ × 0 = 0" is the second — true
+    // of every number there is — and it is the reason a missing-number sheet
+    // never draws a zero.
+    for (const operation of ["multiply", "divide", "both"] as const) {
+      const problems = problemsOf({ style: "missing", operation }, 5);
+      expect(problems.length).toBeGreaterThan(0);
+      for (const problem of problems) {
+        const fits = [];
+        for (let candidate = 0; candidate <= 200; candidate += 1) {
+          const written = problem.prompt.replace("_", String(candidate));
+          // A candidate that makes the sentence unreadable is not a candidate.
+          try {
+            if (holds(written)) fits.push(candidate);
+          } catch {
+            /* not a number sentence at all */
+          }
+        }
+        expect(fits, problem.prompt).toEqual([Number(problem.answer)]);
+      }
+    }
+  });
+
+  it("shows the working of a long multiplication, not just its product", () => {
+    // A long multiplication is marked on its partials as much as on its total,
+    // so the key writes them. Each one is checked by shifting a *string*: the
+    // whole of the exercise is which column a partial lands in, and a test
+    // that multiplied by a power of ten would agree with a family that had the
+    // shift wrong.
+    for (const digits of [
+      { into: 3, by: 2 },
+      { into: 4, by: 3 },
+    ]) {
+      const problems = problemsOf({ style: "long", digits, count: 4 }, 2);
+      expect(problems.length).toBeGreaterThan(0);
+      for (const problem of problems) {
+        const [into, by] = problem.operands ?? [];
+        const working = problem.working ?? [];
+        expect(working.length).toBe(String(by).length);
+
+        let total = 0;
+        working.forEach((partial, place) => {
+          // The digit of the multiplier this row is for, read off the printed
+          // multiplier from the units end.
+          const digit = Number(by[by.length - 1 - place]);
+          expect(Number(partial)).toBe(
+            shifted(times(Number(into), digit), place),
+          );
+          total += Number(partial);
+        });
+        // And they come to the answer on the total line.
+        expect(total).toBe(Number(problem.answer));
+      }
+    }
+  });
+
+  it("writes a remainder the way a child is asked to write one", () => {
+    const problems = problemsOf(
+      {
+        style: "long",
+        operation: "divide",
+        digits: { into: 3, by: 1 },
+        remainders: true,
+        count: 6,
+      },
+      3,
+    );
+    expect(problems.length).toBeGreaterThan(0);
+    for (const problem of problems) {
+      expect(problem.answer).toMatch(/^\d+ r \d+$/);
+      expect(holds(sentences(problem)[0])).toBe(true);
+    }
+    // And never writes "r 0", which is a different and wrong sentence.
+    for (const problem of problemsOf(
+      { style: "long", operation: "divide", digits: { into: 3, by: 1 } },
+      3,
+    )) {
+      expect(problem.answer).toMatch(/^\d+$/);
+    }
+  });
+});
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  it("never divides by zero, on any sheet, at any seed", () => {
+    // The one bound whose failure is not a wrong answer but no answer at all.
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        for (const problem of problemsOf(shape, seed)) {
+          const { sign, right } = read(sentences(problem)[0]);
+          if (sign === "÷") expect(right).toBeGreaterThan(0);
+          // And the printed divisor of a bracket is the same number.
+          if (problem.bracket)
+            expect(Number(problem.bracket.divisor)).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("never puts a table or a factor a parent did not ask for on the page", () => {
+    const ASKS = [
+      { tables: [7], factors: { min: 0, max: 12 } },
+      { tables: [3, 4, 6], factors: { min: 1, max: 10 } },
+      { tables: TABLES, factors: { min: 2, max: 5 } },
+    ];
+    for (const ask of ASKS) {
+      const wanted = new Set(ask.tables);
+      const factors = ask.factors;
+      for (const style of ["standard", "missing"] as const) {
+        for (const operation of ["multiply", "divide"] as const) {
+          const problems = problemsOf({ ...ask, style, operation }, 9);
+          expect(problems.length).toBeGreaterThan(0);
+          for (const problem of problems) {
+            const { left, sign, right, result } = read(sentences(problem)[0]);
+            // A multiplication prints table × factor; a division prints the
+            // product first, so its two other numbers are the pair.
+            const [table, factor] =
+              sign === "×" ? [left, right] : [right, result];
+            // Folded, so either of the two may be the table that was picked.
+            expect(
+              wanted.has(table) || wanted.has(factor),
+              `${sentences(problem)[0]} from ${JSON.stringify(ask)}`,
+            ).toBe(true);
+            for (const value of [table, factor]) {
+              if (!wanted.has(value)) {
+                expect(value).toBeGreaterThanOrEqual(factors.min);
+                expect(value).toBeLessThanOrEqual(factors.max);
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it("gives a long form exactly the digits it was asked for", () => {
+    // "Three-digit by two-digit" is the whole of what a parent chose, and a
+    // sheet that quietly slipped a two-digit multiplicand in is a sheet set at
+    // a level nobody picked.
+    for (const digits of [
+      { into: 2, by: 1 },
+      { into: 3, by: 1 },
+      { into: 3, by: 2 },
+      { into: 4, by: 2 },
+    ]) {
+      for (const operation of ["multiply", "divide"] as const) {
+        const problems = problemsOf(
+          { style: "long", operation, digits, count: 4 },
+          6,
+        );
+        expect(problems.length, JSON.stringify(digits)).toBeGreaterThan(0);
+        for (const problem of problems) {
+          const [into, by] = problem.bracket
+            ? [problem.bracket.dividend, problem.bracket.divisor]
+            : (problem.operands ?? []);
+          expect(into.length, `${into} by ${by}`).toBe(digits.into);
+          expect(by.length, `${into} by ${by}`).toBe(digits.by);
+          // And never by one, which is a sheet with the answer already on it.
+          expect(Number(by)).toBeGreaterThan(1);
+        }
+      }
+    }
+  });
+
+  it("asks the same question twice on no sheet at all", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        const facts = problems.map((problem) => factOf(sentences(problem)[0]));
+        expect(new Set(facts).size, JSON.stringify(shape)).toBe(
+          problems.length,
+        );
+      }
+    }
+  });
+
+  it("keeps a division's two questions apart, and folds a multiplication's", () => {
+    // The note the story turns on: 7 × 8 and 8 × 7 are one problem, while
+    // 56 ÷ 7 and 56 ÷ 8 are two questions with two answers — `masteryKey`
+    // against `drillKey`, and a worksheet is a drill. Read off the page rather
+    // than out of the family's own key.
+    const divisions = problemsOf({ operation: "divide", count: 30 }, 12).map(
+      (problem) => read(sentences(problem)[0]),
+    );
+    const bothWays = divisions.filter((one) =>
+      divisions.some(
+        (other) =>
+          one.result !== one.right &&
+          other.left === one.left &&
+          other.right === one.result,
+      ),
+    );
+    // A page of divisions that had folded them would never draw a pair, and
+    // the sheet would be a third shorter than a parent asked for.
+    expect(bothWays.length).toBeGreaterThan(0);
+
+    const products = problemsOf({ count: 30 }, 12).map((problem) =>
+      read(sentences(problem)[0]),
+    );
+    for (const one of products) {
+      expect(
+        products.filter(
+          (other) => other.left === one.right && other.right === one.left,
+        ).length,
+        `${one.left} × ${one.right} is on the page twice`,
+      ).toBe(one.left === one.right ? 1 : 0);
+    }
+  });
+
+  it("prints the whole small pool rather than repeating itself", () => {
+    // The two times table by nought to five is six facts, folded onto five —
+    // 2 × 2 and 2 × 2 are one — and five is what a parent should get rather
+    // than twenty problems with the same sum in them four times.
+    const problems = problemsOf(
+      { tables: [2], factors: { min: 0, max: 5 }, count: 20 },
+      1,
+    );
+    expect(problems.length).toBe(6);
+    expect(new Set(problems.map((p) => p.prompt)).size).toBe(6);
+  });
+
+  it("prints nothing rather than something wrong when the ask is impossible", () => {
+    // No tables at all, and a long division of a one-digit number by a
+    // two-digit one. Both are empty sheets, which is the honest answer and the
+    // builder's job to prevent (PRINT13).
+    expect(problemsOf({ tables: [] }, 1)).toEqual([]);
+    expect(
+      problemsOf(
+        {
+          style: "long",
+          operation: "divide",
+          digits: { into: 1, by: 2 },
+          count: 4,
+        },
+        1,
+      ),
+    ).toEqual([]);
+  });
+});
+
+/* ── The grid ──────────────────────────────────────────────────────────── */
+
+describe("the multiplication grid", () => {
+  const gridOf = (over: Partial<MultiplicationConfig> = {}): GridSpec => {
+    const grid = multiplicationGrid(config({ style: "grid", ...over }));
+    if (!grid) throw new Error("no grid was built");
+    return grid;
+  };
+
+  it("has a product in every square where a row meets a column", () => {
+    // Verified off the printed headers by repeated addition, so a grid whose
+    // rows and columns had drifted apart from its answers fails here.
+    const grid = gridOf();
+    const { columns, rows, cells = [], answers = [] } = grid;
+    expect(cells.length).toBe(columns * rows);
+    expect(answers.length).toBe(columns * rows);
+
+    for (let row = 1; row < rows; row++) {
+      for (let column = 1; column < columns; column++) {
+        const table = Number(cells[row * columns]);
+        const factor = Number(cells[column]);
+        expect(Number(answers[row * columns + column])).toBe(
+          times(table, factor),
+        );
+      }
+    }
+  });
+
+  it("prints its headers on the sheet and its products only on the key", () => {
+    const { columns, rows, cells = [], answers = [] } = gridOf();
+    expect(cells[0]).toBe("×");
+    for (let index = 0; index < columns * rows; index++) {
+      const header = index < columns || index % columns === 0;
+      // Every square is one or the other, and never both: a header a child
+      // needs from the start, or an answer they are there to write.
+      expect(cells[index] === "", `cell ${index}`).toBe(!header);
+      expect(answers[index] === "", `answer ${index}`).toBe(header);
+    }
+  });
+
+  it("rules the headers off, so they are not read as answers", () => {
+    expect(gridOf().origin).toEqual({ column: 1, row: 1 });
+  });
+
+  it("is marked out of the squares a child has to fill", () => {
+    const sheet = buildSheet(config({ style: "grid", tables: [2, 3, 4] }), 1);
+    expect(sheet.header.score?.outOf).toBe(3 * 13);
+    expect(sheet.header.title).toBe("Multiplication grid to 12");
+  });
+
+  it("is the same wall chart whatever seed it was printed from", () => {
+    // Nothing about a grid is drawn, and that is correct rather than an
+    // oversight: a parent who prints the twelve times square twice should get
+    // the same object both times.
+    expect(buildSheet(config({ style: "grid" }), 1).blocks).toEqual(
+      buildSheet(config({ style: "grid" }), 99).blocks,
+    );
+  });
+
+  it("fits the paper it is printed on, at every stock and margin", () => {
+    for (const size of ["letter", "a4", "legal"] as PaperSize[]) {
+      for (const margin of [
+        "none",
+        "narrow",
+        "normal",
+        "wide",
+      ] as MarginSize[]) {
+        const over = { style: "grid" as const, paper: paper({ size, margin }) };
+        const grid = gridOf(over);
+        const { box } = multiplicationLayout(config(over));
+        expect(
+          grid.cell * grid.columns,
+          `${size}/${margin}`,
+        ).toBeLessThanOrEqual(box.width);
+        expect(grid.cell * grid.rows, `${size}/${margin}`).toBeLessThanOrEqual(
+          box.height,
+        );
+      }
+    }
+  });
+});
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of [...EVERY_SHAPE, { style: "grid" as const }]) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("carries the seed into the footer, so the same sheet can be had again", () => {
+    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
+  });
+
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    // Building twice in one process only proves the draw is a function of
+    // `(config, seed)`. The promise the footer makes is bigger than that: the
+    // seed is printed on the paper so a parent can have the same sheet again
+    // next week, across a deploy. Nothing else in this file would notice a
+    // refactor that moved where the draw consumes `rand()` — the coin spent
+    // only when both operations are asked for, the slot drawn whatever the
+    // fact style, the remainder drawn before the quotient — and every seed a
+    // parent had already printed would quietly start producing a different
+    // sheet. These lists make that a decision somebody takes rather than one
+    // they trip over.
+    expect(
+      problemsOf({ tables: [7], count: 5 }, 4242).map((p) => [
+        p.prompt,
+        p.answer,
+      ]),
+    ).toEqual([
+      ["7 × 3 =", "21"],
+      ["7 × 8 =", "56"],
+      ["7 × 5 =", "35"],
+      ["7 × 9 =", "63"],
+      ["7 × 12 =", "84"],
+    ]);
+
+    expect(
+      problemsOf({ style: "long", digits: { into: 3, by: 2 }, count: 3 }, 7) //
+        .map((p) => [p.operands, p.working, p.answer]),
+    ).toEqual([
+      [["110", "15"], ["550", "1100"], "1650"],
+      [["979", "72"], ["1958", "68530"], "70488"],
+      [["569", "46"], ["3414", "22760"], "26174"],
+    ]);
+
+    expect(
+      problemsOf(
+        {
+          style: "long",
+          operation: "divide",
+          digits: { into: 3, by: 1 },
+          remainders: true,
+          count: 3,
+        },
+        7,
+      ).map((p) => [p.bracket, p.answer]),
+    ).toEqual([
+      [{ divisor: "2", dividend: "979" }, "489 r 1"],
+      [{ divisor: "7", dividend: "466" }, "66 r 4"],
+      [{ divisor: "5", dividend: "596" }, "119 r 1"],
+    ]);
+  });
+
+  /** The problems of `seed`, `seed + 1` and `seed + 2`, pairwise. */
+  function variants(shape: Partial<MultiplicationConfig>, seed: number) {
+    // Compared as sentences rather than as prompts, because a column form and
+    // a bracket have no prompt — the drawing is the prompt.
+    const [a, b, c] = [0, 1, 2].map((offset) =>
+      problemsOf(shape, seed + offset).map((problem) => sentences(problem)[0]),
+    );
+    return [
+      [a, b],
+      [a, c],
+      [b, c],
+    ];
+  }
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    // Three consecutive seeds are the whole of "a different sheet, same
+    // settings" and of variants for a class (§7). Some overlap is inevitable —
+    // one table is thirteen facts however many sheets you print — so what is
+    // asserted is that a third of each variant is new. Three sheets that were
+    // nearly the same sheet would make the feature a lie.
+    for (const shape of EVERY_SHAPE) {
+      for (const [one, other] of variants(shape, 100)) {
+        expect(one).not.toEqual(other);
+        const shared = one.filter((sum) => other.includes(sum)).length;
+        expect(shared, JSON.stringify(shape)).toBeLessThan(
+          (one.length * 2) / 3,
+        );
+      }
+    }
+  });
+});
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    // The failure is silent on screen and obvious on paper: one row too many
+    // is a second sheet out of the printer with two problems on it, and print
+    // is the whole of the output path (§10).
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row } = multiplicationLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used = rows * row + Math.max(0, rows - 1) * PROBLEM_GAP.y;
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("does not throw the page away either", () => {
+    // The half a capacity check cannot see: a family that printed four
+    // problems on a Letter page would satisfy every assertion above.
+    const { box, row, perPage, columns } = multiplicationLayout(config());
+    expect(perPage).toBeGreaterThanOrEqual(20);
+    const rows = perPage / columns;
+    expect((rows + 1) * row + rows * PROBLEM_GAP.y).toBeGreaterThan(box.height);
+
+    // And a page of long division still holds six, which is what a parent
+    // expects to get for the paper.
+    expect(
+      multiplicationLayout(
+        config({
+          style: "long",
+          operation: "divide",
+          digits: { into: 3, by: 1 },
+        }),
+      ).perPage,
+    ).toBeGreaterThanOrEqual(6);
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ count: 12 }, 1).length).toBe(12);
+    expect(problemsOf({ count: 0 }, 1).length).toBe(0);
+    for (const columns of COLUMN_COUNTS) {
+      const block = buildSheet(config({ columns }), 1).blocks[0];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+    // Four is as many columns as a long form is laid out in: a long division
+    // worked in a column an inch wide has nowhere to bring a digit down to.
+    const long = buildSheet(config({ style: "long", columns: 6 }), 1).blocks[0];
+    expect(long.kind === "problems" && long.columns).toBe(4);
+  });
+
+  it("reserves the working space a long form is going to use", () => {
+    // The layout reserves the height and the build attaches the lines, and the
+    // two reading the config differently is the bug the whole "declared, not
+    // measured" design exists to exclude.
+    for (const digits of [
+      { into: 3, by: 2 },
+      { into: 4, by: 3 },
+      { into: 2, by: 1 },
+    ]) {
+      const over = { style: "long" as const, digits, count: 4 };
+      for (const problem of problemsOf(over, 5)) {
+        expect(problem.working?.length ?? 0).toBe(partialLines(digits));
+      }
+      for (const problem of problemsOf({ ...over, operation: "divide" }, 5)) {
+        expect(problem.working).toBeUndefined();
+        expect(problem.workspace).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("reads a saved config's digit counts back safely", () => {
+    // `digits` arrives from outside this build, so it is the one field here
+    // that may be nonsense. A row taller than the paper is a sheet with
+    // nothing on it.
+    expect(longDigits(config({ style: "long" }))).toEqual({ into: 3, by: 2 });
+    expect(
+      longDigits(config({ style: "long", digits: { into: 0, by: 99 } })),
+    ).toEqual({ into: 1, by: 5 });
+    expect(divisionLines({ into: 1, by: 5 })).toBe(2);
+  });
+});

--- a/src/engine/sheets/maths/multiplication.test.ts
+++ b/src/engine/sheets/maths/multiplication.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { PROBLEM_GAP } from "../layout";
+import { PROBLEM_GAP, answerLine } from "../layout";
+import { points } from "../paper";
 import type {
   GridSpec,
   MarginSize,
@@ -11,7 +12,7 @@ import type {
   Problem,
 } from "../types";
 
-import { divisionLines, longDigits, partialLines } from "./long";
+import { BRACKET_EMS, divisionLines, longDigits, partialLines } from "./long";
 import {
   MULTIPLICATION_SHEET,
   multiplicationGrid,
@@ -98,8 +99,15 @@ const EVERY_SHAPE: Array<Partial<MultiplicationConfig>> = [
   { style: "long", digits: { into: 3, by: 2 }, count: 6 },
   { style: "long", digits: { into: 2, by: 1 }, count: 6 },
   { style: "long", digits: { into: 4, by: 3 }, count: 4 },
+  // Equal digit counts, which is the case the folding question turns on: it is
+  // the only shape where a sheet can draw both `26 × 47` and `47 × 26`, and
+  // this family says those are two exercises rather than one repetition. Two
+  // digits by two is also the long multiplication most children are set, so
+  // leaving it out left the headline ask of the story untested.
+  { style: "long", digits: { into: 2, by: 2 }, count: 6 },
   { style: "long", operation: "divide", digits: { into: 3, by: 1 }, count: 6 },
   { style: "long", operation: "divide", digits: { into: 3, by: 2 }, count: 6 },
+  { style: "long", operation: "divide", digits: { into: 3, by: 3 }, count: 4 },
   {
     style: "long",
     operation: "divide",
@@ -217,15 +225,26 @@ function sentences(problem: Problem): string[] {
   return [`${problem.prompt} ${problem.answer}`];
 }
 
-/** What makes two problems the same problem, worked out from the page. */
-function factOf(sentence: string): string {
+/**
+ * What makes two problems the same problem, worked out from the page.
+ *
+ * Multiplication folds and division does not — `masteryKey` against
+ * `drillKey`, established here from the printed page rather than from the key
+ * the family happened to compute.
+ *
+ * Except on a long form, where nothing folds. A fact sheet asks for an answer,
+ * and `7 × 8` and `8 × 7` have the same one; a long form asks for a *method*,
+ * and `26 × 47` and `47 × 26` are worked with different partials in different
+ * columns and a different number of them. So they are two exercises, and
+ * `longKey` in long.ts keeps them apart deliberately. A folding key here would
+ * not be a stricter test — it would be a test of a rule the family does not
+ * have, and it would fail the moment a sheet asked for equal digit counts.
+ */
+function factOf(sentence: string, folds: boolean): string {
   const { left, sign, right } = read(sentence);
-  // Multiplication folds and division does not — `masteryKey` against
-  // `drillKey`, established here from the printed page rather than from the
-  // key the family happened to compute.
-  return sign === "×"
+  return sign === "×" && folds
     ? `×:${Math.min(left, right)}:${Math.max(left, right)}`
-    : `÷:${left}:${right}`;
+    : `${sign}:${left}:${right}`;
 }
 
 /* ── The registry ──────────────────────────────────────────────────────── */
@@ -500,9 +519,14 @@ describe("what may be on the page", () => {
 
   it("asks the same question twice on no sheet at all", () => {
     for (const shape of EVERY_SHAPE) {
+      // A long form is an exercise in a method rather than a fact, so its
+      // repetitions are counted without folding — see `factOf`.
+      const folds = shape.style !== "long";
       for (const seed of SEEDS) {
         const problems = problemsOf(shape, seed);
-        const facts = problems.map((problem) => factOf(sentences(problem)[0]));
+        const facts = problems.map((problem) =>
+          factOf(sentences(problem)[0], folds),
+        );
         expect(new Set(facts).size, JSON.stringify(shape)).toBe(
           problems.length,
         );
@@ -540,6 +564,30 @@ describe("what may be on the page", () => {
         ).length,
         `${one.left} × ${one.right} is on the page twice`,
       ).toBe(one.left === one.right ? 1 : 0);
+    }
+  });
+
+  it("counts a long multiplication as an exercise and not as a fact", () => {
+    // The one place the folding rule above is deliberately off, and the reason
+    // `factOf` has to be told. `26 × 47` and `47 × 26` are one product and two
+    // different pieces of written work — different partials, in different
+    // columns — so a long sheet may print both, and folding them would throw
+    // away half the pool of a sheet whose digit counts are equal.
+    //
+    // Only equal digit counts can draw the pair at all: a three-digit-by-two
+    // sheet has nowhere to put `47 × 269`. This uses the smallest such pool, a
+    // single digit each way, because that is where a page is bound to contain
+    // one rather than merely allowed to.
+    for (const seed of SEEDS) {
+      const drawn = problemsOf(
+        { style: "long", digits: { into: 1, by: 1 }, count: 200, columns: 4 },
+        seed,
+      ).map((problem) => (problem.operands ?? []).map(Number));
+      expect(drawn.length).toBeGreaterThan(0);
+      const both = drawn.filter(([into, by]) =>
+        drawn.some(([a, b]) => into !== by && a === by && b === into),
+      );
+      expect(both.length, `seed ${seed}`).toBeGreaterThan(0);
     }
   });
 
@@ -827,14 +875,43 @@ describe("how much fits", () => {
       { into: 3, by: 2 },
       { into: 4, by: 3 },
       { into: 2, by: 1 },
+      { into: 3, by: 3 },
     ]) {
       const over = { style: "long" as const, digits, count: 4 };
-      for (const problem of problemsOf(over, 5)) {
+      const worked = problemsOf(over, 5);
+      expect(worked.length, JSON.stringify(digits)).toBeGreaterThan(0);
+      for (const problem of worked) {
         expect(problem.working?.length ?? 0).toBe(partialLines(digits));
       }
-      for (const problem of problemsOf({ ...over, operation: "divide" }, 5)) {
-        expect(problem.working).toBeUndefined();
-        expect(problem.workspace).toBeGreaterThan(0);
+
+      // A division attaches no lines — its reservation is blank paper under
+      // the bracket — so "the two agree" has to be checked against the number
+      // itself rather than against a count of what was written.
+      for (const remainders of [false, true]) {
+        const divided = { ...over, operation: "divide" as const, remainders };
+        const where = JSON.stringify(divided);
+        const { fontPt } = config(divided);
+        const reserved = divisionLines(digits) * answerLine(fontPt);
+        const divisions = problemsOf(divided, 5);
+        expect(divisions.length, where).toBeGreaterThan(0);
+
+        for (const problem of divisions) {
+          expect(problem.working, where).toBeUndefined();
+          expect(problem.workspace, where).toBe(reserved);
+          // And the row the layout hands the renderer is the bracket plus that
+          // space, so the working a child is promised is inside the cell it is
+          // printed in rather than over the problem below.
+          expect(multiplicationLayout(config(divided)).row, where) //
+            .toBeGreaterThanOrEqual(points(fontPt * BRACKET_EMS) + reserved);
+          // The reservation is two ruled lines per digit of the quotient, on
+          // the bound that a quotient can be no longer than `into − by + 1`
+          // digits — a bound `divisionLines` computes before any division has
+          // been drawn. This is the half of it a drawn quotient can falsify: a
+          // longer one is a child working past the bottom of their own space.
+          const [quotient] = problem.answer.split(" r ");
+          expect(quotient.length, `${where}: ${problem.answer}`) //
+            .toBeLessThanOrEqual(digits.into - digits.by + 1);
+        }
       }
     }
   });

--- a/src/engine/sheets/maths/multiplication.ts
+++ b/src/engine/sheets/maths/multiplication.ts
@@ -1,0 +1,625 @@
+/**
+ * Multiplication and division.
+ *
+ * The tables The Grid already drills, on paper. Everything the arithmetic
+ * family established holds here unchanged — the answers are computed when the
+ * problem is built and the key only decides to print them, the page comes out
+ * of `(config, seed)` and nothing else, and a problem is drawn and rejected
+ * rather than enumerated — so this file is about the three things that are
+ * genuinely different.
+ *
+ * **A table is a pool, not a range.** "The seven times table" is thirteen
+ * facts, not a span of numbers, and a mixed set is several of those pools
+ * shuffled together. So a config names `tables` and what to multiply them by,
+ * and the difference between a sheet that teaches one table and a sheet that
+ * tests all of them is the length of one array.
+ *
+ * **Division folds in the record book and not in a drill.** 7 × 8 and 8 × 7 are
+ * one fact and one problem — a child who finds both on a page has been given
+ * nineteen problems and a joke — while 56 ÷ 7 and 56 ÷ 8 are two questions with
+ * two answers. That is exactly the distinction `DeckSpec.masteryKey` and
+ * `drillKey` already make for the race, reached here from the same direction: a
+ * worksheet is a drill, so the commutative operation folds and the other does
+ * not.
+ *
+ * **Some sheets have working rather than answers.** The grid is one block with
+ * a hundred and forty-four answers in it, and the long forms are rows whose
+ * height is decided by how many times a child brings a digit down. Both are in
+ * `long.ts` and in `gridOf` below rather than smuggled into the problem shapes.
+ */
+import { arithmeticFactId } from "@/engine/decks/flashcards";
+import { mulberry32 } from "@/engine/random";
+
+import type {
+  Block,
+  GridSpec,
+  Mil,
+  MultiplicationConfig,
+  MultiplicationOperation,
+  Problem,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import { PROBLEM_GAP, columnWidth, fitAcross, type Box } from "../layout";
+import { inches, points } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import {
+  BRACKET_EMS,
+  STACK_EMS,
+  drawLong,
+  longDigits,
+  longKey,
+  longProblem,
+  longRow,
+} from "./long";
+
+/* ── What a problem takes on the page ─────────────────────────────────────
+   Declared, not measured (§4). A fact written along a line is one line of the
+   body type; a fact worked the way it is worked is a column stack for a
+   multiplication and a bracket for a division, which are the same two shapes
+   the long forms use without their working.                                 */
+
+const ROW_EMS = { horizontal: 1.7 } as const;
+
+/** Blank space to work a fact out in, when the config asks for it. */
+const WORKSPACE = inches(0.55);
+
+/** More than six columns of facts is a page nobody can read. */
+const MAX_COLUMNS = 6;
+
+/**
+ * And more than four columns of long forms is a page nobody can work in: a
+ * long division worked in a column an inch wide has nowhere to bring a digit
+ * down to, which is the one thing the sheet is for.
+ */
+const MAX_LONG_COLUMNS = 4;
+
+/**
+ * The largest number a fact sheet will put on either side of the sign.
+ *
+ * Twelve is the wall chart and twelve is what a parent picks; this is only
+ * here so that a config arriving from outside this build can't ask for the
+ * hundred times table and a grid ten thousand squares deep.
+ */
+const MAX_FACT = 20;
+
+/** As `arithmetic.ts` — see the note there on why a budget rather than a proof. */
+const MISS_BUDGET = 500;
+
+const SIGN = { multiply: "×", divide: "÷" } as const;
+
+/** The biggest square a grid is drawn at: bigger is a page with nothing on it. */
+const MAX_GRID_CELL = inches(0.62);
+
+/* ── The pool ──────────────────────────────────────────────────────────────
+   Sanitised once and drawn from many times, because it comes from outside this
+   build: a config in a bookmarked URL may name a table twice, a fractional
+   one, or none at all.                                                      */
+
+type Pool = {
+  /** The tables to multiply, in order. */
+  multiply: number[];
+  /**
+   * The tables to divide by. The same list without zero, which is the whole of
+   * "no division by zero" (§20): there is no path from here to a divisor that
+   * isn't in this array.
+   */
+  divide: number[];
+  factors: number[];
+};
+
+/** Whole, in range, deduplicated and in order. */
+function tablesOf(config: MultiplicationConfig): number[] {
+  const clean = (config.tables ?? [])
+    .map((table) => Math.floor(table))
+    .filter((table) => Number.isFinite(table) && table >= 0)
+    .map((table) => Math.min(MAX_FACT, table));
+  return [...new Set(clean)].sort((a, b) => a - b);
+}
+
+/** What each table is multiplied by, ends included. */
+function factorsOf(config: MultiplicationConfig): number[] {
+  const min = Math.min(
+    MAX_FACT,
+    Math.max(0, Math.floor(config.factors?.min ?? 0)),
+  );
+  const max = Math.min(
+    MAX_FACT,
+    Math.max(min, Math.floor(config.factors?.max ?? 0)),
+  );
+  return Array.from({ length: max - min + 1 }, (_, step) => min + step);
+}
+
+function poolOf(config: MultiplicationConfig): Pool {
+  const tables = tablesOf(config);
+  return {
+    multiply: tables,
+    divide: tables.filter((table) => table > 0),
+    factors: factorsOf(config),
+  };
+}
+
+/* ── Drawing a fact ────────────────────────────────────────────────────── */
+
+/**
+ * One fact, as it will be printed. A multiplication reads `table × factor`; a
+ * division is the same fact read backwards, `product ÷ table`, so the table a
+ * parent picked is the divisor and the factor is the answer.
+ */
+type Fact = {
+  operation: "multiply" | "divide";
+  table: number;
+  factor: number;
+  product: number;
+};
+
+/**
+ * Which way round this problem reads.
+ *
+ * The coin is spent only when the config asks for both, exactly as the deck
+ * builder short-circuits it for a non-commutative operation: a draw that took
+ * one anyway would shift every subsequent problem, and every seed a parent had
+ * already printed would produce a different sheet.
+ */
+function operationOf(
+  operation: MultiplicationOperation,
+  rand: () => number,
+): "multiply" | "divide" {
+  if (operation !== "both") return operation;
+  return rand() < 0.5 ? "multiply" : "divide";
+}
+
+/** One candidate fact, or `null` when what was drawn isn't what was asked for. */
+function drawFact(
+  config: MultiplicationConfig,
+  pool: Pool,
+  operation: "multiply" | "divide",
+  rand: () => number,
+): Fact | null {
+  const tables = operation === "multiply" ? pool.multiply : pool.divide;
+  if (tables.length === 0 || pool.factors.length === 0) return null;
+
+  const table = tables[Math.floor(rand() * tables.length)];
+  const factor = pool.factors[Math.floor(rand() * pool.factors.length)];
+
+  // A blank that any number would fill is not a question. "_ × 0 = 0" is true
+  // of every number there is, and so is "0 ÷ _ = 0" — so a sheet that blanks an
+  // operand never draws a zero, whichever side the blank lands on.
+  if (config.style === "missing" && (table === 0 || factor === 0)) return null;
+
+  return { operation, table, factor, product: table * factor };
+}
+
+/**
+ * What makes two facts the same problem.
+ *
+ * Multiplication folds and division does not, which is `masteryKey` versus
+ * `drillKey` arrived at from the paper side. Which slot a missing-number
+ * problem blanks is not part of it either: "7 × _ = 56" and "_ × 8 = 56" are
+ * one fact wearing two hats, and a child spots that faster than the adult who
+ * printed it does.
+ */
+function keyOf(fact: Fact): string {
+  if (fact.operation === "multiply") {
+    const low = Math.min(fact.table, fact.factor);
+    return `×:${low}:${Math.max(fact.table, fact.factor)}`;
+  }
+  return `÷:${fact.product}:${fact.table}`;
+}
+
+/* ── Turning a fact into a problem ─────────────────────────────────────── */
+
+/** The three numbers in the order they are printed: `left op right = result`. */
+function sentenceOf(fact: Fact): [number, number, number] {
+  return fact.operation === "multiply"
+    ? [fact.table, fact.factor, fact.product]
+    : [fact.product, fact.table, fact.factor];
+}
+
+function problemOf(
+  fact: Fact,
+  config: MultiplicationConfig,
+  slot: number,
+  extras: { workspace?: Mil },
+): Problem {
+  const sign = SIGN[fact.operation];
+  const [left, right, result] = sentenceOf(fact);
+  // The race's own vocabulary for a fact, so a sheet printed from the record
+  // book's trouble facts (§14) names the same things the race does — the table
+  // that was picked, then what it was paired with, whichever way the sheet
+  // happens to ask it.
+  const factId = arithmeticFactId(fact.table, fact.factor);
+
+  if (config.style === "missing") {
+    // Along the line whatever `form` says, for the reason the arithmetic
+    // family gives: a blank in column form sits beside an answer already
+    // written under the rule, and a child who fills in the wrong one was not
+    // wrong.
+    return {
+      prompt:
+        slot === 0
+          ? `_ ${sign} ${right} = ${result}`
+          : `${left} ${sign} _ = ${result}`,
+      answer: String(slot === 0 ? left : right),
+      factId,
+      ...extras,
+    };
+  }
+
+  if (config.form === "vertical") {
+    // Worked the way it is worked, which is two different drawings: a
+    // multiplication is a column stack and a division is the bracket. There is
+    // no stacked form of a division — nobody has ever written one — so the
+    // bracket is what "vertical" means for it.
+    return fact.operation === "multiply"
+      ? {
+          prompt: "",
+          operands: [String(left), String(right)],
+          operator: sign,
+          answer: String(result),
+          factId,
+          ...extras,
+        }
+      : {
+          prompt: "",
+          bracket: { divisor: String(right), dividend: String(left) },
+          answer: String(result),
+          factId,
+          ...extras,
+        };
+  }
+
+  return {
+    prompt: `${left} ${sign} ${right} =`,
+    answer: String(result),
+    factId,
+    ...extras,
+  };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/** How tall one problem stands, working space and all. */
+function rowHeight(config: MultiplicationConfig): Mil {
+  if (config.style === "long") return longRow(config, config.fontPt);
+
+  const worked = config.style === "standard" && config.form === "vertical";
+  // A mixed sheet reserves for the taller of the two drawings, because the row
+  // height is one number for the whole grid of them.
+  const ems = !worked
+    ? ROW_EMS.horizontal
+    : config.operation === "divide"
+      ? BRACKET_EMS
+      : STACK_EMS;
+  return points(config.fontPt * ems) + (config.workspace ? WORKSPACE : 0);
+}
+
+/**
+ * How many problems the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic, not measurement, so `npm run test:unit` can answer "did it fit?"
+ * without a browser — and so the same answer serves the catalog page built at
+ * build time and the builder's preview (§4).
+ */
+export function multiplicationLayout(config: MultiplicationConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of them.
+  const box = sheetBlockBox(headerOf(config), true);
+  const most = config.style === "long" ? MAX_LONG_COLUMNS : MAX_COLUMNS;
+  const columns = clamp(config.columns, 1, most);
+  const row = rowHeight(config);
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
+  };
+}
+
+/**
+ * Every problem on the sheet, in the order they are printed.
+ *
+ * Exported because it is the whole of what a test has to check, and checking it
+ * through the `Sheet` means unwrapping a block union to reach it. A grid has
+ * none — it is one block with the answers inside it — so this is empty there.
+ */
+export function multiplicationProblems(
+  config: MultiplicationConfig,
+  seed: number,
+): Problem[] {
+  if (config.style === "grid") return [];
+
+  const { perPage } = multiplicationLayout(config);
+  // The count is a request, not a promise: a count that overruns is a second
+  // sheet out of the printer with two problems on it.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  const pool = poolOf(config);
+  const seen = new Set<string>();
+  const problems: Problem[] = [];
+  const extras = config.workspace ? { workspace: WORKSPACE } : {};
+
+  let misses = 0;
+  while (problems.length < wanted && misses < MISS_BUDGET) {
+    const operation = operationOf(config.operation, rand);
+    if (config.style === "long") {
+      const form = drawLong(config, operation, rand);
+      const key = form === null ? null : longKey(form);
+      if (form === null || key === null || seen.has(key)) {
+        misses += 1;
+        continue;
+      }
+      seen.add(key);
+      problems.push(longProblem(form, config));
+      misses = 0;
+      continue;
+    }
+
+    const fact = drawFact(config, pool, operation, rand);
+    // Which side of a missing-number problem is blank. Drawn whatever the fact
+    // style, so that switching between standard and missing does not reshuffle
+    // every other problem on a sheet built from the same seed. The long forms
+    // have no slot and take no coin for one.
+    const slot = rand() < 0.5 ? 0 : 1;
+    const key = fact === null ? null : keyOf(fact);
+    if (fact === null || key === null || seen.has(key)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(key);
+    problems.push(problemOf(fact, config, slot, extras));
+    misses = 0;
+  }
+  return problems;
+}
+
+/* ── The grid ──────────────────────────────────────────────────────────────
+   The multiplication square: the tables down the side, what they are
+   multiplied by along the top, and a product in every space where the two
+   meet. Not a set of problems — one block, and the only sheet in the shop
+   whose answers are not written on a rule.                                  */
+
+/**
+ * The square, or `null` when there is nothing to draw one of.
+ *
+ * Nothing here is random, and that is correct rather than an oversight: a
+ * twelve by twelve grid is the same object every time it is printed, and a
+ * parent who prints it twice should get the same wall chart. The seed still
+ * rides in the footer, because the sheet is still reproducible from it.
+ */
+export function multiplicationGrid(
+  config: MultiplicationConfig,
+): GridSpec | null {
+  const { multiply: tables, factors } = poolOf(config);
+  if (tables.length === 0 || factors.length === 0) return null;
+
+  const columns = factors.length + 1;
+  const rows = tables.length + 1;
+  const box = sheetBlockBox(headerOf(config), true);
+  // The square shrinks to fit rather than the drawing being rescaled, for the
+  // reason `Grid` clamps it too: a grid that overran the box would come off the
+  // printer at a size nobody chose, silently.
+  const cell = Math.min(
+    MAX_GRID_CELL,
+    Math.floor(box.width / columns),
+    Math.floor(box.height / rows),
+  );
+  if (cell <= 0) return null;
+
+  // Row-major, headers and body in one pass over the same indices, so the two
+  // lists cannot disagree about which square is which. A cell is either always
+  // printed or only printed on the key — never both, and never neither.
+  const cells: string[] = [];
+  const answers: string[] = [];
+  for (let row = 0; row < rows; row++) {
+    for (let column = 0; column < columns; column++) {
+      const header = row === 0 || column === 0;
+      cells.push(
+        row === 0 && column === 0
+          ? SIGN.multiply
+          : row === 0
+            ? String(factors[column - 1])
+            : column === 0
+              ? String(tables[row - 1])
+              : "",
+      );
+      answers.push(header ? "" : String(tables[row - 1] * factors[column - 1]));
+    }
+  }
+
+  return {
+    kind: "chart",
+    columns,
+    rows,
+    cell,
+    cells,
+    answers,
+    // The heavier pair of rules, under the header row and beside the header
+    // column: without them a child reads the headers as part of the answer.
+    origin: { column: 1, row: 1 },
+  };
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+/** The largest number a fact sheet puts on the page, either side of the sign. */
+function topOf(config: MultiplicationConfig): number {
+  const { multiply: tables, factors } = poolOf(config);
+  return Math.max(0, ...tables, ...factors);
+}
+
+const LONG_NAME = {
+  multiply: "Long multiplication",
+  divide: "Long division",
+  both: "Long multiplication and division",
+} as const;
+
+const MIXED_NAME = {
+  multiply: "Multiplication",
+  divide: "Division",
+  both: "Multiplication and division",
+} as const;
+
+/** "The 7 times table" — the phrase a parent says, and the one they search. */
+function titleOf(config: MultiplicationConfig): string {
+  if (config.style === "long") {
+    // The remainder switch is in the title rather than only in the catalog
+    // line, because it changes what the sheet *is*: a child who has not been
+    // taught remainders and meets one has been set an impossible problem.
+    const divides = config.operation !== "multiply";
+    return divides && config.remainders
+      ? `${LONG_NAME[config.operation]} with remainders`
+      : LONG_NAME[config.operation];
+  }
+
+  const top = topOf(config);
+  if (config.style === "grid") return `Multiplication grid to ${top}`;
+
+  const tables = poolOf(config).multiply;
+  if (tables.length !== 1) return `${MIXED_NAME[config.operation]} to ${top}`;
+  const [table] = tables;
+  switch (config.operation) {
+    case "multiply":
+      return `The ${table} times table`;
+    case "divide":
+      return `Dividing by ${table}`;
+    default:
+      return `The ${table} times table, both ways`;
+  }
+}
+
+function instructionOf(config: MultiplicationConfig): string {
+  switch (config.style) {
+    case "missing":
+      return "Write the missing number in each blank.";
+    case "grid":
+      return "Write each product in the square where its row meets its column.";
+    case "long":
+      return config.remainders && config.operation !== "multiply"
+        ? "Show your working. Write what is left over after an r."
+        : "Show your working.";
+    default:
+      return "Work out each answer.";
+  }
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: MultiplicationConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions: config.instructions ?? instructionOf(config),
+  };
+}
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * The two things a shop's label leaves off are the two that decide whether a
+ * sheet matches the lesson: how the problem is written down, and — for a long
+ * form — how big the numbers are.
+ */
+export function describeMultiplication(config: MultiplicationConfig): string {
+  const digits = longDigits(config);
+  return [
+    titleOf(config),
+    config.style === "long"
+      ? `${digits.into}-digit by ${digits.by}-digit`
+      : null,
+    config.style === "standard" && config.form === "vertical"
+      ? "worked in columns"
+      : null,
+    config.style === "missing" ? "missing number" : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" — ");
+}
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+/** The blocks, and what the sheet is marked out of. */
+function bodyOf(
+  config: MultiplicationConfig,
+  seed: number,
+): { blocks: Block[]; outOf: number } {
+  if (config.style === "grid") {
+    const grid = multiplicationGrid(config);
+    if (grid === null) return { blocks: [], outOf: 0 };
+    return {
+      blocks: [{ kind: "grid", grid }],
+      // Marked out of the squares a child has to fill, which is the grid
+      // without its two headers.
+      outOf: (grid.columns - 1) * (grid.rows - 1),
+    };
+  }
+
+  const items = multiplicationProblems(config, seed);
+  const { columns } = multiplicationLayout(config);
+  return {
+    blocks: [{ kind: "problems", columns, items }],
+    outOf: items.length,
+  };
+}
+
+export function buildMultiplicationSheet(
+  config: MultiplicationConfig,
+  seed: number,
+): Sheet {
+  const head = headerOf(config);
+  const { blocks, outOf } = bodyOf(config, seed);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is actually on the page, not out of what was asked for: a
+      // sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf },
+    },
+    blocks,
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const MULTIPLICATION_SHEET: SheetSpec<MultiplicationConfig> = {
+  id: "multiplication",
+  label: "Multiplication and division",
+  world: SHEET_WORLD,
+  build: buildMultiplicationSheet,
+  // The whole of the answer-key mechanism: every answer on the page was
+  // computed when the problem was built, so a key prints what is already there
+  // rather than generating it a second time and risking a different answer to
+  // the same question.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeMultiplication,
+};

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -159,8 +159,41 @@ export type Problem = {
    * data is a flag that can disagree with it.
    */
   operands?: string[];
-  /** The sign printed beside the stack: "+" or "−". Column form only. */
+  /** The sign printed beside the stack: "+", "−" or "×". Column form only. */
   operator?: string;
+  /**
+   * The working that goes between the stack and its answer, one ruled line
+   * each: the partial products of a long multiplication, one per digit of the
+   * multiplier.
+   *
+   * Blank on the sheet and written in on the key, exactly like every other
+   * answer place — which is the point of carrying the partials rather than a
+   * count of them. A long multiplication is marked on its working as much as on
+   * its total, and a key that showed only the product would leave the parent to
+   * do the sum themselves to find where it went wrong.
+   *
+   * The rule under the problem is drawn above these lines and the total keeps
+   * its own below them, which is the shape the algorithm is taught in. Column
+   * form only, and absent when the multiplier is a single digit: there are no
+   * partials to write, and blank rules over the answer would be a page asking a
+   * child to show working that does not exist.
+   *
+   * `workspace` is the height the lines share, the same bargain `answers`
+   * makes: the family reserved that height, so dividing it between them is what
+   * keeps the row as tall as the layout arithmetic declared.
+   */
+  working?: string[];
+  /**
+   * Long division's tableau: the divisor outside the bracket, the dividend
+   * under the bar, and the quotient written along the top of it.
+   *
+   * A shape of its own rather than a stack with a different sign, because it is
+   * the one arithmetic form that is not a column of numbers — the working
+   * happens under the dividend rather than beside it, and the answer is written
+   * above the problem rather than below. `answer` is the quotient, remainder
+   * and all ("234 r 2").
+   */
+  bracket?: { divisor: string; dividend: string };
   /**
    * Which fact this exercises, in the vocabulary the race already uses
    * ("7:8"). Optional, and the whole of what makes "print the facts they keep
@@ -191,7 +224,21 @@ export type GridSpec = {
   cell: Mil;
   /** What's printed in the squares, row-major. Empty for a blank grid. */
   cells?: string[];
-  /** Coordinate planes only: where the axes cross, counted in squares. */
+  /**
+   * What's printed in the squares only on a key, row-major and alongside
+   * `cells` rather than instead of it.
+   *
+   * A multiplication square is a grid a child fills in, so its headers are on
+   * the sheet from the start and its hundred and forty-four products are the
+   * answer. Two lists rather than one flag, for the reason `operands` is a
+   * stack rather than a boolean: a cell is either always printed or only
+   * printed on the key, and which one it is has to be a fact about the cell.
+   */
+  answers?: string[];
+  /**
+   * Where the two heavier rules cross, counted in squares: a coordinate
+   * plane's axes, or the line under a multiplication grid's headers.
+   */
   origin?: { column: number; row: number };
 };
 
@@ -412,8 +459,76 @@ export type ArithmeticConfig = SheetOptions & {
   workspace?: boolean;
 };
 
+/* ── Multiplication and division ───────────────────────────────────────────
+   The tables the race already drills, on paper — and the two long forms,
+   which are the first sheets where the working is the exercise rather than
+   the answer.                                                              */
+
+/** Which way round the facts are asked. `both` shuffles the two together. */
+export type MultiplicationOperation = "multiply" | "divide" | "both";
+
+/**
+ * What the sheet asks for.
+ *
+ * `standard` gives both numbers and asks for the result; `missing` gives the
+ * result and one number and asks for the other; `grid` is the multiplication
+ * square, a row and a column of headers and a product in every space where
+ * they meet; `long` is the written method — long multiplication, or the
+ * division bracket.
+ */
+export type MultiplicationStyle = "standard" | "missing" | "grid" | "long";
+
+/** Written across the line, or stacked in columns. `long` is always stacked. */
+export type MultiplicationForm = "horizontal" | "vertical";
+
+/**
+ * How many digits each side of a long form has.
+ *
+ * `into` is the number being worked on — the multiplicand, or the dividend —
+ * and `by` the one doing the working: the multiplier, or the divisor. It is
+ * the phrase a teacher already uses ("three-digit by two-digit", "four into
+ * nine hundred"), and it is the only thing that decides how much working space
+ * the row reserves.
+ */
+export type LongDigits = { into: number; by: number };
+
+export type MultiplicationConfig = SheetOptions & {
+  kind: "multiplication";
+  operation: MultiplicationOperation;
+  style: MultiplicationStyle;
+  form: MultiplicationForm;
+  /**
+   * Which tables are on the page. One entry is "the seven times table" and
+   * several is a mixed set, which is the whole of the difference between
+   * learning a table and knowing them.
+   *
+   * A table is the divisor when the sheet divides, so the seven times table
+   * read backwards is dividing by seven — the same pair of facts the record
+   * book folds onto one square and a drill keeps apart.
+   */
+  tables: number[];
+  /** What each table is multiplied by, ends included. */
+  factors: { min: number; max: number };
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  /** Long forms only; ignored by the fact styles, which draw from `tables`. */
+  digits?: LongDigits;
+  /**
+   * Long division only: whether a division may leave a remainder.
+   *
+   * Off unless asked for, because it is a change of question rather than a
+   * harder version of the same one — a child who has not been taught
+   * remainders and meets one has been set an impossible problem.
+   */
+  remainders?: boolean;
+  /** Blank space under every problem, to work in. */
+  workspace?: boolean;
+};
+
 /**
  * Anything a saved sheet can hold. Narrow on `kind` — and only in index.ts,
  * which is the one module that knows the whole union.
  */
-export type SheetConfig = BlankConfig | PaperConfig | ArithmeticConfig;
+export type SheetConfig =
+  BlankConfig | PaperConfig | ArithmeticConfig | MultiplicationConfig;

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -403,9 +403,17 @@
 }
 
 /* Right-aligned over the dividend, not centred: a quotient's last digit
-   belongs over the dividend's last digit, always, whatever either measures. */
+   belongs over the dividend's last digit, always, whatever either measures.
+
+   Which is why the right inset below is the dividend's own, written out again.
+   Both boxes stretch the full width of `.sheet__house`, so their right *edges*
+   already agree — but a quotient without the padding the dividend holds its
+   digits off by would put its units digit two thirds of a digit clear of the
+   one it is supposed to sit over, and place value is the entire exercise. The
+   two values are asserted equal in Sheet.test.tsx so they cannot drift. */
 .sheet__quotient {
   min-height: 1.2em;
+  padding-right: 0.06in;
   text-align: right;
   white-space: nowrap;
 }

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -308,10 +308,14 @@
 }
 
 /* An answer, wherever it is written: in the slot at the end of a sum, in the
-   gap inside one, or under the rule of a column. One weight in one place, so
-   a key reads the same however the problem was set. */
+   gap inside one, under the rule of a column, over a division bracket, on a
+   working line or in a square of a grid. One weight in one place, so a key
+   reads the same however the problem was set. */
 .sheet__slot--answered,
-.sheet__total--answered {
+.sheet__total--answered,
+.sheet__quotient--answered,
+.sheet__work-line--answered,
+.sheet__cell--answered {
   font-weight: 700;
 }
 
@@ -339,6 +343,77 @@
   border-top: 0.75pt solid currentcolor;
   padding-top: 0.03in;
   min-height: 1.2em;
+  text-align: right;
+}
+
+/* ── The long forms ─────────────────────────────────────────────────────────
+   The two sheets where the working is the exercise rather than the answer, and
+   where every rule above is load-bearing twice over. `tabular-nums` is what
+   keeps a partial product in its own column, and a partial written half a
+   column left of where it belongs is the entire mistake these sheets exist to
+   practise out of a child. `nowrap` is what keeps a row the height the layout
+   arithmetic declared, exactly as it is on an answer line.                   */
+
+/* The partial products of a long multiplication. The rule under the sum is
+   this box's top border, each partial gets a line of its own, and the last of
+   those lines is the rule the total is written under — which is the shape of
+   the algorithm, drawn with three borders and no drawing. */
+.sheet__work {
+  display: flex;
+  flex-direction: column;
+  border-top: 0.75pt solid currentcolor;
+  padding-top: 0.03in;
+}
+
+.sheet__work-line {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  overflow: hidden;
+  white-space: nowrap;
+  border-bottom: 0.75pt solid currentcolor;
+}
+
+/* Two strokes at the same height print as one heavy line, so the total gives
+   up its own rule when the working already drew one. */
+.sheet__work + .sheet__total {
+  border-top: 0;
+  padding-top: 0;
+}
+
+/* Long division: the divisor outside the bracket, the dividend under the bar,
+   and the quotient written along the top of it. The bar and the upright are
+   borders rather than an SVG, because they are exactly a border — and because
+   the digits inside have to stay selectable text (§2). */
+.sheet__bracket {
+  display: inline-flex;
+  align-items: flex-end;
+  font-variant-numeric: tabular-nums;
+}
+
+.sheet__divisor {
+  padding-right: 0.05in;
+  padding-bottom: 0.02in;
+}
+
+.sheet__house {
+  display: flex;
+  flex-direction: column;
+  min-width: 0.7in;
+}
+
+/* Right-aligned over the dividend, not centred: a quotient's last digit
+   belongs over the dividend's last digit, always, whatever either measures. */
+.sheet__quotient {
+  min-height: 1.2em;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.sheet__dividend {
+  border-top: 0.75pt solid currentcolor;
+  border-left: 0.75pt solid currentcolor;
+  padding: 0.03in 0.06in 0.02in;
   text-align: right;
 }
 


### PR DESCRIPTION
Closes #50 (PRINT06).

## What this adds

`src/engine/sheets/maths/multiplication.ts` is the second generated sheet
family, registered in `src/engine/sheets/index.ts` alongside blank, paper and
arithmetic. It covers everything the story asked for:

- **Times tables by table and by mixed set** — `standard` and `missing`
  styles, horizontal or vertical form, multiply or divide or both.
- **The multiplication square** — a grid whose headers print on the sheet and
  whose products print only on the key.
- **Long multiplication** — the stack, its partial products, and the total.
- **Long division** — the bracket tableau, with and without remainders.

Everything PRINT05 established holds unchanged: answers are computed when the
problem is built and the key only decides whether to print them, and the
generator draws and rejects rather than enumerating. Three things are genuinely
new.

**A table is a pool, not a range.** "The seven times table" is thirteen facts,
not a span of numbers, so `MultiplicationConfig` names `tables` and the
`factors` they are multiplied by. The difference between a sheet that teaches
one table and one that tests all of them is the length of one array — which is
also the difference between the two titles a parent searches for.

**Division folds in the record book and not in a drill.** 7 × 8 and 8 × 7 are
one problem; 56 ÷ 7 and 56 ÷ 8 are two questions with two answers. That is
`DeckSpec.masteryKey` against `drillKey` reached from the paper side, and a
worksheet is a drill — so the commutative operation folds and the other does
not. The suite proves both halves off the printed page rather than off the key
the family computed.

**Some sheets have working rather than answers**, which is the whole of the
long forms. `long.ts` derives every measurement from two numbers — how many
digits the number being worked on has (`into`) and how many are in the one
doing the working (`by`) — because the partial-product count, the number of
bring-downs in a division, and therefore the height of the row all follow from
those. A long division is built from its answer outwards (divisor, remainder,
quotient, dividend last), because that is the only order in which "three digits
into one" and "no remainder" can both be honoured.

## Supporting changes

- `Problem` grows `working` (the partial products, ruled between the stack and
  its total) and `bracket` (long division's tableau, whose answer sits above
  the problem rather than below). The renderer draws what the data says.
- `GridSpec` grows `answers`, a second list over the same squares, so the blank
  square and the wall chart are one build with `answers` flipped.
- The ruled-answer-line height and the shared problem-grid gap moved from
  `arithmetic.ts` into `layout.ts`, because a second family now divides a page
  by them and a copy that drifted from `sheet.css` would push a row of problems
  below the bottom margin.
- Retired the local `pick` in `arithmetic.ts` for the shared `between` in
  `engine/random.ts` — one definition of "a whole number in a range" instead of
  three.

## Testing

Determinism and bounds tests as PRINT05, and the suite never checks the
generator against the generator:

- a product is verified by repeated addition,
- a division through its inverse built out of that same addition,
- a partial product by shifting a *string* (long multiplication is entirely
  about which column a number lands in, and a test that multiplied by a power
  of ten would agree with a family that had the shift wrong),
- a missing number by searching for every number that fits, which catches a
  wrong answer and an ambiguous blank at once.

Seven mutations were tried against the engine suite and six against the
renderer's; every one failed at least one test. Golden lists pin the draw
across a deploy, because the seed is printed on the paper.

A follow-up commit fixed three things review found on the long forms: the
quotient was not actually sitting over the dividend (only the dividend carried
a 0.06in inset — `Sheet.test.tsx` now compares the two values so they cannot
drift again); `factOf` folded every `×` sentence including long forms, which
left two-digit-by-two-digit long multiplication with no coverage at all; and
long-division working space was asserted rather than verified, and is now
checked against `divisionLines × answerLine` and against a quotient that was
actually drawn.

## Out of scope

No catalog pages and no builder — PRINT10 and PRINT13. This registers the
family; nothing routes to it yet.

## Gate

`type-check`, `lint`, `test:unit` (341 passing), `build` and the browser smoke
test all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
