### PR TITLE
PRINT07: fraction, decimal, percent and money worksheets

### DIFF
--- a/src/components/sheet/FractionArt.tsx
+++ b/src/components/sheet/FractionArt.tsx
@@ -1,0 +1,172 @@
+/**
+ * A whole cut into equal parts, as strokes and one fill.
+ *
+ * The bar and the circle a naming sheet asks about. Unlike every other drawing
+ * on a sheet this one has ink *inside* it — the shaded parts are the question,
+ * so they have to be visible on the blank sheet a child is handed, not only on
+ * the key.
+ *
+ * That is why the shading is an SVG `fill` and not a CSS background. A browser
+ * drops background paint when printing unless the reader has hunted down the
+ * "Background graphics" checkbox (§5), and a naming sheet whose pictures came
+ * out as a row of empty boxes asks a question that isn't there. `fill` is
+ * graphics content: it prints either way. It is also set at a fraction of the
+ * ink so that thirty of these a week is not thirty pages of toner.
+ *
+ * Where the cuts fall is arithmetic and the sizes come from the engine
+ * (`fractionart.ts`), which is the same module the family reserved the row
+ * height with — so the drawing cannot come out taller than the space that was
+ * kept for it.
+ */
+import { artHeight, artWidth } from "@/engine/sheets/fractionart";
+import type { FractionArt, Mil } from "@/engine/sheets/types";
+
+import { HAIRLINE, RULE, inch } from "./units";
+
+/** Half the outline, so a stroke on the edge of the box isn't cut in half. */
+const INSET = Math.round(RULE / 2);
+
+export function FractionArtView({ art }: { art: FractionArt }) {
+  const width = artWidth(art);
+  const height = artHeight(art);
+  if (art.parts < 1) return null;
+
+  return (
+    <svg
+      className="sheet__ink sheet__art"
+      width={inch(width)}
+      height={inch(height)}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      // The picture *is* the question, so describing it is not giving anything
+      // away — it is handing a child who can't see it exactly what a child who
+      // can is looking at. The fraction itself is never said.
+      aria-label={`A ${art.shape} in ${art.parts} equal parts, ${art.shaded} shaded`}
+    >
+      {art.shape === "circle" ? (
+        <Pie art={art} size={Math.min(width, height)} />
+      ) : (
+        <Bar art={art} width={width} height={height} />
+      )}
+    </svg>
+  );
+}
+
+/**
+ * A bar in `parts` equal cells, the first `shaded` of them filled.
+ *
+ * The cuts are computed from the index rather than accumulated, exactly as the
+ * rule positions on a page are: the last cell is then as wide as the first,
+ * whatever the rounding did in between.
+ */
+function Bar({
+  art,
+  width,
+  height,
+}: {
+  art: FractionArt;
+  width: Mil;
+  height: Mil;
+}) {
+  const span = width - INSET * 2;
+  const at = (part: number) => INSET + Math.round((part * span) / art.parts);
+
+  return (
+    <>
+      {art.shaded > 0 && (
+        <rect
+          className="sheet__shade"
+          x={at(0)}
+          y={INSET}
+          width={at(art.shaded) - at(0)}
+          height={height - INSET * 2}
+        />
+      )}
+      <rect
+        className="sheet__shape"
+        x={INSET}
+        y={INSET}
+        width={span}
+        height={height - INSET * 2}
+        strokeWidth={RULE}
+      />
+      {/* One line per cut, which is one fewer than there are parts: the two
+          ends of the bar are its own outline. */}
+      {Array.from({ length: art.parts - 1 }, (_, cut) => (
+        <line
+          className="sheet__rule"
+          key={cut}
+          x1={at(cut + 1)}
+          x2={at(cut + 1)}
+          y1={INSET}
+          y2={height - INSET}
+          strokeWidth={HAIRLINE}
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * A circle cut into `parts` equal slices, the first `shaded` of them filled.
+ *
+ * The shading is one wedge rather than one per slice — the shaded parts are
+ * always the first of them, so a single arc is the whole region and there are
+ * no seams between two fills at the same opacity.
+ */
+function Pie({ art, size }: { art: FractionArt; size: Mil }) {
+  const radius = Math.round(size / 2) - INSET;
+  const centre = Math.round(size / 2);
+  const step = 360 / art.parts;
+  const at = (degrees: number) => ({
+    x: Math.round(centre + radius * Math.sin((degrees * Math.PI) / 180)),
+    y: Math.round(centre - radius * Math.cos((degrees * Math.PI) / 180)),
+  });
+
+  const filled = art.shaded * step;
+  const start = at(0);
+  const end = at(filled);
+
+  return (
+    <>
+      {art.shaded >= art.parts ? (
+        // A whole circle shaded. Drawn as a circle rather than as a 360° wedge,
+        // because an arc that ends where it began draws nothing at all.
+        <circle className="sheet__shade" cx={centre} cy={centre} r={radius} />
+      ) : (
+        art.shaded > 0 && (
+          <path
+            className="sheet__shade"
+            d={`M ${centre} ${centre} L ${start.x} ${start.y} A ${radius} ${radius} 0 ${
+              filled > 180 ? 1 : 0
+            } 1 ${end.x} ${end.y} Z`}
+          />
+        )
+      )}
+      <circle
+        className="sheet__shape"
+        cx={centre}
+        cy={centre}
+        r={radius}
+        strokeWidth={RULE}
+      />
+      {/* A cut from the middle to the edge for each slice. Every one of them is
+          drawn, including the one at twelve o'clock: a circle in halves needs
+          the line across it, and the outline is not that line. */}
+      {Array.from({ length: art.parts }, (_, cut) => {
+        const edge = at(cut * step);
+        return (
+          <line
+            className="sheet__rule"
+            key={cut}
+            x1={centre}
+            y1={centre}
+            x2={edge.x}
+            y2={edge.y}
+            strokeWidth={HAIRLINE}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -11,10 +11,13 @@ import { DEFAULT_PAPER } from "@/engine/sheets/paper";
 import type {
   ArithmeticConfig,
   Block,
+  FractionConfig,
+  MoneyConfig,
   MultiplicationConfig,
   Paper,
   Problem,
   Sheet,
+  SheetConfig,
 } from "@/engine/sheets/types";
 
 import { SheetView } from "./Sheet";
@@ -78,6 +81,15 @@ const EVERY_BLOCK: Block[] = [
         bracket: { divisor: "4", dividend: "938" },
         answer: "234 r 2",
         workspace: 1500,
+      },
+      // And the one problem whose question is a picture: a whole cut into equal
+      // parts with some of them shaded, which prints on the blank sheet as well
+      // as on the key.
+      { prompt: "", answer: "3/4", art: { shape: "bar", parts: 4, shaded: 3 } },
+      {
+        prompt: "",
+        answer: "1/6",
+        art: { shape: "circle", parts: 6, shaded: 1 },
       },
     ],
   },
@@ -374,9 +386,14 @@ const blank = (over: Partial<ArithmeticConfig> = {}) =>
 const keyed = (over: Partial<ArithmeticConfig> = {}) =>
   render(answerKey(arithmetic(over), SEED) as Sheet);
 
-/** The problems of a built sheet, narrowed out of the block union. */
-function itemsOf(over: Partial<ArithmeticConfig> = {}): Problem[] {
-  const block = buildSheet(arithmetic(over), SEED).blocks[0];
+/**
+ * The problems of a built sheet, narrowed out of the block union.
+ *
+ * One helper for every family rather than one each: what a caller holds is a
+ * config, and what it wants is the list the renderer is about to be handed.
+ */
+function itemsOf(config: SheetConfig): Problem[] {
+  const block = buildSheet(config, SEED).blocks[0];
   if (block.kind !== "problems") throw new Error(`got ${block.kind}`);
   return block.items;
 }
@@ -446,7 +463,7 @@ describe("a rendered arithmetic sheet", () => {
   });
 
   it("draws a number line under every problem, ticks and labels included", () => {
-    const items = itemsOf({ numberLine: true });
+    const items = itemsOf(arithmetic({ numberLine: true }));
     const line = items[0].line;
     if (!line) throw new Error("no number line was built");
 
@@ -461,7 +478,9 @@ describe("a rendered arithmetic sheet", () => {
 
   it("rules a line for each of a fact family's four sentences", () => {
     const family = { style: "fact-family" as const, count: 4 };
-    const written = itemsOf(family).flatMap((problem) => problem.answers ?? []);
+    const written = itemsOf(arithmetic(family)).flatMap(
+      (problem) => problem.answers ?? [],
+    );
     expect(written.length).toBe(16);
 
     const sheet = blank(family);
@@ -606,7 +625,7 @@ describe("a rendered multiplication sheet", () => {
   });
 
   it("writes a long multiplication's partials between the rule and the total", () => {
-    const items = itemsOfMultiplication(LONG_MULTIPLICATION);
+    const items = itemsOf(multiplication(LONG_MULTIPLICATION));
     const partials = items.flatMap((problem) => problem.working ?? []);
     expect(partials.length).toBe(items.length * 2);
 
@@ -698,12 +717,155 @@ describe("a rendered multiplication sheet", () => {
   });
 });
 
-/** The problems of a built multiplication sheet, narrowed out of the union. */
-function itemsOfMultiplication(over: Partial<MultiplicationConfig>): Problem[] {
-  const block = buildSheet(multiplication(over), SEED).blocks[0];
-  if (block.kind !== "problems") throw new Error(`got ${block.kind}`);
-  return block.items;
-}
+/* ── The sheets whose questions are pictures, and whose answers have points ──
+   Fractions, decimals and money. The engine's suites prove the answers are
+   right and stop at the edge of the markup; these are the two halves of that
+   which only exist once it is drawn — a diagram that has to survive a printer
+   with background graphics turned off, and a column of amounts whose points
+   have to land under one another.                                           */
+
+const fractions = (over: Partial<FractionConfig> = {}): FractionConfig => ({
+  kind: "fractions",
+  paper: DEFAULT_PAPER,
+  fontPt: 12,
+  fields: ["name"],
+  style: "identify",
+  operation: "add",
+  denominators: [2, 3, 4, 5, 6, 8],
+  pairing: "either",
+  count: 4,
+  columns: 2,
+  ...over,
+});
+
+const named = (over: Partial<FractionConfig> = {}) =>
+  render(buildSheet(fractions(over), SEED) as Sheet);
+const namedKey = (over: Partial<FractionConfig> = {}) =>
+  render(answerKey(fractions(over), SEED) as Sheet);
+
+describe("a rendered fraction sheet", () => {
+  it("draws the picture on the blank sheet, not only on the key", () => {
+    // The one drawing on a sheet that is the *question*. A child handed a
+    // naming sheet with no pictures on it has been handed a page of blanks.
+    const sheet = named();
+    expect(count(sheet, 'class="sheet__ink sheet__art"')).toBe(4);
+    expect(count(namedKey(), 'class="sheet__ink sheet__art"')).toBe(4);
+    expect(count(sheet, 'class="sheet__shade"')).toBe(4);
+  });
+
+  it("shades with a fill, so it survives a printer with backgrounds off", () => {
+    // §5, and the reason this block is drawn rather than styled: a browser
+    // drops background paint unless the reader has found the "Background
+    // graphics" checkbox, and a naming sheet whose shading was a background
+    // comes out as a row of empty boxes. `fill` is content — it always prints.
+    expect(named()).not.toContain("background");
+    const css = read(join(ROOT, "src/styles/sheet.css"));
+    const shade = css.slice(css.indexOf(".sheet__shade {"));
+    const rule = shade.slice(0, shade.indexOf("}"));
+    expect(rule).toContain("fill: currentcolor");
+    expect(rule).not.toContain("background");
+  });
+
+  it("draws the diagram in mil inside a box measured in inches", () => {
+    // The same correspondence every ruled thing on a sheet rests on: the <svg>
+    // is sized in inches while its viewBox counts mil, so one user unit is a
+    // thousandth of an inch. Get it wrong and the picture is a thousand times
+    // the size it says — which a screen never shows.
+    expect(named({ model: "bar" })).toContain(
+      'width="1.3in" height="0.36in" viewBox="0 0 1300 360"',
+    );
+    expect(named({ model: "circle" })).toContain(
+      'width="0.9in" height="0.9in" viewBox="0 0 900 900"',
+    );
+  });
+
+  it("cuts the whole into as many parts as the fraction has", () => {
+    // A bar in sixths has five cuts in it, because its two ends are its own
+    // outline; a circle in sixths has six, because none of them is. A picture
+    // whose cuts and whose answer disagree is a question with no right answer.
+    for (const model of ["bar", "circle"] as const) {
+      const items = itemsOf(fractions({ model, count: 6 }));
+      const drawn = problems(named({ model, count: 6 }));
+      expect(drawn.length).toBe(items.length);
+      items.forEach((problem, index) => {
+        const parts = problem.art?.parts ?? 0;
+        expect(count(drawn[index], "<line")).toBe(
+          model === "bar" ? parts - 1 : parts,
+        );
+      });
+    }
+  });
+
+  it("gives every problem exactly one place to write the answer", () => {
+    // The rule `Problems.tsx` is built around, over the four styles this family
+    // prints: the picture is not an answer place, and the blank beside it is.
+    for (const shape of [
+      { style: "identify" as const },
+      { style: "equivalent" as const },
+      { style: "simplify" as const },
+      { style: "arithmetic" as const },
+    ]) {
+      for (const html of [named(shape), namedKey(shape)]) {
+        const items = problems(html);
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+          expect(count(item, 'class="sheet__slot'), item).toBe(1);
+        }
+      }
+    }
+  });
+
+  it("prints nothing in the blank until the sheet is a key", () => {
+    const sheet = named();
+    expect(sheet).not.toContain("--answered");
+    for (const [, inside] of sheet.matchAll(
+      /<span class="sheet__slot"[^>]*>(.*?)<\/span>/g,
+    )) {
+      expect(inside).toBe("");
+    }
+    // And the key writes the fraction into it — the same drawing, answered.
+    for (const problem of itemsOf(fractions())) {
+      expect(namedKey()).toContain(`>${problem.answer}<`);
+    }
+  });
+});
+
+const money = (over: Partial<MoneyConfig> = {}): MoneyConfig => ({
+  kind: "money",
+  paper: DEFAULT_PAPER,
+  fontPt: 12,
+  fields: ["name"],
+  currency: "gbp",
+  operation: "add",
+  form: "vertical",
+  range: { min: 1, max: 20 },
+  count: 4,
+  columns: 2,
+  ...over,
+});
+
+describe("a rendered money sheet", () => {
+  it("stacks the amounts so their points land under one another", () => {
+    // Every amount carries both its digits of change, so right-aligned tabular
+    // figures put the points in a column with nothing having to align them —
+    // which is the whole of what a stacked money sum teaches. The alignment
+    // itself is `.sheet__column`, asserted with the long forms above; what is
+    // checked here is that the amounts reach it in the shape that makes it
+    // work.
+    const html = render(answerKey(money(), SEED) as Sheet);
+    for (const item of problems(html)) {
+      expect(count(item, 'class="sheet__addend"')).toBe(2);
+      expect(item).toMatch(/<span>£\d+\.\d\d<\/span>/);
+      expect(item).toMatch(
+        /class="sheet__total sheet__total--answered">£\d+\.\d\d</,
+      );
+    }
+    // And the blank sheet is the same stack with nothing under the rule.
+    expect(render(buildSheet(money(), SEED) as Sheet)).toContain(
+      '<span class="sheet__total"></span>',
+    );
+  });
+});
 
 /* ── It has to survive the printer ─────────────────────────────────────── */
 

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -11,6 +11,7 @@ import { DEFAULT_PAPER } from "@/engine/sheets/paper";
 import type {
   ArithmeticConfig,
   Block,
+  FractionArt,
   FractionConfig,
   MoneyConfig,
   MultiplicationConfig,
@@ -743,6 +744,26 @@ const named = (over: Partial<FractionConfig> = {}) =>
 const namedKey = (over: Partial<FractionConfig> = {}) =>
   render(answerKey(fractions(over), SEED) as Sheet);
 
+/**
+ * One numeric attribute off the first element carrying `className`.
+ *
+ * Anchored on the space before the name, because `stroke-width` ends in `width`
+ * too — a regex without it would compare the shading against the ink weight and
+ * pass for the wrong reason.
+ */
+function attr(html: string, className: string, name: string): number {
+  const found = new RegExp(`class="${className}"[^>]*? ${name}="(-?\\d+)"`) //
+    .exec(html);
+  if (found === null) throw new Error(`no ${name} on .${className}`);
+  return Number(found[1]);
+}
+
+/** The picture riding on a problem, which a naming problem always has. */
+function artOf(problem: Problem, where: number): FractionArt {
+  if (problem.art === undefined) throw new Error(`problem ${where} has no art`);
+  return problem.art;
+}
+
 describe("a rendered fraction sheet", () => {
   it("draws the picture on the blank sheet, not only on the key", () => {
     // The one drawing on a sheet that is the *question*. A child handed a
@@ -794,6 +815,48 @@ describe("a rendered fraction sheet", () => {
         );
       });
     }
+  });
+
+  it("shades as much of the bar as the answer says is shaded", () => {
+    // The other half of the test above. The cuts say how many parts there are;
+    // this says how many of them are filled — and on a naming sheet the picture
+    // *is* the question, so a bar that disagrees with the key is a page with no
+    // right answer on it, which every other assertion here would let through.
+    const items = itemsOf(fractions({ model: "bar", count: 6 }));
+    const drawn = problems(named({ model: "bar", count: 6 }));
+    expect(items.length).toBeGreaterThan(0);
+    items.forEach((problem, index) => {
+      const art = artOf(problem, index);
+      // Taken off the outline rather than off a constant: the bar is inset by
+      // half its own stroke, and the shading is a fraction of what is left.
+      const span = attr(drawn[index], "sheet__shape", "width");
+      expect(attr(drawn[index], "sheet__shade", "width"), problem.answer) //
+        .toBe(Math.round((art.shaded * span) / art.parts));
+    });
+  });
+
+  it("sweeps as much of the circle as the answer says is shaded", () => {
+    const items = itemsOf(fractions({ model: "circle", count: 6 }));
+    const drawn = problems(named({ model: "circle", count: 6 }));
+    expect(items.length).toBeGreaterThan(0);
+    items.forEach((problem, index) => {
+      const art = artOf(problem, index);
+      const centre = attr(drawn[index], "sheet__shape", "cx");
+      const radius = attr(drawn[index], "sheet__shape", "r");
+      // The wedge starts at twelve o'clock and ends `turn` degrees round from
+      // it: sine east, cosine *up* the page, because y grows downwards.
+      const turn = (art.shaded * 360) / art.parts;
+      const end = [
+        Math.round(centre + radius * Math.sin((turn * Math.PI) / 180)),
+        Math.round(centre - radius * Math.cos((turn * Math.PI) / 180)),
+      ];
+      const wedge = /A \d+ \d+ 0 ([01]) 1 (-?\d+) (-?\d+) Z/.exec(drawn[index]);
+      if (wedge === null) throw new Error(`problem ${index} draws no wedge`);
+      // The large-arc flag is the difference between five sixths and one sixth:
+      // SVG takes the short way round the circle unless it is told not to.
+      expect(wedge[1], problem.answer).toBe(turn > 180 ? "1" : "0");
+      expect([Number(wedge[2]), Number(wedge[3])], problem.answer).toEqual(end);
+    });
   });
 
   it("gives every problem exactly one place to write the answer", () => {

--- a/src/components/sheet/blocks/Problems.tsx
+++ b/src/components/sheet/blocks/Problems.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from "react";
 
 import type { Problem } from "@/engine/sheets/types";
 
+import { FractionArtView } from "../FractionArt";
 import { NumberLineView } from "../NumberLine";
 import { inch } from "../units";
 import type { BlockProps } from "./block";
@@ -40,6 +41,10 @@ export function Problems({ block, metrics }: BlockProps<"problems">) {
               child is told to "do 4, 7 and 12 of" has to carry its number as
               text anyway. */}
           <span className="sheet__number">{index + 1}.</span>
+          {/* The picture a naming problem asks about, before the blank it is
+              answered in. On the sheet as well as on the key, because it is the
+              question rather than the answer. */}
+          {problem.art && <FractionArtView art={problem.art} />}
           {/* Three drawings and one rule: a problem is set the way the data
               says it is set. A stack when there is a stack, a bracket when
               there is a bracket, and a sentence otherwise — no flag beside the

--- a/src/engine/sheets/fractionart.ts
+++ b/src/engine/sheets/fractionart.ts
@@ -1,0 +1,52 @@
+/**
+ * A whole, cut into equal parts.
+ *
+ * The bar and the circle a fraction is taught from before it is a pair of
+ * numbers. Like a number line, it is a drawing attached to a problem rather
+ * than a block of its own — the problem grid is the shared primitive every
+ * maths family prints through, and a picture the question is *about* belongs
+ * inside the question.
+ *
+ * How big it is drawn lives here rather than in the renderer, for the same
+ * reason `NUMBER_LINE_HEIGHT` does: the family reserves the height of a row
+ * before anything is drawn (§4), and a diagram that came out taller than the
+ * reservation is the bottom row of the page on a second sheet of paper. So
+ * there is one set of dimensions and both halves read it.
+ *
+ * The sizes are inches and do not scale with the body type. A diagram is a
+ * physical object a child colours in — a quarter is a quarter of the same bar
+ * whether the sheet is set at 12pt or at 18pt for a five-year-old — and §17's
+ * larger type is about reading the words, not about growing the pictures.
+ */
+import type { FractionArt, Mil } from "./types";
+
+import { inches } from "./paper";
+
+/** The bar: wide enough to cut into twelfths and still see the twelfths. */
+export const BAR = { width: inches(1.3), height: inches(0.36) };
+
+/** The circle, across. Smaller than the bar is wide, so a row of them reads. */
+export const CIRCLE: Mil = inches(0.9);
+
+export function fractionArt(
+  shape: FractionArt["shape"],
+  parts: number,
+  shaded: number,
+): FractionArt {
+  const cuts = Math.max(1, Math.round(parts));
+  return {
+    shape,
+    parts: cuts,
+    // Clamped rather than trusted: `shaded` past `parts` is a picture with more
+    // shading in it than there is whole, which is not a fraction of anything.
+    shaded: Math.min(cuts, Math.max(0, Math.round(shaded))),
+  };
+}
+
+/** How wide the drawing is. */
+export const artWidth = (art: FractionArt): Mil =>
+  art.shape === "circle" ? CIRCLE : BAR.width;
+
+/** And how tall — a circle is as tall as it is wide, a bar is a band. */
+export const artHeight = (art: FractionArt): Mil =>
+  art.shape === "circle" ? CIRCLE : BAR.height;

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -17,6 +17,9 @@ import type { Sheet, SheetConfig } from "./types";
 
 import { BLANK_SHEET } from "./blank";
 import { ARITHMETIC_SHEET } from "./maths/arithmetic";
+import { DECIMALS_SHEET } from "./maths/decimals";
+import { FRACTIONS_SHEET } from "./maths/fractions";
+import { MONEY_SHEET } from "./maths/money";
 import { MULTIPLICATION_SHEET } from "./maths/multiplication";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
 import { PAPER_SHEET } from "./templates/paper";
@@ -26,6 +29,9 @@ const SHEETS: Record<string, SheetSpec> = {
   [PAPER_SHEET.id]: PAPER_SHEET,
   [ARITHMETIC_SHEET.id]: ARITHMETIC_SHEET,
   [MULTIPLICATION_SHEET.id]: MULTIPLICATION_SHEET,
+  [FRACTIONS_SHEET.id]: FRACTIONS_SHEET,
+  [DECIMALS_SHEET.id]: DECIMALS_SHEET,
+  [MONEY_SHEET.id]: MONEY_SHEET,
 };
 
 /**

--- a/src/engine/sheets/layout.ts
+++ b/src/engine/sheets/layout.ts
@@ -56,6 +56,19 @@ export const answerLine = (fontPt: number): Mil =>
  */
 export const PROBLEM_GAP = { x: inches(0.3), y: inches(0.2) };
 
+/**
+ * The air *inside* a problem, between two lines of one that wrapped.
+ *
+ * `.sheet__problem` is a wrapping flex row, and it has to be: a number line and
+ * a workspace take a line of their own under the sum, and so does the ruled
+ * blank beside a fraction diagram. So a problem is sometimes two lines tall, and
+ * a family that reserves for the second one has to know what the browser will
+ * put between them. Trailing sheet.css exactly as `chromeHeight` does, and for
+ * the same reason: the failure is silent on screen and is a row of problems
+ * below the bottom margin on paper.
+ */
+export const WRAP_GAP: Mil = inches(0.06);
+
 /** The paper minus its margins: everything a sheet is allowed to print in. */
 export function contentBox(paper: Paper): Box {
   const { width, height } = pageSize(paper);

--- a/src/engine/sheets/maths/decimals.test.ts
+++ b/src/engine/sheets/maths/decimals.test.ts
@@ -1,0 +1,646 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { PROBLEM_GAP } from "../layout";
+import type {
+  DecimalConfig,
+  MarginSize,
+  Paper,
+  PaperSize,
+  Problem,
+} from "../types";
+
+import { DECIMALS_SHEET, decimalLayout } from "./decimals";
+
+/**
+ * Decimals and percents, held to the bar the maths families set.
+ *
+ * **Nothing here checks the generator against the generator.** Every answer is
+ * verified from the *printed* problem — the string a child reads — by a path the
+ * family does not use:
+ *
+ * - a decimal is read back as **a whole number over a power of ten**, taken off
+ *   the digits either side of the point, and the sentence is checked by
+ *   **cross-multiplication**. The family never forms a denominator at all: it
+ *   adds hundredths as whole numbers. So a misplaced point — the failure a
+ *   decimals sheet actually has — cannot pass both of them;
+ * - a product is checked by **repeated addition**, which is the definition of
+ *   multiplication `×` is shorthand for, and which no part of `timesWhole`
+ *   resembles;
+ * - a percent is checked by **cross-multiplication too**: `p% of w` is `x`
+ *   exactly when `x × 100` is `p × w`, and there is no division in this file at
+ *   all — which is the point, because division is where a float would get in.
+ *
+ * And every printed number is held to its *shape* as well as its value. A sheet
+ * set at two places whose key says `0.5`, or `0.30000000000000004`, has printed
+ * the right number in the wrong form, and a child taught to line up the points
+ * cannot use either.
+ */
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const config = (over: Partial<DecimalConfig> = {}): DecimalConfig => ({
+  kind: "decimals",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style: "standard",
+  operation: "add",
+  form: "horizontal",
+  places: 2,
+  range: { min: 0, max: 20 },
+  count: 12,
+  columns: 2,
+  ...over,
+});
+
+/** The amounts a percentage sheet is taken of. */
+const PERCENT_RANGE = { min: 10, max: 200 };
+
+/**
+ * Every shape the family can print, which is every acceptance criterion of the
+ * story: decimals added, taken away and multiplied, along a line and in
+ * columns, at each of the three place counts, percentages of amounts, and the
+ * conversions between all three forms.
+ */
+const EVERY_SHAPE: Array<Partial<DecimalConfig>> = [
+  {},
+  { form: "vertical" },
+  { operation: "subtract" },
+  { operation: "subtract", form: "vertical" },
+  { operation: "both" },
+  { operation: "both", form: "vertical" },
+  { operation: "multiply" },
+  { operation: "multiply", form: "vertical" },
+  // The place counts, which are the whole of what makes one of these sheets
+  // easy or hard.
+  { places: 1 },
+  { places: 3 },
+  { places: 1, operation: "both" },
+  { places: 3, operation: "multiply" },
+  { places: 1, range: { min: 0, max: 5 }, count: 8 },
+  { style: "percent", range: PERCENT_RANGE, count: 10 },
+  { style: "percent", range: { min: 20, max: 60 }, count: 6 },
+  { style: "convert", count: 10 },
+  { style: "convert", places: 1, count: 8 },
+  { style: "convert", places: 3, count: 10 },
+  { workspace: true, count: 8 },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** The one block a decimals sheet has, narrowed for the reader. */
+function problemsOf(over: Partial<DecimalConfig>, seed: number): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+/* ── Reading a sheet the way a child does ────────────────────────────────── */
+
+type Value = { n: number; d: number };
+
+/**
+ * A number as it is written on paper, read back as a whole number over a power
+ * of ten: `0.25` is 25 over 100, and `3` is 3 over 1.
+ *
+ * The digits are counted rather than the number parsed, which is the only way
+ * this can catch what it is here to catch. `Number("0.25")` is a float, and a
+ * float that came out of a family printing `0.250000001` would compare equal to
+ * everything a test asked it about.
+ */
+function readNumber(text: string): Value {
+  const written = text.trim();
+  const point = /^(\d+)\.(\d+)$/.exec(written);
+  if (point)
+    return { n: Number(point[1] + point[2]), d: 10 ** point[2].length };
+  const number = /^(\d+)$/.exec(written);
+  if (number) return { n: Number(number[1]), d: 1 };
+  throw new Error(`not a decimal: "${text}"`);
+}
+
+/** How many digits are printed after the point. */
+const placesOf = (text: string): number => (text.split(".")[1] ?? "").length;
+
+/**
+ * A whole number of hundredths, written out as a decimal — by moving the digits
+ * rather than by dividing, so that not even the candidates a search tries are
+ * built out of a float.
+ */
+function asDecimal(units: number, places: number): string {
+  const digits = String(units).padStart(places + 1, "0");
+  const point = digits.length - places;
+  return `${digits.slice(0, point)}.${digits.slice(point)}`;
+}
+
+/** Whether two values are the same, cross-multiplied and never divided. */
+const same = (a: Value, b: Value): boolean => a.n * b.d === b.n * a.d;
+
+/**
+ * `a` added to itself `b` times — the definition of multiplication a child
+ * meets first, and the one `×` is shorthand for. A test that multiplied would
+ * agree with a family that had multiplication wrong.
+ */
+function repeated(a: number, b: number): number {
+  let total = 0;
+  for (let step = 0; step < b; step += 1) total += a;
+  return total;
+}
+
+const OPERATIONS: Record<string, (a: Value, b: Value) => Value> = {
+  "+": (a, b) => ({ n: a.n * b.d + b.n * a.d, d: a.d * b.d }),
+  "−": (a, b) => ({ n: a.n * b.d - b.n * a.d, d: a.d * b.d }),
+  // Over a common denominator, and by repeated addition of the numerators: the
+  // multiplier on a decimals sheet is always a whole number, so `b.n` is a
+  // count of how many times the value is taken.
+  "×": (a, b) => ({ n: repeated(a.n, b.n) * b.d, d: a.d * b.d * b.d }),
+};
+
+/**
+ * The problem, written out in full with its answer put where it belongs.
+ *
+ * Three shapes reduce to one sentence: a sum along a line, a stack of numbers in
+ * column form, and a blank inside the sentence.
+ */
+function sentence(problem: Problem): string {
+  if (problem.operands) {
+    return `${problem.operands.join(` ${problem.operator} `)} = ${problem.answer}`;
+  }
+  if (problem.prompt.includes("_")) {
+    return problem.prompt.replace("_", problem.answer);
+  }
+  return `${problem.prompt} ${problem.answer}`;
+}
+
+/** Whether a written sentence is true. */
+function holds(written: string): boolean {
+  const worked = /^(\S+) ([+−×]) (\S+) = (\S+)$/.exec(written.trim());
+  if (worked) {
+    const [, left, sign, right, answer] = worked;
+    return same(
+      OPERATIONS[sign](readNumber(left), readNumber(right)),
+      readNumber(answer),
+    );
+  }
+
+  // "25% of 80 = 20": the same claim as every other, with the percent written
+  // as what it means — so many hundredths.
+  const percent = /^(\d+)% of (\d+) = (\S+)$/.exec(written.trim());
+  if (percent) {
+    return same(
+      { n: Number(percent[1]) * Number(percent[2]), d: 100 },
+      readNumber(percent[3]),
+    );
+  }
+
+  // A conversion: two ways of writing one number, either of which may be a
+  // percent, a fraction or a decimal.
+  const equal = /^(\S+) = (\S+)$/.exec(written.trim());
+  if (!equal) throw new Error(`not a number sentence: "${written}"`);
+  return same(readForm(equal[1]), readForm(equal[2]));
+}
+
+/** A number in any of the three forms a conversion sheet uses. */
+function readForm(text: string): Value {
+  const percent = /^(\d+)%$/.exec(text.trim());
+  if (percent) return { n: Number(percent[1]), d: 100 };
+  const fraction = /^(\d+)\/(\d+)$/.exec(text.trim());
+  if (fraction) return { n: Number(fraction[1]), d: Number(fraction[2]) };
+  return readNumber(text);
+}
+
+/** Every decimal printed on a problem, prompt and answer alike. */
+function decimalsOn(problem: Problem): string[] {
+  return sentence(problem)
+    .split(/[\s=+−×]+/)
+    .filter((word) => /^\d+\.\d+$/.test(word));
+}
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the decimals family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("decimals")).toBe(DECIMALS_SHEET);
+    expect(sheetSpec("decimals").label).toBe("Decimals and percents");
+  });
+
+  it("names what it prints, in the terms a parent chose it by", () => {
+    expect(describeSheet(config())).toBe("Adding decimals — hundredths");
+    expect(describeSheet(config({ places: 1 }))).toBe(
+      "Adding decimals — tenths",
+    );
+    expect(describeSheet(config({ places: 3, form: "vertical" }))).toBe(
+      "Adding decimals — thousandths — in columns",
+    );
+    expect(describeSheet(config({ operation: "both" }))).toBe(
+      "Adding and subtracting decimals — hundredths",
+    );
+    expect(describeSheet(config({ operation: "multiply" }))).toBe(
+      "Multiplying decimals — hundredths",
+    );
+    expect(describeSheet(config({ style: "percent" }))).toBe(
+      "Percentages of amounts",
+    );
+    expect(describeSheet(config({ style: "convert" }))).toBe(
+      "Fractions, decimals and percents — hundredths",
+    );
+  });
+
+  it("gives the sheet a title and a score box it can be marked against", () => {
+    const sheet = buildSheet(config({ count: 8 }), 3);
+    const block = sheet.blocks[0];
+    expect(sheet.header.title).toBe("Adding decimals");
+    // Out of what is on the page, not out of what was asked for.
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+
+  it("tells a child what to do with a form they have not met before", () => {
+    expect(buildSheet(config({ form: "vertical" }), 1).header.instructions) //
+      .toBe("Work out each answer. Keep the points under one another.");
+    // The conversion sheet's blanks cannot say what they want, so the header
+    // does: a child who writes a fraction where a decimal was wanted has
+    // answered a question nobody asked and would be marked wrong for it.
+    expect(buildSheet(config({ style: "convert" }), 1).header.instructions) //
+      .toBe(
+        "Fill in each blank. A blank with a % after it wants a percent; every other blank wants a decimal.",
+      );
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("is right on every problem of every sheet this family can print", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+        for (const problem of problems) {
+          const written = sentence(problem);
+          expect(holds(written), `${JSON.stringify(shape)}: ${written}`) //
+            .toBe(true);
+        }
+      }
+    }
+  });
+
+  it("never prints a number a float would have made", () => {
+    // The failure this family exists to design out. `0.1 + 0.2` is
+    // 0.30000000000000004 in the language this is written in, and that answer
+    // would print — so every number on the page is held to the shape a decimal
+    // has, digit for digit, as well as to its value.
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        for (const problem of problemsOf(shape, seed)) {
+          for (const word of sentence(problem).split(/[\s=+−×]+/)) {
+            if (word.includes(".")) {
+              expect(word, JSON.stringify(shape)).toMatch(/^\d+\.\d{1,3}$/);
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it("prints every decimal to the places the sheet was set at", () => {
+    // Trailing zeros are not noise here: `0.5` on a two-place sheet is the same
+    // number written in a form a child lining up the points cannot use, and it
+    // is what a family that formatted with `toString` would print.
+    for (const places of [1, 2, 3]) {
+      for (const style of ["standard", "convert"] as const) {
+        for (const seed of SEEDS) {
+          const over = { places, style, count: 8 };
+          const problems = problemsOf(over, seed);
+          expect(problems.length, JSON.stringify(over)).toBeGreaterThan(0);
+          for (const problem of problems) {
+            for (const written of decimalsOn(problem)) {
+              expect(placesOf(written), `${written} at ${places}`).toBe(places);
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it("keeps a percentage's answer a whole number", () => {
+    // 15% of 80 is 12 and 15% of 81 is 12.15 — a different lesson, and one that
+    // belongs on a money sheet. The draw rejects the pairs that don't come out
+    // whole rather than rounding them.
+    for (const seed of SEEDS) {
+      const problems = problemsOf(
+        { style: "percent", range: PERCENT_RANGE, count: 10 },
+        seed,
+      );
+      expect(problems.length).toBeGreaterThan(0);
+      for (const problem of problems) {
+        expect(problem.answer, problem.prompt).toMatch(/^\d+$/);
+        expect(holds(sentence(problem)), sentence(problem)).toBe(true);
+      }
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    for (const shape of EVERY_SHAPE) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+
+  it("leaves exactly one number that would fit a conversion blank", () => {
+    // Searched over the hundredths rather than over the whole numbers, because
+    // that is the alphabet the answer is written in: two failures caught at
+    // once, an answer that is wrong and a blank more than one would fill.
+    for (const places of [1, 2, 3]) {
+      const problems = problemsOf({ style: "convert", places, count: 8 }, 5);
+      expect(problems.length).toBeGreaterThan(0);
+      for (const problem of problems) {
+        const fits = [];
+        // Far enough for either alphabet: every percent up to two hundred, and
+        // every decimal up to one whole at the places the sheet is set at.
+        for (let units = 1; units <= Math.max(200, 10 ** places); units += 1) {
+          const candidate = problem.prompt.endsWith("%")
+            ? String(units)
+            : asDecimal(units, places);
+          try {
+            if (holds(problem.prompt.replace("_", candidate))) {
+              fits.push(candidate);
+            }
+          } catch {
+            /* not a number sentence at all */
+          }
+        }
+        expect(fits, problem.prompt).toEqual([problem.answer]);
+      }
+    }
+  });
+});
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  it("never puts a number outside the range a parent asked for", () => {
+    const ASKS = [
+      { min: 0, max: 5 },
+      { min: 1, max: 20 },
+      { min: 10, max: 100 },
+    ];
+    for (const range of ASKS) {
+      for (const operation of ["add", "subtract", "multiply"] as const) {
+        const problems = problemsOf({ range, operation, count: 8 }, 9);
+        expect(problems.length, JSON.stringify(range)).toBeGreaterThan(0);
+        for (const problem of problems) {
+          // The numbers a child *sees*, which is what a range promises: an
+          // answer may run past the top of it, and that is what carrying is.
+          const asked = problem.operands ?? problem.prompt.split(" ");
+          for (const word of asked) {
+            if (!/^\d+\.\d+$/.test(word)) continue;
+            const value = readNumber(word);
+            expect(value.n).toBeGreaterThan(0);
+            expect(value.n / value.d).toBeGreaterThanOrEqual(range.min);
+            expect(value.n / value.d).toBeLessThanOrEqual(range.max);
+          }
+        }
+      }
+    }
+  });
+
+  it("never asks a child to take more away than there is", () => {
+    for (const shape of [
+      { operation: "subtract" as const },
+      { operation: "both" as const },
+      { operation: "subtract" as const, form: "vertical" as const },
+    ]) {
+      for (const seed of SEEDS) {
+        for (const problem of problemsOf({ ...shape, count: 12 }, seed)) {
+          expect(problem.answer, sentence(problem)).not.toContain("-");
+          expect(readNumber(problem.answer).n, sentence(problem)) //
+            .toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("stacks a column sheet and writes a line sheet along the line", () => {
+    for (const problem of problemsOf({ form: "vertical", count: 6 }, 2)) {
+      expect(problem.operands?.length).toBe(2);
+      expect(problem.operator).toBe("+");
+      // No second copy of the sum written along a line for the two to disagree
+      // about — the stack is the prompt.
+      expect(problem.prompt).toBe("");
+    }
+    for (const problem of problemsOf({ count: 6 }, 2)) {
+      expect(problem.operands).toBeUndefined();
+      expect(problem.prompt).toMatch(/^\d+\.\d\d \+ \d+\.\d\d =$/);
+    }
+  });
+
+  it("multiplies by a whole number, so the places stay where they were put", () => {
+    // `0.25 × 0.4` is 0.1 and `2.5 × 2.5` is 6.25 — one has fewer places than
+    // either number that made it and the other has more. A sheet set at two
+    // places whose answers are at four is a sheet nobody chose.
+    for (const seed of SEEDS) {
+      const problems = problemsOf({ operation: "multiply", count: 8 }, seed);
+      expect(problems.length).toBeGreaterThan(0);
+      for (const problem of problems) {
+        // The second number of the problem, wherever it is written: the stack
+        // holds two operands, and the sentence reads `value × by =`.
+        const by = problem.operands
+          ? problem.operands[1]
+          : problem.prompt.split(" ")[2];
+        expect(by, problem.prompt).toMatch(/^\d+$/);
+        expect(placesOf(problem.answer)).toBe(2);
+      }
+    }
+  });
+
+  it("asks the same question twice on no sheet at all", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        const asked = problems.map((problem) => sentence(problem));
+        expect(new Set(asked).size, JSON.stringify(shape)).toBe(
+          problems.length,
+        );
+      }
+    }
+  });
+
+  it("prints nothing rather than something wrong when the ask is impossible", () => {
+    // A range of nothing at all: every draw is a value of zero, which is not a
+    // question about decimals. An empty sheet is the honest answer, and the
+    // builder's job to prevent (PRINT13).
+    expect(problemsOf({ range: { min: 0, max: 0 } }, 1)).toEqual([]);
+  });
+});
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("carries the seed into the footer, so the same sheet can be had again", () => {
+    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
+  });
+
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    // The promise the footer makes: the seed is printed on the paper so a
+    // parent can have the same sheet again next week, across a deploy. Nothing
+    // else in this file would notice a refactor that moved where the draw
+    // consumes `rand()` — the operation coin spent only when both are asked
+    // for, the multiplier drawn instead of a second value — and every seed a
+    // parent had already printed would quietly produce a different sheet.
+    expect(
+      problemsOf({ operation: "both", count: 4 }, 4242).map((p) => [
+        p.prompt,
+        p.answer,
+      ]),
+    ).toEqual(GOLDEN.both);
+
+    expect(
+      problemsOf({ style: "percent", range: PERCENT_RANGE, count: 4 }, 7).map(
+        (p) => [p.prompt, p.answer],
+      ),
+    ).toEqual(GOLDEN.percent);
+
+    expect(
+      problemsOf({ style: "convert", count: 4 }, 7).map((p) => [
+        p.prompt,
+        p.answer,
+      ]),
+    ).toEqual(GOLDEN.convert);
+  });
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    for (const shape of EVERY_SHAPE) {
+      const [a, b, c] = [0, 1, 2].map((offset) =>
+        problemsOf({ ...shape, count: 6 }, 100 + offset).map(sentence),
+      );
+      for (const [one, other] of [
+        [a, b],
+        [a, c],
+        [b, c],
+      ]) {
+        expect(one).not.toEqual(other);
+        const shared = one.filter((asked) => other.includes(asked)).length;
+        expect(shared, JSON.stringify(shape)).toBeLessThan(
+          (one.length * 2) / 3,
+        );
+      }
+    }
+  });
+});
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row } = decimalLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used = rows * row + Math.max(0, rows - 1) * PROBLEM_GAP.y;
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("does not throw the page away either", () => {
+    const { box, row, perPage, columns } = decimalLayout(config());
+    expect(perPage).toBeGreaterThanOrEqual(20);
+    const rows = perPage / columns;
+    expect((rows + 1) * row + rows * PROBLEM_GAP.y).toBeGreaterThan(box.height);
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ count: 10 }, 1).length).toBe(10);
+    expect(problemsOf({ count: 0 }, 1).length).toBe(0);
+    for (const columns of [1, 2, 3, 4]) {
+      const block = buildSheet(config({ columns }), 1).blocks[0];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+    // Four is as many columns as a decimal sheet is laid out in: `13.47 + 8.06`
+    // in a column an inch wide is a problem that wraps, and a wrapped problem
+    // is a row taller than the layout reserved.
+    const wide = buildSheet(config({ columns: 6 }), 1).blocks[0];
+    expect(wide.kind === "problems" && wide.columns).toBe(4);
+  });
+
+  it("reserves more room for a stacked sheet than for a written one", () => {
+    // The layout reserves the height and the build attaches the stack, and the
+    // two reading the config differently is the bug the whole "declared, not
+    // measured" design exists to exclude.
+    expect(decimalLayout(config({ form: "vertical" })).row).toBeGreaterThan(
+      decimalLayout(config()).row,
+    );
+    // And a conversion sheet is never stacked, so `form` cannot make its rows
+    // taller than the sentences it prints in them.
+    expect(decimalLayout(config({ style: "convert", form: "vertical" })).row) //
+      .toBe(decimalLayout(config({ style: "convert" })).row);
+  });
+});
+
+/**
+ * What three sheets came out as on the day this shipped.
+ *
+ * Recorded rather than computed — every one of them is proved right by the
+ * assertions above, and what these hold is that they do not silently *change*.
+ */
+const GOLDEN = {
+  both: [
+    ["18.63 − 5.57 =", "13.06"],
+    ["13.38 − 5.76 =", "7.62"],
+    ["8.03 + 6.88 =", "14.91"],
+    ["15.09 − 14.63 =", "0.46"],
+  ],
+  percent: [
+    ["100% of 143 =", "143"],
+    ["40% of 55 =", "22"],
+    ["15% of 80 =", "12"],
+    ["25% of 112 =", "28"],
+  ],
+  convert: [
+    ["0.07 = _%", "7"],
+    ["13/25 = _", "0.52"],
+    ["40% = _", "0.40"],
+    ["0.56 = _%", "56"],
+  ],
+};

--- a/src/engine/sheets/maths/decimals.test.ts
+++ b/src/engine/sheets/maths/decimals.test.ts
@@ -28,8 +28,9 @@ import { DECIMALS_SHEET, decimalLayout } from "./decimals";
  *   multiplication `×` is shorthand for, and which no part of `timesWhole`
  *   resembles;
  * - a percent is checked by **cross-multiplication too**: `p% of w` is `x`
- *   exactly when `x × 100` is `p × w`, and there is no division in this file at
- *   all — which is the point, because division is where a float would get in.
+ *   exactly when `x × 100` is `p × w`. No number read off a sheet is divided
+ *   anywhere in this file, bounds included — which is the point, because
+ *   division is where a float would get in.
  *
  * And every printed number is held to its *shape* as well as its value. A sheet
  * set at two places whose key says `0.5`, or `0.30000000000000004`, has printed
@@ -267,6 +268,15 @@ describe("the decimals family", () => {
   it("tells a child what to do with a form they have not met before", () => {
     expect(buildSheet(config({ form: "vertical" }), 1).header.instructions) //
       .toBe("Work out each answer. Keep the points under one another.");
+    // A stacked multiplication has nothing to line the points up on: the
+    // multiplier is a whole number, so the sentence above would send a child
+    // looking for a point that was never printed.
+    expect(
+      buildSheet(config({ form: "vertical", operation: "multiply" }), 1).header
+        .instructions,
+    ).toBe(
+      "Work out each answer. Line the digits up on the right, then put the point back in.",
+    );
     // The conversion sheet's blanks cannot say what they want, so the header
     // does: a child who writes a fraction where a decimal was wanted has
     // answered a question nobody asked and would be marked wrong for it.
@@ -415,8 +425,11 @@ describe("what may be on the page", () => {
             if (!/^\d+\.\d+$/.test(word)) continue;
             const value = readNumber(word);
             expect(value.n).toBeGreaterThan(0);
-            expect(value.n / value.d).toBeGreaterThanOrEqual(range.min);
-            expect(value.n / value.d).toBeLessThanOrEqual(range.max);
+            // Cross-multiplied, like every other claim here: `n/d ≥ min` is
+            // `n ≥ min·d` with both sides whole, and the divided form would put
+            // back the one float this suite exists to keep out.
+            expect(value.n).toBeGreaterThanOrEqual(range.min * value.d);
+            expect(value.n).toBeLessThanOrEqual(range.max * value.d);
           }
         }
       }

--- a/src/engine/sheets/maths/decimals.ts
+++ b/src/engine/sheets/maths/decimals.ts
@@ -1,0 +1,529 @@
+/**
+ * Decimals and percents.
+ *
+ * The same machinery as every family before it — answers computed when the
+ * problem is built, the page a function of `(config, seed)`, problems drawn and
+ * rejected rather than enumerated — over numbers that are famously easy to get
+ * subtly wrong.
+ *
+ * **Nothing here is ever a float.** `0.1 + 0.2` is 0.30000000000000004 in the
+ * language this is written in, and that answer would print. So a value is a
+ * whole number of tenths, hundredths or thousandths from the moment it is drawn
+ * to the moment `fixedText` writes the point into it, and the arithmetic is
+ * whole-number arithmetic. `maths/exact.ts` holds the type and the reason.
+ *
+ * **Multiplying is by a whole number.** `0.25 × 0.4` has fewer places than
+ * either number that made it and `2.5 × 2.5` has more, so a sheet set at two
+ * places would quietly print answers at four. Three lots of 1.25 is the
+ * question a child is actually set at this stage, and it keeps the promise the
+ * config makes.
+ *
+ * **A percent answer is a whole number, by construction.** 15% of 80 is 12, and
+ * 15% of 81 is 12.15 — a different lesson, and one that belongs on a money
+ * sheet where two places are the point. So the draw rejects any pair that
+ * doesn't come out whole rather than rounding one that doesn't.
+ */
+import { between, mulberry32 } from "@/engine/random";
+
+import type {
+  DecimalConfig,
+  DecimalOperation,
+  Mil,
+  Problem,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import {
+  PROBLEM_GAP,
+  WRAP_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches, points } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import {
+  fixed,
+  fixedText,
+  gcd,
+  minusFixed,
+  plusFixed,
+  scale,
+  timesWhole,
+  type Fixed,
+} from "./exact";
+
+/* ── What a problem takes on the page ─────────────────────────────────────
+   Declared, not measured (§4). Stacked it is the two numbers, the rule and the
+   answer under it — the same drawing an addition sheet has, with the points
+   lined up.                                                                  */
+
+const STACK_EMS = 4.4;
+
+/**
+ * How tall a problem written along a line stands: two lines of the body type,
+ * and the air a wrap puts between them.
+ *
+ * Two rather than one, because `13.47 + 8.06 =` with a ruled blank after it is
+ * a wide sentence, and `.sheet__problem` wraps rather than overflowing — so the
+ * second line is either inside the row the layout declared, or it is the bottom
+ * of the page coming out of the printer on a second sheet. Reserving for the
+ * wrap is the only version of this a page can be laid out from without
+ * measuring text.
+ */
+const writtenRow = (fontPt: number): Mil => 2 * answerLine(fontPt) + WRAP_GAP;
+
+/** Blank space to work a problem out in, when the config asks for it. */
+const WORKSPACE = inches(0.55);
+
+/** Four columns. `13.47 + 8.06 =` is twice the sentence `7 × 8 =` is. */
+const MAX_COLUMNS = 4;
+
+/** Tenths, hundredths, thousandths. Past that it is a physics sheet. */
+const MAX_PLACES = 3;
+
+/** What a decimal is multiplied by: three lots of 1.25, never seventy of it. */
+const MULTIPLIER = { min: 2, max: 9 };
+
+/**
+ * The percentages a sheet asks for.
+ *
+ * The ones a child is taught to recognise rather than every whole number
+ * between 1 and 100: "37% of 200" is a calculator question, and "25% of 80" is
+ * a quarter of eighty, which is the whole point of the lesson.
+ */
+const PERCENTS = [5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100];
+
+/**
+ * The denominators a conversion sheet uses.
+ *
+ * Only fractions that *stop* — a third is 0.333… and there is no number of
+ * places at which it is exactly right. Which of these survive is decided by the
+ * places the sheet is set at: eighths are exact in thousandths and not in
+ * hundredths, so `scale % d` does the filtering rather than a second list.
+ */
+const FRIENDLY = [2, 4, 5, 8, 10, 20, 25, 50, 100];
+
+/** As `arithmetic.ts` — see the note there on why a budget rather than a proof. */
+const MISS_BUDGET = 500;
+
+/**
+ * How far apart two percents are that a sheet at this scale can write down.
+ *
+ * Every percent is exact in hundredths and finer, and only the tens are exact
+ * in tenths: 45% is 0.45, which a sheet set at one place cannot print. So the
+ * step is one at two places and ten at one, and the draw walks in steps rather
+ * than drawing and rejecting.
+ */
+const percentStep = (by: number): number => 100 / gcd(100, by);
+
+const SIGN = { add: "+", subtract: "−", multiply: "×" } as const;
+
+/* ── The numbers on the page ───────────────────────────────────────────────
+   Both bounds are sanitised once, because they arrive from outside this build:
+   a config in a bookmarked URL may ask for nine places, or for a range that
+   runs backwards.                                                            */
+
+const placesOf = (config: DecimalConfig): number =>
+  Math.min(MAX_PLACES, Math.max(1, Math.floor(config.places ?? 2)));
+
+function bounds(range: { min: number; max: number }): {
+  min: number;
+  max: number;
+} {
+  const min = Math.max(0, Math.floor(range?.min ?? 0));
+  return { min, max: Math.max(min, Math.floor(range?.max ?? 0)) };
+}
+
+/**
+ * One value from the range, in the smallest unit the sheet counts in.
+ *
+ * Drawn as a whole number of hundredths rather than as a decimal rounded
+ * afterwards: rounding is where a place count stops being a promise. A value of
+ * nothing is rejected — `0.00 + 3.45` is not a question about decimals.
+ */
+function drawValue(config: DecimalConfig, rand: () => number): Fixed | null {
+  const places = placesOf(config);
+  const by = scale(places);
+  const { min, max } = bounds(config.range);
+  const units = between(min * by, max * by, rand);
+  return units > 0 ? fixed(units, places) : null;
+}
+
+/* ── Drawing a problem ─────────────────────────────────────────────────────
+   Each style draws its own shape, and they have little in common beyond having
+   an answer. So each returns the same four answers: what it reads, what the
+   answer is, how it is stacked if it is stacked, and what makes two of them the
+   same problem.                                                              */
+
+type Drawn = {
+  key: string;
+  prompt: string;
+  answer: string;
+  operands?: string[];
+  operator?: string;
+};
+
+/** Which way round an `either` sheet's problem reads. */
+function operationOf(
+  operation: DecimalOperation,
+  rand: () => number,
+): Exclude<DecimalOperation, "both"> {
+  if (operation !== "both") return operation;
+  return rand() < 0.5 ? "add" : "subtract";
+}
+
+/** A sum, a difference, or a decimal taken so many times. */
+function drawStandard(config: DecimalConfig, rand: () => number): Drawn | null {
+  const operation = operationOf(config.operation, rand);
+  const left = drawValue(config, rand);
+  if (left === null) return null;
+
+  if (operation === "multiply") {
+    const by = between(MULTIPLIER.min, MULTIPLIER.max, rand);
+    return written(
+      config,
+      operation,
+      [fixedText(left), String(by)],
+      fixedText(timesWhole(left, by)),
+    );
+  }
+
+  const right = drawValue(config, rand);
+  if (right === null) return null;
+  if (operation === "add") {
+    return written(
+      config,
+      operation,
+      [fixedText(left), fixedText(right)],
+      fixedText(plusFixed(left, right)),
+    );
+  }
+
+  // Nothing on a decimals sheet goes below zero, so the pair is turned round
+  // rather than thrown away — the same bargain the arithmetic family strikes.
+  // A difference of nothing is thrown away, because it answers itself.
+  if (left.units === right.units) return null;
+  const [top, bottom] =
+    left.units > right.units ? [left, right] : [right, left];
+  return written(
+    config,
+    operation,
+    [fixedText(top), fixedText(bottom)],
+    fixedText(minusFixed(top, bottom)),
+  );
+}
+
+/**
+ * A problem written the way the config asks: along a line, or stacked.
+ *
+ * Column form is where the sheet earns its keep. Every value prints to the same
+ * number of places, so two of them right-aligned in `tabular-nums` put their
+ * points in a column without anything having to align them — which is the one
+ * thing a child working a decimal sum has to get right.
+ */
+function written(
+  config: DecimalConfig,
+  operation: Exclude<DecimalOperation, "both">,
+  operands: string[],
+  answer: string,
+): Drawn {
+  const sign = SIGN[operation];
+  // Addition folds — `1.4 + 0.25` and `0.25 + 1.4` are one problem — while a
+  // difference and a multiple do not.
+  const key =
+    operation === "add"
+      ? `${operation}:${[...operands].sort().join(":")}`
+      : `${operation}:${operands.join(":")}`;
+  if (config.form === "vertical") {
+    return { key, prompt: "", operands, operator: sign, answer };
+  }
+  return { key, prompt: `${operands[0]} ${sign} ${operands[1]} =`, answer };
+}
+
+/** "25% of 80 =", and only when the answer comes out whole. */
+function drawPercent(config: DecimalConfig, rand: () => number): Drawn | null {
+  const percent = PERCENTS[Math.floor(rand() * PERCENTS.length)];
+  const { min, max } = bounds(config.range);
+  const amount = between(min, max, rand);
+  const part = percent * amount;
+  if (amount <= 0 || part % 100 !== 0) return null;
+  return {
+    key: `percent:${percent}:${amount}`,
+    prompt: `${percent}% of ${amount} =`,
+    answer: String(part / 100),
+  };
+}
+
+/**
+ * The same number in another form: a decimal as a percent, a percent as a
+ * decimal, or a fraction as a decimal.
+ *
+ * Three directions rather than every pair, because the blank has to say what it
+ * wants without a sentence beside it: a blank with a `%` after it wants a
+ * percent and every other blank wants a decimal, which is one rule a child can
+ * hold. "0.75 = _" answered with a fraction would be a right answer marked
+ * wrong.
+ *
+ * Each direction draws only from what is legal at the places the sheet is set
+ * at, rather than drawing freely and rejecting. That is not an optimisation:
+ * a tenths sheet has ten legal percents and a hundred illegal ones, so a
+ * rejecting draw spends nine tenths of its budget on the one direction that
+ * always succeeds, and prints a page of "70% = _" with two other questions
+ * hiding at the bottom.
+ */
+function drawConvert(config: DecimalConfig, rand: () => number): Drawn | null {
+  const places = placesOf(config);
+  const by = scale(places);
+  const direction = between(0, 2, rand);
+
+  if (direction === 0) {
+    // A decimal, as a percent — drawn as the percent and written out as the
+    // decimal, which is the same question from the end that has whole numbers
+    // in it. Values up to one whole, which is where percents are taught before
+    // anything is over a hundred of them.
+    const percent = between(1, 100 / percentStep(by), rand) * percentStep(by);
+    return {
+      key: `convert:decimal:${percent}`,
+      prompt: `${fixedText(fixed((percent * by) / 100, places))} = _%`,
+      answer: String(percent),
+    };
+  }
+
+  if (direction === 1) {
+    const usable = PERCENTS.filter((percent) => (percent * by) % 100 === 0);
+    if (usable.length === 0) return null;
+    const percent = usable[Math.floor(rand() * usable.length)];
+    return {
+      key: `convert:percent:${percent}`,
+      prompt: `${percent}% = _`,
+      answer: fixedText(fixed((percent * by) / 100, places)),
+    };
+  }
+
+  const usable = FRIENDLY.filter((d) => by % d === 0);
+  if (usable.length === 0) return null;
+  const d = usable[Math.floor(rand() * usable.length)];
+  const n = between(1, d - 1, rand);
+  // In lowest terms, so the fraction on the page is the one a child recognises:
+  // `2/4 = 0.5` teaches them to simplify first and then convert, which is two
+  // questions in one blank.
+  if (gcd(n, d) !== 1) return null;
+  return {
+    key: `convert:fraction:${n}:${d}`,
+    prompt: `${n}/${d} = _`,
+    answer: fixedText(fixed((n * by) / d, places)),
+  };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/** Whether this sheet stacks its problems. Only the arithmetic one can. */
+const stacked = (config: DecimalConfig): boolean =>
+  config.style === "standard" && config.form === "vertical";
+
+/** How tall one problem stands, working space and all. */
+function rowHeight(config: DecimalConfig): Mil {
+  // A stack is one flex item and cannot wrap, so it is reserved for as what it
+  // is: two numbers, a rule and the answer under it.
+  const body = stacked(config)
+    ? points(config.fontPt * STACK_EMS)
+    : writtenRow(config.fontPt);
+  return body + (config.workspace ? WORKSPACE : 0);
+}
+
+/**
+ * How many problems the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic, not measurement, so `npm run test:unit` can answer "did it fit?"
+ * without a browser — and so the same answer serves the catalog page built at
+ * build time and the builder's preview (§4).
+ */
+export function decimalLayout(config: DecimalConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of them.
+  const box = sheetBlockBox(headerOf(config), true);
+  const columns = clamp(config.columns, 1, MAX_COLUMNS);
+  const row = rowHeight(config);
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
+  };
+}
+
+/**
+ * Every problem on the sheet, in the order they are printed.
+ *
+ * Exported because it is the whole of what a test has to check, and checking it
+ * through the `Sheet` means unwrapping a block union to reach it.
+ */
+export function decimalProblems(
+  config: DecimalConfig,
+  seed: number,
+): Problem[] {
+  const { perPage } = decimalLayout(config);
+  // The count is a request, not a promise: a count that overruns is a second
+  // sheet out of the printer with two problems on it.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  const seen = new Set<string>();
+  const problems: Problem[] = [];
+  const extras = config.workspace ? { workspace: WORKSPACE } : {};
+
+  let misses = 0;
+  while (problems.length < wanted && misses < MISS_BUDGET) {
+    const drawn =
+      config.style === "percent"
+        ? drawPercent(config, rand)
+        : config.style === "convert"
+          ? drawConvert(config, rand)
+          : drawStandard(config, rand);
+    // Not what was asked for, or already on the page. Either way the budget
+    // ticks down, and a pool that has run out ends the draw rather than
+    // repeating itself.
+    if (drawn === null || seen.has(drawn.key)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(drawn.key);
+    problems.push({
+      prompt: drawn.prompt,
+      answer: drawn.answer,
+      ...(drawn.operands
+        ? { operands: drawn.operands, operator: drawn.operator }
+        : {}),
+      ...extras,
+    });
+    misses = 0;
+  }
+  return problems;
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const OPERATION_NAME = {
+  add: "Adding",
+  subtract: "Subtracting",
+  multiply: "Multiplying",
+  both: "Adding and subtracting",
+} as const;
+
+/** What a place count is called out loud, which is how a lesson names it. */
+const PLACE_NAME = ["", "tenths", "hundredths", "thousandths"] as const;
+
+/** "Adding decimals" — the phrase a parent says, and the one they search. */
+function titleOf(config: DecimalConfig): string {
+  switch (config.style) {
+    case "percent":
+      return "Percentages of amounts";
+    case "convert":
+      return "Fractions, decimals and percents";
+    default:
+      return `${OPERATION_NAME[config.operation] ?? OPERATION_NAME.add} decimals`;
+  }
+}
+
+function instructionOf(config: DecimalConfig): string {
+  switch (config.style) {
+    case "percent":
+      return "Work out each amount.";
+    case "convert":
+      // Said plainly, because the blank cannot say it: a child who writes a
+      // fraction where a decimal was wanted has answered a question nobody
+      // asked, and would be marked wrong for it.
+      return "Fill in each blank. A blank with a % after it wants a percent; every other blank wants a decimal.";
+    default:
+      return stacked(config)
+        ? "Work out each answer. Keep the points under one another."
+        : "Work out each answer.";
+  }
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: DecimalConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions: config.instructions ?? instructionOf(config),
+  };
+}
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * The two things the title leaves off are the two that decide whether a sheet
+ * matches the lesson: how far past the point the numbers go, and whether the
+ * sum is written along a line or worked in columns.
+ */
+export function describeDecimals(config: DecimalConfig): string {
+  return [
+    titleOf(config),
+    config.style === "percent" ? null : PLACE_NAME[placesOf(config)],
+    stacked(config) ? "in columns" : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" — ");
+}
+
+export function buildDecimalSheet(config: DecimalConfig, seed: number): Sheet {
+  const items = decimalProblems(config, seed);
+  const { columns } = decimalLayout(config);
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is actually on the page, not out of what was asked for: a
+      // sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf: items.length },
+    },
+    blocks: [{ kind: "problems", columns, items }],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const DECIMALS_SHEET: SheetSpec<DecimalConfig> = {
+  id: "decimals",
+  label: "Decimals and percents",
+  world: SHEET_WORLD,
+  build: buildDecimalSheet,
+  // The whole of the answer-key mechanism: every answer on the page was
+  // computed in whole units when the problem was built, so a key prints what is
+  // already there rather than working it out a second time.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeDecimals,
+};

--- a/src/engine/sheets/maths/decimals.ts
+++ b/src/engine/sheets/maths/decimals.ts
@@ -449,9 +449,15 @@ function instructionOf(config: DecimalConfig): string {
       // asked, and would be marked wrong for it.
       return "Fill in each blank. A blank with a % after it wants a percent; every other blank wants a decimal.";
     default:
-      return stacked(config)
-        ? "Work out each answer. Keep the points under one another."
-        : "Work out each answer.";
+      if (!stacked(config)) return "Work out each answer.";
+      // A stack of sums lines up on the point, because every value on the sheet
+      // is printed to the same number of places. A multiplier is not a decimal
+      // at all — `1.25 × 3` has one point in it — so "keep the points under one
+      // another" describes a column that isn't there, and §10 makes this
+      // sentence the whole of the guidance a child gets.
+      return config.operation === "multiply"
+        ? "Work out each answer. Line the digits up on the right, then put the point back in."
+        : "Work out each answer. Keep the points under one another.";
   }
 }
 

--- a/src/engine/sheets/maths/exact.ts
+++ b/src/engine/sheets/maths/exact.ts
@@ -1,0 +1,188 @@
+/**
+ * Numbers a worksheet can be marked against.
+ *
+ * The three families below this file — fractions, decimals and money — share
+ * one hazard the tables never had. `7 × 8` is 56 in any arithmetic anybody has
+ * ever implemented; `0.1 + 0.2` is 0.30000000000000004 in the one every
+ * JavaScript program is written in, and `4/8` is a correct answer written the
+ * wrong way. Both failures print. A key that says 0.30000000000000004, or that
+ * marks `2/3` wrong because it computed `4/6`, is worse than no key at all.
+ *
+ * So neither value is ever a float:
+ *
+ * - a **fraction** is a pair of whole numbers, and reducing it is a division
+ *   that is exact by construction — the greatest common divisor of the two;
+ * - a **fixed-point** number is a whole number of thousandths, hundredths or
+ *   tenths with the point written in when it is printed. £3.45 is 345 pence all
+ *   the way through, and the only division anywhere near it is by ten.
+ *
+ * Nothing here knows what a sheet is. It is arithmetic over plain data, the
+ * bottom of the bottom layer, and it is the only place these two shapes are
+ * defined — a second copy of "how do I write 5/4 as a mixed number" is a second
+ * answer to the same question.
+ */
+
+/* ── Fractions ─────────────────────────────────────────────────────────────
+   A numerator and a denominator, both whole, the denominator positive. Nothing
+   in the Print Shop draws a negative fraction — a subtraction sheet orders its
+   operands so it doesn't have to — so the sign is not a case this has to
+   carry.                                                                     */
+
+export type Fraction = { n: number; d: number };
+
+/**
+ * The greatest common divisor, by Euclid.
+ *
+ * Every fraction question in the shop reduces to this one function: lowest
+ * terms is dividing by it, equivalent fractions are multiplying past it, and
+ * "is this already simplified?" is asking whether it is one.
+ */
+export function gcd(a: number, b: number): number {
+  let left = Math.abs(Math.trunc(a));
+  let right = Math.abs(Math.trunc(b));
+  while (right > 0) {
+    const next = left % right;
+    left = right;
+    right = next;
+  }
+  return left;
+}
+
+/** The same value with nothing left to cancel. Zero is `0/1`, always. */
+export function reduced(value: Fraction): Fraction {
+  if (value.n === 0) return { n: 0, d: 1 };
+  const by = gcd(value.n, value.d);
+  return by <= 1 ? { ...value } : { n: value.n / by, d: value.d / by };
+}
+
+/** Whether a fraction is already written the smallest way it can be. */
+export const lowest = (value: Fraction): boolean =>
+  value.n === 0 ? value.d === 1 : gcd(value.n, value.d) === 1;
+
+/**
+ * The four operations, over a common denominator of `a.d × b.d`.
+ *
+ * Deliberately not the *lowest* common denominator: the product is always a
+ * common one, `reduced` takes the answer down to lowest terms afterwards, and
+ * the numbers a worksheet works in are small enough that the intermediate never
+ * approaches an unsafe integer. One less thing to be subtly wrong.
+ */
+export const plus = (a: Fraction, b: Fraction): Fraction =>
+  reduced({ n: a.n * b.d + b.n * a.d, d: a.d * b.d });
+
+export const minus = (a: Fraction, b: Fraction): Fraction =>
+  reduced({ n: a.n * b.d - b.n * a.d, d: a.d * b.d });
+
+export const times = (a: Fraction, b: Fraction): Fraction =>
+  reduced({ n: a.n * b.n, d: a.d * b.d });
+
+/** Dividing by a fraction is multiplying by it upside down. */
+export const over = (a: Fraction, b: Fraction): Fraction =>
+  reduced({ n: a.n * b.d, d: a.d * b.n });
+
+/**
+ * Which of two fractions is the larger: negative, zero or positive, the way a
+ * comparator answers.
+ *
+ * Cross-multiplied rather than divided out, because dividing is where the
+ * floats would get back in. Both denominators are positive, so the sense of the
+ * comparison survives the multiplication.
+ */
+export const compare = (a: Fraction, b: Fraction): number =>
+  a.n * b.d - b.n * a.d;
+
+/** A whole number of parts: `3` is `3/1`, which is how a mixed number is built. */
+export const whole = (value: number): Fraction => ({ n: value, d: 1 });
+
+/**
+ * A fraction as it is written on paper: "3/4", or "3" when there is nothing
+ * under the line to say.
+ *
+ * A solidus rather than a stacked drawing, and that is a decision rather than a
+ * shortcut. A stacked fraction would be a `Problem` shape of its own — new
+ * markup, new alignment, and an answer nobody can type — where "3/4" is real
+ * text a search engine reads, a screen reader says correctly and a parent can
+ * copy (§2). It is also how a child writes one in the blank.
+ */
+export function fractionText(value: Fraction): string {
+  if (value.d === 1) return String(value.n);
+  return `${value.n}/${value.d}`;
+}
+
+/**
+ * The same value as a whole number and what is left over: "1 1/4" rather than
+ * "5/4".
+ *
+ * Which of the two forms is right depends on what the sheet asked for, so the
+ * choice lives with the family and this is only the writing of it.
+ */
+export function mixedText(value: Fraction): string {
+  if (value.d === 1 || value.n < value.d) return fractionText(value);
+  const units = Math.floor(value.n / value.d);
+  const left = value.n - units * value.d;
+  return left === 0 ? String(units) : `${units} ${left}/${value.d}`;
+}
+
+/** Written the way the sheet asks: as a mixed number, or left top-heavy. */
+export const writeFraction = (value: Fraction, mixed: boolean): string =>
+  mixed ? mixedText(value) : fractionText(value);
+
+/* ── Fixed point ───────────────────────────────────────────────────────────
+   A whole number of hundredths, and a count of how many digits go after the
+   point. $3.45 is `{ units: 345, places: 2 }` from the moment it is drawn to
+   the moment it is printed, and the point is written in by `fixedText` — the
+   one function in the shop that knows where it goes.                        */
+
+export type Fixed = { units: number; places: number };
+
+/** Ten to the `places` — how many of the smallest unit make one whole. */
+export const scale = (places: number): number => 10 ** Math.max(0, places);
+
+export const fixed = (units: number, places: number): Fixed => ({
+  units: Math.round(units),
+  places: Math.max(0, Math.trunc(places)),
+});
+
+/**
+ * Adding and subtracting are adding and subtracting the units, which is the
+ * whole point of holding a decimal this way: two amounts at the same number of
+ * places are two whole numbers, and whole numbers do not drift.
+ */
+export const plusFixed = (a: Fixed, b: Fixed): Fixed =>
+  fixed(a.units + b.units, a.places);
+
+export const minusFixed = (a: Fixed, b: Fixed): Fixed =>
+  fixed(a.units - b.units, a.places);
+
+/**
+ * A decimal multiplied by a whole number — three lots of £1.25.
+ *
+ * Whole numbers only, and that is what keeps the promise the config makes:
+ * `0.25 × 0.4` is 0.1, which has fewer places than either number that made it,
+ * and `2.5 × 2.5` has more. A sheet set at two places whose answers are at four
+ * is a sheet nobody chose.
+ */
+export const timesWhole = (value: Fixed, by: number): Fixed =>
+  fixed(value.units * Math.round(by), value.places);
+
+/**
+ * The number with its point written in: "3.45", "0.60", "12.000".
+ *
+ * Padded to the places the value carries rather than trimmed, because trailing
+ * zeros are not noise on a worksheet — they are how a column of decimals lines
+ * up under itself, and how a child is taught that 0.6 and 0.60 are the same
+ * number.
+ */
+export function fixedText(value: Fixed): string {
+  const units = Math.abs(value.units);
+  const by = scale(value.places);
+  const sign = value.units < 0 ? "-" : "";
+  const front = Math.floor(units / by);
+  if (value.places === 0) return `${sign}${front}`;
+  const back = String(units - front * by).padStart(value.places, "0");
+  return `${sign}${front}.${back}`;
+}
+
+/** The same value as a fraction, for the sheets that ask for both forms. */
+export const fixedFraction = (value: Fixed): Fraction =>
+  reduced({ n: value.units, d: scale(value.places) });

--- a/src/engine/sheets/maths/fractions.test.ts
+++ b/src/engine/sheets/maths/fractions.test.ts
@@ -1,0 +1,741 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { PROBLEM_GAP } from "../layout";
+import type {
+  FractionConfig,
+  MarginSize,
+  Paper,
+  PaperSize,
+  Problem,
+} from "../types";
+
+import { FRACTIONS_SHEET, fractionLayout } from "./fractions";
+
+/**
+ * Fractions, held to the bar the two families before it set.
+ *
+ * **Nothing here checks the generator against the generator.** Every answer is
+ * verified from the *printed* problem — the string a child reads, and the
+ * picture they look at — by a path the family does not use:
+ *
+ * - an answer is checked by **cross-multiplication**, which is the definition of
+ *   two fractions being equal and is not how any of them was computed: `a/b` is
+ *   `c/d` exactly when `a × d` is `c × b`, and no division happens anywhere in
+ *   this file;
+ * - "in its lowest terms" is checked by **looking for a common factor**, one
+ *   number at a time. A test that called the same `gcd` the family reduces with
+ *   would agree with a broken `gcd` about everything;
+ * - a missing number is checked by **searching for every number that fits**,
+ *   which catches the two ways that question goes bad at once: an answer that is
+ *   wrong, and a blank that more than one answer would fill;
+ * - a picture is read as **what is shaded out of how many parts**, off the art
+ *   the sheet actually carries.
+ *
+ * The last of those is the one this family adds. A fraction answer can be right
+ * and still be wrong — `4/8` is the same value as `1/2` and only one of them
+ * will be marked correct — so "right" here is two assertions, always: the value
+ * is equal, and it is written the smallest way it can be.
+ */
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+/** The denominators a mixed sheet draws from: what a primary book covers. */
+const DENOMINATORS = [2, 3, 4, 5, 6, 8, 10, 12];
+
+const config = (over: Partial<FractionConfig> = {}): FractionConfig => ({
+  kind: "fractions",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style: "arithmetic",
+  operation: "add",
+  denominators: DENOMINATORS,
+  pairing: "either",
+  count: 12,
+  columns: 2,
+  ...over,
+});
+
+/**
+ * Every shape the family can print, which is every acceptance criterion of the
+ * story: naming from bars and from circles, equivalence, simplifying, the four
+ * operations, like and unlike denominators, and mixed numbers through all of it.
+ */
+const EVERY_SHAPE: Array<Partial<FractionConfig>> = [
+  {},
+  { pairing: "like" },
+  { pairing: "unlike" },
+  { operation: "subtract" },
+  { operation: "subtract", pairing: "like" },
+  { operation: "subtract", pairing: "unlike" },
+  { operation: "both" },
+  { operation: "both", pairing: "unlike" },
+  { operation: "multiply" },
+  { operation: "divide" },
+  // Mixed numbers, through every operation that can carry one.
+  { mixed: true },
+  { mixed: true, pairing: "unlike" },
+  { mixed: true, operation: "subtract" },
+  { mixed: true, operation: "both" },
+  { mixed: true, operation: "multiply" },
+  { mixed: true, operation: "divide" },
+  // The three styles that are not arithmetic at all.
+  { style: "identify", count: 6 },
+  { style: "identify", model: "circle", count: 6 },
+  { style: "identify", model: "both", count: 6 },
+  { style: "equivalent", count: 10 },
+  { style: "simplify", count: 10 },
+  { workspace: true, count: 8 },
+  // A small pool, which is where the draw has to stop rather than repeat.
+  { denominators: [2, 4], count: 6 },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** The one block a fraction sheet has, narrowed for the reader. */
+function problemsOf(over: Partial<FractionConfig>, seed: number): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+/* ── Reading a sheet the way a child does ──────────────────────────────────
+   Everything below works from the printed problem — the prompt, the answer and
+   the picture — and never from the config that produced it.                 */
+
+type Value = { n: number; d: number };
+
+/**
+ * A fraction as it is written on paper, read back.
+ *
+ * Three forms, because the family prints three: `3/4`, the whole number `2`,
+ * and the mixed number `2 1/4`. Anything else is not a fraction, and saying so
+ * is half the point — a family that started printing `2.25` would fail here
+ * rather than quietly change what the sheet asks for.
+ */
+function readFraction(text: string): Value {
+  const mixed = /^(\d+) (\d+)\/(\d+)$/.exec(text.trim());
+  if (mixed) {
+    const [whole, n, d] = [+mixed[1], +mixed[2], +mixed[3]];
+    // A mixed number whose fraction is not proper is written wrong even when
+    // its value is right: `1 5/4` is nobody's answer.
+    expect(n, `${text} has an improper part`).toBeLessThan(d);
+    expect(d, `${text} is over nothing`).toBeGreaterThan(0);
+    return { n: whole * d + n, d };
+  }
+  const parts = /^(\d+)\/(\d+)$/.exec(text.trim());
+  if (parts) {
+    expect(+parts[2], `${text} is over nothing`).toBeGreaterThan(0);
+    return { n: +parts[1], d: +parts[2] };
+  }
+  const number = /^(\d+)$/.exec(text.trim());
+  if (number) return { n: +number[1], d: 1 };
+  throw new Error(`not a fraction: "${text}"`);
+}
+
+/** Whether two fractions are the same value, cross-multiplied and not divided. */
+const same = (a: Value, b: Value): boolean => a.n * b.d === b.n * a.d;
+
+/**
+ * Whether two whole numbers share a factor, found by looking for one.
+ *
+ * The long way round on purpose. `gcd` is what the family reduces with, so a
+ * test that asked it whether a fraction was in lowest terms would agree with a
+ * broken `gcd` about every fraction on the page.
+ */
+function shareAFactor(a: number, b: number): boolean {
+  const most = Math.min(Math.abs(a), Math.abs(b));
+  for (let by = 2; by <= most; by += 1) {
+    if (a % by === 0 && b % by === 0) return true;
+  }
+  return false;
+}
+
+/** Whether a printed answer is written the smallest way it can be. */
+function lowestTerms(text: string): boolean {
+  const written = text.trim();
+  const mixed = /^(\d+) (\d+)\/(\d+)$/.exec(written);
+  if (mixed) return !shareAFactor(+mixed[2], +mixed[3]);
+  const parts = /^(\d+)\/(\d+)$/.exec(written);
+  // A whole number has nothing to cancel; a fraction over one is a whole number
+  // that was written the long way, which is not lowest terms either.
+  if (!parts) return true;
+  return +parts[2] !== 1 && !shareAFactor(+parts[1], +parts[2]);
+}
+
+/** The two sides of a printed sentence, with the answer put in its blank. */
+function completed(problem: Problem): string {
+  return problem.prompt.includes("_")
+    ? problem.prompt.replace("_", problem.answer)
+    : `${problem.prompt} ${problem.answer}`;
+}
+
+const OPERATIONS: Record<string, (a: Value, b: Value) => Value> = {
+  // Not one of these divides. Each is the identity that defines the operation
+  // over a common denominator of `b × d`, left unreduced — `same` compares by
+  // cross-multiplication, so an unreduced left-hand side is not a problem.
+  "+": (a, b) => ({ n: a.n * b.d + b.n * a.d, d: a.d * b.d }),
+  "−": (a, b) => ({ n: a.n * b.d - b.n * a.d, d: a.d * b.d }),
+  "×": (a, b) => ({ n: a.n * b.n, d: a.d * b.d }),
+  "÷": (a, b) => ({ n: a.n * b.d, d: a.d * b.n }),
+};
+
+/** Whether a written sentence — `3/4 + 1/6 = 11/12` — is true. */
+function holds(sentence: string): boolean {
+  const worked = /^(.+?) ([+−×÷]) (.+?) = (.+)$/.exec(sentence.trim());
+  if (worked) {
+    const [, left, sign, right, answer] = worked;
+    return same(
+      OPERATIONS[sign](readFraction(left), readFraction(right)),
+      readFraction(answer),
+    );
+  }
+  // The other three styles are all one claim: these two fractions are equal.
+  const equal = /^(.+?) = (.+)$/.exec(sentence.trim());
+  if (!equal) throw new Error(`not a fraction sentence: "${sentence}"`);
+  return same(readFraction(equal[1]), readFraction(equal[2]));
+}
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the fractions family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("fractions")).toBe(FRACTIONS_SHEET);
+    expect(sheetSpec("fractions").label).toBe("Fractions");
+  });
+
+  it("names what it prints, in the terms a parent chose it by", () => {
+    expect(describeSheet(config())).toBe(
+      "Adding fractions — denominators to 12",
+    );
+    expect(describeSheet(config({ pairing: "unlike" }))).toBe(
+      "Adding fractions with unlike denominators — denominators to 12",
+    );
+    expect(describeSheet(config({ operation: "both", pairing: "like" }))).toBe(
+      "Adding and subtracting fractions with like denominators — denominators to 12",
+    );
+    // Multiplying has no like-and-unlike lesson, so the title doesn't claim one.
+    expect(
+      describeSheet(config({ operation: "multiply", pairing: "unlike" })),
+    ).toBe("Multiplying fractions — denominators to 12");
+    expect(describeSheet(config({ mixed: true, operation: "divide" }))).toBe(
+      "Dividing mixed numbers — denominators to 12",
+    );
+    expect(describeSheet(config({ style: "identify", model: "both" }))).toBe(
+      "Naming fractions — bars and circles",
+    );
+    expect(describeSheet(config({ style: "simplify" }))).toBe(
+      "Simplifying fractions — denominators to 12",
+    );
+  });
+
+  it("gives the sheet a title and a score box it can be marked against", () => {
+    const sheet = buildSheet(config({ style: "equivalent", count: 8 }), 3);
+    const block = sheet.blocks[0];
+    expect(sheet.header.title).toBe("Equivalent fractions");
+    expect(sheet.header.instructions).toBe(
+      "Write the missing number in each blank.",
+    );
+    // Out of what is on the page, not out of what was asked for.
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+
+  it("tells a child which of two right answers is wanted", () => {
+    // The whole hazard of the family in one line of the header: `7/6` and
+    // `1 1/6` are the same value, and a sheet that didn't say which it wanted
+    // would mark half its class wrong.
+    expect(buildSheet(config(), 1).header.instructions).toBe(
+      "Work out each answer and write it in its lowest terms.",
+    );
+    expect(buildSheet(config({ mixed: true }), 1).header.instructions).toBe(
+      "Work out each answer and write it in its lowest terms. Write anything over one as a mixed number.",
+    );
+    expect(
+      buildSheet(config({ style: "identify" }), 1).header.instructions,
+    ).toBe("Write the fraction each picture shows.");
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("is right on every problem of every sheet this family can print", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+        for (const problem of problems) {
+          // A naming problem's sentence is its picture: what is shaded, out of
+          // how many parts the whole was cut into.
+          const sentence = problem.art
+            ? `${problem.art.shaded}/${problem.art.parts} = ${problem.answer}`
+            : completed(problem);
+          expect(holds(sentence), `${JSON.stringify(shape)}: ${sentence}`) //
+            .toBe(true);
+        }
+      }
+    }
+  });
+
+  it("writes every answer in its lowest terms", () => {
+    // The half of "right" that cross-multiplication cannot see: `4/8` is the
+    // same value as `1/2` and is not the answer. Every style, because every
+    // style has an answer a parent will mark.
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        for (const problem of problemsOf(shape, seed)) {
+          expect(
+            lowestTerms(problem.answer),
+            `${JSON.stringify(shape)}: ${problem.answer}`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    // The key is not built again from the seed — it is the build, told to print
+    // what it already worked out. So the blocks on the two are equal, and a key
+    // cannot disagree with the sheet it belongs to. The picture on a naming
+    // sheet is part of that: it is the question, so it is on both.
+    for (const shape of EVERY_SHAPE) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+
+  it("leaves exactly one number that would fit an equivalence blank", () => {
+    // Two failures caught by one search: an answer that is wrong, and a blank
+    // more than one number would fill.
+    for (const seed of SEEDS) {
+      const problems = problemsOf({ style: "equivalent", count: 10 }, seed);
+      expect(problems.length).toBeGreaterThan(0);
+      for (const problem of problems) {
+        const fits = [];
+        for (let candidate = 1; candidate <= 200; candidate += 1) {
+          try {
+            if (holds(problem.prompt.replace("_", String(candidate)))) {
+              fits.push(candidate);
+            }
+          } catch {
+            /* not a fraction sentence at all */
+          }
+        }
+        expect(fits, problem.prompt).toEqual([Number(problem.answer)]);
+      }
+    }
+  });
+
+  it("gives a simplifying sheet something to simplify", () => {
+    // A page of fractions already in their lowest terms is a page of nothing to
+    // do, and every answer on it would still be "right".
+    for (const seed of SEEDS) {
+      const problems = problemsOf({ style: "simplify", count: 10 }, seed);
+      expect(problems.length).toBeGreaterThan(0);
+      for (const problem of problems) {
+        const [written] = problem.prompt.split(" =");
+        expect(lowestTerms(written), problem.prompt).toBe(false);
+        expect(lowestTerms(problem.answer), problem.answer).toBe(true);
+      }
+    }
+  });
+
+  it("writes a mixed-number sheet's answers as mixed numbers", () => {
+    // `7/6` is the right value and the wrong answer on a sheet whose header
+    // asked for mixed numbers — and the top-heavy form is what a family that
+    // had forgotten the switch would print. An answer *under* one is a fraction
+    // on any sheet, so what is checked is that nothing top-heavy survives.
+    for (const operation of ["add", "multiply", "both", "subtract"] as const) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf({ mixed: true, operation }, seed);
+        expect(problems.length).toBeGreaterThan(0);
+        for (const problem of problems) {
+          const top = /^(\d+)\/(\d+)$/.exec(problem.answer);
+          if (top) {
+            expect(+top[1], `${problem.prompt} ${problem.answer}`) //
+              .toBeLessThan(+top[2]);
+          }
+        }
+      }
+    }
+    // And a sheet that did not ask for them keeps the top-heavy form, which is
+    // the same assertion from the other side: over a hundred problems, some
+    // sum of two proper fractions is bound to pass one.
+    const improper = problemsOf({ count: 30, columns: 4 }, 3).filter(
+      (problem) => /^\d+\/\d+$/.test(problem.answer),
+    );
+    expect(improper.length).toBeGreaterThan(0);
+  });
+});
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  /** Every denominator printed in a problem, answer included. */
+  function denominatorsOn(problem: Problem): number[] {
+    const written = problem.art
+      ? [`${problem.art.shaded}/${problem.art.parts}`, problem.answer]
+      : [completed(problem)];
+    return written
+      .join(" ")
+      .split(/[\s=+−×÷]+/)
+      .filter((word) => word.includes("/"))
+      .map((word) => readFraction(word).d);
+  }
+
+  it("never draws a denominator a parent did not ask for", () => {
+    // The naming and arithmetic styles print the pool itself. Equivalence and
+    // simplifying scale one of their fractions up on purpose, so what is
+    // checked there is that the fraction in lowest terms — the one the parent
+    // picked — is from the pool.
+    const ASKS = [[2, 4], [3, 6, 9], DENOMINATORS];
+    for (const denominators of ASKS) {
+      const wanted = new Set(denominators);
+      for (const style of ["identify", "arithmetic"] as const) {
+        for (const seed of SEEDS) {
+          const problems = problemsOf({ denominators, style, count: 6 }, seed);
+          expect(problems.length, JSON.stringify(denominators)) //
+            .toBeGreaterThan(0);
+          for (const problem of problems) {
+            for (const d of denominatorsOn(problem)) {
+              // An answer may land on a denominator the pool has never heard
+              // of — a half plus a third is a sixth — so only the fractions in
+              // the question itself are held to the pool.
+              if (problem.art || problem.prompt.includes(`/${d}`)) {
+                expect(wanted.has(d), `${problem.prompt} ${problem.answer}`) //
+                  .toBe(true);
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it("keeps like denominators alike, and unlike ones apart", () => {
+    // The switch the family turns on: adding quarters to quarters is the week
+    // before adding quarters to thirds.
+    for (const seed of SEEDS) {
+      for (const problem of problemsOf({ pairing: "like", count: 10 }, seed)) {
+        const [left, right] = problem.prompt.split(/ [+−×÷] /);
+        expect(readFraction(left).d, problem.prompt).toBe(
+          readFraction(right.replace(" =", "")).d,
+        );
+      }
+      for (const problem of problemsOf(
+        { pairing: "unlike", count: 10 },
+        seed,
+      )) {
+        const [left, right] = problem.prompt.split(/ [+−×÷] /);
+        expect(readFraction(left).d, problem.prompt).not.toBe(
+          readFraction(right.replace(" =", "")).d,
+        );
+      }
+    }
+  });
+
+  it("never asks a child to take more away than there is", () => {
+    // Nothing in the Print Shop prints a negative fraction, and a difference of
+    // nothing is a question that answers itself.
+    for (const shape of [
+      { operation: "subtract" as const },
+      { operation: "subtract" as const, mixed: true },
+      { operation: "both" as const },
+    ]) {
+      for (const seed of SEEDS) {
+        for (const problem of problemsOf({ ...shape, count: 12 }, seed)) {
+          expect(problem.answer, problem.prompt).not.toContain("-");
+          expect(readFraction(problem.answer).n, problem.prompt) //
+            .toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("draws a picture whose answer can only be written one way", () => {
+    // A bar in eighths with four of them shaded has two right answers — `4/8`
+    // and `1/2` — and a child would be marked wrong for the one the adult
+    // didn't think of. So a naming sheet only ever draws a fraction that is
+    // already in its lowest terms.
+    for (const model of ["bar", "circle", "both"] as const) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(
+          { style: "identify", model, count: 6 },
+          seed,
+        );
+        expect(problems.length).toBeGreaterThan(0);
+        for (const { art, answer, prompt } of problems) {
+          if (!art) throw new Error("a naming problem with no picture");
+          expect(art.shaded).toBeGreaterThan(0);
+          expect(art.shaded).toBeLessThan(art.parts);
+          expect(
+            shareAFactor(art.shaded, art.parts),
+            `${art.shaded}/${art.parts}`,
+          ) //
+            .toBe(false);
+          if (model !== "both") expect(art.shape).toBe(model);
+          // The picture is the whole question: there is nothing written to
+          // read, and one place to write the answer.
+          expect(prompt).toBe("");
+          expect(answer).toBe(`${art.shaded}/${art.parts}`);
+        }
+      }
+    }
+    // A `both` sheet draws both, rather than picking one and calling it a mix.
+    const shapes = new Set(
+      problemsOf({ style: "identify", model: "both", count: 12 }, 5) //
+        .map((problem) => problem.art?.shape),
+    );
+    expect(shapes).toEqual(new Set(["bar", "circle"]));
+  });
+
+  it("asks the same question twice on no sheet at all", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        const asked = problems.map((problem) =>
+          problem.art
+            ? `${problem.art.shaded}/${problem.art.parts}`
+            : problem.prompt,
+        );
+        expect(new Set(asked).size, JSON.stringify(shape)).toBe(
+          problems.length,
+        );
+      }
+    }
+  });
+
+  it("prints the whole small pool rather than repeating itself", () => {
+    // Halves and quarters make three naming problems — 1/2, 1/4 and 3/4 — and
+    // three is what a parent should get rather than twelve problems with the
+    // same picture in them four times.
+    const problems = problemsOf(
+      { style: "identify", denominators: [2, 4], count: 12 },
+      1,
+    );
+    expect(problems.length).toBe(3);
+    expect(new Set(problems.map((p) => p.answer)).size).toBe(3);
+  });
+
+  it("prints nothing rather than something wrong when the ask is impossible", () => {
+    // No denominators at all, and unlike denominators from a pool with one
+    // denominator in it. Both are empty sheets, which is the honest answer and
+    // the builder's job to prevent (PRINT13).
+    expect(problemsOf({ denominators: [] }, 1)).toEqual([]);
+    expect(problemsOf({ denominators: [4], pairing: "unlike" }, 1)).toEqual([]);
+    // And a nought in a saved config is not a slow sheet — it is a fraction
+    // over nothing, which is why the pool drops it rather than drawing from it.
+    expect(problemsOf({ denominators: [0, 1] }, 1)).toEqual([]);
+  });
+});
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("carries the seed into the footer, so the same sheet can be had again", () => {
+    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
+  });
+
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    // Building twice in one process only proves the draw is a function of
+    // `(config, seed)`. The promise the footer makes is bigger than that: the
+    // seed is printed on the paper so a parent can have the same sheet again
+    // next week, across a deploy. Nothing else in this file would notice a
+    // refactor that moved where the draw consumes `rand()` — the operation coin
+    // spent only when both are asked for, the second denominator not drawn at
+    // all on a like sheet, the whole number drawn only on a mixed one — and
+    // every seed a parent had already printed would quietly start producing a
+    // different sheet.
+    expect(
+      problemsOf({ pairing: "unlike", count: 4 }, 4242).map((p) => [
+        p.prompt,
+        p.answer,
+      ]),
+    ).toEqual(GOLDEN.unlike);
+
+    expect(
+      problemsOf({ mixed: true, operation: "subtract", count: 4 }, 7).map(
+        (p) => [p.prompt, p.answer],
+      ),
+    ).toEqual(GOLDEN.mixed);
+
+    expect(
+      problemsOf({ style: "identify", model: "both", count: 4 }, 7).map((p) => [
+        p.art?.shape,
+        p.art?.parts,
+        p.art?.shaded,
+        p.answer,
+      ]),
+    ).toEqual(GOLDEN.identify);
+  });
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    // Three consecutive seeds are the whole of "a different sheet, same
+    // settings" and of variants for a class (§7). Some overlap is inevitable —
+    // halves and quarters are three naming problems however many sheets you
+    // print — so what is asserted is that a third of each variant is new.
+    //
+    // Six problems rather than the shape's own count, because what is being
+    // asserted is that the *draw* moves and some of these pools are genuinely
+    // small: subtracting like denominators from a primary pool is about thirty
+    // problems, and three sheets of twelve out of thirty would overlap however
+    // well the draw worked.
+    for (const shape of EVERY_SHAPE) {
+      // The one shape with no room to differ: a pool of two denominators has
+      // three naming problems in it and every sheet prints all three.
+      if (shape.denominators?.length === 2) continue;
+      const [a, b, c] = [0, 1, 2].map((offset) =>
+        problemsOf({ ...shape, count: 6 }, 100 + offset).map((problem) =>
+          problem.art ? problem.answer : problem.prompt,
+        ),
+      );
+      for (const [one, other] of [
+        [a, b],
+        [a, c],
+        [b, c],
+      ]) {
+        expect(one).not.toEqual(other);
+        const shared = one.filter((asked) => other.includes(asked)).length;
+        expect(shared, JSON.stringify(shape)).toBeLessThan(
+          (one.length * 2) / 3,
+        );
+      }
+    }
+  });
+});
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    // The failure is silent on screen and obvious on paper: one row too many is
+    // a second sheet out of the printer with two problems on it, and print is
+    // the whole of the output path (§10).
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row } = fractionLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used = rows * row + Math.max(0, rows - 1) * PROBLEM_GAP.y;
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("does not throw the page away either", () => {
+    // The half a capacity check cannot see: a family that printed four problems
+    // on a Letter page would satisfy every assertion above.
+    const { box, row, perPage, columns } = fractionLayout(config());
+    expect(perPage).toBeGreaterThanOrEqual(18);
+    const rows = perPage / columns;
+    expect((rows + 1) * row + rows * PROBLEM_GAP.y).toBeGreaterThan(box.height);
+
+    // And a page of pictures still holds a dozen, which is what a parent
+    // expects to get for the paper.
+    expect(
+      fractionLayout(config({ style: "identify", model: "circle", columns: 3 }))
+        .perPage,
+    ).toBeGreaterThanOrEqual(12);
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ count: 8 }, 1).length).toBe(8);
+    expect(problemsOf({ count: 0 }, 1).length).toBe(0);
+    for (const columns of [1, 2, 3, 4]) {
+      const block = buildSheet(config({ columns }), 1).blocks[0];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+    // Three is as many columns of pictures as a page is laid out in: a bar an
+    // inch wide beside a ruled blank has nowhere to be.
+    const drawn = buildSheet(config({ style: "identify", columns: 6 }), 1)
+      .blocks[0];
+    expect(drawn.kind === "problems" && drawn.columns).toBe(3);
+  });
+
+  it("reserves the room the picture is going to take", () => {
+    // The layout reserves the height and the build attaches the drawing, and
+    // the two reading the config differently is the bug the whole "declared,
+    // not measured" design exists to exclude. A circle is taller than a bar, so
+    // a sheet of circles reserves more — and a `both` sheet reserves for the
+    // taller of the two, because the row height is one number for the grid.
+    const bars = fractionLayout(config({ style: "identify", model: "bar" }));
+    const circles = fractionLayout(
+      config({ style: "identify", model: "circle" }),
+    );
+    const mixture = fractionLayout(
+      config({ style: "identify", model: "both" }),
+    );
+    expect(circles.row).toBeGreaterThan(bars.row);
+    expect(mixture.row).toBe(circles.row);
+    // And a written sheet reserves less than either, because it draws nothing.
+    expect(fractionLayout(config()).row).toBeLessThan(bars.row);
+  });
+});
+
+/**
+ * What three sheets came out as on the day this shipped.
+ *
+ * Recorded rather than computed — every one of them is proved right by the
+ * assertions above, and what these hold is that they do not silently *change*.
+ */
+const GOLDEN = {
+  unlike: [
+    ["1/2 + 1/3 =", "5/6"],
+    ["5/6 + 2/5 =", "37/30"],
+    ["7/10 + 3/5 =", "13/10"],
+    ["11/12 + 2/3 =", "19/12"],
+  ],
+  mixed: [
+    ["3 1/2 − 2 1/2 =", "1"],
+    ["3 3/5 − 1 1/3 =", "2 4/15"],
+    ["3 7/8 − 2 5/6 =", "1 1/24"],
+    ["2 1/2 − 1 1/3 =", "1 1/6"],
+  ],
+  identify: [
+    ["bar", 2, 1, "1/2"],
+    ["bar", 3, 2, "2/3"],
+    ["circle", 4, 1, "1/4"],
+    ["circle", 6, 1, "1/6"],
+  ],
+};

--- a/src/engine/sheets/maths/fractions.ts
+++ b/src/engine/sheets/maths/fractions.ts
@@ -1,0 +1,594 @@
+/**
+ * Fractions.
+ *
+ * Everything the arithmetic and multiplication families established holds here
+ * unchanged — the answers are computed when the problem is built and the key
+ * only decides to print them, the page comes out of `(config, seed)` and
+ * nothing else, and a problem is drawn and rejected rather than enumerated. So
+ * this file is about the three things a fraction sheet has that a page of sums
+ * does not.
+ *
+ * **An answer can be right and still be wrong.** `4/8` and `1/2` are the same
+ * value, and only one of them is the answer a parent will mark as correct. So
+ * every answer this family computes is reduced (`exact.ts` does the reducing),
+ * every naming problem is drawn so that what is shaded is *already* in lowest
+ * terms — a picture of four eighths has two right answers and no way for a
+ * child to know which was wanted — and the sheet says so in its instructions.
+ *
+ * **Some fractions are pictures.** A naming sheet asks what fraction of a bar
+ * or a circle is shaded, so the question is a drawing and the drawing is on the
+ * blank sheet as well as on the key. It rides on the problem as `art`, the way
+ * a number line does, and its size is in `fractionart.ts` where both the row
+ * reservation and the renderer read it.
+ *
+ * **Like and unlike is the whole lesson.** Adding quarters to quarters is the
+ * week before adding quarters to thirds, and `pairing` is the switch between
+ * them — this family's `regrouping`. A sheet that mixed the two would be set at
+ * a level nobody chose.
+ */
+import { between, mulberry32 } from "@/engine/random";
+
+import type {
+  Denominators,
+  FractionArt,
+  FractionConfig,
+  FractionOperation,
+  FractionStyle,
+  Mil,
+  Problem,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import { artHeight, fractionArt } from "../fractionart";
+import {
+  PROBLEM_GAP,
+  WRAP_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import {
+  gcd,
+  minus,
+  over,
+  plus,
+  times,
+  whole,
+  writeFraction,
+  type Fraction,
+} from "./exact";
+
+/* ── What a problem takes on the page ─────────────────────────────────────
+   Declared, not measured (§4).                                              */
+
+/**
+ * How tall a problem written along a line stands: two lines of the body type,
+ * and the air a wrap puts between them.
+ *
+ * Two rather than one, because a fraction sentence is long. `3 5/12 ÷ 2 7/8 =`
+ * with a ruled blank after it does not fit across a third of a page, and
+ * `.sheet__problem` wraps rather than overflowing — so the second line is
+ * either inside the row the layout declared, or it is the bottom of the page
+ * coming out of the printer on a second sheet. Reserving for the wrap is the
+ * only version of this that a page can be laid out from without measuring text,
+ * and a sheet whose problems all fit on one line is left a little airier than it
+ * needed to be — which on a fraction sheet is where the common denominator gets
+ * worked out.
+ */
+const writtenRow = (fontPt: number): Mil => 2 * answerLine(fontPt) + WRAP_GAP;
+
+/** Blank space to work a problem out in, when the config asks for it. */
+const WORKSPACE = inches(0.55);
+
+/**
+ * Four columns of fractions, and three of pictures.
+ *
+ * Fewer than the six a page of tables holds, because the problems are wider:
+ * `3/4 + 5/6 =` is three times the sentence `7 × 8 =` is, and a problem that
+ * wraps is a row taller than the layout reserved for it.
+ */
+const MAX_COLUMNS = 4;
+const MAX_ART_COLUMNS = 3;
+
+/** Halves to twentieths. Beyond that a diagram is a bar with hairlines on it. */
+const MAX_DENOMINATOR = 20;
+
+/**
+ * How far an equivalent or simplified fraction may be scaled up, and how far
+ * the denominator it lands on may go.
+ *
+ * `3/4 = _/24` is a fair question; `3/4 = _/96` is arithmetic homework wearing
+ * a fraction's clothes. Both bounds are needed: the multiplier keeps the
+ * numbers a child can see, and the ceiling stops a pool of twelfths reaching
+ * sixtieths.
+ */
+const MAX_SCALE = 5;
+const MAX_SCALED_DENOMINATOR = 24;
+
+/** The whole numbers in front of a mixed number: `2 1/4`, never `17 1/4`. */
+const MAX_WHOLE = 3;
+
+/** As `arithmetic.ts` — see the note there on why a budget rather than a proof. */
+const MISS_BUDGET = 500;
+
+const SIGN = {
+  add: "+",
+  subtract: "−",
+  multiply: "×",
+  divide: "÷",
+} as const;
+
+/* ── The pool ──────────────────────────────────────────────────────────────
+   Sanitised once and drawn from many times, because it comes from outside this
+   build: a config in a bookmarked URL may name a denominator twice, a
+   fractional one, or a nought — and a nought is not a slow sheet, it is a
+   division by zero.                                                          */
+
+/** Whole, at least two, in range, deduplicated and in order. */
+function denominatorsOf(config: FractionConfig): number[] {
+  const clean = (config.denominators ?? [])
+    .map((value) => Math.floor(value))
+    .filter((value) => Number.isFinite(value) && value >= 2)
+    .map((value) => Math.min(MAX_DENOMINATOR, value));
+  return [...new Set(clean)].sort((a, b) => a - b);
+}
+
+const pick = <T>(items: T[], rand: () => number): T =>
+  items[Math.floor(rand() * items.length)];
+
+/* ── Drawing a problem ─────────────────────────────────────────────────────
+   Each style draws its own shape and they have little in common — a picture, a
+   pair with a gap in it, a fraction to cancel down, a sum — so each returns the
+   same three answers instead: what it reads, what the answer is, and what makes
+   two of them the same problem.                                              */
+
+type Drawn = { key: string; prompt: string; answer: string; art?: FractionArt };
+
+/**
+ * A proper fraction over `d`, already in lowest terms — or `null`.
+ *
+ * The rejection is the point rather than a cost. Every style here needs a
+ * fraction whose value has exactly one right way of being written: a naming
+ * picture of `4/8` could be answered `4/8` or `1/2` and a child would be marked
+ * wrong for the one the adult didn't think of, and `8/12` scaled up for a
+ * simplifying sheet is a fraction whose "lowest terms" are not what the sheet
+ * meant either.
+ */
+function properOver(d: number, rand: () => number): Fraction | null {
+  const n = between(1, d - 1, rand);
+  return gcd(n, d) === 1 ? { n, d } : null;
+}
+
+/** A picture with some of its parts shaded, and the fraction that names it. */
+function drawIdentify(
+  config: FractionConfig,
+  pool: number[],
+  rand: () => number,
+): Drawn | null {
+  const model = config.model ?? "bar";
+  // The coin is spent only when the config asks for both, exactly as the other
+  // families short-circuit theirs: a draw that took one anyway would shift
+  // every subsequent problem, and every seed a parent had already printed would
+  // produce a different sheet.
+  const shape = model === "both" ? (rand() < 0.5 ? "bar" : "circle") : model;
+  const value = properOver(pick(pool, rand), rand);
+  if (value === null) return null;
+  return {
+    // Folded on the value rather than on the picture: a bar showing three
+    // quarters and a circle showing three quarters are one question asked
+    // twice, and a child notices that faster than the adult who printed it.
+    key: `identify:${value.n}:${value.d}`,
+    prompt: "",
+    answer: writeFraction(value, false),
+    art: fractionArt(shape, value.d, value.n),
+  };
+}
+
+/**
+ * The same value written over a bigger denominator, with one of the four
+ * numbers missing: `3/4 = _/12`, or `3/4 = 9/_`.
+ *
+ * Which number is blank is drawn, because a sheet that always blanked the
+ * numerator would teach a child to multiply the top and never ask them why.
+ */
+function drawEquivalent(pool: number[], rand: () => number): Drawn | null {
+  const value = properOver(pick(pool, rand), rand);
+  const by = between(2, MAX_SCALE, rand);
+  const top = rand() < 0.5;
+  if (value === null || value.d * by > MAX_SCALED_DENOMINATOR) return null;
+  const scaled = { n: value.n * by, d: value.d * by };
+  return {
+    key: `equivalent:${value.n}:${value.d}:${by}:${top ? "n" : "d"}`,
+    prompt: top
+      ? `${value.n}/${value.d} = _/${scaled.d}`
+      : `${value.n}/${value.d} = ${scaled.n}/_`,
+    answer: String(top ? scaled.n : scaled.d),
+  };
+}
+
+/** A fraction with something left to cancel, and what it cancels down to. */
+function drawSimplify(pool: number[], rand: () => number): Drawn | null {
+  const value = properOver(pick(pool, rand), rand);
+  const by = between(2, MAX_SCALE, rand);
+  if (value === null || value.d * by > MAX_SCALED_DENOMINATOR) return null;
+  return {
+    key: `simplify:${value.n * by}:${value.d * by}`,
+    // Scaled up from a fraction already in lowest terms, so what the sheet
+    // asks for is what `reduced` would answer and there is no second opinion.
+    prompt: `${value.n * by}/${value.d * by} =`,
+    answer: writeFraction(value, false),
+  };
+}
+
+/** Which way round an `either` sheet's problem reads. */
+function operationOf(
+  operation: FractionOperation,
+  rand: () => number,
+): Exclude<FractionOperation, "both"> {
+  if (operation !== "both") return operation;
+  return rand() < 0.5 ? "add" : "subtract";
+}
+
+/**
+ * One operand: a proper fraction, with a whole number in front of it when the
+ * sheet is a mixed-number sheet.
+ */
+function operandOf(
+  d: number,
+  mixed: boolean,
+  rand: () => number,
+): Fraction | null {
+  const part = properOver(d, rand);
+  if (part === null) return null;
+  return mixed ? plus(whole(between(1, MAX_WHOLE, rand)), part) : part;
+}
+
+/** A sum, a difference, a product or a quotient of two fractions. */
+function drawArithmetic(
+  config: FractionConfig,
+  pool: number[],
+  rand: () => number,
+): Drawn | null {
+  const operation = operationOf(config.operation, rand);
+  const pairing: Denominators = config.pairing ?? "either";
+  const mixed = config.mixed === true;
+
+  const first = pick(pool, rand);
+  // Like denominators take no second draw at all, which is what keeps a `like`
+  // sheet and an `unlike` sheet from being the same sheet with two problems
+  // swapped: they are different questions, drawn differently.
+  const second = pairing === "like" ? first : pick(pool, rand);
+  if (pairing === "unlike" && first === second) return null;
+
+  const left = operandOf(first, mixed, rand);
+  const right = operandOf(second, mixed, rand);
+  if (left === null || right === null) return null;
+
+  const pair = order(operation, left, right);
+  if (pair === null) return null;
+  const [a, b] = pair;
+
+  const answer = ANSWER[operation](a, b);
+  const written = [writeFraction(a, mixed), writeFraction(b, mixed)];
+  return {
+    // Addition and multiplication fold — `1/2 + 1/3` and `1/3 + 1/2` are one
+    // problem — while subtraction and division do not, which is the same
+    // distinction `masteryKey` and `drillKey` draw for the race.
+    key: FOLDS[operation]
+      ? `${operation}:${[...written].sort().join(":")}`
+      : `${operation}:${written.join(":")}`,
+    prompt: `${written[0]} ${SIGN[operation]} ${written[1]} =`,
+    answer: writeFraction(answer, mixed),
+  };
+}
+
+const ANSWER: Record<
+  Exclude<FractionOperation, "both">,
+  (a: Fraction, b: Fraction) => Fraction
+> = { add: plus, subtract: minus, multiply: times, divide: over };
+
+const FOLDS: Record<Exclude<FractionOperation, "both">, boolean> = {
+  add: true,
+  subtract: false,
+  multiply: true,
+  divide: false,
+};
+
+/**
+ * The two operands in the order they are printed, or `null` when the pair makes
+ * no problem.
+ *
+ * Nothing in the Print Shop prints a negative fraction, so a difference is
+ * written larger first — the same bargain the arithmetic family strikes with
+ * its subtraction, and for the same reason: rejecting half the draws instead
+ * would halve the pool for no gain. A difference of nothing is thrown away
+ * rather than turned round, because `3/4 − 3/4` is a question that answers
+ * itself.
+ */
+function order(
+  operation: Exclude<FractionOperation, "both">,
+  left: Fraction,
+  right: Fraction,
+): [Fraction, Fraction] | null {
+  if (operation !== "subtract") return [left, right];
+  const difference = left.n * right.d - right.n * left.d;
+  if (difference === 0) return null;
+  return difference > 0 ? [left, right] : [right, left];
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/**
+ * How tall the picture on a naming sheet stands.
+ *
+ * Measured through `artHeight` rather than from a number of its own, because
+ * the renderer sizes the drawing with the same function: a second copy of "how
+ * tall is a circle" here would be a reservation that agrees with the drawing
+ * until somebody changes one of them.
+ *
+ * A circle is taller than a bar, and a `both` sheet reserves for the taller of
+ * the two — the row height is one number for the whole grid of them.
+ */
+function artRow(config: FractionConfig): Mil {
+  const shape = (config.model ?? "bar") === "bar" ? "bar" : "circle";
+  return artHeight({ shape, parts: 1, shaded: 0 });
+}
+
+/** How tall one problem stands, picture and working space and all. */
+function rowHeight(config: FractionConfig): Mil {
+  // A naming problem is its picture and a ruled blank, and the blank is
+  // reserved as a second line for the reason above: a bar and a blank do not
+  // fit across a third of a page, so the row is the drawing, the wrap, and the
+  // line the answer is written on.
+  const body =
+    config.style === "identify"
+      ? artRow(config) + WRAP_GAP + answerLine(config.fontPt)
+      : writtenRow(config.fontPt);
+  return body + (config.workspace ? WORKSPACE : 0);
+}
+
+/**
+ * How many problems the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic, not measurement, so `npm run test:unit` can answer "did it fit?"
+ * without a browser — and so the same answer serves the catalog page built at
+ * build time and the builder's preview (§4).
+ */
+export function fractionLayout(config: FractionConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of them.
+  const box = sheetBlockBox(headerOf(config), true);
+  const most = config.style === "identify" ? MAX_ART_COLUMNS : MAX_COLUMNS;
+  const columns = clamp(config.columns, 1, most);
+  const row = rowHeight(config);
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
+  };
+}
+
+/**
+ * Every problem on the sheet, in the order they are printed.
+ *
+ * Exported because it is the whole of what a test has to check, and checking it
+ * through the `Sheet` means unwrapping a block union to reach it.
+ */
+export function fractionProblems(
+  config: FractionConfig,
+  seed: number,
+): Problem[] {
+  const { perPage } = fractionLayout(config);
+  // The count is a request, not a promise: a count that overruns is a second
+  // sheet out of the printer with two problems on it.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  const pool = denominatorsOf(config);
+  const seen = new Set<string>();
+  const problems: Problem[] = [];
+  const extras = config.workspace ? { workspace: WORKSPACE } : {};
+  if (pool.length === 0) return problems;
+
+  let misses = 0;
+  while (problems.length < wanted && misses < MISS_BUDGET) {
+    const drawn = drawOne(config, pool, rand);
+    // Not what was asked for, or already on the page. Either way the budget
+    // ticks down, and a pool that has run out ends the draw rather than
+    // repeating itself: halves, thirds and quarters make eleven naming
+    // problems, and eleven is the honest answer to a request for twenty.
+    if (drawn === null || seen.has(drawn.key)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(drawn.key);
+    problems.push({
+      prompt: drawn.prompt,
+      answer: drawn.answer,
+      ...(drawn.art ? { art: drawn.art } : {}),
+      ...extras,
+    });
+    misses = 0;
+  }
+  return problems;
+}
+
+function drawOne(
+  config: FractionConfig,
+  pool: number[],
+  rand: () => number,
+): Drawn | null {
+  switch (config.style) {
+    case "identify":
+      return drawIdentify(config, pool, rand);
+    case "equivalent":
+      return drawEquivalent(pool, rand);
+    case "simplify":
+      return drawSimplify(pool, rand);
+    default:
+      return drawArithmetic(config, pool, rand);
+  }
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const OPERATION_NAME = {
+  add: "Adding",
+  subtract: "Subtracting",
+  multiply: "Multiplying",
+  divide: "Dividing",
+  both: "Adding and subtracting",
+} as const;
+
+/** Whether like and unlike denominators are a question this sheet answers. */
+const takesDenominators = (config: FractionConfig): boolean =>
+  config.style === "arithmetic" &&
+  config.operation !== "multiply" &&
+  config.operation !== "divide";
+
+/**
+ * "Adding fractions with unlike denominators" — the phrase a parent says out
+ * loud, and the one they type into a search box.
+ *
+ * A mixed-number sheet says so in the noun rather than in a qualifier, because
+ * that is what it is called: nobody searches for "adding fractions with whole
+ * numbers in front".
+ */
+function titleOf(config: FractionConfig): string {
+  switch (config.style) {
+    case "identify":
+      return "Naming fractions";
+    case "equivalent":
+      return "Equivalent fractions";
+    case "simplify":
+      return "Simplifying fractions";
+    default: {
+      const noun = config.mixed ? "mixed numbers" : "fractions";
+      const name = `${OPERATION_NAME[config.operation]} ${noun}`;
+      const pairing = config.pairing ?? "either";
+      return takesDenominators(config) && pairing !== "either"
+        ? `${name} with ${pairing} denominators`
+        : name;
+    }
+  }
+}
+
+const INSTRUCTION: Record<FractionStyle, string> = {
+  identify: "Write the fraction each picture shows.",
+  equivalent: "Write the missing number in each blank.",
+  simplify: "Write each fraction in its lowest terms.",
+  arithmetic: "Work out each answer and write it in its lowest terms.",
+};
+
+function instructionOf(config: FractionConfig): string {
+  const said = INSTRUCTION[config.style] ?? INSTRUCTION.arithmetic;
+  // Said on the sheet rather than assumed, because it is the difference
+  // between a right answer and a wrong one: a child who writes `7/6` on a
+  // mixed-number sheet has answered the question nobody asked.
+  return config.style === "arithmetic" && config.mixed
+    ? `${said} Write anything over one as a mixed number.`
+    : said;
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: FractionConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions: config.instructions ?? instructionOf(config),
+  };
+}
+
+const MODEL_NAME = {
+  bar: "fraction bars",
+  circle: "fraction circles",
+  both: "bars and circles",
+} as const;
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * The two things the title leaves off are the two that decide whether a sheet
+ * matches the lesson: which pictures a naming sheet draws, and how far up the
+ * denominators go.
+ */
+export function describeFractions(config: FractionConfig): string {
+  const pool = denominatorsOf(config);
+  return [
+    titleOf(config),
+    config.style === "identify"
+      ? MODEL_NAME[config.model ?? "bar"]
+      : pool.length > 0
+        ? `denominators to ${pool[pool.length - 1]}`
+        : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" — ");
+}
+
+export function buildFractionSheet(
+  config: FractionConfig,
+  seed: number,
+): Sheet {
+  const items = fractionProblems(config, seed);
+  const { columns } = fractionLayout(config);
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is actually on the page, not out of what was asked for: a
+      // sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf: items.length },
+    },
+    blocks: [{ kind: "problems", columns, items }],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const FRACTIONS_SHEET: SheetSpec<FractionConfig> = {
+  id: "fractions",
+  label: "Fractions",
+  world: SHEET_WORLD,
+  build: buildFractionSheet,
+  // The whole of the answer-key mechanism: every answer on the page was reduced
+  // when the problem was built, so a key prints what is already there rather
+  // than reducing a second time and risking a different answer to the same
+  // question.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeFractions,
+};

--- a/src/engine/sheets/maths/money.test.ts
+++ b/src/engine/sheets/maths/money.test.ts
@@ -203,6 +203,14 @@ describe("the money family", () => {
   it("tells a child to keep the points in line when the sums are stacked", () => {
     expect(buildSheet(config({ form: "vertical" }), 1).header.instructions) //
       .toBe("Work out each answer. Keep the points under one another.");
+    // Except on a stacked multiplication, where there is no second point to
+    // line the first one up on — `$1.25 × 3` stacks an amount over a count.
+    expect(
+      buildSheet(config({ form: "vertical", operation: "multiply" }), 1).header
+        .instructions,
+    ).toBe(
+      "Work out each answer. Line the digits up on the right, then put the point back in.",
+    );
   });
 });
 

--- a/src/engine/sheets/maths/money.test.ts
+++ b/src/engine/sheets/maths/money.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { PROBLEM_GAP } from "../layout";
+import type {
+  Currency,
+  MarginSize,
+  MoneyConfig,
+  Paper,
+  PaperSize,
+  Problem,
+} from "../types";
+
+import { CURRENCIES, MONEY_SHEET, currencyOf, moneyLayout } from "./money";
+
+/**
+ * Money, held to the bar the maths families set.
+ *
+ * **Nothing here checks the generator against the generator.** Every answer is
+ * verified from the *printed* problem by a path the family does not use: an
+ * amount is read back as **a whole number of the smallest coin**, taken off the
+ * digits either side of the point, and the sentence is checked in that coin —
+ * with a product checked by **repeated addition**, which is what buying three
+ * of something is. The family works in pence too, but it never parses anything:
+ * a misplaced point, a dropped trailing zero or a symbol on the wrong side all
+ * survive its arithmetic and fail here.
+ *
+ * The shape of the printed amount is held as tightly as its value, because on a
+ * money sheet the shape *is* the value: `$6.5` is not an amount of money, and
+ * `$6.50` written as `6.5` is what a family formatting with `toString` would
+ * print.
+ */
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const config = (over: Partial<MoneyConfig> = {}): MoneyConfig => ({
+  kind: "money",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  currency: "usd",
+  operation: "add",
+  form: "horizontal",
+  range: { min: 0, max: 20 },
+  count: 12,
+  columns: 2,
+  ...over,
+});
+
+const EVERY_CURRENCY: Currency[] = ["usd", "gbp", "eur"];
+
+/**
+ * Every shape the family can print, which is every acceptance criterion of the
+ * story: amounts added, taken away and bought several of, along a line and in
+ * columns, in each of the three currencies.
+ */
+const EVERY_SHAPE: Array<Partial<MoneyConfig>> = [
+  {},
+  { form: "vertical" },
+  { operation: "subtract" },
+  { operation: "subtract", form: "vertical" },
+  { operation: "both" },
+  { operation: "both", form: "vertical" },
+  { operation: "multiply" },
+  { operation: "multiply", form: "vertical" },
+  { currency: "gbp" },
+  { currency: "gbp", operation: "both" },
+  { currency: "eur" },
+  { currency: "eur", operation: "multiply" },
+  // Small change only, which is where the pool gets thin and the draw has to
+  // stop rather than repeat itself.
+  { range: { min: 0, max: 1 }, count: 8 },
+  { range: { min: 5, max: 50 }, count: 10 },
+  { workspace: true, count: 8 },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** The one block a money sheet has, narrowed for the reader. */
+function problemsOf(over: Partial<MoneyConfig>, seed: number): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+/* ── Reading a sheet the way a child does ────────────────────────────────── */
+
+/** Every symbol the shop can print, so a stray one is a stray one. */
+const SYMBOLS = EVERY_CURRENCY.map((id) => CURRENCIES[id].symbol);
+
+/**
+ * An amount as it is printed, read back as a whole number of the smallest coin.
+ *
+ * The digits are counted rather than the number parsed. `Number("3.45") * 100`
+ * is 344.99999999999994, which is the whole reason this family holds amounts in
+ * pence — and a test that reached for it would be the one place the floats got
+ * back in.
+ */
+function pence(text: string): number {
+  const written = text.trim();
+  const match = /^(.)(\d+)\.(\d\d)$/.exec(written);
+  if (!match) throw new Error(`not an amount: "${text}"`);
+  if (!SYMBOLS.includes(match[1])) throw new Error(`not money: "${text}"`);
+  return Number(match[2]) * 100 + Number(match[3]);
+}
+
+/** `a` added to itself `b` times — what buying three of something is. */
+function repeated(a: number, b: number): number {
+  let total = 0;
+  for (let step = 0; step < b; step += 1) total += a;
+  return total;
+}
+
+/** The problem, written out in full with its answer put where it belongs. */
+function sentence(problem: Problem): string {
+  if (problem.operands) {
+    return `${problem.operands.join(` ${problem.operator} `)} = ${problem.answer}`;
+  }
+  return `${problem.prompt} ${problem.answer}`;
+}
+
+/** Whether a written sentence is true, counted in the smallest coin there is. */
+function holds(written: string): boolean {
+  const worked = /^(\S+) ([+−×]) (\S+) = (\S+)$/.exec(written.trim());
+  if (!worked) throw new Error(`not a money sentence: "${written}"`);
+  const [, left, sign, right, answer] = worked;
+  if (sign === "×") {
+    // The count is a plain number rather than an amount: `$1.25 × $3` is not a
+    // thing anybody can buy.
+    if (!/^\d+$/.test(right)) return false;
+    return repeated(pence(left), Number(right)) === pence(answer);
+  }
+  const total = pence(answer);
+  return sign === "+"
+    ? pence(left) + pence(right) === total
+    : pence(left) - pence(right) === total;
+}
+
+/** Every amount printed on a problem, prompt and answer alike. */
+function amountsOn(problem: Problem): string[] {
+  return sentence(problem)
+    .split(/[\s=+−×]+/)
+    .filter((word) => SYMBOLS.some((symbol) => word.startsWith(symbol)));
+}
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the money family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("money")).toBe(MONEY_SHEET);
+    expect(sheetSpec("money").label).toBe("Money");
+  });
+
+  it("names the sheet in the words the country it is for uses", () => {
+    // Not decoration: "adding pounds and pence" and "adding dollars and cents"
+    // are two different searches, and a parent types the one their child says.
+    expect(describeSheet(config())).toBe("Adding dollars and cents — to $20");
+    expect(describeSheet(config({ currency: "gbp" }))).toBe(
+      "Adding pounds and pence — to £20",
+    );
+    expect(
+      describeSheet(config({ currency: "eur", operation: "subtract" })),
+    ).toBe("Subtracting euros and cents — to €20");
+    expect(describeSheet(config({ operation: "both", form: "vertical" }))).toBe(
+      "Adding and subtracting dollars and cents — to $20 — in columns",
+    );
+    expect(describeSheet(config({ operation: "multiply" }))).toBe(
+      "Multiplying dollars and cents — to $20",
+    );
+  });
+
+  it("reads a currency this build has never heard of back safely", () => {
+    // `currency` arrives from outside this build — a bookmarked URL, a sheet
+    // saved before a fourth one was added — so the lookup has to answer rather
+    // than hand back `undefined` and print `undefined3.45`.
+    const stale = { ...config(), currency: "btc" as Currency };
+    expect(currencyOf(stale)).toBe(CURRENCIES.usd);
+    // And `toString` is the case a plain `??` fallback gets wrong: it resolves
+    // on Object.prototype, is truthy, and is not a currency.
+    expect(currencyOf({ ...config(), currency: "toString" as Currency })).toBe(
+      CURRENCIES.usd,
+    );
+  });
+
+  it("gives the sheet a title and a score box it can be marked against", () => {
+    const sheet = buildSheet(config({ currency: "gbp", count: 8 }), 3);
+    const block = sheet.blocks[0];
+    expect(sheet.header.title).toBe("Adding pounds and pence");
+    expect(sheet.header.instructions).toBe("Work out each answer.");
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+
+  it("tells a child to keep the points in line when the sums are stacked", () => {
+    expect(buildSheet(config({ form: "vertical" }), 1).header.instructions) //
+      .toBe("Work out each answer. Keep the points under one another.");
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("is right on every problem of every sheet this family can print", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+        for (const problem of problems) {
+          const written = sentence(problem);
+          expect(holds(written), `${JSON.stringify(shape)}: ${written}`) //
+            .toBe(true);
+        }
+      }
+    }
+  });
+
+  it("writes every amount with both its digits of change", () => {
+    // `$6.5` is not an amount of money, and it is exactly what a family that
+    // formatted its answer with `toString` would print — right value, wrong
+    // form, and useless to a child taught to line the points up.
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        for (const problem of problemsOf(shape, seed)) {
+          for (const amount of amountsOn(problem)) {
+            expect(amount, JSON.stringify(shape)).toMatch(/^.\d+\.\d\d$/);
+          }
+        }
+      }
+    }
+  });
+
+  it("prints one currency's symbol and no other's", () => {
+    for (const currency of EVERY_CURRENCY) {
+      const { symbol } = CURRENCIES[currency];
+      for (const seed of SEEDS) {
+        const problems = problemsOf({ currency, count: 8 }, seed);
+        expect(problems.length).toBeGreaterThan(0);
+        for (const problem of problems) {
+          const amounts = amountsOn(problem);
+          expect(amounts.length).toBeGreaterThan(0);
+          for (const amount of amounts) {
+            expect(amount.startsWith(symbol), `${currency}: ${amount}`) //
+              .toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    for (const shape of EVERY_SHAPE) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+});
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  it("never puts an amount outside the range a parent asked for", () => {
+    const ASKS = [
+      { min: 0, max: 1 },
+      { min: 1, max: 20 },
+      { min: 5, max: 50 },
+    ];
+    for (const range of ASKS) {
+      for (const operation of ["add", "subtract", "multiply"] as const) {
+        const problems = problemsOf({ range, operation, count: 8 }, 9);
+        expect(problems.length, JSON.stringify(range)).toBeGreaterThan(0);
+        for (const problem of problems) {
+          // The amounts a child *sees*, which is what a range promises: a total
+          // may run past the top of it, which is what carrying is.
+          const asked = problem.operands ?? problem.prompt.split(" ");
+          for (const word of asked) {
+            if (!SYMBOLS.some((symbol) => word.startsWith(symbol))) continue;
+            expect(pence(word)).toBeGreaterThan(0);
+            expect(pence(word)).toBeGreaterThanOrEqual(range.min * 100);
+            expect(pence(word)).toBeLessThanOrEqual(range.max * 100);
+          }
+        }
+      }
+    }
+  });
+
+  it("never hands back less than nothing", () => {
+    // No till does. A difference of nothing is thrown away too, because it
+    // answers itself.
+    for (const shape of [
+      { operation: "subtract" as const },
+      { operation: "both" as const },
+      { operation: "subtract" as const, form: "vertical" as const },
+    ]) {
+      for (const seed of SEEDS) {
+        for (const problem of problemsOf({ ...shape, count: 12 }, seed)) {
+          expect(problem.answer, sentence(problem)).not.toContain("-");
+          expect(pence(problem.answer), sentence(problem)).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("stacks a column sheet and writes a line sheet along the line", () => {
+    for (const problem of problemsOf({ form: "vertical", count: 6 }, 2)) {
+      expect(problem.operands?.length).toBe(2);
+      expect(problem.operator).toBe("+");
+      // No second copy of the sum written along a line for the two to disagree
+      // about — the stack is the prompt.
+      expect(problem.prompt).toBe("");
+    }
+    for (const problem of problemsOf({ count: 6 }, 2)) {
+      expect(problem.operands).toBeUndefined();
+      expect(problem.prompt).toMatch(/^\$\d+\.\d\d \+ \$\d+\.\d\d =$/);
+    }
+  });
+
+  it("asks the same question twice on no sheet at all", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const problems = problemsOf(shape, seed);
+        const asked = problems.map(sentence);
+        expect(new Set(asked).size, JSON.stringify(shape)).toBe(
+          problems.length,
+        );
+      }
+    }
+  });
+
+  it("prints nothing rather than something wrong when the ask is impossible", () => {
+    // A range with no money in it: every draw is nothing at all, which is not a
+    // question about money. An empty sheet is the honest answer, and the
+    // builder's job to prevent (PRINT13).
+    expect(problemsOf({ range: { min: 0, max: 0 } }, 1)).toEqual([]);
+  });
+});
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("draws the same amounts whatever currency they are printed in", () => {
+    // The currency is a symbol and a title, and nothing else. Three sheets that
+    // drew different sums would be three sheets, and "the same worksheet in
+    // pounds" would stop being true.
+    const inPence = (currency: Currency) =>
+      problemsOf({ currency, count: 8 }, 5).map((problem) =>
+        amountsOn(problem).map(pence),
+      );
+    expect(inPence("gbp")).toEqual(inPence("usd"));
+    expect(inPence("eur")).toEqual(inPence("usd"));
+  });
+
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    // The promise the footer makes: the seed is printed on the paper so a
+    // parent can have the same sheet again next week, across a deploy.
+    expect(
+      problemsOf({ operation: "both", count: 4 }, 4242).map((p) => [
+        p.prompt,
+        p.answer,
+      ]),
+    ).toEqual(GOLDEN.both);
+
+    expect(
+      problemsOf({ currency: "gbp", operation: "multiply", count: 4 }, 7).map(
+        (p) => [p.prompt, p.answer],
+      ),
+    ).toEqual(GOLDEN.pounds);
+  });
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    for (const shape of EVERY_SHAPE) {
+      const [a, b, c] = [0, 1, 2].map((offset) =>
+        problemsOf({ ...shape, count: 6 }, 100 + offset).map(sentence),
+      );
+      for (const [one, other] of [
+        [a, b],
+        [a, c],
+        [b, c],
+      ]) {
+        expect(one).not.toEqual(other);
+        const shared = one.filter((asked) => other.includes(asked)).length;
+        expect(shared, JSON.stringify(shape)).toBeLessThan(
+          (one.length * 2) / 3,
+        );
+      }
+    }
+  });
+});
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row } = moneyLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used = rows * row + Math.max(0, rows - 1) * PROBLEM_GAP.y;
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("does not throw the page away either", () => {
+    const { box, row, perPage, columns } = moneyLayout(config());
+    expect(perPage).toBeGreaterThanOrEqual(20);
+    const rows = perPage / columns;
+    expect((rows + 1) * row + rows * PROBLEM_GAP.y).toBeGreaterThan(box.height);
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ count: 10 }, 1).length).toBe(10);
+    expect(problemsOf({ count: 0 }, 1).length).toBe(0);
+    for (const columns of [1, 2, 3, 4]) {
+      const block = buildSheet(config({ columns }), 1).blocks[0];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+    const wide = buildSheet(config({ columns: 6 }), 1).blocks[0];
+    expect(wide.kind === "problems" && wide.columns).toBe(4);
+  });
+});
+
+/**
+ * What two sheets came out as on the day this shipped.
+ *
+ * Recorded rather than computed — both are proved right by the assertions
+ * above, and what these hold is that they do not silently *change*.
+ */
+const GOLDEN = {
+  both: [
+    ["$18.63 − $5.57 =", "$13.06"],
+    ["$13.38 − $5.76 =", "$7.62"],
+    ["$8.03 + $6.88 =", "$14.91"],
+    ["$15.09 − $14.63 =", "$0.46"],
+  ],
+  pounds: [
+    ["£0.23 × 2 =", "£0.46"],
+    ["£19.54 × 7 =", "£136.78"],
+    ["£10.43 × 5 =", "£52.15"],
+    ["£9.32 × 3 =", "£27.96"],
+  ],
+};

--- a/src/engine/sheets/maths/money.ts
+++ b/src/engine/sheets/maths/money.ts
@@ -1,0 +1,419 @@
+/**
+ * Money.
+ *
+ * A two-place decimal with a symbol in front of it, which is why this family is
+ * small: the values are the `Fixed` of `exact.ts` at two places, so £3.45 is 345
+ * pence from the moment it is drawn to the moment the point is written into it,
+ * and there is no arithmetic here that isn't whole-number arithmetic. A money
+ * sheet whose key says $6.500000000000001 is the failure this design exists to
+ * make impossible.
+ *
+ * **The currency is a switch, not a constant.** The same reason A4 is (§4): a
+ * British child counting dollars has been set a question about a foreign
+ * country, and the sheet is otherwise identical. It changes the symbol, the
+ * title — "Adding pounds and pence" is what that sheet is called and what a
+ * parent searches for — and nothing else, because the arithmetic of money is
+ * the same everywhere.
+ *
+ * The amount is written the way an English-language worksheet writes it: the
+ * symbol in front, a point between the units and the change. A euro sheet
+ * printed in Germany would want `5,00 €`, and that is a locale question rather
+ * than a currency one — it belongs with the day a sheet is printed in German.
+ *
+ * **Word problems are not here.** "Ella buys two apples at 45c" is PRINT09's
+ * templated set; this is the arithmetic underneath it, which a child has to be
+ * able to do before the words are a help rather than a second obstacle.
+ */
+import { between, mulberry32 } from "@/engine/random";
+
+import type {
+  Currency,
+  Mil,
+  MoneyConfig,
+  MoneyOperation,
+  Problem,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import {
+  PROBLEM_GAP,
+  WRAP_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches, own, points } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import {
+  fixed,
+  fixedText,
+  minusFixed,
+  plusFixed,
+  timesWhole,
+  type Fixed,
+} from "./exact";
+
+/* ── The currencies ────────────────────────────────────────────────────────
+   Three, and what each one calls its small change. The name is not decoration:
+   it is the title of the sheet, and "Adding pounds and pence" is a different
+   search from "Adding dollars and cents".                                    */
+
+export type CurrencySpec = {
+  id: Currency;
+  /** How it is offered in a picker. */
+  label: string;
+  symbol: string;
+  /** What the sheet is about, in the words that country uses. */
+  units: string;
+};
+
+export const CURRENCIES: Record<Currency, CurrencySpec> = {
+  usd: { id: "usd", label: "Dollars", symbol: "$", units: "dollars and cents" },
+  gbp: { id: "gbp", label: "Pounds", symbol: "£", units: "pounds and pence" },
+  eur: { id: "eur", label: "Euros", symbol: "€", units: "euros and cents" },
+};
+
+/**
+ * Two digits of change, in all three. Not a per-currency field, because a
+ * currency with a different number of them — yen has none — is a currency this
+ * family has not been taught to draw, and a config that named one would want
+ * more than a symbol changing.
+ */
+const PLACES = 2;
+
+/** Resolves a currency. Never throws — a saved config may name a fourth one. */
+export const currencyOf = (config: MoneyConfig): CurrencySpec =>
+  own(CURRENCIES, config.currency, CURRENCIES.usd);
+
+/* ── What a problem takes on the page ─────────────────────────────────────
+   Declared, not measured (§4), and the same two shapes an addition sheet has:
+   a sentence along a line, or the numbers stacked with a rule under them.    */
+
+const STACK_EMS = 4.4;
+
+/**
+ * How tall a problem written along a line stands: two lines of the body type,
+ * and the air a wrap puts between them.
+ *
+ * Two rather than one, because `$13.47 + $8.06 =` with a ruled blank after it
+ * is a wide sentence, and `.sheet__problem` wraps rather than overflowing — so
+ * the second line is either inside the row the layout declared, or it is the
+ * bottom of the page coming out of the printer on a second sheet.
+ */
+const writtenRow = (fontPt: number): Mil => 2 * answerLine(fontPt) + WRAP_GAP;
+
+/** Blank space to work an amount out in, when the config asks for it. */
+const WORKSPACE = inches(0.55);
+
+/** Four columns. `$13.47 + $8.06 =` is a wide sentence. */
+const MAX_COLUMNS = 4;
+
+/** How many of a thing a child is asked to buy. */
+const MULTIPLIER = { min: 2, max: 9 };
+
+/** As `arithmetic.ts` — see the note there on why a budget rather than a proof. */
+const MISS_BUDGET = 500;
+
+const SIGN = { add: "+", subtract: "−", multiply: "×" } as const;
+
+/* ── Drawing an amount ─────────────────────────────────────────────────── */
+
+function bounds(range: { min: number; max: number }): {
+  min: number;
+  max: number;
+} {
+  const min = Math.max(0, Math.floor(range?.min ?? 0));
+  return { min, max: Math.max(min, Math.floor(range?.max ?? 0)) };
+}
+
+/**
+ * One amount, drawn in the smallest coin there is.
+ *
+ * The range is in whole units — a parent asks for "amounts up to ten pounds" —
+ * and the draw is over the pence inside it, so every amount between £0.01 and
+ * £10.00 can come up rather than the ten round ones. Nothing is ever nothing:
+ * `$0.00 + $3.45` is not a question about money.
+ */
+function drawAmount(config: MoneyConfig, rand: () => number): Fixed | null {
+  const { min, max } = bounds(config.range);
+  const units = between(min * 100, max * 100, rand);
+  return units > 0 ? fixed(units, PLACES) : null;
+}
+
+/** An amount as it is printed: the symbol, then two digits of change. */
+const amountText = (money: CurrencySpec, value: Fixed): string =>
+  `${money.symbol}${fixedText(value)}`;
+
+/* ── Drawing a problem ─────────────────────────────────────────────────── */
+
+type Drawn = {
+  key: string;
+  prompt: string;
+  answer: string;
+  operands?: string[];
+  operator?: string;
+};
+
+/** Which way round an `either` sheet's problem reads. */
+function operationOf(
+  operation: MoneyOperation,
+  rand: () => number,
+): Exclude<MoneyOperation, "both"> {
+  if (operation !== "both") return operation;
+  return rand() < 0.5 ? "add" : "subtract";
+}
+
+function drawProblem(config: MoneyConfig, rand: () => number): Drawn | null {
+  const money = currencyOf(config);
+  const operation = operationOf(config.operation, rand);
+  const left = drawAmount(config, rand);
+  if (left === null) return null;
+
+  if (operation === "multiply") {
+    // How many of a thing, so the count is a plain number and only the price
+    // carries a symbol: `$1.25 × 3` is three of them, and `$1.25 × $3` is not
+    // an amount of money at all.
+    const by = between(MULTIPLIER.min, MULTIPLIER.max, rand);
+    return written(
+      config,
+      operation,
+      [amountText(money, left), String(by)],
+      amountText(money, timesWhole(left, by)),
+    );
+  }
+
+  const right = drawAmount(config, rand);
+  if (right === null) return null;
+  if (operation === "add") {
+    return written(
+      config,
+      operation,
+      [amountText(money, left), amountText(money, right)],
+      amountText(money, plusFixed(left, right)),
+    );
+  }
+
+  // No till hands back less than nothing, so the larger amount goes on top —
+  // the same bargain the arithmetic family strikes with its subtraction. A
+  // difference of nothing is thrown away, because it answers itself.
+  if (left.units === right.units) return null;
+  const [top, bottom] =
+    left.units > right.units ? [left, right] : [right, left];
+  return written(
+    config,
+    operation,
+    [amountText(money, top), amountText(money, bottom)],
+    amountText(money, minusFixed(top, bottom)),
+  );
+}
+
+/**
+ * A problem written the way the config asks: along a line, or stacked.
+ *
+ * Stacked is worth more on a money sheet than anywhere else: every amount has
+ * two digits of change, so right-aligning them in `tabular-nums` puts the
+ * points — and the pence — in a column with nothing having to align them.
+ */
+function written(
+  config: MoneyConfig,
+  operation: Exclude<MoneyOperation, "both">,
+  operands: string[],
+  answer: string,
+): Drawn {
+  const sign = SIGN[operation];
+  // Addition folds — `$1.40 + $0.25` and `$0.25 + $1.40` are one problem —
+  // while a difference and a multiple do not.
+  const key =
+    operation === "add"
+      ? `${operation}:${[...operands].sort().join(":")}`
+      : `${operation}:${operands.join(":")}`;
+  if (config.form === "vertical") {
+    return { key, prompt: "", operands, operator: sign, answer };
+  }
+  return { key, prompt: `${operands[0]} ${sign} ${operands[1]} =`, answer };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/** How tall one problem stands, working space and all. */
+function rowHeight(config: MoneyConfig): Mil {
+  // A stack is one flex item and cannot wrap, so it is reserved for as what it
+  // is: two amounts, a rule and the answer under it.
+  const body =
+    config.form === "vertical"
+      ? points(config.fontPt * STACK_EMS)
+      : writtenRow(config.fontPt);
+  return body + (config.workspace ? WORKSPACE : 0);
+}
+
+/**
+ * How many problems the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic, not measurement, so `npm run test:unit` can answer "did it fit?"
+ * without a browser — and so the same answer serves the catalog page built at
+ * build time and the builder's preview (§4).
+ */
+export function moneyLayout(config: MoneyConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of them.
+  const box = sheetBlockBox(headerOf(config), true);
+  const columns = clamp(config.columns, 1, MAX_COLUMNS);
+  const row = rowHeight(config);
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
+  };
+}
+
+/**
+ * Every problem on the sheet, in the order they are printed.
+ *
+ * Exported because it is the whole of what a test has to check, and checking it
+ * through the `Sheet` means unwrapping a block union to reach it.
+ */
+export function moneyProblems(config: MoneyConfig, seed: number): Problem[] {
+  const { perPage } = moneyLayout(config);
+  // The count is a request, not a promise: a count that overruns is a second
+  // sheet out of the printer with two problems on it.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  const seen = new Set<string>();
+  const problems: Problem[] = [];
+  const extras = config.workspace ? { workspace: WORKSPACE } : {};
+
+  let misses = 0;
+  while (problems.length < wanted && misses < MISS_BUDGET) {
+    const drawn = drawProblem(config, rand);
+    // Not what was asked for, or already on the page. Either way the budget
+    // ticks down, and a pool that has run out ends the draw rather than
+    // repeating itself: amounts up to ten cents are nine problems, and nine is
+    // the honest answer to a request for twenty.
+    if (drawn === null || seen.has(drawn.key)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(drawn.key);
+    problems.push({
+      prompt: drawn.prompt,
+      answer: drawn.answer,
+      ...(drawn.operands
+        ? { operands: drawn.operands, operator: drawn.operator }
+        : {}),
+      ...extras,
+    });
+    misses = 0;
+  }
+  return problems;
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const OPERATION_NAME = {
+  add: "Adding",
+  subtract: "Subtracting",
+  multiply: "Multiplying",
+  both: "Adding and subtracting",
+} as const;
+
+/** "Adding pounds and pence" — the phrase that country says, and searches. */
+function titleOf(config: MoneyConfig): string {
+  const name = OPERATION_NAME[config.operation] ?? OPERATION_NAME.add;
+  return `${name} ${currencyOf(config).units}`;
+}
+
+function instructionOf(config: MoneyConfig): string {
+  return config.form === "vertical"
+    ? "Work out each answer. Keep the points under one another."
+    : "Work out each answer.";
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: MoneyConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions: config.instructions ?? instructionOf(config),
+  };
+}
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * The two things the title leaves off are how big the amounts get and whether
+ * they are stacked — which is the difference between a sheet a child adds in
+ * their head and one they work in columns.
+ */
+export function describeMoney(config: MoneyConfig): string {
+  const money = currencyOf(config);
+  const { max } = bounds(config.range);
+  return [
+    titleOf(config),
+    `to ${money.symbol}${max}`,
+    config.form === "vertical" ? "in columns" : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" — ");
+}
+
+export function buildMoneySheet(config: MoneyConfig, seed: number): Sheet {
+  const items = moneyProblems(config, seed);
+  const { columns } = moneyLayout(config);
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is actually on the page, not out of what was asked for: a
+      // sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf: items.length },
+    },
+    blocks: [{ kind: "problems", columns, items }],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const MONEY_SHEET: SheetSpec<MoneyConfig> = {
+  id: "money",
+  label: "Money",
+  world: SHEET_WORLD,
+  build: buildMoneySheet,
+  // The whole of the answer-key mechanism: every answer on the page was
+  // computed in whole pence when the problem was built, so a key prints what is
+  // already there rather than working it out a second time.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeMoney,
+};

--- a/src/engine/sheets/maths/money.ts
+++ b/src/engine/sheets/maths/money.ts
@@ -338,9 +338,15 @@ function titleOf(config: MoneyConfig): string {
 }
 
 function instructionOf(config: MoneyConfig): string {
-  return config.form === "vertical"
-    ? "Work out each answer. Keep the points under one another."
-    : "Work out each answer.";
+  if (config.form !== "vertical") return "Work out each answer.";
+  // Stacked amounts line up on the point, because every one of them has two
+  // digits of change. A multiplier does not: `$1.25 × 3` is three of them, and
+  // the `3` has no point to put under anything — so the stacking sentence would
+  // describe a column that isn't there, and §10 makes this line the whole of
+  // the guidance a child gets.
+  return config.operation === "multiply"
+    ? "Work out each answer. Line the digits up on the right, then put the point back in."
+    : "Work out each answer. Keep the points under one another.";
 }
 
 /**

--- a/src/engine/sheets/paper.ts
+++ b/src/engine/sheets/paper.ts
@@ -50,8 +50,13 @@ export const toPoints = (mil: Mil): number => (mil * 72) / MIL_PER_INCH;
  * `??` never fires and the caller is handed a function where it expected a
  * stock or a pitch. Nothing throws at that point; the lengths computed from it
  * just quietly become `NaN`. Asking for an *own* property is the whole fix.
+ *
+ * Exported because the hazard is not about paper. Every table in the shop that
+ * is keyed by something a saved config carries has it — the currencies in
+ * `maths/money.ts` are the second — and a second copy of this three-line
+ * function would be a second place for somebody to write the `??` instead.
  */
-function own<T>(table: Record<string, T>, key: string, fallback: T): T {
+export function own<T>(table: Record<string, T>, key: string, fallback: T): T {
   return Object.hasOwn(table, key) ? table[key] : fallback;
 }
 

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -117,6 +117,27 @@ export type NumberLine = {
   width: Mil;
 };
 
+/**
+ * A whole cut into equal parts, some of them shaded.
+ *
+ * The picture a fraction is taught from before it is a pair of numbers, and the
+ * only thing on a maths sheet that is a drawing rather than a sentence. Two
+ * numbers and a shape is the whole of it: how many equal parts the whole was cut
+ * into, and how many of them are filled in.
+ *
+ * How big it is drawn is deliberately not here. `fractionart.ts` is the one
+ * place a bar's width and a circle's diameter are written down, so the height a
+ * family reserves for the row and the height the renderer draws cannot disagree
+ * (§4) — the same bargain `NumberLine` makes by declaring its width.
+ */
+export type FractionArt = {
+  shape: "bar" | "circle";
+  /** How many equal parts the whole is cut into — the denominator. */
+  parts: number;
+  /** How many of them are shaded — the numerator. */
+  shaded: number;
+};
+
 export type Problem = {
   /**
    * How it reads on the sheet: "7 × 8 =".
@@ -201,6 +222,18 @@ export type Problem = {
    * turns them into problems without either side learning the other's shape.
    */
   factId?: string;
+  /**
+   * A fraction diagram beside the problem: a bar or a circle with some of its
+   * parts shaded in.
+   *
+   * On a naming sheet this *is* the question — the child reads the picture and
+   * writes the fraction — so it prints on the blank sheet as well as on the key,
+   * exactly as a column stack does. Which is why it is shaded with an SVG fill
+   * rather than with a CSS background: background paint is what a browser drops
+   * when printing (§5), and a naming sheet whose pictures came out as empty
+   * boxes asks a question that isn't there.
+   */
+  art?: FractionArt;
   /** A number line under the problem, to count along. */
   line?: NumberLine;
   /** Blank height under the problem for working out. Absent means none. */
@@ -526,9 +559,149 @@ export type MultiplicationConfig = SheetOptions & {
   workspace?: boolean;
 };
 
+/* ── Fractions ─────────────────────────────────────────────────────────────
+   The first family whose answer is not a number a child can count to. Every
+   sheet above this line is marked by reading a total; a fraction is two numbers
+   that mean one value, several pairs mean the same value, and only one of those
+   pairs is the answer — so "right" here includes "in its lowest terms".       */
+
+/**
+ * What the sheet asks for.
+ *
+ * `identify` shows a picture and asks what fraction is shaded; `equivalent`
+ * gives one pair and half of another; `simplify` asks for the same value
+ * written the smallest way; `arithmetic` is the four operations.
+ */
+export type FractionStyle =
+  "identify" | "equivalent" | "simplify" | "arithmetic";
+
+/**
+ * Which operation is on the page. `both` is addition and subtraction shuffled
+ * together — the pair a child meets in one lesson. Multiplying and dividing
+ * fractions is a different lesson, and a different sheet.
+ */
+export type FractionOperation =
+  "add" | "subtract" | "multiply" | "divide" | "both";
+
+/**
+ * Whether the two fractions in a problem share a denominator.
+ *
+ * The switch this family turns on, the way regrouping is the switch on an
+ * addition sheet: adding halves to quarters is a different week's work from
+ * adding quarters to quarters, and a sheet that mixed them would be set at a
+ * level nobody chose. `either` is whatever the draw happens to give.
+ */
+export type Denominators = "like" | "unlike" | "either";
+
+/** Which picture a naming sheet draws. `both` shuffles the two together. */
+export type FractionModel = "bar" | "circle" | "both";
+
+export type FractionConfig = SheetOptions & {
+  kind: "fractions";
+  style: FractionStyle;
+  /** Arithmetic only; the other three styles have no operation to choose. */
+  operation: FractionOperation;
+  /**
+   * The denominators a sheet draws from — halves, thirds, quarters, and as far
+   * up as a parent wants. A pool rather than a range, for the reason `tables`
+   * is: "sevenths" is a choice somebody makes, and 2 to 12 is not.
+   */
+  denominators: number[];
+  pairing: Denominators;
+  /**
+   * Whether whole numbers ride along with the fractions: `2 1/4` rather than
+   * `1/4`, on the page and in the answer.
+   */
+  mixed?: boolean;
+  /** Naming sheets only. */
+  model?: FractionModel;
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  /** Blank space under every problem, to work in. */
+  workspace?: boolean;
+};
+
+/* ── Decimals, percents and money ──────────────────────────────────────────
+   Three sheets built on one idea: a number with a point in it is a whole
+   number of hundredths wearing a costume. Everything in `maths/exact.ts` is
+   there so that nothing below ever holds 0.1 + 0.2 as a float.               */
+
+/** What the sheet asks for. */
+export type DecimalStyle = "standard" | "percent" | "convert";
+
+/** `both` shuffles addition and subtraction, as it does on an arithmetic sheet. */
+export type DecimalOperation = "add" | "subtract" | "multiply" | "both";
+
+/**
+ * Written across the line, or stacked in columns.
+ *
+ * Column form is worth more here than anywhere else in the shop: every value on
+ * a decimal sheet prints to the same number of places, so stacking them
+ * right-aligned puts the points in a column — which is the one thing a child
+ * lining up a decimal sum has to get right.
+ */
+export type DecimalForm = "horizontal" | "vertical";
+
+export type DecimalConfig = SheetOptions & {
+  kind: "decimals";
+  style: DecimalStyle;
+  operation: DecimalOperation;
+  form: DecimalForm;
+  /**
+   * How many digits after the point, 1 to 3. The whole of what makes a decimal
+   * sheet easy or hard, and the one thing every other generator of these gets
+   * wrong by rounding a float into the answer key.
+   */
+  places: number;
+  /** The whole numbers the values sit between, ends included. */
+  range: { min: number; max: number };
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  /** Blank space under every problem, to work in. */
+  workspace?: boolean;
+};
+
+/**
+ * Which money is on the page.
+ *
+ * A switch rather than a build-time constant, for the same reason A4 is (§4):
+ * a British child counting dollars is being asked a question about a foreign
+ * country, and the sheet is otherwise identical.
+ */
+export type Currency = "usd" | "gbp" | "eur";
+
+/** `both` shuffles addition and subtraction — the two a till does. */
+export type MoneyOperation = "add" | "subtract" | "multiply" | "both";
+
+export type MoneyConfig = SheetOptions & {
+  kind: "money";
+  currency: Currency;
+  operation: MoneyOperation;
+  /**
+   * Money is a two-place decimal with a symbol in front of it, so it is written
+   * down the same two ways a decimal is.
+   */
+  form: DecimalForm;
+  /** The whole units the amounts sit between — dollars, pounds or euros. */
+  range: { min: number; max: number };
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  /** Blank space under every problem, to work in. */
+  workspace?: boolean;
+};
+
 /**
  * Anything a saved sheet can hold. Narrow on `kind` — and only in index.ts,
  * which is the one module that knows the whole union.
  */
 export type SheetConfig =
-  BlankConfig | PaperConfig | ArithmeticConfig | MultiplicationConfig;
+  | BlankConfig
+  | PaperConfig
+  | ArithmeticConfig
+  | MultiplicationConfig
+  | FractionConfig
+  | DecimalConfig
+  | MoneyConfig;

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -223,6 +223,25 @@
   stroke: none;
 }
 
+/* The shaded parts of a fraction bar or circle.
+
+   The one place a sheet paints inside a shape rather than only round it, and
+   the ink note above is exactly why it is a `fill`: the shading is the question
+   on a naming sheet, so it has to survive a printer with background graphics
+   switched off, and only foreground paint does. A fraction of the ink, because
+   a solid quarter-circle thirty times a week is a cartridge. */
+.sheet__shade {
+  fill: currentcolor;
+  stroke: none;
+  opacity: 22%;
+}
+
+/* The picture sits in the row with the number and the blank, and gives itself a
+   little air rather than butting against either. */
+.sheet__art {
+  margin-right: 0.06in;
+}
+
 /* The solution stroke on a word search. Lighter than the letters it crosses,
    so the key is still readable underneath it. */
 .sheet__found {


### PR DESCRIPTION
Closes #51.

## What changed

Three new worksheet families under `src/engine/sheets/maths/` — fractions, decimals/percents, and money — plus the SVG fraction art they render with.

**Fractions** (`fractions.ts`): naming from a picture, equivalence, simplifying, and the four operations across like and unlike denominators and mixed numbers.

**Decimals and percents** (`decimals.ts`): addition, subtraction and multiplication by a whole number at one to three configurable places, percentages of amounts, and conversions between fraction, decimal and percent forms.

**Money** (`money.ts`): the same arithmetic behind a currency switch — `$`, `£`, `€`. The switch changes the symbol and the sheet title ("Adding pounds and pence" is both what the sheet is called and what a parent searches for) and nothing else.

## Why it is built this way

**No answer is ever a float.** `maths/exact.ts` is the reason the three families can share a correctness story: a fraction is a pair of whole numbers reduced by their GCD, and a decimal is a whole number of tenths/hundredths/thousandths with the point written in only at print time. `$3.45` is 345 cents from the moment it is drawn. `0.1 + 0.2` is `0.30000000000000004` in JavaScript, and on a printable that answer ships to a child on paper with no way to correct it. Every answer is reduced, and every decimal is padded to the places the sheet was configured for, because trailing zeros are how a column of figures lines up.

**Fraction art is an SVG fill, not a CSS background.** Browsers drop background paint when printing with backgrounds disabled — which is the default — so a naming sheet whose pictures came out as empty boxes would ask a question that isn't on the page. The art rides on the problem as `art`, the same way a number line already does. `fractionart.ts` is the single place its size is written down, so the row height a family reserves and the drawing the renderer makes cannot drift apart.

**One geometry fix the families forced.** A fraction or money sentence is long enough to wrap inside a narrow column, and `.sheet__problem` wraps rather than overflowing — so a row reserved for a single line would push the bottom of the page onto a second sheet. `WRAP_GAP` joins the constants in `layout.ts` that trail `sheet.css`, and all three families reserve for the wrap.

## Answer keys are verified independently

The acceptance criteria ask for answer keys verified independently, with fraction answers compared in lowest terms. Each suite recomputes every printed answer by a path the families themselves do not use:

- cross-multiplication for fractions and decimals — there is no division anywhere in the three suites
- repeated addition for products
- a common-factor search for lowest terms, rather than the `gcd` the families reduce with
- a candidate search for every blank

Each check was validated against deliberate mutations — an unreduced answer, a misplaced decimal point, a dropped currency symbol, a percentage rounded from a float, a picture shaded one part short — and every mutation fails the suite.

The follow-up commit closes three review findings, of which the load-bearing one is that the rendered picture was never tied to the fraction it names: the suite proved a shade existed and counted the cuts, but nothing asserted that the shaded geometry matched `art.shaded`. A regression in bar width or pie sweep would have shipped worksheets whose question and answer key disagree, silently. Both models now assert shading measured off the outline the renderer actually drew. The second finding: a vertical sheet told every child to line the decimal points up, including on `$1.25 × 3`, where the multiplier has no point at all — now conditioned on the operation.

## Validation

`type-check`, `lint`, `test:unit` (423 passing), `build` (static, 45 pages) and the browser smoke test all pass locally against this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
