### PR TITLE
PRINT09: pre-algebra, integers and statistics worksheets

### DIFF
--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -20,10 +20,15 @@ import { ARITHMETIC_SHEET } from "./maths/arithmetic";
 import { DECIMALS_SHEET } from "./maths/decimals";
 import { FRACTIONS_SHEET } from "./maths/fractions";
 import { GEOMETRY_SHEET } from "./maths/geometry";
+import { INTEGERS_SHEET } from "./maths/integers";
 import { MEASURE_SHEET } from "./maths/measure";
 import { MONEY_SHEET } from "./maths/money";
 import { MULTIPLICATION_SHEET } from "./maths/multiplication";
+import { PREALGEBRA_SHEET } from "./maths/prealgebra";
+import { RATIO_SHEET } from "./maths/ratio";
+import { STATISTICS_SHEET } from "./maths/statistics";
 import { TIME_SHEET } from "./maths/time";
+import { WORD_PROBLEMS_SHEET } from "./maths/wordproblems";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
 import { PAPER_SHEET } from "./templates/paper";
 
@@ -38,6 +43,11 @@ const SHEETS: Record<string, SheetSpec> = {
   [TIME_SHEET.id]: TIME_SHEET,
   [MEASURE_SHEET.id]: MEASURE_SHEET,
   [GEOMETRY_SHEET.id]: GEOMETRY_SHEET,
+  [INTEGERS_SHEET.id]: INTEGERS_SHEET,
+  [PREALGEBRA_SHEET.id]: PREALGEBRA_SHEET,
+  [RATIO_SHEET.id]: RATIO_SHEET,
+  [STATISTICS_SHEET.id]: STATISTICS_SHEET,
+  [WORD_PROBLEMS_SHEET.id]: WORD_PROBLEMS_SHEET,
 };
 
 /**

--- a/src/engine/sheets/maths/exact.ts
+++ b/src/engine/sheets/maths/exact.ts
@@ -127,6 +127,39 @@ export function mixedText(value: Fraction): string {
 export const writeFraction = (value: Fraction, mixed: boolean): string =>
   mixed ? mixedText(value) : fractionText(value);
 
+/* ── Signed whole numbers ──────────────────────────────────────────────────
+   The third shape a worksheet's numbers take, and the one that looks like it
+   needs no help at all. It does: a minus sign is the whole of the difference
+   between a right answer and a wrong one on an integers sheet, and where it is
+   written down is a typographic question with a right answer of its own.     */
+
+/**
+ * The proper minus sign, U+2212 — not a hyphen.
+ *
+ * The same character `arithmetic.ts` prints as its operator, and for the same
+ * reason: a hyphen is narrower than a plus and sits at the wrong height beside
+ * one, so a column of sums set in the two of them looks like a typing error to
+ * the adult marking it.
+ */
+export const MINUS = "−";
+
+/** A signed whole number as it is written on its own: "7", "−7". */
+export const signedText = (value: number): string =>
+  value < 0 ? `${MINUS}${Math.abs(value)}` : String(value);
+
+/**
+ * The same number written *after* an operator: "7", "(−7)".
+ *
+ * The bracket is the notation rather than a nicety — `7 + −4` is two operators
+ * in a row, and a child asked to read it aloud has been asked the wrong
+ * question. Algebra is the one place this does not apply: `3x − 4` is how a
+ * negative constant is written in an equation, with the sign folded into the
+ * operator, and a sheet printing `3x + (−4)` would be teaching notation nobody
+ * uses.
+ */
+export const factorText = (value: number): string =>
+  value < 0 ? `(${signedText(value)})` : String(value);
+
 /* ── Fixed point ───────────────────────────────────────────────────────────
    A whole number of hundredths, and a count of how many digits go after the
    point. $3.45 is `{ units: 345, places: 2 }` from the moment it is drawn to

--- a/src/engine/sheets/maths/geometry.ts
+++ b/src/engine/sheets/maths/geometry.ts
@@ -29,7 +29,6 @@ import type {
   GeometryConfig,
   GeometryStyle,
   GridMark,
-  GridSpec,
   Mil,
   Problem,
   Sheet,
@@ -56,6 +55,14 @@ import {
   type Box,
 } from "../layout";
 import { inches } from "../paper";
+import {
+  letterAt,
+  markAt,
+  planeFloor,
+  planeHeight,
+  planeOf,
+  type Plane,
+} from "../plane";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
 import { cubed, figureUnitsOf, squared } from "./units";
 
@@ -83,78 +90,10 @@ const MISS_BUDGET = 500;
 /* ── The plane ─────────────────────────────────────────────────────────────
    One grid at the top of the page and the questions under it, rather than a
    little pair of axes beside every problem: a child reads the scale once and
-   then uses it a dozen times.                                               */
+   then uses it a dozen times.
 
-/** The biggest a square on the plane is drawn, and how much page it may take. */
-const GRID_CELL = inches(0.4);
-const GRID_SHARE = 0.55;
-
-/** How far the axes run from the origin, in each of the two shapes. */
-const QUADRANT_SPAN = 10;
-const FOUR_QUADRANT_SPAN = 8;
-
-export type Plane = {
-  /** How far the axes run from nought. */
-  span: number;
-  /** Whether the plane has negative coordinates on it. */
-  negative: boolean;
-  grid: GridSpec;
-};
-
-/**
- * The grid a coordinate sheet is drawn on.
- *
- * A first-quadrant plane keeps one square of margin below and to the left of the
- * axes, which is where the numbers along them go: the drawing is exactly as wide
- * as its squares say it is (§4), so a numeral outside the grid is a numeral off
- * the edge of the drawing.
- */
-export function planeOf(config: GeometryConfig, box: Box): Plane {
-  const negative = Math.floor(config.quadrants ?? 1) === 4;
-  const span = negative ? FOUR_QUADRANT_SPAN : QUADRANT_SPAN;
-  const pad = negative ? span : 1;
-  const columns = span + pad;
-  const rows = span + pad;
-  const cell = Math.max(
-    1,
-    Math.min(
-      GRID_CELL,
-      Math.floor(box.width / columns),
-      Math.floor((box.height * GRID_SHARE) / rows),
-    ),
-  );
-  return {
-    span,
-    negative,
-    grid: {
-      kind: "coordinate",
-      columns,
-      rows,
-      cell,
-      origin: { column: pad, row: span },
-      // What is on the plane, as against what the ruling runs to. On a
-      // first-quadrant plane the padding square outside the axes is where the
-      // numerals go, not a column of −1: this is what stops one being printed
-      // there, on the sheet that promised no negative numbers at all.
-      axis: { min: negative ? -span : 0, max: span },
-    },
-  };
-}
-
-/** Where a point sits on the plane, in squares from the top-left of the grid. */
-const markAt = (
-  plane: Plane,
-  x: number,
-  y: number,
-  label: string,
-): GridMark => ({
-  column: (plane.grid.origin?.column ?? 0) + x,
-  row: (plane.grid.origin?.row ?? 0) - y,
-  label,
-});
-
-/** A, B, C … the letters a point is called by. */
-const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+   The geometry of it lives in `plane.ts`, because a plane is the question on a
+   pre-algebra sheet as well as on this one — see the note there.             */
 
 /* ── Drawing a problem ─────────────────────────────────────────────────────
    Each style draws its own shape and they have little in common, so each
@@ -413,14 +352,14 @@ function drawPoint(
   index: number,
   rand: () => number,
 ): Drawn | null {
-  const low = plane.negative ? -plane.span : 1;
+  const low = planeFloor(plane);
   const x = between(low, plane.span, rand);
   const y = between(low, plane.span, rand);
   // Never on an axis. A dot sitting on one of the two heavy rules is a dot a
   // child has to look twice at, and nought is not the part of this that is
   // being taught.
   if (x === 0 || y === 0) return null;
-  const label = LETTERS[index % LETTERS.length];
+  const label = letterAt(index);
   return {
     key: `point:${x}:${y}`,
     prompt: `${label} = _`,
@@ -478,11 +417,13 @@ export function geometryLayout(config: GeometryConfig): {
   const row = rowHeight(config);
 
   const plane =
-    config.style === "coordinates" ? planeOf(config, box) : undefined;
+    config.style === "coordinates"
+      ? planeOf(config.quadrants ?? 1, box)
+      : undefined;
   // The grid is a block of its own above the problems, so it takes its height
   // and the gap under it out of what is left for them.
   const left = plane
-    ? Math.max(0, box.height - plane.grid.rows * plane.grid.cell - BLOCK_GAP)
+    ? Math.max(0, box.height - planeHeight(plane) - BLOCK_GAP)
     : box.height;
 
   return {

--- a/src/engine/sheets/maths/integers.test.ts
+++ b/src/engine/sheets/maths/integers.test.ts
@@ -281,6 +281,12 @@ describe("the integers family", () => {
     expect(describeSheet(config({ style: "powers", negatives: false }))).toBe(
       "Powers and roots — positive numbers only — squares and cubes",
     );
+    // A config arrives from a bookmark or from a sheet saved months ago, so the
+    // numbers in it are not to be trusted: seven operations prints three, and
+    // the line has to say three.
+    expect(describeSheet(config({ style: "order", terms: 7 }))).toBe(
+      "Order of operations — positive and negative — numbers to 12 — 3 operations",
+    );
   });
 
   it("gives the sheet a title and a score box it can be marked against", () => {
@@ -449,6 +455,41 @@ describe("what may be on the page", () => {
             expect(Math.abs(value), problem.prompt).toBeLessThanOrEqual(
               range.max,
             );
+          }
+        }
+      }
+    }
+  });
+
+  it("keeps an order-of-operations expression inside the ceiling it declares", () => {
+    // The family holds these numbers down to twelve whatever the range says,
+    // because the rule being practised is which operation goes first. What the
+    // cap must not do is turn the range round on the way: a range starting
+    // above it would draw *between* the cap and the ask — thirteen to nineteen
+    // on a sheet that asked for twenty to thirty — which is neither.
+    //
+    // Written out here rather than imported, as everything in this file is.
+    const CEILING = 12;
+    for (const range of [
+      { min: 1, max: 9 },
+      { min: 2, max: 30 },
+      { min: 20, max: 30 },
+    ]) {
+      for (const terms of [2, 3]) {
+        const shape = { style: "order" as const, terms, range, count: 9 };
+        // A dividend runs past the range exactly as a product does — it is
+        // built from two drawn numbers — so the lines it is on are read for
+        // what they say about the draw everywhere else in this suite, and left
+        // out of a bound on the numbers themselves.
+        const problems = problemsOf(shape, 5).filter(
+          (problem) => !problem.prompt.includes("÷"),
+        );
+        expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+        for (const problem of problems) {
+          for (const token of tokens(problem.prompt)) {
+            if (!/\d/.test(token)) continue;
+            expect(Math.abs(numberOf(token)), problem.prompt) //
+              .toBeLessThanOrEqual(Math.min(range.max, CEILING));
           }
         }
       }

--- a/src/engine/sheets/maths/integers.test.ts
+++ b/src/engine/sheets/maths/integers.test.ts
@@ -1,0 +1,616 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { PROBLEM_GAP } from "../layout";
+import type {
+  IntegerConfig,
+  MarginSize,
+  Paper,
+  PaperSize,
+  Problem,
+} from "../types";
+
+import { INTEGERS_SHEET, integerLayout } from "./integers";
+
+/**
+ * Integers, order of operations, powers and roots — held to the bar the maths
+ * families set.
+ *
+ * **Nothing here checks the generator against the generator.** The family holds
+ * every number as a signed integer and prints it at the end; this file only ever
+ * reads what was *printed*, tokenises it, and works the answer out again by a
+ * path the family does not have:
+ *
+ * - **addition and subtraction are counted**, one step at a time along the
+ *   number line, which is the only arithmetic in this file that is not built out
+ *   of `walk`. A sign dropped anywhere between the draw and the paper fails
+ *   here, because counting down from 7 nine times reaches −2 whatever the
+ *   generator believed;
+ * - **multiplication is repeated addition** and its sign comes from counting the
+ *   negative factors, not from a product;
+ * - **division is checked by multiplying back** — the classic independent check,
+ *   and the only honest one for a quotient;
+ * - **an expression is parsed**, with its own precedence, from the characters on
+ *   the page. A template whose text and value disagree — the one bug an
+ *   order-of-operations sheet can have — has nowhere to hide, because the value
+ *   in the key was never consulted while reading the line.
+ */
+
+/* ── Arithmetic, from ±1 upwards ─────────────────────────────────────────── */
+
+/** `from`, stepped one at a time. The only arithmetic here that is not this. */
+function walk(from: number, by: number): number {
+  let value = from;
+  for (let step = 0; step < Math.abs(by); step += 1) value += by < 0 ? -1 : 1;
+  return value;
+}
+
+/**
+ * `a` added to itself `b` times, and the sign counted rather than computed.
+ *
+ * Added the fewer number of times of the two, which is the same product and a
+ * great deal less counting: the roots below are searched for by raising every
+ * candidate, and a suite that takes a minute is a suite nobody runs.
+ */
+function multiply(a: number, b: number): number {
+  const negatives = (a < 0 ? 1 : 0) + (b < 0 ? 1 : 0);
+  const [each, times] =
+    Math.abs(a) > Math.abs(b)
+      ? [Math.abs(a), Math.abs(b)]
+      : [Math.abs(b), Math.abs(a)];
+  let total = 0;
+  for (let step = 0; step < times; step += 1) total = walk(total, each);
+  return negatives === 1 ? -total : total;
+}
+
+/** The number that multiplies back, or nothing at all. */
+function divide(a: number, b: number): number {
+  if (b === 0) throw new Error("divided by nothing");
+  for (let q = -SEARCH; q <= SEARCH; q += 1) {
+    if (multiply(q, b) === a) return q;
+  }
+  throw new Error(`${a} ÷ ${b} is not a whole number`);
+}
+
+/** How far a quotient is looked for. Bigger than any sheet asks for. */
+const SEARCH = 400;
+
+/** And a root, which is a much smaller number: 20³ is eight thousand. */
+const ROOT_SEARCH = 20;
+
+/* ── Reading what was printed ────────────────────────────────────────────── */
+
+/**
+ * The characters of an expression, split into numbers, operators and brackets.
+ *
+ * A minus sign that belongs to a *number* is written against it — "−4" — and a
+ * minus sign that is an operator has a space on each side, which is what tells
+ * the two apart without knowing anything about where they came from.
+ */
+function tokens(text: string): string[] {
+  const src = text.replace(/=$/, "").trim();
+  const out: string[] = [];
+  let at = 0;
+  while (at < src.length) {
+    const char = src[at];
+    if (char === " ") {
+      at += 1;
+    } else if ("()+×÷²³√∛".includes(char)) {
+      out.push(char);
+      at += 1;
+    } else if (
+      /\d/.test(char) ||
+      (char === "−" && /\d/.test(src[at + 1] ?? ""))
+    ) {
+      let end = char === "−" ? at + 1 : at;
+      while (/\d/.test(src[end] ?? "")) end += 1;
+      out.push(src.slice(at, end));
+      at = end;
+    } else if (char === "−") {
+      out.push("−");
+      at += 1;
+    } else {
+      throw new Error(`what is "${char}" doing in "${text}"?`);
+    }
+  }
+  return out;
+}
+
+const numberOf = (token: string): number =>
+  token.startsWith("−") ? -Number(token.slice(1)) : Number(token);
+
+/**
+ * What an expression works out to, read off the page.
+ *
+ * A recursive descent with the precedence a child is taught: brackets, then
+ * powers and roots, then × and ÷, then + and −. Written out longhand rather
+ * than handed to `eval`, both because the sheet prints × and ÷ rather than
+ * their keyboard spellings and because the point of the exercise is to have a
+ * second opinion about what the line says.
+ */
+function evaluate(text: string): number {
+  const list = tokens(text);
+  let at = 0;
+  const peek = (): string | undefined => list[at];
+  const take = (): string => list[at++];
+
+  function sum(): number {
+    let value = product();
+    while (peek() === "+" || peek() === "−") {
+      const operator = take();
+      const right = product();
+      value = operator === "+" ? walk(value, right) : walk(value, -right);
+    }
+    return value;
+  }
+
+  function product(): number {
+    let value = power();
+    while (peek() === "×" || peek() === "÷") {
+      const operator = take();
+      const right = power();
+      value = operator === "×" ? multiply(value, right) : divide(value, right);
+    }
+    return value;
+  }
+
+  function power(): number {
+    const base = atom();
+    if (peek() === "²") {
+      take();
+      return multiply(base, base);
+    }
+    if (peek() === "³") {
+      take();
+      return multiply(multiply(base, base), base);
+    }
+    return base;
+  }
+
+  function atom(): number {
+    const token = take();
+    if (token === "(") {
+      const value = sum();
+      if (take() !== ")") throw new Error(`unclosed bracket in "${text}"`);
+      return value;
+    }
+    // A root is the one prefix on a sheet: the number under it is the whole of
+    // the question, and what comes back is the number that powers up to it.
+    if (token === "√" || token === "∛") {
+      const under = atom();
+      for (let root = -ROOT_SEARCH; root <= ROOT_SEARCH; root += 1) {
+        const raised =
+          token === "√"
+            ? multiply(root, root)
+            : multiply(multiply(root, root), root);
+        // A square root is the positive one by convention, and nothing else.
+        if (raised === under && (token === "∛" || root >= 0)) return root;
+      }
+      throw new Error(`${token}${under} is not a whole number`);
+    }
+    return numberOf(token);
+  }
+
+  const value = sum();
+  if (at !== list.length) throw new Error(`did not read all of "${text}"`);
+  return value;
+}
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const config = (over: Partial<IntegerConfig> = {}): IntegerConfig => ({
+  kind: "integers",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style: "arithmetic",
+  operation: "both",
+  range: { min: 1, max: 12 },
+  count: 12,
+  columns: 3,
+  ...over,
+});
+
+/**
+ * Every shape the family can print, which is every acceptance criterion of the
+ * story: the four operations over the integers, order of operations with two
+ * operations and with three, and powers with the roots that undo them.
+ */
+const EVERY_SHAPE: Array<Partial<IntegerConfig>> = [
+  {},
+  { operation: "add" },
+  { operation: "subtract" },
+  { operation: "multiply" },
+  { operation: "divide" },
+  { operation: "both", negatives: false },
+  { range: { min: 2, max: 30 } },
+  { style: "order" },
+  { style: "order", terms: 3 },
+  { style: "order", negatives: false },
+  { style: "order", terms: 3, negatives: false, range: { min: 2, max: 9 } },
+  { style: "powers" },
+  { style: "powers", negatives: false },
+  { style: "powers", range: { min: 2, max: 7 } },
+  { workspace: true, count: 8 },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** The one block an integer sheet has, narrowed for the reader. */
+function problemsOf(over: Partial<IntegerConfig>, seed: number): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+const everyProblem = function* (
+  shapes: Array<Partial<IntegerConfig>> = EVERY_SHAPE,
+): Generator<[Partial<IntegerConfig>, Problem]> {
+  for (const shape of shapes) {
+    for (const seed of SEEDS) {
+      const problems = problemsOf(shape, seed);
+      expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+      for (const problem of problems) yield [shape, problem];
+    }
+  }
+};
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the integers family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("integers")).toBe(INTEGERS_SHEET);
+    expect(sheetSpec("integers").label).toBe("Integers and powers");
+  });
+
+  it("names the sheet in the words a parent chose it by", () => {
+    expect(describeSheet(config({ operation: "multiply" }))).toBe(
+      "Multiplying integers — positive and negative — numbers to 12",
+    );
+    expect(describeSheet(config({ style: "order", terms: 3 }))).toBe(
+      "Order of operations — positive and negative — numbers to 12 — 3 operations",
+    );
+    expect(describeSheet(config({ style: "powers", negatives: false }))).toBe(
+      "Powers and roots — positive numbers only — squares and cubes",
+    );
+  });
+
+  it("gives the sheet a title and a score box it can be marked against", () => {
+    const sheet = buildSheet(config({ count: 8 }), 3);
+    const block = sheet.blocks[0];
+    expect(sheet.header.title).toBe("Integer arithmetic");
+    expect(sheet.header.instructions).toBe(
+      "Work out each answer. Watch the signs.",
+    );
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+
+  it("tells a child which rule an order-of-operations sheet is about", () => {
+    expect(buildSheet(config({ style: "order" }), 1).header.instructions).toBe(
+      "Work out each answer. Brackets first, then powers, then × and ÷.",
+    );
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("gets the sign right on every sum, counted along the number line", () => {
+    for (const [shape, problem] of everyProblem(
+      EVERY_SHAPE.filter((one) => (one.style ?? "arithmetic") === "arithmetic"),
+    )) {
+      const said = JSON.stringify(shape);
+      const [left, operator, right] = parts(problem.prompt);
+      const answer = numberOf(problem.answer);
+      if (operator === "+")
+        expect(answer, `${problem.prompt} ${said}`).toBe(walk(left, right));
+      if (operator === "−")
+        expect(answer, `${problem.prompt} ${said}`).toBe(walk(left, -right));
+      if (operator === "×")
+        expect(answer, `${problem.prompt} ${said}`).toBe(multiply(left, right));
+      // The one check that is not a second computation but a proof: a quotient
+      // is right when it multiplies back to what it was divided out of.
+      if (operator === "÷")
+        expect(multiply(answer, right), `${problem.prompt} ${said}`).toBe(left);
+    }
+  });
+
+  it("works every expression out again from the characters on the page", () => {
+    for (const [shape, problem] of everyProblem(
+      EVERY_SHAPE.filter((one) => one.style === "order"),
+    )) {
+      expect(
+        numberOf(problem.answer),
+        `${problem.prompt} ${JSON.stringify(shape)}`,
+      ) //
+        .toBe(evaluate(problem.prompt));
+    }
+  });
+
+  it("raises and roots by repeated multiplication", () => {
+    for (const [, problem] of everyProblem(
+      EVERY_SHAPE.filter((one) => one.style === "powers"),
+    )) {
+      expect(numberOf(problem.answer), problem.prompt).toBe(
+        evaluate(problem.prompt),
+      );
+    }
+  });
+
+  it("never asks for the square root of a negative number", () => {
+    // There isn't one, and a sheet that asked would have a blank a child cannot
+    // fill in however well they have been taught.
+    for (const [, problem] of everyProblem([
+      { style: "powers" },
+      { style: "powers", range: { min: 2, max: 12 } },
+    ])) {
+      expect(problem.prompt, problem.prompt).not.toMatch(/√\s*−/);
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    for (const shape of EVERY_SHAPE) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+});
+
+/** The three parts of a sum written along a line: two numbers and a sign. */
+function parts(prompt: string): [number, string, number] {
+  const list = tokens(prompt);
+  if (list.length !== 3 && list.length !== 5)
+    throw new Error(`not a sum: "${prompt}"`);
+  // A negative operand is bracketed, which is three tokens where one would do.
+  const right = list.length === 3 ? list[2] : list[3];
+  return [numberOf(list[0]), list[1], numberOf(right)];
+}
+
+/* ── Signs, which are the whole of this family (§20) ─────────────────────── */
+
+describe("how a sign is written", () => {
+  it("brackets a negative number that follows an operator", () => {
+    // `7 + −4` is two operators in a row, and a child asked to read it aloud
+    // has been asked the wrong question.
+    for (const [, problem] of everyProblem()) {
+      expect(problem.prompt, problem.prompt).not.toMatch(/[+−×÷] −/);
+    }
+  });
+
+  it("puts no minus sign at all on a sheet that turned them off", () => {
+    // Not in the question, not in the answer, and not in the middle either:
+    // `(4 − 9) × 3` has every number positive and is still an integers sheet.
+    for (const [, problem] of everyProblem(
+      EVERY_SHAPE.filter((one) => one.negatives === false),
+    )) {
+      const sentence = `${problem.prompt} ${problem.answer}`;
+      expect(sentence, sentence).not.toMatch(/−\d/);
+      expect(evaluate(problem.prompt), problem.prompt).toBeGreaterThanOrEqual(
+        0,
+      );
+      const bracket = /\((\d+) ([+−]) (\d+)\)/.exec(problem.prompt);
+      if (bracket) {
+        const [left, right] = [Number(bracket[1]), Number(bracket[3])];
+        expect(
+          bracket[2] === "+" ? left + right : left - right,
+        ).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it("puts minus signs on a sheet that asked for them", () => {
+    // The other half of the switch: a family that quietly stopped drawing
+    // negatives would pass every test above this one.
+    const seen = problemsOf({ count: 20 }, 3).filter((problem) =>
+      /−\d/.test(`${problem.prompt} ${problem.answer}`),
+    );
+    expect(seen.length).toBeGreaterThan(4);
+  });
+});
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  it("draws its numbers inside the range a parent asked for", () => {
+    // The sizes, sign aside — and the numbers *drawn*, which is what a range
+    // means everywhere in the shop: a product or a dividend built from two of
+    // them runs past it, exactly as a sum does on an addition sheet.
+    for (const range of [
+      { min: 1, max: 9 },
+      { min: 2, max: 12 },
+      { min: 5, max: 30 },
+    ]) {
+      for (const operation of ["add", "subtract", "multiply"] as const) {
+        for (const problem of problemsOf({ range, operation, count: 12 }, 6)) {
+          const [left, , right] = parts(problem.prompt);
+          for (const value of [left, right]) {
+            expect(Math.abs(value), problem.prompt).toBeGreaterThanOrEqual(
+              range.min,
+            );
+            expect(Math.abs(value), problem.prompt).toBeLessThanOrEqual(
+              range.max,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("never divides by nothing", () => {
+    for (const [, problem] of everyProblem([
+      { operation: "divide", count: 16 },
+      { operation: "divide", range: { min: 1, max: 4 } },
+      { style: "order", terms: 2 },
+    ])) {
+      expect(problem.prompt, problem.prompt).not.toMatch(/÷ \(?0/);
+    }
+  });
+
+  it("gives every problem exactly one place to write the answer", () => {
+    for (const [, problem] of everyProblem()) {
+      expect(problem.prompt.split("_").length - 1).toBe(0);
+      expect(problem.answers).toBeUndefined();
+    }
+  });
+
+  it("asks the same question twice on no sheet at all", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const asked = problemsOf(shape, seed).map((problem) => problem.prompt);
+        expect(new Set(asked).size, JSON.stringify(shape)).toBe(asked.length);
+      }
+    }
+  });
+
+  it("prints nothing rather than something wrong when the ask is impossible", () => {
+    // Cubes of numbers from fifty to sixty is a request with no answers in it.
+    expect(
+      problemsOf({ style: "powers", range: { min: 50, max: 60 } }, 1),
+    ).toEqual([]);
+    expect(problemsOf({ count: 0 }, 1)).toEqual([]);
+  });
+});
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    // The promise the footer makes: the seed is printed on the paper so a
+    // parent can have the same sheet again next week, across a deploy.
+    expect(problemsOf({ count: 4 }, 4242).map(said)).toEqual(GOLDEN.arithmetic);
+    expect(problemsOf({ style: "order", count: 3 }, 7).map(said)).toEqual(
+      GOLDEN.order,
+    );
+    expect(problemsOf({ style: "powers", count: 4 }, 11).map(said)).toEqual(
+      GOLDEN.powers,
+    );
+  });
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    for (const shape of EVERY_SHAPE) {
+      const [a, b, c] = [0, 1, 2].map((offset) =>
+        problemsOf({ ...shape, count: 6 }, 100 + offset).map(
+          (problem) => problem.prompt,
+        ),
+      );
+      for (const [one, other] of [
+        [a, b],
+        [a, c],
+        [b, c],
+      ]) {
+        expect(one, JSON.stringify(shape)).not.toEqual(other);
+        const shared = one.filter((asked) => other.includes(asked)).length;
+        expect(shared, JSON.stringify(shape)).toBeLessThan(
+          (one.length * 2) / 3,
+        );
+      }
+    }
+  });
+});
+
+const said = (problem: Problem): [string, string] => [
+  problem.prompt,
+  problem.answer,
+];
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row } = integerLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used = rows * row + Math.max(0, rows - 1) * PROBLEM_GAP.y;
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("does not throw the page away either", () => {
+    const { box, row, perPage, columns } = integerLayout(config());
+    expect(perPage).toBeGreaterThanOrEqual(20);
+    const rows = perPage / columns;
+    expect((rows + 1) * row + rows * PROBLEM_GAP.y).toBeGreaterThan(box.height);
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ count: 10 }, 1).length).toBe(10);
+    for (const columns of [1, 2, 3]) {
+      const block = buildSheet(config({ columns }), 1).blocks[0];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+    // Two columns of expressions, because `(9 − 4) × 3 + 7 =` is half a line
+    // of type before its answer slot.
+    const wide = buildSheet(config({ style: "order", columns: 6 }), 1)
+      .blocks[0];
+    expect(wide.kind === "problems" && wide.columns).toBe(2);
+  });
+});
+
+/**
+ * What three sheets came out as on the day this shipped.
+ *
+ * Recorded rather than computed — all three are proved right by the assertions
+ * above, and what these hold is that they do not silently *change*.
+ */
+const GOLDEN = {
+  arithmetic: [
+    ["4 × 7 =", "28"],
+    ["−4 − 5 =", "−9"],
+    ["10 × (−12) =", "−120"],
+    ["88 ÷ (−11) =", "−8"],
+  ],
+  order: [
+    ["1 + 9 × (−5) =", "−44"],
+    ["7 − (−4) × 10 =", "47"],
+    ["−5 − (−7) × (−12) =", "−89"],
+  ],
+  powers: [
+    ["5³ =", "125"],
+    ["(−5)³ =", "−125"],
+    ["(−4)³ =", "−64"],
+    ["√81 =", "9"],
+  ],
+};

--- a/src/engine/sheets/maths/integers.ts
+++ b/src/engine/sheets/maths/integers.ts
@@ -428,6 +428,17 @@ const TEMPLATES: Template[] = [
 const EXPRESSION_MAX = 12;
 
 /**
+ * How many operations an expression on this sheet has.
+ *
+ * Read by the draw and by the line that names the sheet, from one place. A
+ * config arrives from a bookmarked URL or from a sheet saved months ago, so
+ * `terms: 7` is a thing that happens — it draws three operations, and a
+ * description reading the raw number would advertise seven of them.
+ */
+const termsOf = (config: IntegerConfig): number =>
+  Math.max(2, Math.min(3, Math.floor(config.terms ?? 2)));
+
+/**
  * One expression, or `null` when what came out is not what the sheet asked for.
  *
  * A sheet with no negatives on it means no negative *anywhere*: not in the
@@ -440,11 +451,16 @@ function drawExpression(
   config: IntegerConfig,
   rand: () => number,
 ): Drawn | null {
-  const wanted = Math.max(2, Math.min(3, Math.floor(config.terms ?? 2)));
+  const wanted = termsOf(config);
   const pool = TEMPLATES.filter((one) => one.ops === wanted);
   const template = pick(pool, rand);
   const { min, max } = bounds(config.range);
-  const range = { min, max: Math.min(max, EXPRESSION_MAX) };
+  // Both ends, because the cap moves the top: a range that started above it
+  // would come out inverted, and `between(20, 12)` draws from thirteen to
+  // nineteen — numbers that are neither what the parent asked for nor what this
+  // cap allows. `drawPower` guards the same thing; this draw was the outlier.
+  const high = Math.min(max, EXPRESSION_MAX);
+  const range = { min: Math.min(min, high), max: high };
   const drawn = template.draw(() => draw(config, rand, range), rand);
   if (drawn === null) return null;
 
@@ -621,7 +637,7 @@ export function describeIntegers(config: IntegerConfig): string {
     titleOf(config),
     signed(config) ? "positive and negative" : "positive numbers only",
     config.style === "powers" ? "squares and cubes" : `numbers to ${max}`,
-    config.style === "order" ? `${config.terms ?? 2} operations` : null,
+    config.style === "order" ? `${termsOf(config)} operations` : null,
   ]
     .filter((part): part is string => part !== null)
     .join(" — ");

--- a/src/engine/sheets/maths/integers.ts
+++ b/src/engine/sheets/maths/integers.ts
@@ -1,0 +1,666 @@
+/**
+ * Integers, order of operations, powers and roots.
+ *
+ * The first family where a *right* answer and a *wrong* answer are the same
+ * digits. 7 − 9 is 2 to a child who has not met the number line going the other
+ * way, and −2 to one who has; both look like an answer, and a key that lost a
+ * minus sign somewhere between the draw and the print would be marked as
+ * correct by a parent reading down the column. So a sign is never inferred from
+ * a subtraction and never recovered from a string: every number in this file is
+ * a signed JavaScript integer from the moment it is drawn, and the only place a
+ * minus sign is written is `signedText` and `factorText`, at the point of
+ * printing.
+ *
+ * **A negative operand is bracketed.** `7 + −4` is two operators in a row and
+ * `7 − −4` is worse; every worksheet, board and textbook writes `7 + (−4)`, so
+ * the bracket is not decoration but the notation, and a sheet without it is one
+ * a child cannot read aloud. `factorText` in `exact.ts` is where that lives.
+ *
+ * **Order of operations is the one sheet whose answer depends on nothing but
+ * the reading.** `4 + 3 × 2` is 10 or 14 depending only on which rule a child
+ * has been taught, so the expression printed on the page and the value in the
+ * key must come from one structure — which is what each template returns. The
+ * suite then reads the *printed* expression back with a precedence-aware parser
+ * of its own, so a template whose text and value disagree fails there rather
+ * than on paper.
+ *
+ * Everything the earlier families established holds unchanged: the answers are
+ * computed when the problem is built and the key only decides to print them, a
+ * problem is drawn and rejected rather than enumerated, and the whole page comes
+ * out of `(config, seed)`.
+ */
+import { between, mulberry32 } from "@/engine/random";
+
+import type {
+  IntegerConfig,
+  IntegerOperation,
+  IntegerStyle,
+  Mil,
+  Problem,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import {
+  PROBLEM_GAP,
+  WRAP_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import { MINUS, factorText, signedText } from "./exact";
+
+/* ── What a problem takes on the page ─────────────────────────────────────
+   Declared, not measured (§4).                                              */
+
+/**
+ * Two lines of the body type and the air a wrap puts between them.
+ *
+ * `−12 ÷ (−4) =` with a ruled slot after it is wider than a third of a page,
+ * and `.sheet__problem` wraps rather than overflowing — so the second line is
+ * either inside the row the layout declared, or it is the bottom of the page
+ * coming out of the printer on a second sheet.
+ */
+const writtenRow = (fontPt: number): Mil => 2 * answerLine(fontPt) + WRAP_GAP;
+
+/** Blank space to work an answer out in, when the config asks for it. */
+const WORKSPACE = inches(0.55);
+
+/**
+ * Three columns of sums, and two of expressions.
+ *
+ * `(9 − 4) × 3 + 7 =` is half a line of type before its answer slot, and a
+ * column narrower than the sentence is a page of problems each wrapped onto
+ * three lines.
+ */
+const MAX_COLUMNS = 3;
+const MAX_EXPRESSION_COLUMNS = 2;
+
+/** As `arithmetic.ts` — see the note there on why a budget rather than a proof. */
+const MISS_BUDGET = 500;
+
+const SIGN: Record<Exclude<IntegerOperation, "both">, string> = {
+  add: "+",
+  subtract: MINUS,
+  multiply: "×",
+  divide: "÷",
+};
+
+const OPERATIONS = ["add", "subtract", "multiply", "divide"] as const;
+
+/* ── Drawing a number ──────────────────────────────────────────────────── */
+
+function bounds(range: { min: number; max: number }): {
+  min: number;
+  max: number;
+} {
+  const min = Math.max(1, Math.floor(range?.min ?? 1));
+  return { min, max: Math.max(min, Math.floor(range?.max ?? 1)) };
+}
+
+const pick = <T>(items: readonly T[], rand: () => number): T =>
+  items[Math.floor(rand() * items.length)];
+
+/** Whether this sheet may print a minus sign on a number. On unless refused. */
+const signed = (config: IntegerConfig): boolean => config.negatives !== false;
+
+/**
+ * One number of the size the config asked for, with its sign drawn separately.
+ *
+ * The range counts magnitudes — "numbers to twenty" is what a parent says, and
+ * they mean twenty either way — so the sign is a coin rather than the bottom of
+ * the range. Nought is never drawn: it is not an integer question, it is the
+ * one number with no sign, and `0 ÷ 4` teaches nothing.
+ */
+function draw(
+  config: IntegerConfig,
+  rand: () => number,
+  range = bounds(config.range),
+): number {
+  const size = between(range.min, range.max, rand);
+  return signed(config) && rand() < 0.5 ? -size : size;
+}
+
+/* ── The four operations ───────────────────────────────────────────────── */
+
+type Drawn = { key: string; prompt: string; answer: string };
+
+/**
+ * One sum over the integers.
+ *
+ * Division is built from its answer outwards — the quotient and the divisor are
+ * drawn and the dividend is their product — for the same reason a unit
+ * conversion is built from the larger unit (`measure.ts`): a dividend drawn on
+ * its own divides exactly about a tenth of the time, and the nine draws thrown
+ * away are nine chances for the sheet to come up short. Every sign follows from
+ * the two numbers drawn, so the key cannot disagree with the page.
+ */
+function drawSum(config: IntegerConfig, rand: () => number): Drawn | null {
+  const operation =
+    config.operation === "both" || !OPERATIONS.includes(config.operation)
+      ? pick(OPERATIONS, rand)
+      : config.operation;
+
+  if (operation === "divide") {
+    const divisor = draw(config, rand);
+    const quotient = draw(config, rand);
+    return sum(operation, divisor * quotient, divisor, quotient);
+  }
+
+  const left = draw(config, rand);
+  const right = draw(config, rand);
+  if (operation === "add") return sum(operation, left, right, left + right);
+  if (operation === "subtract") {
+    // A sheet with the minus signs turned off means the *answers* too, and a
+    // difference is the one operation here that goes below nought out of two
+    // numbers that never did. So the pair is turned round rather than thrown
+    // away — the same move `arithmetic.ts` makes, and for the same reason:
+    // rejecting half the draws would halve the pool for no gain.
+    const top = signed(config) ? left : Math.max(left, right);
+    const bottom = signed(config) ? right : Math.min(left, right);
+    return sum(operation, top, bottom, top - bottom);
+  }
+  return sum(operation, left, right, left * right);
+}
+
+/**
+ * The sum as it is printed, and what makes two of them the same problem.
+ *
+ * Adding and multiplying fold on the pair — `3 × (−5)` and `−5 × 3` are one
+ * fact, and a child who finds both on a page has been given nineteen problems
+ * and a joke — while subtracting and dividing do not: turning those two round
+ * gives a different answer, which is most of what this sheet is teaching.
+ */
+function sum(
+  operation: Exclude<IntegerOperation, "both">,
+  left: number,
+  right: number,
+  result: number,
+): Drawn {
+  const folds = operation === "add" || operation === "multiply";
+  const pair = folds
+    ? [Math.min(left, right), Math.max(left, right)]
+    : [left, right];
+  return {
+    key: `${operation}:${pair[0]}:${pair[1]}`,
+    prompt: `${signedText(left)} ${SIGN[operation]} ${factorText(right)} =`,
+    answer: signedText(result),
+  };
+}
+
+/* ── Powers and roots ──────────────────────────────────────────────────────
+   Written with the superscripts and the radicals a child will meet, because a
+   sheet that printed "5^2" would be teaching them to read a keyboard.        */
+
+/** The two powers a child is taught by name, and the roots that undo them. */
+const POWERS = [
+  { exponent: 2, mark: "²", radical: "√" },
+  { exponent: 3, mark: "³", radical: "∛" },
+] as const;
+
+/**
+ * How big a base may get, by power.
+ *
+ * A square to fifteen is 225 and a cube to seven is 343; a cube of twelve is
+ * 1728, which is not a harder question so much as a different one — the child
+ * is being asked to multiply three-digit numbers, and that sheet lives in the
+ * multiplication family.
+ */
+const BIGGEST_BASE = { 2: 15, 3: 7 } as const;
+
+/**
+ * A power, or the root that undoes it.
+ *
+ * The root is the same draw read backwards, which is why both are here rather
+ * than in two functions: `√81` is `9²` printed the other way round, so there is
+ * one number in this problem and no second computation of it to be wrong. A
+ * square root is never asked of a negative — there isn't one — while a cube
+ * root of a negative is a perfectly good question, and the one place a minus
+ * sign lives inside a radical.
+ */
+function drawPower(config: IntegerConfig, rand: () => number): Drawn | null {
+  const { exponent, mark, radical } = pick(POWERS, rand);
+  const { min, max } = bounds(config.range);
+  // Nothing to draw when the range starts above the biggest base this power
+  // allows — "cubes of numbers from ten to twenty" is a request with no
+  // answers in it, and an empty draw is the honest reply.
+  const low = Math.max(2, min);
+  const high = Math.min(max, BIGGEST_BASE[exponent]);
+  if (low > high) return null;
+
+  const base = draw(config, rand, { min: low, max: high });
+  const value = exponent === 2 ? base * base : base * base * base;
+  const root = rand() < 0.5;
+
+  if (!root) {
+    return {
+      key: `power:${exponent}:${base}`,
+      // A negative base is bracketed for a reason a child is about to be
+      // examined on: `−3²` is minus nine, because the power binds tighter than
+      // the sign, and `(−3)²` is nine. The bracket is the question.
+      prompt: `${factorText(base)}${mark} =`,
+      answer: signedText(value),
+    };
+  }
+  // The root of a square is the positive one, always: √81 is 9, and a sheet
+  // whose key said −9 would be marked wrong by every teacher there is.
+  if (exponent === 2 && base < 0) return null;
+  return {
+    key: `root:${exponent}:${value}`,
+    prompt: `${radical}${factorText(value)} =`,
+    answer: signedText(base),
+  };
+}
+
+/* ── Order of operations ───────────────────────────────────────────────────
+   The one style whose answer depends on nothing but how the line is read, so
+   the text and the value are returned together by the template that made them:
+   there is no second reading of the printed sentence anywhere in this file for
+   the first one to disagree with.
+
+   Every template names the numbers it draws `a`, `b`, `c`, `d` in the order
+   they are printed, and a division is built from its quotient outwards — so a
+   number *drawn* is inside the range a parent asked for, while a product or a
+   dividend built from two of them may run past it, exactly as a sum does on an
+   addition sheet.                                                            */
+
+type Expression = { text: string; value: number };
+
+type Template = {
+  id: string;
+  /** How many operations it holds, which is what `terms` chooses between. */
+  ops: number;
+  draw(pull: () => number, rand: () => number): Expression | null;
+};
+
+const TEMPLATES: Template[] = [
+  {
+    id: "add-times",
+    ops: 2,
+    draw: (pull) => {
+      const [a, b, c] = [pull(), pull(), pull()];
+      return {
+        text: `${signedText(a)} + ${factorText(b)} × ${factorText(c)} =`,
+        value: a + b * c,
+      };
+    },
+  },
+  {
+    id: "minus-times",
+    ops: 2,
+    draw: (pull) => {
+      const [a, b, c] = [pull(), pull(), pull()];
+      return {
+        text: `${signedText(a)} ${MINUS} ${factorText(b)} × ${factorText(c)} =`,
+        value: a - b * c,
+      };
+    },
+  },
+  {
+    id: "bracket-times",
+    ops: 2,
+    draw: (pull) => {
+      const [a, b, c] = [pull(), pull(), pull()];
+      return {
+        text: `(${signedText(a)} + ${factorText(b)}) × ${factorText(c)} =`,
+        value: (a + b) * c,
+      };
+    },
+  },
+  {
+    id: "bracket-minus-times",
+    ops: 2,
+    draw: (pull) => {
+      const [a, b, c] = [pull(), pull(), pull()];
+      return {
+        text: `${signedText(c)} × (${signedText(a)} ${MINUS} ${factorText(b)}) =`,
+        value: c * (a - b),
+      };
+    },
+  },
+  {
+    id: "divide-add",
+    ops: 2,
+    draw: (pull) => {
+      const [quotient, divisor, c] = [pull(), pull(), pull()];
+      // Dividing by one is not the step this sheet is about — the line would
+      // read as an addition with a decoration on the front of it.
+      if (Math.abs(divisor) === 1) return null;
+      return {
+        text: `${signedText(quotient * divisor)} ÷ ${factorText(divisor)} + ${factorText(c)} =`,
+        value: quotient + c,
+      };
+    },
+  },
+  {
+    id: "bracket-divide",
+    ops: 2,
+    draw: (pull) => {
+      const [quotient, divisor, c] = [pull(), pull(), pull()];
+      if (Math.abs(divisor) === 1) return null;
+      return {
+        text: `(${signedText(quotient * divisor - c)} + ${factorText(c)}) ÷ ${factorText(divisor)} =`,
+        value: quotient,
+      };
+    },
+  },
+  {
+    id: "square-add",
+    ops: 2,
+    draw: (pull, rand) => {
+      const [a, b] = [pull(), pull()];
+      const plus = rand() < 0.5;
+      return {
+        text: `${factorText(a)}² ${plus ? "+" : MINUS} ${factorText(b)} =`,
+        value: plus ? a * a + b : a * a - b,
+      };
+    },
+  },
+  {
+    id: "times-add-times",
+    ops: 3,
+    draw: (pull) => {
+      const [a, b, c, d] = [pull(), pull(), pull(), pull()];
+      return {
+        text: `${signedText(a)} × ${factorText(b)} + ${factorText(c)} × ${factorText(d)} =`,
+        value: a * b + c * d,
+      };
+    },
+  },
+  {
+    id: "add-times-minus",
+    ops: 3,
+    draw: (pull) => {
+      const [a, b, c, d] = [pull(), pull(), pull(), pull()];
+      return {
+        text: `${signedText(a)} + ${factorText(b)} × ${factorText(c)} ${MINUS} ${factorText(d)} =`,
+        value: a + b * c - d,
+      };
+    },
+  },
+  {
+    id: "bracket-times-minus",
+    ops: 3,
+    draw: (pull) => {
+      const [a, b, c, d] = [pull(), pull(), pull(), pull()];
+      return {
+        text: `(${signedText(a)} + ${factorText(b)}) × ${factorText(c)} ${MINUS} ${factorText(d)} =`,
+        value: (a + b) * c - d,
+      };
+    },
+  },
+  {
+    id: "add-bracket-times",
+    ops: 3,
+    draw: (pull) => {
+      const [a, b, c, d] = [pull(), pull(), pull(), pull()];
+      return {
+        text: `${signedText(a)} + (${signedText(b)} ${MINUS} ${factorText(c)}) × ${factorText(d)} =`,
+        value: a + (b - c) * d,
+      };
+    },
+  },
+  {
+    id: "square-times",
+    ops: 3,
+    draw: (pull) => {
+      const [a, b, c] = [pull(), pull(), pull()];
+      return {
+        text: `${factorText(a)}² + ${factorText(b)} × ${factorText(c)} =`,
+        value: a * a + b * c,
+      };
+    },
+  },
+];
+
+/**
+ * How big an expression's numbers may be, whatever the range says.
+ *
+ * Three operations over numbers to fifty is a page of five-digit answers, which
+ * is a multiplication lesson wearing an order-of-operations sheet's clothes.
+ * The rule being practised is which operation goes first, and it is practised
+ * on numbers a child can hold in their head.
+ */
+const EXPRESSION_MAX = 12;
+
+/**
+ * One expression, or `null` when what came out is not what the sheet asked for.
+ *
+ * A sheet with no negatives on it means no negative *anywhere*: not in the
+ * numbers, not in the answer, and not in the middle either. `(4 − 9) × 3` has
+ * every number positive and is a question about integers, which is the sheet a
+ * parent turned off. Checking the printed text for a minus sign is what makes
+ * that one rule rather than a condition inside every template.
+ */
+function drawExpression(
+  config: IntegerConfig,
+  rand: () => number,
+): Drawn | null {
+  const wanted = Math.max(2, Math.min(3, Math.floor(config.terms ?? 2)));
+  const pool = TEMPLATES.filter((one) => one.ops === wanted);
+  const template = pick(pool, rand);
+  const { min, max } = bounds(config.range);
+  const range = { min, max: Math.min(max, EXPRESSION_MAX) };
+  const drawn = template.draw(() => draw(config, rand, range), rand);
+  if (drawn === null) return null;
+
+  if (!signed(config)) {
+    // Three checks and not one, because a minus sign has three ways onto a
+    // page that promised none: on a number the template printed (`−12 ÷ 3`),
+    // on the answer, and inside the one bracket, which is the only intermediate
+    // an expression works out before its result. A minus sign *on a number* is
+    // written without the space a binary one carries, which is what tells the
+    // two apart in the printed line.
+    if (/−\d/.test(drawn.text)) return null;
+    if (drawn.value < 0) return null;
+    if (bracketed(drawn.text) < 0) return null;
+  }
+  return {
+    key: `${template.id}:${drawn.text}`,
+    prompt: drawn.text,
+    answer: signedText(drawn.value),
+  };
+}
+
+/**
+ * The value of the one bracket in an expression, or nought where there is none.
+ *
+ * The templates put at most one bracketed sub-expression on a line and it is
+ * the only place a positive-only sheet can go negative in the middle, so this
+ * is the whole of "no negative anywhere" rather than a condition repeated
+ * twelve times. `(−3)` is a bracketed *number* rather than a sub-expression,
+ * and never appears on a sheet with no negatives to draw.
+ */
+function bracketed(text: string): number {
+  const inner = /\((\d+) ([+−]) (\d+)\)/.exec(text);
+  if (!inner) return 0;
+  const [left, right] = [Number(inner[1]), Number(inner[3])];
+  return inner[2] === "+" ? left + right : left - right;
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/**
+ * How many problems the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic, not measurement, so `npm run test:unit` can answer "did it fit?"
+ * without a browser — and so the same answer serves the catalog page built at
+ * build time and the builder's preview (§4).
+ */
+export function integerLayout(config: IntegerConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of them.
+  const box = sheetBlockBox(headerOf(config), true);
+  const most = config.style === "order" ? MAX_EXPRESSION_COLUMNS : MAX_COLUMNS;
+  const columns = clamp(config.columns, 1, most);
+  const row = writtenRow(config.fontPt) + (config.workspace ? WORKSPACE : 0);
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
+  };
+}
+
+/**
+ * Every problem on the sheet, in the order they are printed.
+ *
+ * Exported because it is the whole of what a test has to check, and checking it
+ * through the `Sheet` means unwrapping a block union to reach it.
+ */
+export function integerProblems(
+  config: IntegerConfig,
+  seed: number,
+): Problem[] {
+  const { perPage } = integerLayout(config);
+  // The count is a request, not a promise: a count that overruns is a second
+  // sheet out of the printer with two problems on it.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  const seen = new Set<string>();
+  const problems: Problem[] = [];
+  const extras = config.workspace ? { workspace: WORKSPACE } : {};
+
+  let misses = 0;
+  while (problems.length < wanted && misses < MISS_BUDGET) {
+    const drawn = drawOne(config, rand);
+    // Not what was asked for, or already on the page. Either way the budget
+    // ticks down, and a pool that has run out ends the draw rather than
+    // repeating itself: there are twenty-eight squares and cubes under a
+    // hundred, and twenty-eight is the honest answer to a request for forty.
+    if (drawn === null || seen.has(drawn.key)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(drawn.key);
+    problems.push({ prompt: drawn.prompt, answer: drawn.answer, ...extras });
+    misses = 0;
+  }
+  return problems;
+}
+
+function drawOne(config: IntegerConfig, rand: () => number): Drawn | null {
+  switch (config.style) {
+    case "order":
+      return drawExpression(config, rand);
+    case "powers":
+      return drawPower(config, rand);
+    default:
+      return drawSum(config, rand);
+  }
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const OPERATION_NAME: Record<IntegerOperation, string> = {
+  add: "Adding integers",
+  subtract: "Subtracting integers",
+  multiply: "Multiplying integers",
+  divide: "Dividing integers",
+  both: "Integer arithmetic",
+};
+
+/** "Multiplying integers" — the phrase a parent says, and the one they search. */
+function titleOf(config: IntegerConfig): string {
+  if (config.style === "order") return "Order of operations";
+  if (config.style === "powers") return "Powers and roots";
+  return OPERATION_NAME[config.operation] ?? OPERATION_NAME.both;
+}
+
+const INSTRUCTION: Record<IntegerStyle, string> = {
+  arithmetic: "Work out each answer. Watch the signs.",
+  order: "Work out each answer. Brackets first, then powers, then × and ÷.",
+  powers: "Work out each answer.",
+};
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: IntegerConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions:
+      config.instructions ??
+      INSTRUCTION[config.style] ??
+      INSTRUCTION.arithmetic,
+  };
+}
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * What the title leaves off is the one thing that decides whether the sheet is
+ * this term's work or last term's: whether there are minus signs on it at all.
+ */
+export function describeIntegers(config: IntegerConfig): string {
+  const { max } = bounds(config.range);
+  return [
+    titleOf(config),
+    signed(config) ? "positive and negative" : "positive numbers only",
+    config.style === "powers" ? "squares and cubes" : `numbers to ${max}`,
+    config.style === "order" ? `${config.terms ?? 2} operations` : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" — ");
+}
+
+export function buildIntegerSheet(config: IntegerConfig, seed: number): Sheet {
+  const items = integerProblems(config, seed);
+  const { columns } = integerLayout(config);
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is actually on the page, not out of what was asked for: a
+      // sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf: items.length },
+    },
+    blocks: [{ kind: "problems", columns, items }],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const INTEGERS_SHEET: SheetSpec<IntegerConfig> = {
+  id: "integers",
+  label: "Integers and powers",
+  world: SHEET_WORLD,
+  build: buildIntegerSheet,
+  // The whole of the answer-key mechanism: every answer on the page was
+  // computed from the same signed numbers the problem was printed from, so a
+  // key prints what is already there rather than reading the sentence back.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeIntegers,
+};

--- a/src/engine/sheets/maths/prealgebra.test.ts
+++ b/src/engine/sheets/maths/prealgebra.test.ts
@@ -1,0 +1,673 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { BLOCK_GAP, PROBLEM_GAP } from "../layout";
+import type {
+  GridMark,
+  MarginSize,
+  Paper,
+  PaperSize,
+  PreAlgebraConfig,
+  Problem,
+} from "../types";
+
+import { PREALGEBRA_SHEET, preAlgebraLayout } from "./prealgebra";
+
+/**
+ * Pre-algebra, held to the bar the maths families set — and to one more, because
+ * three of these five styles have an answer that can be nearly right.
+ *
+ * **Nothing here checks the generator against the generator.** Every assertion
+ * starts from the characters that were printed:
+ *
+ * - **an equation is checked by substitution**, which is the only check on a
+ *   solution worth having: the answer goes back into the printed left-hand side
+ *   and has to come out as the printed right-hand one. The family never
+ *   substituted anything — it built the equation around the answer — so this is
+ *   a path it does not have;
+ * - **an inequality is checked by trying numbers.** Forty candidates either side
+ *   of the boundary are put into the printed inequality and into the printed
+ *   answer, and the two have to agree about every one of them. A sign that
+ *   should have flipped and didn't disagrees on all forty;
+ * - **a slope is cross-multiplied** against the two points it was read from, and
+ *   proved to be in lowest terms by a factor search rather than by the greatest
+ *   common divisor the family reduced with;
+ * - **a graph's points are recovered from the marks on the grid**, so the dots a
+ *   child reads and the key they are marked against are tied together on the
+ *   page rather than in the generator.
+ */
+
+/* ── Reading algebra back off the page ───────────────────────────────────── */
+
+/** A number as this family writes one: the proper minus sign, U+2212. */
+const num = (text: string): number => Number(text.replace(/−/g, "-"));
+
+/**
+ * A linear expression, as `(p·x + q) / r` with `r` positive.
+ *
+ * Parsed from the printed text and from nothing else — the family's own
+ * description of the same side is never consulted, which is what makes the
+ * substitution below a check rather than a restatement.
+ */
+type Side = { p: number; q: number; r: number };
+
+function sideOf(text: string): Side {
+  const bracket = /^(−?\d+)\(x( ([+−]) (\d+))?\)$/.exec(text);
+  if (bracket) {
+    const outside = num(bracket[1]);
+    const inside = constantOf(bracket[3], bracket[4]);
+    return { p: outside, q: outside * inside, r: 1 };
+  }
+  const over = /^x\/(\d+)( ([+−]) (\d+))?$/.exec(text);
+  if (over) {
+    const divisor = Number(over[1]);
+    return { p: 1, q: divisor * constantOf(over[3], over[4]), r: divisor };
+  }
+  const times = /^(−?\d*)x( ([+−]) (\d+))?$/.exec(text);
+  if (times) {
+    return {
+      p: coefficientOf(times[1]),
+      q: constantOf(times[3], times[4]),
+      r: 1,
+    };
+  }
+  throw new Error(`not a linear expression: "${text}"`);
+}
+
+/** "" is one and "−" is minus one — nobody writes `1x`. */
+const coefficientOf = (written: string): number =>
+  written === "" ? 1 : written === "−" ? -1 : num(written);
+
+/** The constant on the end, with the sign that the operator in front carries. */
+const constantOf = (
+  sign: string | undefined,
+  size: string | undefined,
+): number => (size === undefined ? 0 : (sign === "−" ? -1 : 1) * Number(size));
+
+/** What a side is worth at a value, as a fraction so nothing is rounded. */
+const worth = (side: Side, x: number): { n: number; d: number } => ({
+  n: side.p * x + side.q,
+  d: side.r,
+});
+
+/**
+ * Every term of a collected expression: how many `x` and how many units.
+ *
+ * The first term carries its own sign against it — "−10x" — and every later one
+ * has an operator with a space on each side, which is exactly how the printed
+ * line distinguishes them.
+ */
+function collected(text: string): { x: number; units: number } {
+  const parts = text
+    .replace(/ =$/, "")
+    .trim()
+    .split(/ ([+−]) /);
+  let x = 0;
+  let units = 0;
+  for (let at = 0; at < parts.length; at += 2) {
+    // The operator in front of a term is the element before it, which is what
+    // splitting on a capture leaves behind. The first term has none, and wears
+    // its own sign instead.
+    const sign = at === 0 ? 1 : parts[at - 1] === "−" ? -1 : 1;
+    const piece = parts[at];
+    const letter = /^(−?\d*)x$/.exec(piece);
+    if (letter) x += sign * coefficientOf(letter[1]);
+    else if (/^−?\d+$/.test(piece)) units += sign * num(piece);
+    else throw new Error(`what is "${piece}" in "${text}"?`);
+  }
+  return { x, units };
+}
+
+/** The greatest common divisor, found by trying every factor there is. */
+function commonFactor(a: number, b: number): number {
+  let most = 1;
+  for (let by = 1; by <= Math.min(Math.abs(a), Math.abs(b)); by += 1) {
+    if (a % by === 0 && b % by === 0) most = by;
+  }
+  return most;
+}
+
+/** A slope as it is written: "3", "−1/2", "0". */
+function slopeOf(text: string): { n: number; d: number } {
+  const over = /^(−?\d+)\/(−?\d+)$/.exec(text);
+  if (over) return { n: num(over[1]), d: num(over[2]) };
+  if (/^−?\d+$/.test(text)) return { n: num(text), d: 1 };
+  throw new Error(`not a slope: "${text}"`);
+}
+
+/**
+ * That a printed slope really is the slope of the line through two points.
+ *
+ * Cross-multiplied, so there is no division anywhere in the check, and held to
+ * lowest terms with a positive denominator: 6/4, 3/−2 and −3/2 are one number
+ * written three ways, and a child who wrote either of the first two would be
+ * marked wrong by the same teacher who accepted the key.
+ */
+function expectSlope(
+  written: string,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  said: string,
+): void {
+  const { n, d } = slopeOf(written);
+  expect(d, said).toBeGreaterThan(0);
+  expect(
+    commonFactor(n, d),
+    `${written} is not in lowest terms — ${said}`,
+  ).toBe(1);
+  // Compared rather than asserted equal, because a slope of nought over a line
+  // drawn right to left is minus nought, which `toBe` and a child both call
+  // zero and only one of them means it.
+  expect(n * (to.x - from.x) === d * (to.y - from.y), said).toBe(true);
+}
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const config = (over: Partial<PreAlgebraConfig> = {}): PreAlgebraConfig => ({
+  kind: "prealgebra",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style: "expression",
+  range: { min: 1, max: 12 },
+  count: 10,
+  columns: 2,
+  ...over,
+});
+
+/**
+ * Every shape the family can print, which is every acceptance criterion of the
+ * story: expressions, one- and two-step equations, inequalities, slope from a
+ * pair of points and slope from a graph.
+ */
+const EVERY_SHAPE: Array<Partial<PreAlgebraConfig>> = [
+  {},
+  { negatives: false },
+  { style: "equation" },
+  { style: "equation", steps: 2 },
+  { style: "equation", steps: 2, negatives: false },
+  { style: "equation", range: { min: 2, max: 30 } },
+  { style: "inequality" },
+  { style: "inequality", steps: 2 },
+  { style: "inequality", steps: 2, negatives: false },
+  { style: "slope" },
+  { style: "slope", negatives: false },
+  { style: "graph" },
+  { style: "graph", quadrants: 1 },
+  { workspace: true, count: 6 },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** The problems block, which is the last one whatever else is on the sheet. */
+function problemsOf(over: Partial<PreAlgebraConfig>, seed: number): Problem[] {
+  const blocks = buildSheet(config(over), seed).blocks;
+  const block = blocks[blocks.length - 1];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+/** And the plane above them, on the one style that has one. */
+function marksOf(over: Partial<PreAlgebraConfig>, seed: number): GridMark[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "grid")
+    throw new Error(`expected a grid, got ${block.kind}`);
+  return block.grid.marks ?? [];
+}
+
+const everyProblem = function* (
+  shapes: Array<Partial<PreAlgebraConfig>> = EVERY_SHAPE,
+): Generator<[Partial<PreAlgebraConfig>, Problem]> {
+  for (const shape of shapes) {
+    for (const seed of SEEDS) {
+      const problems = problemsOf(shape, seed);
+      expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+      for (const problem of problems) yield [shape, problem];
+    }
+  }
+};
+
+const shapesOf = (style: string): Array<Partial<PreAlgebraConfig>> =>
+  EVERY_SHAPE.filter((one) => (one.style ?? "expression") === style);
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the pre-algebra family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("prealgebra")).toBe(PREALGEBRA_SHEET);
+    expect(sheetSpec("prealgebra").label).toBe("Pre-algebra");
+  });
+
+  it("names the sheet in the words a parent chose it by", () => {
+    expect(describeSheet(config({ style: "equation", steps: 2 }))).toBe(
+      "Two-step equations — positive and negative — numbers to 12",
+    );
+    expect(
+      describeSheet(config({ style: "inequality", negatives: false })),
+    ).toBe("One-step inequalities — positive numbers only — numbers to 12");
+    expect(describeSheet(config({ style: "graph", quadrants: 1 }))).toBe(
+      "Slope from a graph — the first quadrant",
+    );
+  });
+
+  it("tells a child what to write, which is not a number on three of these", () => {
+    expect(
+      buildSheet(config({ style: "equation" }), 1).header.instructions,
+    ).toBe("Solve each equation. Write the value of x.");
+    expect(
+      buildSheet(config({ style: "inequality" }), 1).header.instructions,
+    ).toBe("Solve each inequality. Write it as x and a sign.");
+    expect(buildSheet(config({ style: "graph" }), 1).header.instructions).toBe(
+      "Read each pair of points off the graph and write the slope.",
+    );
+  });
+
+  it("marks the sheet out of what is on it", () => {
+    const sheet = buildSheet(config({ count: 7 }), 3);
+    const block = sheet.blocks[sheet.blocks.length - 1];
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("solves every equation, checked by putting the answer back in", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("equation"))) {
+      const said = `${problem.prompt} → ${problem.answer} ${JSON.stringify(shape)}`;
+      const [left, right] = problem.prompt.split(" = ");
+      const answer = /^x = (−?\d+)$/.exec(problem.answer);
+      expect(answer, said).not.toBeNull();
+      const value = worth(sideOf(left), num(answer?.[1] ?? "0"));
+      // Cross-multiplied rather than divided out: `x/4 + 2 = 5` is checked as
+      // whole numbers, and there is no division in this file at all.
+      expect(value.n, said).toBe(num(right) * value.d);
+    }
+  });
+
+  it("turns an inequality round when it has to, checked by trying numbers", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("inequality"))) {
+      const said = `${problem.prompt} → ${problem.answer} ${JSON.stringify(shape)}`;
+      const asked = /^(.+) ([<>≤≥]) (−?\d+)$/.exec(problem.prompt);
+      const told = /^x ([<>≤≥]) (−?\d+)$/.exec(problem.answer);
+      expect(asked, said).not.toBeNull();
+      expect(told, said).not.toBeNull();
+      if (!asked || !told) continue;
+
+      const side = sideOf(asked[1]);
+      const against = num(asked[3]);
+      const boundary = num(told[2]);
+      for (let x = boundary - 20; x <= boundary + 20; x += 1) {
+        const value = worth(side, x);
+        // `r` is positive, so multiplying both sides by it leaves the sense of
+        // the comparison alone — which is the whole of why `Side` carries a
+        // positive denominator.
+        expect(
+          holds(value.n, asked[2], against * value.d),
+          `${said} at x = ${x}`,
+        ) //
+          .toBe(holds(x, told[1], boundary));
+      }
+    }
+  });
+
+  it("works out every expression again from the letters on the page", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("expression"))) {
+      const said = `${problem.prompt} → ${problem.answer} ${JSON.stringify(shape)}`;
+      const two = /^(−?\d*)x ([+−]) (\d+)y when x = (−?\d+), y = (−?\d+)$/.exec(
+        problem.prompt,
+      );
+      if (two) {
+        // Two letters, so each term is multiplied by its own value and the
+        // operator between them says what happens to the second.
+        const first = coefficientOf(two[1]) * num(two[4]);
+        const second = Number(two[3]) * num(two[5]);
+        expect(num(problem.answer), said).toBe(
+          two[2] === "−" ? first - second : first + second,
+        );
+        continue;
+      }
+      const one = /^(.+) when x = (−?\d+)$/.exec(problem.prompt);
+      if (one) {
+        const value = worth(sideOf(one[1]), num(one[2]));
+        expect(num(problem.answer) * value.d, said).toBe(value.n);
+        continue;
+      }
+      // Nothing to put in: the question is the tidying up, so both sides are
+      // collected the same way and have to come out the same.
+      expect(collected(problem.answer), said).toEqual(
+        collected(problem.prompt),
+      );
+    }
+  });
+
+  it("reduces every slope, and never writes one over a negative", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("slope"))) {
+      const points = [...problem.prompt.matchAll(/\((−?\d+), (−?\d+)\)/g)].map(
+        (found) => ({ x: num(found[1]), y: num(found[2]) }),
+      );
+      expect(points.length, problem.prompt).toBe(2);
+      expectSlope(
+        problem.answer,
+        points[0],
+        points[1],
+        `${problem.prompt} ${JSON.stringify(shape)}`,
+      );
+    }
+  });
+
+  it("reads a graph's slopes off the dots that are printed on it", () => {
+    for (const shape of shapesOf("graph")) {
+      for (const seed of SEEDS) {
+        const points = plotted(marksOf(shape, seed), shape);
+        for (const problem of problemsOf(shape, seed)) {
+          const named = /^([A-Z]) and ([A-Z])$/.exec(problem.prompt);
+          expect(named, problem.prompt).not.toBeNull();
+          const [from, to] = [
+            points[named?.[1] ?? ""],
+            points[named?.[2] ?? ""],
+          ];
+          expect(from, problem.prompt).toBeDefined();
+          expect(to, problem.prompt).toBeDefined();
+          expectSlope(problem.answer, from, to, problem.prompt);
+        }
+      }
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    for (const shape of EVERY_SHAPE) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+});
+
+/**
+ * The two things that can have been done to the letter: multiplied by
+ * something, and had something added to it.
+ *
+ * Which is what "one step" and "two steps" mean at the top of the page — one of
+ * these, or both — read off the printed side rather than taken from the config.
+ */
+function movesOf(prompt: string): { scaled: boolean; shifted: boolean } {
+  const side = sideOf(prompt.split(/ [=<>≤≥] /)[0]);
+  return { scaled: side.p !== 1 || side.r !== 1, shifted: side.q !== 0 };
+}
+
+/** Whether a comparison is true, in the four signs a sheet may print. */
+function holds(left: number, relation: string, right: number): boolean {
+  if (relation === "<") return left < right;
+  if (relation === ">") return left > right;
+  if (relation === "≤") return left <= right;
+  if (relation === "≥") return left >= right;
+  throw new Error(`what sign is "${relation}"?`);
+}
+
+/**
+ * Where each lettered point sits, recovered from the marks on the grid.
+ *
+ * Counted back through the origin, the same way a child counts squares out from
+ * where the two heavy rules cross — so what the suite marks against is the dot
+ * on the paper rather than the number the generator drew.
+ */
+function plotted(
+  marks: GridMark[],
+  shape: Partial<PreAlgebraConfig>,
+): Record<string, { x: number; y: number }> {
+  const quadrants = Math.floor(shape.quadrants ?? 4);
+  // One square of margin on a quarter plane, and a whole span on a full one:
+  // the numerals live in that margin, and the origin sits past it.
+  const span = quadrants === 4 ? 8 : 10;
+  const origin = { column: quadrants === 4 ? span : 1, row: span };
+  const out: Record<string, { x: number; y: number }> = {};
+  for (const mark of marks) {
+    out[mark.label] = {
+      x: mark.column - origin.column,
+      y: origin.row - mark.row,
+    };
+  }
+  return out;
+}
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  it("never prints a coefficient of one, which nobody writes", () => {
+    for (const [, problem] of everyProblem()) {
+      expect(problem.prompt, problem.prompt).not.toMatch(/(^|[^\d])1x/);
+      expect(problem.answer, problem.answer).not.toMatch(/(^|[^\d])1x/);
+    }
+  });
+
+  it("never divides by nothing, and never asks for a vertical line", () => {
+    for (const [, problem] of everyProblem()) {
+      expect(problem.prompt, problem.prompt).not.toMatch(/x\/0/);
+      // A vertical line's slope is not a number, so no answer may say it is.
+      expect(problem.answer, problem.answer).not.toMatch(/\/0$/);
+    }
+  });
+
+  it("puts no minus sign at all on a sheet that turned them off", () => {
+    for (const [, problem] of everyProblem(
+      EVERY_SHAPE.filter((one) => one.negatives === false),
+    )) {
+      const sentence = `${problem.prompt} ${problem.answer}`;
+      expect(sentence, sentence).not.toMatch(/−\d/);
+      expect(sentence, sentence).not.toMatch(/−x/);
+    }
+  });
+
+  it("asks about one step or two, and says which at the top of the page", () => {
+    // A two-step sheet whose problems come undone in one move is a sheet set at
+    // a level nobody chose — and the title says which, so it is also a lie.
+    for (const style of ["equation", "inequality"] as const) {
+      for (const seed of SEEDS) {
+        for (const problem of problemsOf(
+          { style, steps: 1, count: 10 },
+          seed,
+        )) {
+          // One step: the letter is either multiplied by something or has
+          // something added to it, and never both.
+          const { scaled, shifted } = movesOf(problem.prompt);
+          expect(scaled !== shifted, problem.prompt).toBe(true);
+        }
+        for (const problem of problemsOf(
+          { style, steps: 2, count: 10 },
+          seed,
+        )) {
+          // Two steps: something done to the letter, and something done after.
+          const { scaled, shifted } = movesOf(problem.prompt);
+          expect(scaled && shifted, problem.prompt).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("marks every point on a graph inside the plane, each at its own x", () => {
+    // Two points at the same x make a vertical line, whose slope is not a
+    // number a child can write in a blank.
+    for (const shape of shapesOf("graph")) {
+      for (const seed of SEEDS) {
+        const points = Object.values(plotted(marksOf(shape, seed), shape));
+        const span = Math.floor(shape.quadrants ?? 4) === 4 ? 8 : 10;
+        const low = Math.floor(shape.quadrants ?? 4) === 4 ? -span : 1;
+        expect(new Set(points.map((point) => point.x)).size).toBe(
+          points.length,
+        );
+        for (const point of points) {
+          for (const at of [point.x, point.y]) {
+            expect(at, JSON.stringify(point)).toBeGreaterThanOrEqual(low);
+            expect(at, JSON.stringify(point)).toBeLessThanOrEqual(span);
+            // Never on an axis: a dot on one of the two heavy rules is a dot a
+            // child has to look twice at.
+            expect(at, JSON.stringify(point)).not.toBe(0);
+          }
+        }
+      }
+    }
+  });
+
+  it("gives every problem exactly one place to write the answer", () => {
+    for (const [, problem] of everyProblem()) {
+      expect(problem.prompt.split("_").length - 1).toBe(0);
+      expect(problem.answers).toBeUndefined();
+    }
+  });
+
+  it("asks the same question twice on no sheet at all", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const asked = problemsOf(shape, seed).map((problem) => problem.prompt);
+        expect(new Set(asked).size, JSON.stringify(shape)).toBe(asked.length);
+      }
+    }
+  });
+});
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    expect(problemsOf({ style: "equation", steps: 2, count: 3 }, 7).map(said)) //
+      .toEqual(GOLDEN.equation);
+    expect(
+      problemsOf({ style: "inequality", steps: 2, count: 3 }, 7).map(said),
+    ).toEqual(GOLDEN.inequality);
+    expect(problemsOf({ style: "slope", count: 3 }, 7).map(said)).toEqual(
+      GOLDEN.slope,
+    );
+  });
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    for (const shape of EVERY_SHAPE) {
+      const [a, b, c] = [0, 1, 2].map((offset) =>
+        problemsOf({ ...shape, count: 6 }, 100 + offset).map(
+          (problem) => problem.prompt,
+        ),
+      );
+      for (const [one, other] of [
+        [a, b],
+        [a, c],
+        [b, c],
+      ]) {
+        expect(one, JSON.stringify(shape)).not.toEqual(other);
+        const shared = one.filter((asked) => other.includes(asked)).length;
+        expect(shared, JSON.stringify(shape)).toBeLessThan(
+          (one.length * 2) / 3,
+        );
+      }
+    }
+  });
+});
+
+const said = (problem: Problem): [string, string] => [
+  problem.prompt,
+  problem.answer,
+];
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row, plane } = preAlgebraLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used =
+              rows * row +
+              Math.max(0, rows - 1) * PROBLEM_GAP.y +
+              (plane ? plane.grid.rows * plane.grid.cell + BLOCK_GAP : 0);
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("does not throw the page away either", () => {
+    const { box, row, perPage, columns } = preAlgebraLayout(config());
+    expect(perPage).toBeGreaterThanOrEqual(12);
+    const rows = perPage / columns;
+    expect((rows + 1) * row + rows * PROBLEM_GAP.y).toBeGreaterThan(box.height);
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ style: "equation", count: 9 }, 1).length).toBe(9);
+    for (const columns of [1, 2, 3]) {
+      const blocks = buildSheet(
+        config({ style: "equation", columns }),
+        1,
+      ).blocks;
+      const block = blocks[blocks.length - 1];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+    // Two columns of expressions, because `2x + 3y when x = 4, y = 2` is most
+    // of a line of type before its answer slot.
+    const wide = buildSheet(config({ columns: 6 }), 1).blocks[0];
+    expect(wide.kind === "problems" && wide.columns).toBe(2);
+  });
+});
+
+/**
+ * What three sheets came out as on the day this shipped.
+ *
+ * Recorded rather than computed — all three are proved right by the assertions
+ * above, and what these hold is that they do not silently *change*.
+ */
+const GOLDEN = {
+  equation: [
+    ["2x + 9 = −1", "x = −5"],
+    ["8x − 4 = 76", "x = 10"],
+    ["−6x − 7 = 65", "x = −12"],
+  ],
+  inequality: [
+    ["2x + 9 < −1", "x < −5"],
+    ["x/10 + 2 > −5", "x > −70"],
+    ["−7x − 12 < 65", "x > −11"],
+  ],
+  slope: [
+    ["(−1, 12) and (−7, −6)", "3"],
+    ["(7, −4) and (10, −3)", "1/3"],
+    ["(4, 4) and (3, −3)", "7"],
+  ],
+};

--- a/src/engine/sheets/maths/prealgebra.test.ts
+++ b/src/engine/sheets/maths/prealgebra.test.ts
@@ -256,6 +256,15 @@ describe("the pre-algebra family", () => {
     expect(describeSheet(config({ style: "graph", quadrants: 1 }))).toBe(
       "Slope from a graph — the first quadrant",
     );
+    // A config arrives from a bookmark or from a sheet saved months ago, so the
+    // numbers in it are not to be trusted: five steps prints two-step problems,
+    // and the name has to be the name of what came out.
+    expect(describeSheet(config({ style: "equation", steps: 5 }))).toBe(
+      "Two-step equations — positive and negative — numbers to 12",
+    );
+    expect(describeSheet(config({ style: "inequality", steps: 0 }))).toBe(
+      "One-step inequalities — positive and negative — numbers to 12",
+    );
   });
 
   it("tells a child what to write, which is not a number on three of these", () => {
@@ -499,6 +508,18 @@ describe("what may be on the page", () => {
           const { scaled, shifted } = movesOf(problem.prompt);
           expect(scaled && shifted, problem.prompt).toBe(true);
         }
+      }
+      // And a number nobody chose — a saved config, or a bookmarked URL — is
+      // drawn as the nearest one that exists and *named* as that one. A page of
+      // two-step problems under "One-step equations" is the same lie the other
+      // way round.
+      const wild = { style, steps: 5, count: 10 };
+      expect(buildSheet(config(wild), 1).header.title, style).toBe(
+        `Two-step ${style === "equation" ? "equations" : "inequalities"}`,
+      );
+      for (const problem of problemsOf(wild, 1)) {
+        const { scaled, shifted } = movesOf(problem.prompt);
+        expect(scaled && shifted, problem.prompt).toBe(true);
       }
     }
   });

--- a/src/engine/sheets/maths/prealgebra.ts
+++ b/src/engine/sheets/maths/prealgebra.ts
@@ -393,11 +393,22 @@ const FORMS: Form[] = [
 const valueAt = (side: Side, x: number): number =>
   (side.p * x + side.q) / side.r;
 
+/**
+ * How many moves this sheet's problems take to undo.
+ *
+ * Read by the draw and by the title, from one place. A config arrives from a
+ * bookmarked URL or from a sheet saved months ago, so `steps: 5` is a thing
+ * that happens — it draws two-step problems, and a heading reading the raw
+ * number would call them one-step over a page that is nothing of the kind.
+ */
+const stepsOf = (config: PreAlgebraConfig): number =>
+  Math.max(1, Math.min(2, Math.floor(config.steps ?? 1)));
+
 function drawSide(
   config: PreAlgebraConfig,
   rand: () => number,
 ): { side: Side; x: number } {
-  const wanted = Math.max(1, Math.min(2, Math.floor(config.steps ?? 1)));
+  const wanted = stepsOf(config);
   return pick(
     FORMS.filter((form) => form.steps === wanted),
     rand,
@@ -666,7 +677,7 @@ function drawOne(
 
 /** "Two-step equations" — the phrase a parent says, and the one they search. */
 function titleOf(config: PreAlgebraConfig): string {
-  const steps = Math.floor(config.steps ?? 1) === 2 ? "Two-step" : "One-step";
+  const steps = stepsOf(config) === 2 ? "Two-step" : "One-step";
   switch (config.style) {
     case "equation":
       return `${steps} equations`;

--- a/src/engine/sheets/maths/prealgebra.ts
+++ b/src/engine/sheets/maths/prealgebra.ts
@@ -1,0 +1,786 @@
+/**
+ * Expressions, equations, inequalities and slope.
+ *
+ * The family where the answer stops being a number. `x = 5` is a sentence,
+ * `x > −4` is every number past a point, and a slope is a pair of numbers that
+ * is only right written the smallest way — so three of the five styles here
+ * have an answer that a generator can get *nearly* right, which is the same as
+ * wrong on a page a child is marked against.
+ *
+ * Three decisions carry the family.
+ *
+ * **Every equation is built from its solution.** The number that makes it true
+ * is drawn first and the equation is assembled around it, so the key is not the
+ * result of solving anything — there is nothing to solve, and therefore nothing
+ * to solve wrongly. The suite then puts the answer back into the printed
+ * equation, which is the only check on a solution that is worth anything.
+ *
+ * **A sign flips when you divide by a negative.** `−2x > 8` is `x < −4`, and it
+ * is the single most-missed step in pre-algebra. It lives in exactly one place
+ * here — `solutionOf` — because a second copy of that rule is a second chance to
+ * get it backwards, and a page of inequalities each turned the wrong way looks
+ * completely plausible.
+ *
+ * **Algebra folds a sign into the operator.** The integers sheet writes
+ * `7 + (−4)`, because two operators in a row cannot be read aloud; algebra
+ * writes `3x − 4`, because that is what a textbook, a board and an exam paper
+ * print. Both conventions are right for their sheet and neither is right for the
+ * other, which is why `factorText` is imported by one of these files and not the
+ * other.
+ */
+import { between, mulberry32, shuffled } from "@/engine/random";
+
+import type {
+  AlgebraStyle,
+  GridMark,
+  Mil,
+  PreAlgebraConfig,
+  Problem,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import {
+  BLOCK_GAP,
+  PROBLEM_GAP,
+  WRAP_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches } from "../paper";
+import {
+  letterAt,
+  markAt,
+  planeFloor,
+  planeHeight,
+  planeOf,
+  type Plane,
+} from "../plane";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import { MINUS, fractionText, reduced, signedText } from "./exact";
+
+/* ── What a problem takes on the page ─────────────────────────────────────
+   Declared, not measured (§4).                                              */
+
+/** Two lines of the body type and the air a wrap puts between them. */
+const writtenRow = (fontPt: number): Mil => 2 * answerLine(fontPt) + WRAP_GAP;
+
+/** Blank space to work an answer out in, when the config asks for it. */
+const WORKSPACE = inches(0.55);
+
+/**
+ * Three columns of equations, and two of expressions.
+ *
+ * `2x + 3y when x = 4, y = 2` is most of a line of type before its answer slot,
+ * and a column narrower than the sentence is a page of problems each wrapped
+ * onto three lines.
+ */
+const MAX_COLUMNS = 3;
+const MAX_EXPRESSION_COLUMNS = 2;
+
+/** As `arithmetic.ts` — see the note there on why a budget rather than a proof. */
+const MISS_BUDGET = 500;
+
+/** The letter this family solves for. Every sheet in the world uses it. */
+const X = "x";
+
+/**
+ * How many points a graph sheet marks on its plane.
+ *
+ * Six points make fifteen pairs, which is more questions than fit under a plane
+ * that has taken half the page — and few enough that a child is not hunting
+ * through an alphabet to find the one they were asked about.
+ */
+const POINTS = 6;
+
+/* ── Writing algebra ───────────────────────────────────────────────────────
+   Four small functions, and between them every line this family prints. The
+   sign of a constant is folded into the operator in front of it, which is what
+   makes `3x − 4` rather than `3x + (−4)`.                                    */
+
+/**
+ * A term in a letter: "x", "−x", "3x", "−3x" — or "3y", on the one sheet with
+ * two letters on it.
+ *
+ * One is never printed: `1x` is not a thing anybody writes, and a child copying
+ * it into their working would be copying a mistake.
+ */
+function termText(coefficient: number, letter = X): string {
+  if (coefficient === 1) return letter;
+  if (coefficient === -1) return `${MINUS}${letter}`;
+  return `${signedText(coefficient)}${letter}`;
+}
+
+/** What follows it: " + 4", " − 4", or nothing at all when there is nothing. */
+const thenText = (value: number): string =>
+  value === 0 ? "" : ` ${value < 0 ? MINUS : "+"} ${Math.abs(value)}`;
+
+/** A whole linear expression: "3x + 4", "−x − 5", "6" when the letter cancels. */
+const linearText = (coefficient: number, constant: number): string =>
+  coefficient === 0
+    ? String(constant)
+    : `${termText(coefficient)}${thenText(constant)}`;
+
+/* ── Drawing a number ──────────────────────────────────────────────────── */
+
+function bounds(range: { min: number; max: number }): {
+  min: number;
+  max: number;
+} {
+  const min = Math.max(1, Math.floor(range?.min ?? 1));
+  return { min, max: Math.max(min, Math.floor(range?.max ?? 1)) };
+}
+
+const pick = <T>(items: readonly T[], rand: () => number): T =>
+  items[Math.floor(rand() * items.length)];
+
+/** Whether this sheet may put a minus sign on a number. On unless refused. */
+const signed = (config: PreAlgebraConfig): boolean =>
+  config.negatives !== false;
+
+/**
+ * One number of the size the config asked for, with its sign drawn separately.
+ *
+ * The range counts magnitudes, as it does on an integers sheet: a parent asks
+ * for "numbers to twenty" and means twenty either way round.
+ */
+function draw(
+  config: PreAlgebraConfig,
+  rand: () => number,
+  range = bounds(config.range),
+): number {
+  const size = between(range.min, range.max, rand);
+  return signed(config) && rand() < 0.5 ? -size : size;
+}
+
+/** A coefficient never being one, which would make a two-step sheet one-step. */
+const drawCoefficient = (
+  config: PreAlgebraConfig,
+  rand: () => number,
+): number => {
+  const { min, max } = bounds(config.range);
+  return draw(config, rand, { min: Math.max(2, min), max: Math.max(2, max) });
+};
+
+type Drawn = { key: string; prompt: string; answer: string };
+
+/* ── Expressions ───────────────────────────────────────────────────────────
+   Two questions under one heading, because they are the two halves of one
+   lesson: putting a number into a rule, and tidying a rule up before anybody
+   puts a number into it.                                                    */
+
+/**
+ * A rule with a number put into it: "3x + 4 when x = 5".
+ *
+ * Every shape here is built so the arithmetic lands whole — the division form
+ * draws the multiple rather than the value — and the answer is worked out from
+ * the same three numbers the sentence is printed from.
+ */
+function drawEvaluate(config: PreAlgebraConfig, rand: () => number): Drawn {
+  const coefficient = drawCoefficient(config, rand);
+  const constant = draw(config, rand);
+  const value = draw(config, rand);
+  const shape = Math.floor(rand() * 4);
+
+  if (shape === 0) {
+    return evaluated(
+      `${linearText(coefficient, constant)} when ${X} = ${signedText(value)}`,
+      coefficient * value + constant,
+    );
+  }
+  if (shape === 1) {
+    // A bracket, which is the same rule with the multiplying done last — and
+    // the one shape on the sheet where a child who works left to right gets a
+    // different answer from one who does not.
+    return evaluated(
+      `${signedText(coefficient)}(${X}${thenText(constant)}) when ${X} = ${signedText(value)}`,
+      coefficient * (value + constant),
+    );
+  }
+  if (shape === 2) {
+    // Over a divisor, so the value put in is a multiple of it: a sheet whose
+    // answer is 4⅓ is a fractions sheet that got in by the back door.
+    const divisor = Math.abs(drawCoefficient(config, rand));
+    const multiple = draw(config, rand);
+    return evaluated(
+      `${X}/${divisor}${thenText(constant)} when ${X} = ${signedText(multiple * divisor)}`,
+      multiple + constant,
+    );
+  }
+  // Two letters, which is the first time a child meets an expression that
+  // cannot be tidied up before the numbers arrive.
+  const second = drawCoefficient(config, rand);
+  const other = draw(config, rand);
+  return evaluated(
+    `${termText(coefficient)}${thenText(second)}y when ${X} = ${signedText(value)}, y = ${signedText(other)}`,
+    coefficient * value + second * other,
+  );
+}
+
+const evaluated = (prompt: string, value: number): Drawn => ({
+  key: `evaluate:${prompt}`,
+  prompt,
+  answer: signedText(value),
+});
+
+/**
+ * Like terms, collected: "5x + 3x − 2x =" makes "6x".
+ *
+ * The answer is assembled by `linearText` from two totals, which is what keeps
+ * `0x + 7` off the page: an expression whose letters cancel is written as the
+ * number it is, and one whose numbers cancel is written without them.
+ */
+function drawSimplify(
+  config: PreAlgebraConfig,
+  rand: () => number,
+): Drawn | null {
+  const first = drawCoefficient(config, rand);
+  const second = drawCoefficient(config, rand);
+  const withNumbers = rand() < 0.5;
+
+  if (!withNumbers) {
+    // A magnitude, because the sign is already printed in front of it: the
+    // third term is the one this shape *subtracts*, and a negative third would
+    // print "− 8x" while taking away minus eight of them.
+    const third = Math.abs(drawCoefficient(config, rand));
+    const total = first + second - third;
+    // Every letter cancelling leaves "0", which is a true answer to a question
+    // nobody asked: the sheet is about collecting terms, not about nought. And
+    // three positive terms can still collect to a negative one, which is a
+    // minus sign on a sheet that turned them off.
+    if (total === 0) return null;
+    if (!signed(config) && total < 0) return null;
+    return {
+      key: `simplify:${first}:${second}:${third}`,
+      prompt: `${termText(first)}${thenText(second)}${X} ${MINUS} ${third}${X} =`,
+      answer: termText(total),
+    };
+  }
+
+  const constant = draw(config, rand);
+  const other = draw(config, rand);
+  const letters = first + second;
+  const numbers = constant + other;
+  if (letters === 0 && numbers === 0) return null;
+  return {
+    key: `simplify:${first}:${constant}:${second}:${other}`,
+    prompt: `${termText(first)}${thenText(constant)}${thenText(second)}${X}${thenText(other)} =`,
+    answer: linearText(letters, numbers),
+  };
+}
+
+/* ── Equations and inequalities ────────────────────────────────────────────
+   One shape for both, because they are the same six forms with a different
+   sign in the middle — and because the flip that an inequality suffers when it
+   is divided by a negative has to live in one place or be wrong in two.      */
+
+/**
+ * The left-hand side, and what it is worth at a given `x`.
+ *
+ * `(p·x + q) / r`, with `r` positive, which covers every form this family
+ * prints and is exact by construction: the value the equation is set equal to
+ * is worked out at the solution, not looked for afterwards.
+ */
+type Side = { text: string; p: number; q: number; r: number };
+
+type Form = {
+  id: string;
+  /** How many moves it takes to undo. The switch `steps` chooses between. */
+  steps: number;
+  draw(config: PreAlgebraConfig, rand: () => number): { side: Side; x: number };
+};
+
+const FORMS: Form[] = [
+  {
+    id: "add",
+    steps: 1,
+    draw: (config, rand) => {
+      const constant = draw(config, rand);
+      const x = draw(config, rand);
+      return {
+        side: { text: linearText(1, constant), p: 1, q: constant, r: 1 },
+        x,
+      };
+    },
+  },
+  {
+    id: "times",
+    steps: 1,
+    draw: (config, rand) => {
+      const coefficient = drawCoefficient(config, rand);
+      const x = draw(config, rand);
+      return {
+        side: { text: termText(coefficient), p: coefficient, q: 0, r: 1 },
+        x,
+      };
+    },
+  },
+  {
+    id: "over",
+    steps: 1,
+    draw: (config, rand) => {
+      // The divisor is never negative: dividing by a negative *number* is a
+      // different lesson from multiplying by one, and `x/−3` is not how anybody
+      // writes it. A negative coefficient is where that lesson lives.
+      const divisor = Math.abs(drawCoefficient(config, rand));
+      const multiple = draw(config, rand);
+      return {
+        side: { text: `${X}/${divisor}`, p: 1, q: 0, r: divisor },
+        x: multiple * divisor,
+      };
+    },
+  },
+  {
+    id: "times-add",
+    steps: 2,
+    draw: (config, rand) => {
+      const coefficient = drawCoefficient(config, rand);
+      const constant = draw(config, rand);
+      const x = draw(config, rand);
+      return {
+        side: {
+          text: linearText(coefficient, constant),
+          p: coefficient,
+          q: constant,
+          r: 1,
+        },
+        x,
+      };
+    },
+  },
+  {
+    id: "over-add",
+    steps: 2,
+    draw: (config, rand) => {
+      const divisor = Math.abs(drawCoefficient(config, rand));
+      const constant = draw(config, rand);
+      const multiple = draw(config, rand);
+      return {
+        side: {
+          text: `${X}/${divisor}${thenText(constant)}`,
+          p: 1,
+          q: constant * divisor,
+          r: divisor,
+        },
+        x: multiple * divisor,
+      };
+    },
+  },
+  {
+    id: "bracket",
+    steps: 2,
+    draw: (config, rand) => {
+      const coefficient = drawCoefficient(config, rand);
+      const constant = draw(config, rand);
+      const x = draw(config, rand);
+      return {
+        side: {
+          text: `${signedText(coefficient)}(${X}${thenText(constant)})`,
+          p: coefficient,
+          q: coefficient * constant,
+          r: 1,
+        },
+        x,
+      };
+    },
+  },
+];
+
+/** What the side is worth at the solution — a whole number, by construction. */
+const valueAt = (side: Side, x: number): number =>
+  (side.p * x + side.q) / side.r;
+
+function drawSide(
+  config: PreAlgebraConfig,
+  rand: () => number,
+): { side: Side; x: number } {
+  const wanted = Math.max(1, Math.min(2, Math.floor(config.steps ?? 1)));
+  return pick(
+    FORMS.filter((form) => form.steps === wanted),
+    rand,
+  ).draw(config, rand);
+}
+
+function drawEquation(config: PreAlgebraConfig, rand: () => number): Drawn {
+  const { side, x } = drawSide(config, rand);
+  const value = valueAt(side, x);
+  return {
+    key: `equation:${side.text}:${value}`,
+    prompt: `${side.text} = ${signedText(value)}`,
+    // Written out as a sentence rather than as a bare number, because that is
+    // what the child is asked to write and what the instruction says. A key
+    // reading "5" beside a page of `x = …` is a key in a different language.
+    answer: `${X} = ${signedText(x)}`,
+  };
+}
+
+/** The four signs, and what each becomes when the inequality is turned round. */
+const RELATIONS = ["<", ">", "≤", "≥"] as const;
+const FLIPPED: Record<string, string> = {
+  "<": ">",
+  ">": "<",
+  "≤": "≥",
+  "≥": "≤",
+};
+
+/**
+ * The solution to an inequality, sign and all.
+ *
+ * The one place the flip is written down. Dividing both sides by a negative
+ * turns the sign round — and this family's forms put a negative in exactly one
+ * place, the coefficient, because the divisor is drawn positive. So `p < 0` is
+ * the whole of the condition, and a sheet of inequalities each turned the wrong
+ * way is a mistake that can only be made here.
+ */
+const solutionOf = (side: Side, relation: string, x: number): string =>
+  `${X} ${side.p < 0 ? FLIPPED[relation] : relation} ${signedText(x)}`;
+
+function drawInequality(config: PreAlgebraConfig, rand: () => number): Drawn {
+  const { side, x } = drawSide(config, rand);
+  const relation = pick(RELATIONS, rand);
+  const value = valueAt(side, x);
+  return {
+    key: `inequality:${side.text}:${relation}:${value}`,
+    prompt: `${side.text} ${relation} ${signedText(value)}`,
+    answer: solutionOf(side, relation, x),
+  };
+}
+
+/* ── Slope ─────────────────────────────────────────────────────────────────
+   Rise over run, which is a fraction — so it is held as one and reduced by the
+   same greatest common divisor every fraction in the shop is reduced by. A key
+   that said 6/4 where a child wrote 3/2 would mark the child wrong.          */
+
+/** The slope of the line through two points, written the smallest way. */
+function slopeText(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): string | null {
+  const run = to.x - from.x;
+  // A vertical line has no slope at all — not nought, and not a number a child
+  // can write in a blank. It is a lesson of its own, and not this one.
+  if (run === 0) return null;
+  // The denominator carries no sign: −3/4 and 3/−4 are one number written two
+  // ways, and only the first is ever marked right.
+  const sign = run < 0 ? -1 : 1;
+  const slope = reduced({ n: sign * (to.y - from.y), d: sign * run });
+  // The sign is written here rather than left to `fractionText`, which puts a
+  // JavaScript hyphen in front of a negative numerator. This is the one family
+  // in the shop whose fractions go below nought (see the note at the top of
+  // `exact.ts`), and a page carrying two different minus signs — a hyphen in
+  // the answers and a proper one everywhere else — reads as a typing error.
+  return slope.n < 0
+    ? `${MINUS}${fractionText({ n: -slope.n, d: slope.d })}`
+    : fractionText(slope);
+}
+
+function drawSlope(config: PreAlgebraConfig, rand: () => number): Drawn | null {
+  const points = [0, 1].map(() => ({
+    x: draw(config, rand),
+    y: draw(config, rand),
+  }));
+  const slope = slopeText(points[0], points[1]);
+  if (slope === null) return null;
+  // Two points with no minus sign between them still make a line that goes
+  // downhill, and a sheet that promised no negative numbers has just printed
+  // one in its key.
+  if (!signed(config) && slope.startsWith(MINUS)) return null;
+  const said = points
+    .map((point) => `(${signedText(point.x)}, ${signedText(point.y)})`)
+    .join(" and ");
+  return { key: `slope:${said}`, prompt: said, answer: slope };
+}
+
+/* ── The graph ─────────────────────────────────────────────────────────────
+   The same question with the numbers taken off the page and put on a plane:
+   the child reads two points off the grid and works the slope out from them,
+   which is where slope is met before it is ever an ordered pair in a bracket.  */
+
+type Marked = { x: number; y: number; label: string };
+
+/**
+ * The points a graph sheet marks, every one of them at a different `x`.
+ *
+ * Which is not tidiness: two points sharing an `x` make a vertical line, whose
+ * slope is not a number, and a sheet that asked for it would have a blank that
+ * cannot be filled in. Drawing the `x` values without replacement means every
+ * pair of points on the plane is a fair question, rather than most of them.
+ *
+ * Nothing sits on an axis, for the reason `geometry.ts` gives: a dot on one of
+ * the two heavy rules is a dot a child has to look twice at.
+ */
+function markPoints(plane: Plane, rand: () => number): Marked[] {
+  const low = planeFloor(plane);
+  const places: number[] = [];
+  for (let at = low; at <= plane.span; at += 1) if (at !== 0) places.push(at);
+
+  const across = shuffled(places, rand).slice(0, POINTS);
+  return across.map((x, index) => ({
+    x,
+    y: pick(places, rand),
+    label: letterAt(index),
+  }));
+}
+
+/** Two of the marked points, named by their letters. */
+function drawPair(points: Marked[], rand: () => number): Drawn | null {
+  if (points.length < 2) return null;
+  const first = Math.floor(rand() * points.length);
+  const second = Math.floor(rand() * points.length);
+  if (first === second) return null;
+  const [from, to] = [points[first], points[second]];
+  const slope = slopeText(from, to);
+  if (slope === null) return null;
+  // Folded on the pair, because the slope of AB is the slope of BA: the same
+  // question asked twice, and a child spots it faster than the adult printing
+  // it does.
+  const pair = [from.label, to.label].sort();
+  return {
+    key: `pair:${pair.join("")}`,
+    prompt: `${from.label} and ${to.label}`,
+    answer: slope,
+  };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/**
+ * How many problems the paper holds, how wide a column of them is, and — on a
+ * graph sheet — the plane they are asked about.
+ *
+ * Arithmetic, not measurement, so `npm run test:unit` can answer "did it fit?"
+ * without a browser — and so the same answer serves the catalog page built at
+ * build time and the builder's preview (§4).
+ */
+export function preAlgebraLayout(config: PreAlgebraConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+  plane?: Plane;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of them.
+  const box = sheetBlockBox(headerOf(config), true);
+  const most =
+    config.style === "expression" ? MAX_EXPRESSION_COLUMNS : MAX_COLUMNS;
+  const columns = clamp(config.columns, 1, most);
+  const row = writtenRow(config.fontPt) + (config.workspace ? WORKSPACE : 0);
+
+  const plane =
+    config.style === "graph" ? planeOf(config.quadrants ?? 4, box) : undefined;
+  // The grid is a block of its own above the problems, so it takes its height
+  // and the gap under it out of what is left for them.
+  const left = plane
+    ? Math.max(0, box.height - planeHeight(plane) - BLOCK_GAP)
+    : box.height;
+
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(left, row, PROBLEM_GAP.y),
+    ...(plane ? { plane } : {}),
+  };
+}
+
+/**
+ * Every problem on the sheet, and the points marked on the plane above them.
+ *
+ * Exported because it is the whole of what a test has to check, and checking it
+ * through the `Sheet` means unwrapping a block union to reach it. The marks come
+ * back with the problems rather than being worked out again from them, so a dot
+ * on the grid and the slope it is answered with cannot disagree.
+ */
+export function preAlgebraProblems(
+  config: PreAlgebraConfig,
+  seed: number,
+): { items: Problem[]; marks: GridMark[] } {
+  const { perPage, plane } = preAlgebraLayout(config);
+  // The count is a request, not a promise: a count that overruns is a second
+  // sheet out of the printer with two problems on it.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  // The points come first, before any problem is drawn, because they are what
+  // the questions are *about* — a sheet whose plane depended on how many
+  // questions fitted would redraw the whole graph when a margin changed.
+  const points = plane ? markPoints(plane, rand) : [];
+  const seen = new Set<string>();
+  const items: Problem[] = [];
+  const extras = config.workspace ? { workspace: WORKSPACE } : {};
+
+  let misses = 0;
+  while (items.length < wanted && misses < MISS_BUDGET) {
+    const drawn = drawOne(config, points, rand);
+    // Not what was asked for, or already on the page. Either way the budget
+    // ticks down, and a pool that has run out ends the draw rather than
+    // repeating itself: six points make fifteen pairs, and fifteen is the
+    // honest answer to a request for twenty.
+    if (drawn === null || seen.has(drawn.key)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(drawn.key);
+    items.push({ prompt: drawn.prompt, answer: drawn.answer, ...extras });
+    misses = 0;
+  }
+  return {
+    items,
+    marks: plane
+      ? points.map((point) => markAt(plane, point.x, point.y, point.label))
+      : [],
+  };
+}
+
+function drawOne(
+  config: PreAlgebraConfig,
+  points: Marked[],
+  rand: () => number,
+): Drawn | null {
+  switch (config.style) {
+    case "equation":
+      return drawEquation(config, rand);
+    case "inequality":
+      return drawInequality(config, rand);
+    case "slope":
+      return drawSlope(config, rand);
+    case "graph":
+      return drawPair(points, rand);
+    default:
+      return rand() < 0.5
+        ? drawEvaluate(config, rand)
+        : drawSimplify(config, rand);
+  }
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+/** "Two-step equations" — the phrase a parent says, and the one they search. */
+function titleOf(config: PreAlgebraConfig): string {
+  const steps = Math.floor(config.steps ?? 1) === 2 ? "Two-step" : "One-step";
+  switch (config.style) {
+    case "equation":
+      return `${steps} equations`;
+    case "inequality":
+      return `${steps} inequalities`;
+    case "slope":
+      return "Slope from two points";
+    case "graph":
+      return "Slope from a graph";
+    default:
+      return "Expressions";
+  }
+}
+
+const INSTRUCTION: Record<AlgebraStyle, string> = {
+  expression: "Work out each expression.",
+  equation: `Solve each equation. Write the value of ${X}.`,
+  inequality: `Solve each inequality. Write it as ${X} and a sign.`,
+  slope: "Work out the slope of the line through each pair of points.",
+  graph: "Read each pair of points off the graph and write the slope.",
+};
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: PreAlgebraConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions:
+      config.instructions ??
+      INSTRUCTION[config.style] ??
+      INSTRUCTION.expression,
+  };
+}
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * The title says which lesson it is; what it leaves off is whether there are
+ * minus signs on it, which is the difference between this term's sheet and last
+ * term's — and, on a graph, how much of the plane a child has to read.
+ */
+export function describePreAlgebra(config: PreAlgebraConfig): string {
+  const title = titleOf(config);
+  // A graph sheet takes neither of the other two: how far the plane runs is
+  // what decides how hard it is, and `negatives` has nothing to say — a line
+  // drawn downhill has a negative slope in any quadrant there is.
+  if (config.style === "graph") {
+    return `${title} — ${
+      Math.floor(config.quadrants ?? 4) === 4
+        ? "four quadrants"
+        : "the first quadrant"
+    }`;
+  }
+  return [
+    title,
+    signed(config) ? "positive and negative" : "positive numbers only",
+    `numbers to ${bounds(config.range).max}`,
+  ].join(" — ");
+}
+
+export function buildPreAlgebraSheet(
+  config: PreAlgebraConfig,
+  seed: number,
+): Sheet {
+  const { items, marks } = preAlgebraProblems(config, seed);
+  const { columns, plane } = preAlgebraLayout(config);
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is actually on the page, not out of what was asked for: a
+      // sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf: items.length },
+    },
+    blocks: [
+      // The plane, then the questions about it — one graph for the sheet rather
+      // than one beside every problem, because a child reads the scale once and
+      // then uses it a dozen times.
+      ...(plane
+        ? [{ kind: "grid" as const, grid: { ...plane.grid, marks } }]
+        : []),
+      { kind: "problems", columns, items },
+    ],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const PREALGEBRA_SHEET: SheetSpec<PreAlgebraConfig> = {
+  id: "prealgebra",
+  label: "Pre-algebra",
+  world: SHEET_WORLD,
+  build: buildPreAlgebraSheet,
+  // The whole of the answer-key mechanism: every equation was built around the
+  // number that solves it, so a key prints what is already there rather than
+  // solving anything a second time.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describePreAlgebra,
+};

--- a/src/engine/sheets/maths/ratio.test.ts
+++ b/src/engine/sheets/maths/ratio.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { PROBLEM_GAP } from "../layout";
+import type {
+  MarginSize,
+  Paper,
+  PaperSize,
+  Problem,
+  RatioConfig,
+} from "../types";
+
+import { RATIO_SHEET, ratioLayout } from "./ratio";
+
+/**
+ * Ratio, proportion and unit rate.
+ *
+ * **Nothing here checks the generator against the generator.** Every number is
+ * read off the printed line and put back together by a path the family does not
+ * have:
+ *
+ * - a **simplified ratio** is checked by cross-multiplication — `a : b` reduces
+ *   to `c : d` only if `a·d = b·c` — and then held to lowest terms by searching
+ *   for a common factor, rather than by the greatest common divisor the family
+ *   reduced with. An answer of `4 : 6` where the child wrote `2 : 3` fails
+ *   there, and it is the failure that matters: both are true, and only one is
+ *   marked right;
+ * - a **proportion** is checked the same way, with the answer put back into the
+ *   gap it came out of;
+ * - a **rate** is checked by multiplying back, in repeated addition, which is
+ *   the only honest check on something that was divided.
+ */
+
+/* ── Arithmetic, from repeated addition ──────────────────────────────────── */
+
+/** `a` added to itself `b` times — the only multiplication in this file. */
+function multiply(a: number, b: number): number {
+  const [each, times] = a > b ? [a, b] : [b, a];
+  let total = 0;
+  for (let step = 0; step < times; step += 1) total += each;
+  return total;
+}
+
+/** The greatest common divisor, found by trying every factor there is. */
+function commonFactor(a: number, b: number): number {
+  let most = 1;
+  for (let by = 1; by <= Math.min(a, b); by += 1) {
+    if (a % by === 0 && b % by === 0) most = by;
+  }
+  return most;
+}
+
+/** The numbers on a line, in the order they are printed. */
+const numbersOn = (text: string): number[] =>
+  [...text.matchAll(/\d+/g)].map((found) => Number(found[0]));
+
+/** The problem, written out in full with its answer put where the gap is. */
+const sentence = (problem: Problem): string =>
+  problem.prompt.replace("_", problem.answer);
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const config = (over: Partial<RatioConfig> = {}): RatioConfig => ({
+  kind: "ratio",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style: "simplify",
+  range: { min: 1, max: 12 },
+  count: 12,
+  columns: 3,
+  ...over,
+});
+
+/**
+ * Every shape the family can print, which is every acceptance criterion of the
+ * story: ratio, proportion and unit rate.
+ */
+const EVERY_SHAPE: Array<Partial<RatioConfig>> = [
+  {},
+  { range: { min: 2, max: 20 } },
+  { style: "proportion" },
+  { style: "proportion", range: { min: 1, max: 9 } },
+  { style: "rate" },
+  { style: "rate", range: { min: 2, max: 20 } },
+  { workspace: true, count: 8 },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** The one block a ratio sheet has, narrowed for the reader. */
+function problemsOf(over: Partial<RatioConfig>, seed: number): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+const everyProblem = function* (
+  shapes: Array<Partial<RatioConfig>> = EVERY_SHAPE,
+): Generator<[Partial<RatioConfig>, Problem]> {
+  for (const shape of shapes) {
+    for (const seed of SEEDS) {
+      const problems = problemsOf(shape, seed);
+      expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+      for (const problem of problems) yield [shape, problem];
+    }
+  }
+};
+
+const shapesOf = (style: string): Array<Partial<RatioConfig>> =>
+  EVERY_SHAPE.filter((one) => (one.style ?? "simplify") === style);
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the ratio family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("ratio")).toBe(RATIO_SHEET);
+    expect(sheetSpec("ratio").label).toBe("Ratio and rate");
+  });
+
+  it("names the sheet in the words a parent chose it by", () => {
+    expect(describeSheet(config())).toBe("Simplifying ratios — numbers to 12");
+    expect(describeSheet(config({ style: "rate" }))).toBe(
+      "Unit rate — numbers to 12",
+    );
+  });
+
+  it("tells a child what to write", () => {
+    expect(buildSheet(config(), 1).header.instructions).toBe(
+      "Write each ratio in its simplest form.",
+    );
+    expect(buildSheet(config({ style: "rate" }), 1).header.instructions).toBe(
+      "Work out the amount for one.",
+    );
+  });
+
+  it("marks the sheet out of what is on it", () => {
+    const sheet = buildSheet(config({ count: 7 }), 3);
+    const block = sheet.blocks[0];
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("simplifies every ratio, cross-multiplied and in lowest terms", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("simplify"))) {
+      const said = `${problem.prompt} ${problem.answer} ${JSON.stringify(shape)}`;
+      const [left, right] = numbersOn(problem.prompt);
+      const [small, large] = numbersOn(problem.answer);
+      // The same ratio: `left : right` is `small : large` when the two
+      // cross-products match, and there is no division in the check.
+      expect(multiply(left, large), said).toBe(multiply(right, small));
+      expect(commonFactor(small, large), `${said} is not in lowest terms`).toBe(
+        1,
+      );
+    }
+  });
+
+  it("fills a proportion's gap with the number that scales", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("proportion"))) {
+      const said = `${sentence(problem)} ${JSON.stringify(shape)}`;
+      const [a, b, c, d] = numbersOn(sentence(problem));
+      expect(multiply(a, d), said).toBe(multiply(b, c));
+    }
+  });
+
+  it("works a rate back out by multiplying it up again", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("rate"))) {
+      const said = `${sentence(problem)} ${JSON.stringify(shape)}`;
+      const [total, many, each] = numbersOn(sentence(problem));
+      expect(multiply(each, many), said).toBe(total);
+    }
+  });
+
+  it("names the same thing on both sides of a rate", () => {
+    // "240 words in 4 minutes = 60 miles per minute" is arithmetic with a story
+    // stapled to it, and a child who read it would be right to be confused.
+    for (const [, problem] of everyProblem(shapesOf("rate"))) {
+      const said = /^\d+ (.+) in \d+ (.+) = _ (.+) per (.+)$/.exec(
+        problem.prompt,
+      );
+      expect(said, problem.prompt).not.toBeNull();
+      expect(said?.[1], problem.prompt).toBe(said?.[3]);
+      // The plural is what several of them are called and the singular is what
+      // one is: "minutes" and "minute", never the same word twice.
+      expect(said?.[2], problem.prompt).toBe(`${said?.[4]}s`);
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    for (const shape of EVERY_SHAPE) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+});
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  it("never asks a child to simplify something already simple", () => {
+    // `7 : 12` is in its simplest form, and asking for it teaches only that
+    // the sheet sometimes asks for nothing.
+    for (const [, problem] of everyProblem(shapesOf("simplify"))) {
+      const [left, right] = numbersOn(problem.prompt);
+      expect(commonFactor(left, right), problem.prompt).toBeGreaterThan(1);
+    }
+  });
+
+  it("never prints a ratio of one to one, or a rate of one", () => {
+    for (const [, problem] of everyProblem()) {
+      expect(sentence(problem), problem.prompt).not.toMatch(/\b1 : 1\b/);
+    }
+    for (const [, problem] of everyProblem(shapesOf("rate"))) {
+      // One of something is the answer written into the question.
+      const [, many] = numbersOn(sentence(problem));
+      expect(many, problem.prompt).toBeGreaterThan(1);
+    }
+  });
+
+  it("gives every problem exactly one place to write the answer", () => {
+    for (const [, problem] of everyProblem()) {
+      expect(problem.prompt.split("_").length - 1).toBeLessThanOrEqual(1);
+      expect(problem.answers).toBeUndefined();
+    }
+  });
+
+  it("puts the gap in all four places on a proportion sheet", () => {
+    // A gap that is always in the same corner is a gap a child fills in by
+    // pattern rather than by proportion.
+    const places = new Set<number>();
+    for (const seed of SEEDS) {
+      for (const problem of problemsOf(
+        { style: "proportion", count: 12 },
+        seed,
+      )) {
+        places.add(problem.prompt.split(" ").indexOf("_"));
+      }
+    }
+    expect(places.size).toBe(4);
+  });
+
+  it("asks the same question twice on no sheet at all", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const asked = problemsOf(shape, seed).map((problem) => problem.prompt);
+        expect(new Set(asked).size, JSON.stringify(shape)).toBe(asked.length);
+      }
+    }
+  });
+});
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    expect(problemsOf({ count: 3 }, 7).map(said)).toEqual(GOLDEN.simplify);
+    expect(problemsOf({ style: "rate", count: 3 }, 7).map(said)).toEqual(
+      GOLDEN.rate,
+    );
+  });
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    for (const shape of EVERY_SHAPE) {
+      const [a, b, c] = [0, 1, 2].map((offset) =>
+        problemsOf({ ...shape, count: 6 }, 100 + offset).map(
+          (problem) => problem.prompt,
+        ),
+      );
+      for (const [one, other] of [
+        [a, b],
+        [a, c],
+        [b, c],
+      ]) {
+        expect(one, JSON.stringify(shape)).not.toEqual(other);
+        const shared = one.filter((asked) => other.includes(asked)).length;
+        expect(shared, JSON.stringify(shape)).toBeLessThan(
+          (one.length * 2) / 3,
+        );
+      }
+    }
+  });
+});
+
+const said = (problem: Problem): [string, string] => [
+  problem.prompt,
+  problem.answer,
+];
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row } = ratioLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used = rows * row + Math.max(0, rows - 1) * PROBLEM_GAP.y;
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("does not throw the page away either", () => {
+    const { box, row, perPage, columns } = ratioLayout(config());
+    expect(perPage).toBeGreaterThanOrEqual(20);
+    const rows = perPage / columns;
+    expect((rows + 1) * row + rows * PROBLEM_GAP.y).toBeGreaterThan(box.height);
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ count: 10 }, 1).length).toBe(10);
+    for (const columns of [1, 2, 3]) {
+      const block = buildSheet(config({ columns }), 1).blocks[0];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+    // Two columns of rates, because a rate is a sentence rather than a sum.
+    const wide = buildSheet(config({ style: "rate", columns: 6 }), 1).blocks[0];
+    expect(wide.kind === "problems" && wide.columns).toBe(2);
+  });
+});
+
+/**
+ * What two sheets came out as on the day this shipped.
+ *
+ * Recorded rather than computed — both are proved right by the assertions
+ * above, and what these hold is that they do not silently *change*.
+ */
+const GOLDEN = {
+  simplify: [
+    ["45 : 35 =", "9 : 7"],
+    ["27 : 12 =", "9 : 4"],
+    ["30 : 21 =", "10 : 7"],
+  ],
+  rate: [
+    ["18 words in 9 minutes = _ words per minute", "2"],
+    ["35 seats in 5 rows = _ seats per row", "7"],
+    ["24 litres in 6 minutes = _ litres per minute", "4"],
+  ],
+};

--- a/src/engine/sheets/maths/ratio.ts
+++ b/src/engine/sheets/maths/ratio.ts
@@ -1,0 +1,356 @@
+/**
+ * Ratio, proportion and unit rate.
+ *
+ * Three names for one idea — two numbers whose *relationship* is the answer —
+ * and one hazard, which `exact.ts` has already met: `12 : 18` and `2 : 3` are
+ * the same ratio and only one of them gets a tick. So a ratio is a pair of whole
+ * numbers reduced by their greatest common divisor, exactly as a fraction is,
+ * and there is no division anywhere in this file that is not exact by
+ * construction.
+ *
+ * **A proportion is built by scaling, not by solving.** The pair on the left is
+ * drawn and the pair on the right is that pair multiplied up, so the missing
+ * number was known before the question existed. Which of the four places is
+ * blank is drawn separately — a sheet whose gap is always at the end is a sheet
+ * a child answers by pattern rather than by proportion.
+ *
+ * **A rate is built from the amount for one.** `240 words in 4 minutes` is 60
+ * words a minute multiplied back out, so the answer is a whole number without
+ * anything being rounded — the same move `measure.ts` makes by building a
+ * conversion from the larger unit.
+ */
+import { between, mulberry32 } from "@/engine/random";
+
+import type {
+  Mil,
+  Problem,
+  RatioConfig,
+  RatioStyle,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import {
+  PROBLEM_GAP,
+  WRAP_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import { gcd } from "./exact";
+
+/* ── What a problem takes on the page ─────────────────────────────────────
+   Declared, not measured (§4).                                              */
+
+/** Two lines of the body type and the air a wrap puts between them. */
+const writtenRow = (fontPt: number): Mil => 2 * answerLine(fontPt) + WRAP_GAP;
+
+/** Blank space to work an answer out in, when the config asks for it. */
+const WORKSPACE = inches(0.55);
+
+/**
+ * Three columns of ratios, and two of rates.
+ *
+ * `240 words in 4 minutes = _ words per minute` is a sentence rather than a
+ * sum, and a column narrower than the sentence is a page of problems each
+ * wrapped onto three lines.
+ */
+const MAX_COLUMNS = 3;
+const MAX_RATE_COLUMNS = 2;
+
+/** As `arithmetic.ts` — see the note there on why a budget rather than a proof. */
+const MISS_BUDGET = 500;
+
+/**
+ * How far a proportion is scaled up: `3 : 4` becomes `9 : 12`, not `93 : 124`.
+ *
+ * Small on purpose. What is being practised is that the two pairs are the same
+ * relationship, and a factor a child cannot spot turns that into a long
+ * multiplication with a proportion painted on the front.
+ */
+const MOST_SCALE = 9;
+
+/* ── Drawing ───────────────────────────────────────────────────────────── */
+
+type Drawn = { key: string; prompt: string; answer: string };
+
+function bounds(range: { min: number; max: number }): {
+  min: number;
+  max: number;
+} {
+  const min = Math.max(1, Math.floor(range?.min ?? 1));
+  return { min, max: Math.max(min, Math.floor(range?.max ?? 1)) };
+}
+
+const pick = <T>(items: readonly T[], rand: () => number): T =>
+  items[Math.floor(rand() * items.length)];
+
+/** A ratio as it is written on a sheet: two numbers with a colon between. */
+const ratioText = (left: number, right: number): string => `${left} : ${right}`;
+
+/**
+ * A ratio to be written the smallest way.
+ *
+ * Drawn as a multiple of a smaller pair rather than drawn and tested, so the
+ * question always has something to do: `7 : 12` is already in its simplest form
+ * and asking for it teaches a child only that the sheet sometimes asks for
+ * nothing.
+ */
+function drawSimplify(config: RatioConfig, rand: () => number): Drawn | null {
+  const { min, max } = bounds(config.range);
+  const left = between(min, max, rand);
+  const right = between(min, max, rand);
+  const by = between(2, Math.max(2, Math.min(MOST_SCALE, max)), rand);
+  // Already sharing a factor means the pair the child writes is smaller than
+  // the pair that was drawn, and the key would be the wrong one of the two.
+  const factor = gcd(left, right);
+  if (factor !== 1) return null;
+  if (left === right) return null;
+  return {
+    key: `simplify:${left}:${right}:${by}`,
+    prompt: `${ratioText(left * by, right * by)} =`,
+    answer: ratioText(left, right),
+  };
+}
+
+/**
+ * Two pairs that scale together, with one of the four numbers missing.
+ *
+ * Which one is missing is drawn, because the skill is reading the pair that is
+ * whole and applying it to the pair that is not — and a gap that is always in
+ * the same corner is a gap a child fills in without ever doing that.
+ */
+function drawProportion(config: RatioConfig, rand: () => number): Drawn | null {
+  const { min, max } = bounds(config.range);
+  const left = between(min, max, rand);
+  const right = between(min, max, rand);
+  // The pair has to be in its simplest form for the scaled one to be a
+  // question about scaling — and `1 : 1` is the pair that survives that and is
+  // still nothing to work out.
+  if (gcd(left, right) !== 1 || left === right) return null;
+  const by = between(2, Math.max(2, Math.min(MOST_SCALE, max)), rand);
+
+  const numbers = [left, right, left * by, right * by];
+  const gap = Math.floor(rand() * numbers.length);
+  const written = numbers.map((value, at) =>
+    at === gap ? "_" : String(value),
+  );
+  return {
+    key: `proportion:${left}:${right}:${by}:${gap}`,
+    prompt: `${written[0]} : ${written[1]} = ${written[2]} : ${written[3]}`,
+    answer: String(numbers[gap]),
+  };
+}
+
+/* ── Rates ─────────────────────────────────────────────────────────────────
+   The one style with words in it, so the words are a small closed list rather
+   than a sentence built out of parts: a rate is only a real question if the
+   thing being counted and the thing it is counted against go together, and
+   "240 apples in 4 hours" is a sum with a story stapled to it.               */
+
+type Rate = {
+  /** What is counted: "words", "miles". */
+  what: string;
+  /** What it is counted against, in the plural: "minutes". */
+  per: string;
+  /** And in the singular, which is what "per" takes: "minute". */
+  one: string;
+};
+
+const RATES: Rate[] = [
+  { what: "words", per: "minutes", one: "minute" },
+  { what: "miles", per: "hours", one: "hour" },
+  { what: "pages", per: "days", one: "day" },
+  { what: "litres", per: "minutes", one: "minute" },
+  { what: "beats", per: "minutes", one: "minute" },
+  { what: "seats", per: "rows", one: "row" },
+  { what: "sweets", per: "bags", one: "bag" },
+  { what: "photos", per: "albums", one: "album" },
+];
+
+/**
+ * How much for one, worked back out of how much for several.
+ *
+ * The rate is drawn first and the total is the multiplication, so the division
+ * the child does is exact and the key never rounds anything.
+ */
+function drawRate(config: RatioConfig, rand: () => number): Drawn | null {
+  const { min, max } = bounds(config.range);
+  const rate = pick(RATES, rand);
+  const each = between(Math.max(2, min), Math.max(2, max), rand);
+  // Two of something is a rate; one of it is the answer written into the
+  // question, and a child who spotted that would be right to stop reading.
+  const many = between(2, Math.max(2, Math.min(MOST_SCALE, max)), rand);
+  return {
+    key: `rate:${rate.what}:${each}:${many}`,
+    prompt: `${each * many} ${rate.what} in ${many} ${rate.per} = _ ${rate.what} per ${rate.one}`,
+    answer: String(each),
+  };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/**
+ * How many problems the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic, not measurement, so `npm run test:unit` can answer "did it fit?"
+ * without a browser — and so the same answer serves the catalog page built at
+ * build time and the builder's preview (§4).
+ */
+export function ratioLayout(config: RatioConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of them.
+  const box = sheetBlockBox(headerOf(config), true);
+  const most = config.style === "rate" ? MAX_RATE_COLUMNS : MAX_COLUMNS;
+  const columns = clamp(config.columns, 1, most);
+  const row = writtenRow(config.fontPt) + (config.workspace ? WORKSPACE : 0);
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
+  };
+}
+
+/**
+ * Every problem on the sheet, in the order they are printed.
+ *
+ * Exported because it is the whole of what a test has to check, and checking it
+ * through the `Sheet` means unwrapping a block union to reach it.
+ */
+export function ratioProblems(config: RatioConfig, seed: number): Problem[] {
+  const { perPage } = ratioLayout(config);
+  // The count is a request, not a promise: a count that overruns is a second
+  // sheet out of the printer with two problems on it.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  const seen = new Set<string>();
+  const problems: Problem[] = [];
+  const extras = config.workspace ? { workspace: WORKSPACE } : {};
+
+  let misses = 0;
+  while (problems.length < wanted && misses < MISS_BUDGET) {
+    const drawn = drawOne(config, rand);
+    // Not what was asked for, or already on the page. Either way the budget
+    // ticks down, and a pool that has run out ends the draw rather than
+    // repeating itself.
+    if (drawn === null || seen.has(drawn.key)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(drawn.key);
+    problems.push({ prompt: drawn.prompt, answer: drawn.answer, ...extras });
+    misses = 0;
+  }
+  return problems;
+}
+
+function drawOne(config: RatioConfig, rand: () => number): Drawn | null {
+  switch (config.style) {
+    case "proportion":
+      return drawProportion(config, rand);
+    case "rate":
+      return drawRate(config, rand);
+    default:
+      return drawSimplify(config, rand);
+  }
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const TITLE: Record<RatioStyle, string> = {
+  simplify: "Simplifying ratios",
+  proportion: "Solving proportions",
+  rate: "Unit rate",
+};
+
+const INSTRUCTION: Record<RatioStyle, string> = {
+  simplify: "Write each ratio in its simplest form.",
+  proportion: "Write the missing number in each blank.",
+  rate: "Work out the amount for one.",
+};
+
+const titleOf = (config: RatioConfig): string =>
+  TITLE[config.style] ?? TITLE.simplify;
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: RatioConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions:
+      config.instructions ?? INSTRUCTION[config.style] ?? INSTRUCTION.simplify,
+  };
+}
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * What the title leaves off is the size of the numbers, which on this family is
+ * the difference between a sheet done in the head and one done on paper.
+ */
+export function describeRatio(config: RatioConfig): string {
+  return `${titleOf(config)} — numbers to ${bounds(config.range).max}`;
+}
+
+export function buildRatioSheet(config: RatioConfig, seed: number): Sheet {
+  const items = ratioProblems(config, seed);
+  const { columns } = ratioLayout(config);
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is actually on the page, not out of what was asked for: a
+      // sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf: items.length },
+    },
+    blocks: [{ kind: "problems", columns, items }],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const RATIO_SHEET: SheetSpec<RatioConfig> = {
+  id: "ratio",
+  label: "Ratio and rate",
+  world: SHEET_WORLD,
+  build: buildRatioSheet,
+  // The whole of the answer-key mechanism: every pair on the page was built by
+  // scaling a pair that was already in its simplest form, so a key prints what
+  // is already there rather than reducing anything a second time.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeRatio,
+};

--- a/src/engine/sheets/maths/statistics.test.ts
+++ b/src/engine/sheets/maths/statistics.test.ts
@@ -1,0 +1,496 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { PROBLEM_GAP, answerLine } from "../layout";
+import type {
+  MarginSize,
+  Paper,
+  PaperSize,
+  Problem,
+  StatisticsConfig,
+} from "../types";
+
+import { STATISTICS_SHEET, modeOf, statisticsLayout } from "./statistics";
+
+/**
+ * Mean, median, mode and range.
+ *
+ * **Nothing here checks the generator against the generator.** Every set is read
+ * off the printed line and summarised again by a path the family does not have:
+ *
+ * - the **mean** is checked by multiplying back — the answer added to itself
+ *   once per number in the set has to make the total — so there is no division
+ *   anywhere in this file;
+ * - the **median** is found with an insertion sort written out here, and
+ *   compared *in halves*: a set of four whose middles are 9 and 10 has a median
+ *   of nineteen halves, and the printed "9.5" has to be exactly that. A generator
+ *   that rounded, floored or averaged in floating point fails;
+ * - the **mode** is tallied, and the tally has to have a single winner. A set
+ *   with two values tied has two right answers, and this is where a key naming
+ *   one of them is caught;
+ * - the **range** is the largest less the smallest, found by looking at every
+ *   number rather than by trusting the order.
+ */
+
+/* ── Summarising a set, the long way round ───────────────────────────────── */
+
+/** `a` added to itself `b` times — the only multiplication in this file. */
+function multiply(a: number, b: number): number {
+  const [each, times] = a > b ? [a, b] : [b, a];
+  let total = 0;
+  for (let step = 0; step < times; step += 1) total += each;
+  return total;
+}
+
+/** Smallest first, by insertion — nothing here calls the family's own sort. */
+function ordered(values: number[]): number[] {
+  const out: number[] = [];
+  for (const value of values) {
+    let at = 0;
+    while (at < out.length && out[at] <= value) at += 1;
+    out.splice(at, 0, value);
+  }
+  return out;
+}
+
+/** How many of each number there are. */
+function tally(values: number[]): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return counts;
+}
+
+/**
+ * The median in halves, so that a set of an even size can be checked exactly.
+ *
+ * Twice the median, which is a whole number whether the middle lands on one of
+ * the numbers or between two of them — and which is what makes ".5" a fact to
+ * assert rather than a rounding to hope about.
+ */
+function halves(values: number[]): number {
+  const order = ordered(values);
+  const middle = Math.floor(order.length / 2);
+  return order.length % 2 === 1
+    ? order[middle] + order[middle]
+    : order[middle - 1] + order[middle];
+}
+
+/** And the same reading of what was printed: "9" is 18 halves, "9.5" is 19. */
+function halvesOf(text: string): number {
+  const half = /^(\d+)\.5$/.exec(text);
+  if (half) return Number(half[1]) + Number(half[1]) + 1;
+  if (!/^\d+$/.test(text)) throw new Error(`not a median: "${text}"`);
+  return Number(text) + Number(text);
+}
+
+/** The numbers of a set, as they are printed. */
+const setOn = (problem: Problem): number[] =>
+  problem.prompt.split(", ").map((written) => {
+    if (!/^\d+$/.test(written)) throw new Error(`not a number: "${written}"`);
+    return Number(written);
+  });
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const config = (over: Partial<StatisticsConfig> = {}): StatisticsConfig => ({
+  kind: "statistics",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style: "mean",
+  size: 5,
+  range: { min: 1, max: 20 },
+  count: 8,
+  columns: 2,
+  ...over,
+});
+
+/**
+ * Every shape the family can print, which is every acceptance criterion of the
+ * story — including the two that are usually got wrong: a set of an even size,
+ * whose median falls between two numbers, and a mode that has to be the only
+ * one.
+ */
+const EVERY_SHAPE: Array<Partial<StatisticsConfig>> = [
+  {},
+  { size: 6 },
+  { style: "median" },
+  { style: "median", size: 4 },
+  { style: "median", size: 8 },
+  { style: "mode" },
+  { style: "mode", size: 7 },
+  { style: "range" },
+  { style: "range", size: 4, range: { min: 0, max: 9 } },
+  { style: "all" },
+  { style: "all", size: 6 },
+  { size: 4, range: { min: 1, max: 9 } },
+  { workspace: true, count: 6 },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** The one block a statistics sheet has, narrowed for the reader. */
+function problemsOf(over: Partial<StatisticsConfig>, seed: number): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+const everyProblem = function* (
+  shapes: Array<Partial<StatisticsConfig>> = EVERY_SHAPE,
+): Generator<[Partial<StatisticsConfig>, Problem]> {
+  for (const shape of shapes) {
+    for (const seed of SEEDS) {
+      const problems = problemsOf(shape, seed);
+      expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+      for (const problem of problems) yield [shape, problem];
+    }
+  }
+};
+
+const shapesOf = (style: string): Array<Partial<StatisticsConfig>> =>
+  EVERY_SHAPE.filter((one) => (one.style ?? "mean") === style);
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the statistics family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("statistics")).toBe(STATISTICS_SHEET);
+    expect(sheetSpec("statistics").label).toBe("Mean, median and mode");
+  });
+
+  it("names the sheet in the words a parent chose it by", () => {
+    expect(describeSheet(config())).toBe(
+      "Finding the mean — sets of 5 — numbers to 20",
+    );
+    expect(describeSheet(config({ style: "all", size: 6 }))).toBe(
+      "Mean, median, mode and range — sets of 6 — numbers to 20",
+    );
+  });
+
+  it("tells a child which of the four a sheet is about", () => {
+    expect(buildSheet(config({ style: "mode" }), 1).header.instructions).toBe(
+      "Write the mode of each set of numbers.",
+    );
+    expect(buildSheet(config({ style: "all" }), 1).header.instructions).toBe(
+      "Write the mean, median, mode and range of each set.",
+    );
+  });
+
+  it("marks the sheet out of what is on it", () => {
+    const sheet = buildSheet(config({ count: 5 }), 3);
+    const block = sheet.blocks[0];
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("means by multiplying back, so nothing is ever divided", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("mean"))) {
+      const values = setOn(problem);
+      const total = values.reduce((sum, value) => sum + value, 0);
+      expect(
+        multiply(Number(problem.answer), values.length),
+        `${problem.prompt} ${JSON.stringify(shape)}`,
+      ).toBe(total);
+    }
+  });
+
+  it("medians in halves, so an even-sized set lands where it should", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("median"))) {
+      expect(
+        halvesOf(problem.answer),
+        `${problem.prompt} → ${problem.answer} ${JSON.stringify(shape)}`,
+      ).toBe(halves(setOn(problem)));
+    }
+  });
+
+  it("names a mode only where there is exactly one", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("mode"))) {
+      expectMode(setOn(problem), problem.answer, JSON.stringify(shape));
+    }
+  });
+
+  it("names no mode at all where two values tie", () => {
+    // The one rule here a set can fail, and the draw builds sets that pass it on
+    // purpose — so it is checked directly, with a tie handed to it. A family
+    // that lost this would print a question with two right answers on it.
+    expect(modeOf([3, 3, 7, 7, 9])).toBeNull();
+    expect(modeOf([1, 2, 3, 4])).toBeNull();
+    expect(modeOf([4, 4, 9, 2])).toBe(4);
+    expect(modeOf([5, 5, 5, 8, 8])).toBe(5);
+  });
+
+  it("ranges from the smallest number to the largest", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("range"))) {
+      const order = ordered(setOn(problem));
+      expect(
+        Number(problem.answer),
+        `${problem.prompt} ${JSON.stringify(shape)}`,
+      ).toBe(order[order.length - 1] - order[0]);
+    }
+  });
+
+  it("answers all four from one set, each on its own line", () => {
+    for (const [shape, problem] of everyProblem(shapesOf("all"))) {
+      const said = `${problem.prompt} ${JSON.stringify(shape)}`;
+      const values = setOn(problem);
+      const lines = problem.answers ?? [];
+      expect(lines.length, said).toBe(4);
+      // The one-line answer is the same four joined up, so anything that wants
+      // the answer as a string cannot get a different one.
+      expect(problem.answer, said).toBe(lines.join(", "));
+
+      const written = Object.fromEntries(
+        lines.map((line) => line.split(" = ") as [string, string]),
+      );
+      const total = values.reduce((sum, value) => sum + value, 0);
+      expect(multiply(Number(written.mean), values.length), said).toBe(total);
+      expect(halvesOf(written.median), said).toBe(halves(values));
+      expectMode(values, written.mode, said);
+      const order = ordered(values);
+      expect(Number(written.range), said).toBe(
+        order[order.length - 1] - order[0],
+      );
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    for (const shape of EVERY_SHAPE) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+});
+
+/**
+ * That a printed mode is *the* mode: it appears more often than anything else,
+ * and nothing else appears as often.
+ *
+ * The second half is the one that matters. A set with two values tied has two
+ * right answers and belongs on no sheet at all, and a generator that named the
+ * first of them would pass a check that only asked whether the answer was
+ * common.
+ */
+function expectMode(values: number[], written: string, said: string): void {
+  const counts = tally(values);
+  const mode = Number(written);
+  const most = counts.get(mode) ?? 0;
+  expect(most, `${values.join(", ")} → ${written} ${said}`).toBeGreaterThan(1);
+  for (const [value, count] of counts) {
+    if (value === mode) continue;
+    expect(count, `${values.join(", ")} ties on ${value} — ${said}`) //
+      .toBeLessThan(most);
+  }
+}
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  it("draws every number inside the range a parent asked for", () => {
+    for (const range of [
+      { min: 1, max: 9 },
+      { min: 0, max: 20 },
+      { min: 5, max: 50 },
+    ]) {
+      for (const style of ["mean", "median", "mode", "range", "all"] as const) {
+        for (const problem of problemsOf({ range, style, count: 6 }, 5)) {
+          for (const value of setOn(problem)) {
+            expect(value, problem.prompt).toBeGreaterThanOrEqual(range.min);
+            expect(value, problem.prompt).toBeLessThanOrEqual(range.max);
+          }
+        }
+      }
+    }
+  });
+
+  it("puts as many numbers in a set as were asked for", () => {
+    for (const size of [3, 4, 5, 6, 7, 9]) {
+      for (const problem of problemsOf({ size, count: 5 }, 2)) {
+        expect(setOn(problem).length, problem.prompt).toBe(size);
+      }
+    }
+  });
+
+  it("lands a median between two numbers when the set has an even size", () => {
+    // The half is the whole reason an even-sized set is a different question,
+    // so a family that never produced one would have quietly stopped asking it.
+    const answers = SEEDS.flatMap((seed) =>
+      problemsOf({ style: "median", size: 4, count: 8 }, seed).map(
+        (problem) => problem.answer,
+      ),
+    );
+    expect(answers.some((answer) => answer.endsWith(".5"))).toBe(true);
+    expect(answers.some((answer) => !answer.endsWith(".5"))).toBe(true);
+  });
+
+  it("never prints a range of nothing", () => {
+    // "The range of 7, 7, 7" is a question about nothing.
+    for (const [, problem] of everyProblem(shapesOf("range"))) {
+      expect(Number(problem.answer), problem.prompt).toBeGreaterThan(0);
+    }
+  });
+
+  it("rules four lines for four answers, and one blank for one", () => {
+    // A problem has exactly one place to write the answer: four ruled lines, or
+    // a slot, and never both.
+    for (const [shape, problem] of everyProblem()) {
+      if (shape.style === "all") {
+        expect(problem.answers?.length, problem.prompt).toBe(4);
+        expect(problem.workspace, problem.prompt).toBe(4 * answerLine(12));
+      } else {
+        expect(problem.answers, problem.prompt).toBeUndefined();
+      }
+      expect(problem.prompt.split("_").length - 1).toBe(0);
+    }
+  });
+
+  it("asks the same set twice on no sheet at all", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const asked = problemsOf(shape, seed).map((problem) =>
+          ordered(setOn(problem)).join(":"),
+        );
+        // Folded on the set sorted, because the same numbers in another order
+        // are the same question and have all four of the same answers.
+        expect(new Set(asked).size, JSON.stringify(shape)).toBe(asked.length);
+      }
+    }
+  });
+});
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    expect(problemsOf({ count: 3 }, 7).map(said)).toEqual(GOLDEN.mean);
+    expect(
+      problemsOf({ style: "all", size: 6, count: 2 }, 7).map(said),
+    ).toEqual(GOLDEN.all);
+  });
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    for (const shape of EVERY_SHAPE) {
+      const [a, b, c] = [0, 1, 2].map((offset) =>
+        problemsOf({ ...shape, count: 5 }, 100 + offset).map(
+          (problem) => problem.prompt,
+        ),
+      );
+      for (const [one, other] of [
+        [a, b],
+        [a, c],
+        [b, c],
+      ]) {
+        expect(one, JSON.stringify(shape)).not.toEqual(other);
+        const shared = one.filter((asked) => other.includes(asked)).length;
+        expect(shared, JSON.stringify(shape)).toBeLessThan(
+          (one.length * 2) / 3,
+        );
+      }
+    }
+  });
+});
+
+const said = (problem: Problem): [string, string] => [
+  problem.prompt,
+  problem.answer,
+];
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row } = statisticsLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used = rows * row + Math.max(0, rows - 1) * PROBLEM_GAP.y;
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("reserves the four answer lines rather than adding to them", () => {
+    // The lines a child writes on are the answer place, not paper under it —
+    // and a row taller than the layout declared is the last problem of the page
+    // printed on a second sheet.
+    for (const fontPt of [10, 12, 18]) {
+      const four = statisticsLayout(config({ style: "all", fontPt }));
+      const one = statisticsLayout(config({ style: "mean", fontPt }));
+      expect(four.row - one.row).toBe(4 * answerLine(fontPt));
+    }
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ count: 6 }, 1).length).toBe(6);
+    for (const columns of [1, 2]) {
+      const block = buildSheet(config({ columns }), 1).blocks[0];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+    // One column when all four are asked at once: the answers are sentences
+    // rather than numbers, and they go underneath.
+    const wide = buildSheet(config({ style: "all", columns: 4 }), 1).blocks[0];
+    expect(wide.kind === "problems" && wide.columns).toBe(1);
+  });
+});
+
+/**
+ * What two sheets came out as on the day this shipped.
+ *
+ * Recorded rather than computed — both are proved right by the assertions
+ * above, and what these hold is that they do not silently *change*.
+ */
+const GOLDEN = {
+  mean: [
+    ["7, 8, 3, 3, 19", "8"],
+    ["14, 19, 11, 17, 14", "15"],
+    ["17, 13, 17, 3, 20", "14"],
+  ],
+  all: [
+    ["11, 4, 18, 3, 18, 6", "mean = 10, median = 8.5, mode = 18, range = 15"],
+    ["9, 16, 6, 16, 17, 2", "mean = 11, median = 12.5, mode = 16, range = 15"],
+  ],
+};

--- a/src/engine/sheets/maths/statistics.test.ts
+++ b/src/engine/sheets/maths/statistics.test.ts
@@ -326,9 +326,39 @@ describe("what may be on the page", () => {
   });
 
   it("puts as many numbers in a set as were asked for", () => {
-    for (const size of [3, 4, 5, 6, 7, 9]) {
-      for (const problem of problemsOf({ size, count: 5 }, 2)) {
-        expect(setOn(problem).length, problem.prompt).toBe(size);
+    // Every style, because only two of them build the set rather than drawing
+    // it: a mode has to be placed, and the placing is where a set can come out
+    // shorter than the heading over it says.
+    for (const style of ["mean", "median", "mode", "range", "all"] as const) {
+      for (const size of [3, 4, 5, 6, 7, 9]) {
+        const said = `${style}, sets of ${size}`;
+        const problems = problemsOf({ style, size, count: 5 }, 2);
+        expect(problems.length, said).toBeGreaterThan(0);
+        for (const problem of problems) {
+          expect(setOn(problem).length, `${problem.prompt} — ${said}`).toBe(
+            size,
+          );
+        }
+      }
+    }
+  });
+
+  it("names the smaller set a narrow range can fill, and prints that", () => {
+    // A mode set wants every value but the repeated one to be different, so
+    // nine numbers cannot be built out of one, two and three however long the
+    // draw runs at it. Whichever size it settles on, the sets on the page and
+    // the size the catalog line advertises have to be the same number.
+    for (const style of ["mode", "all"] as const) {
+      const shape = { style, size: 9, range: { min: 1, max: 3 }, count: 6 };
+      const said = describeSheet(config(shape));
+      const named = Number(/sets of (\d+)/.exec(said)?.[1]);
+      expect(named, said).toBeLessThan(9);
+      const problems = problemsOf(shape, 5);
+      expect(problems.length, said).toBeGreaterThan(0);
+      for (const problem of problems) {
+        expect(setOn(problem).length, `${problem.prompt} — ${said}`).toBe(
+          named,
+        );
       }
     }
   });

--- a/src/engine/sheets/maths/statistics.ts
+++ b/src/engine/sheets/maths/statistics.ts
@@ -172,6 +172,39 @@ const needsMean = (style: StatisticStyle): boolean =>
   style === "mean" || style === "all";
 
 /**
+ * How often the repeated value appears, in a set of this size.
+ *
+ * Twice on a small set, and three times on a big one — a value appearing twice
+ * in nine numbers is a mode by the letter of the definition and not by anything
+ * a child would see.
+ */
+const repeatsIn = (size: number): number => (size >= 7 ? 3 : 2);
+
+/**
+ * How many numbers a set will actually hold — which is not always the ask.
+ *
+ * A mode set needs every value but the repeated one to be different, so it can
+ * only be as wide as the range has distinct numbers to fill it: nine numbers
+ * with three of them the same want seven different values, and one to three
+ * has three. The size comes *down* to what can be built rather than the draw
+ * quietly stopping short of it, because the size is also what the catalog line
+ * and the header advertise — and a page of fives under "sets of 9" is the sheet
+ * disagreeing with its own heading. Read by the draw and by the description
+ * from here, so the two cannot part company.
+ */
+function sizeOf(config: StatisticsConfig): number {
+  const wanted = clamp(config.size, SIZES.min, SIZES.max);
+  if (!needsMode(config.style)) return wanted;
+  const { min, max } = bounds(config.range);
+  const distinct = max - min + 1;
+  // The repeated value, and one each of `size − repeats` others that are all
+  // different from it and from each other.
+  let size = wanted;
+  while (size > SIZES.min && distinct < size - repeatsIn(size) + 1) size -= 1;
+  return size;
+}
+
+/**
  * A set of numbers, built to have the answer the sheet is going to ask for.
  *
  * Where a mode is wanted the set is *constructed* rather than drawn and tested:
@@ -180,18 +213,18 @@ const needsMean = (style: StatisticStyle): boolean =>
  * about half the time on a set of five, and the half it fails on is a sheet that
  * quietly comes up four problems short.
  */
-function drawValues(config: StatisticsConfig, rand: () => number): number[] {
-  const size = clamp(config.size, SIZES.min, SIZES.max);
+function drawValues(
+  config: StatisticsConfig,
+  size: number,
+  rand: () => number,
+): number[] {
   const { min, max } = bounds(config.range);
   if (!needsMode(config.style)) {
     return Array.from({ length: size }, () => between(min, max, rand));
   }
 
   const repeated = between(min, max, rand);
-  // Twice on a small set, and three times on a big one — a value appearing
-  // twice in nine numbers is a mode by the letter of the definition and not by
-  // anything a child would see.
-  const times = size >= 7 ? 3 : 2;
+  const times = repeatsIn(size);
   const others: number[] = [];
   const seen = new Set([repeated]);
   let misses = 0;
@@ -217,8 +250,12 @@ function drawValues(config: StatisticsConfig, rand: () => number): number[] {
  * 7" is a question about nothing.
  */
 function drawSet(config: StatisticsConfig, rand: () => number): Drawn | null {
-  const values = drawValues(config, rand);
-  if (values.length < SIZES.min) return null;
+  const size = sizeOf(config);
+  const values = drawValues(config, size, rand);
+  // Against the size this sheet says it prints, not against the smallest set
+  // there is: a mode draw that ran out of distinct values comes back short, and
+  // a short set accepted here is a page that contradicts its own heading.
+  if (values.length < size) return null;
 
   const summary = summaryOf(values);
   if (needsMean(config.style) && summary.mean === null) return null;
@@ -389,10 +426,11 @@ function headerOf(config: StatisticsConfig): SheetOptions {
  * harder one: the median lands between two numbers rather than on one.
  */
 export function describeStatistics(config: StatisticsConfig): string {
-  const size = clamp(config.size, SIZES.min, SIZES.max);
   return [
     titleOf(config),
-    `sets of ${size}`,
+    // What the sets on the page actually hold, which a narrow range can make
+    // smaller than the ask (see `sizeOf`).
+    `sets of ${sizeOf(config)}`,
     `numbers to ${bounds(config.range).max}`,
   ].join(" — ");
 }

--- a/src/engine/sheets/maths/statistics.ts
+++ b/src/engine/sheets/maths/statistics.ts
@@ -1,0 +1,439 @@
+/**
+ * Mean, median, mode and range.
+ *
+ * The one maths family whose question is a *set* rather than a sum, and the one
+ * where the usual generator bug is invisible on the page. Three of them:
+ *
+ * **A set with two modes has two right answers.** `3, 3, 7, 7, 9` has no mode
+ * worth asking for, and a key naming either of them marks half the class wrong.
+ * So a sheet that asks for the mode builds one: a value is placed two or three
+ * times and every other value in the set is different from it and from each
+ * other, which makes the answer unique by construction rather than by luck.
+ *
+ * **An even-sized set has its median between two numbers.** Four numbers have
+ * no middle one, and the answer is halfway between the second and the third —
+ * which is a half as often as not. `medianText` writes that half out rather
+ * than rounding it away, and it does it in whole numbers: the sum of the two
+ * middles is either even, and halves exactly, or odd, and ends in `.5`.
+ *
+ * **A mean that isn't whole is a decimals sheet in disguise.** So a set whose
+ * mean is asked for is drawn until its total divides by its size, and the sheet
+ * a parent gets is the one they chose.
+ *
+ * Everything else the maths families established holds: the answers are
+ * computed when the problem is built, the key only decides to print them, and
+ * the page comes out of `(config, seed)`.
+ */
+import { between, mulberry32, shuffled } from "@/engine/random";
+
+import type {
+  Mil,
+  Problem,
+  Sheet,
+  SheetOptions,
+  StatisticStyle,
+  StatisticsConfig,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import {
+  PROBLEM_GAP,
+  WRAP_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+
+/* ── What a problem takes on the page ─────────────────────────────────────
+   Declared, not measured (§4).                                              */
+
+/** Two lines of the body type and the air a wrap puts between them. */
+const writtenRow = (fontPt: number): Mil => 2 * answerLine(fontPt) + WRAP_GAP;
+
+/** Blank space to work an answer out in, when the config asks for it. */
+const WORKSPACE = inches(0.55);
+
+/** The four answers an "all four" problem asks for, one ruled line each. */
+const ALL_LINES = 4;
+
+/** The room those four lines take, which is what the row reserves for them. */
+const allSpace = (fontPt: number): Mil => ALL_LINES * answerLine(fontPt);
+
+/**
+ * Two columns of sets, and one when all four statistics are asked at once.
+ *
+ * A set of eight numbers is a long line before its answer slot, and the four
+ * answers underneath are sentences rather than numbers.
+ */
+const MAX_COLUMNS = 2;
+const MAX_ALL_COLUMNS = 1;
+
+/** How many numbers a set may hold, whatever a saved config asks for. */
+const SIZES = { min: 3, max: 9 };
+
+/** As `arithmetic.ts` — see the note there on why a budget rather than a proof. */
+const MISS_BUDGET = 500;
+
+/* ── The four statistics ───────────────────────────────────────────────────
+   Worked out once, from the set, and read from there by everything below. A
+   second computation of a median is a second answer to the same question.   */
+
+type Summary = {
+  /** The mean, when it comes out whole — and `null` when it does not. */
+  mean: number | null;
+  /** The median, written out, halves and all. */
+  median: string;
+  /** The one value that appears most often, or `null` when several tie. */
+  mode: number | null;
+  range: number;
+};
+
+/** Smallest first, without disturbing the order the set is printed in. */
+const sorted = (values: number[]): number[] =>
+  [...values].sort((a, b) => a - b);
+
+/**
+ * The middle of a set, written the way a child writes it.
+ *
+ * An odd-sized set has a middle number. An even-sized one has two, and the
+ * answer is halfway between them — which is a whole number when they add to an
+ * even total and a half when they do not. Both are worked out from the *sum* of
+ * the two, so nothing is ever divided into a float.
+ */
+function medianText(values: number[]): string {
+  const order = sorted(values);
+  const middle = Math.floor(order.length / 2);
+  if (order.length % 2 === 1) return String(order[middle]);
+  const total = order[middle - 1] + order[middle];
+  const half = Math.floor(total / 2);
+  return total % 2 === 0 ? String(half) : `${half}.5`;
+}
+
+/**
+ * The value that appears most often, when exactly one value does.
+ *
+ * Exported because it is the one judgement in this file that a set can fail, and
+ * because the draw below builds sets that pass it on purpose — so the rule
+ * itself is only reachable from a test that hands it a tie directly. A family
+ * that lost this would print a question with two right answers on it, which is
+ * the failure the header names first.
+ */
+export function modeOf(values: number[]): number | null {
+  const tally = new Map<number, number>();
+  for (const value of values) tally.set(value, (tally.get(value) ?? 0) + 1);
+  const most = Math.max(...tally.values());
+  const top = [...tally].filter(([, count]) => count === most);
+  // A set where every value appears once has no mode, and one where two values
+  // tie has two: both are honest answers to a question this sheet is not
+  // asking, so neither is drawn.
+  return top.length === 1 && most > 1 ? top[0][0] : null;
+}
+
+function summaryOf(values: number[]): Summary {
+  const total = values.reduce((sum, value) => sum + value, 0);
+  const order = sorted(values);
+  return {
+    mean: total % values.length === 0 ? total / values.length : null,
+    median: medianText(values),
+    mode: modeOf(values),
+    range: order[order.length - 1] - order[0],
+  };
+}
+
+/* ── Drawing a set ─────────────────────────────────────────────────────── */
+
+type Drawn = {
+  key: string;
+  prompt: string;
+  answer: string;
+  answers?: string[];
+};
+
+function bounds(range: { min: number; max: number }): {
+  min: number;
+  max: number;
+} {
+  const min = Math.max(0, Math.floor(range?.min ?? 0));
+  return { min, max: Math.max(min, Math.floor(range?.max ?? 1)) };
+}
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/** Whether this sheet's answer needs one value to appear more than the rest. */
+const needsMode = (style: StatisticStyle): boolean =>
+  style === "mode" || style === "all";
+
+/** And whether it needs the total to divide by how many numbers there are. */
+const needsMean = (style: StatisticStyle): boolean =>
+  style === "mean" || style === "all";
+
+/**
+ * A set of numbers, built to have the answer the sheet is going to ask for.
+ *
+ * Where a mode is wanted the set is *constructed* rather than drawn and tested:
+ * one value is placed two or three times and the rest are all different from it
+ * and from each other. Drawing at random and hoping for a unique mode works
+ * about half the time on a set of five, and the half it fails on is a sheet that
+ * quietly comes up four problems short.
+ */
+function drawValues(config: StatisticsConfig, rand: () => number): number[] {
+  const size = clamp(config.size, SIZES.min, SIZES.max);
+  const { min, max } = bounds(config.range);
+  if (!needsMode(config.style)) {
+    return Array.from({ length: size }, () => between(min, max, rand));
+  }
+
+  const repeated = between(min, max, rand);
+  // Twice on a small set, and three times on a big one — a value appearing
+  // twice in nine numbers is a mode by the letter of the definition and not by
+  // anything a child would see.
+  const times = size >= 7 ? 3 : 2;
+  const others: number[] = [];
+  const seen = new Set([repeated]);
+  let misses = 0;
+  while (others.length < size - times && misses < MISS_BUDGET) {
+    const value = between(min, max, rand);
+    if (seen.has(value)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(value);
+    others.push(value);
+    misses = 0;
+  }
+  return shuffled([...Array(times).fill(repeated), ...others], rand);
+}
+
+/**
+ * The set as it will be printed, with the answer the style asks for.
+ *
+ * Every rejection here is a set that cannot answer its own question: no whole
+ * mean where the sheet asks for the mean, no single mode where it asks for the
+ * mode, and — on a range sheet — no spread at all, because "the range of 7, 7,
+ * 7" is a question about nothing.
+ */
+function drawSet(config: StatisticsConfig, rand: () => number): Drawn | null {
+  const values = drawValues(config, rand);
+  if (values.length < SIZES.min) return null;
+
+  const summary = summaryOf(values);
+  if (needsMean(config.style) && summary.mean === null) return null;
+  if (needsMode(config.style) && summary.mode === null) return null;
+  if (config.style === "range" && summary.range === 0) return null;
+
+  const prompt = values.join(", ");
+  // Folded on the set sorted, because a set is a set: the same nine numbers in
+  // another order is the same question, and a child spots that faster than the
+  // adult who printed it does.
+  const key = `set:${sorted(values).join(":")}`;
+
+  if (config.style === "all") {
+    // One list, printed two ways and built once, so the two cannot disagree:
+    // `answers` is what the sheet rules lines for and the key writes on them,
+    // `answer` the same four on one line for anything wanting a string.
+    const written = [
+      `mean = ${summary.mean}`,
+      `median = ${summary.median}`,
+      `mode = ${summary.mode}`,
+      `range = ${summary.range}`,
+    ];
+    return { key, prompt, answer: written.join(", "), answers: written };
+  }
+  return { key, prompt, answer: answerOf(summary, config.style) };
+}
+
+/** Which of the four the sheet asked for, as it is written in the blank. */
+function answerOf(summary: Summary, style: StatisticStyle): string {
+  if (style === "median") return summary.median;
+  if (style === "mode") return String(summary.mode);
+  if (style === "range") return String(summary.range);
+  return String(summary.mean);
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+/**
+ * How many problems the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic, not measurement, so `npm run test:unit` can answer "did it fit?"
+ * without a browser — and so the same answer serves the catalog page built at
+ * build time and the builder's preview (§4).
+ */
+export function statisticsLayout(config: StatisticsConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of them.
+  const box = sheetBlockBox(headerOf(config), true);
+  const most = config.style === "all" ? MAX_ALL_COLUMNS : MAX_COLUMNS;
+  const columns = clamp(config.columns, 1, most);
+  // The four answer lines are the answer place, not extra paper under it —
+  // exactly as a fact family's four sentences are in `arithmetic.ts`.
+  const under =
+    config.style === "all"
+      ? allSpace(config.fontPt)
+      : config.workspace
+        ? WORKSPACE
+        : 0;
+  const row = writtenRow(config.fontPt) + under;
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
+  };
+}
+
+/**
+ * Every problem on the sheet, in the order they are printed.
+ *
+ * Exported because it is the whole of what a test has to check, and checking it
+ * through the `Sheet` means unwrapping a block union to reach it.
+ */
+export function statisticsProblems(
+  config: StatisticsConfig,
+  seed: number,
+): Problem[] {
+  const { perPage } = statisticsLayout(config);
+  // The count is a request, not a promise: a count that overruns is a second
+  // sheet out of the printer with two problems on it.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  const seen = new Set<string>();
+  const problems: Problem[] = [];
+  const workspace =
+    config.style === "all"
+      ? { workspace: allSpace(config.fontPt) }
+      : config.workspace
+        ? { workspace: WORKSPACE }
+        : {};
+
+  let misses = 0;
+  while (problems.length < wanted && misses < MISS_BUDGET) {
+    const drawn = drawSet(config, rand);
+    // Not what was asked for, or already on the page. Either way the budget
+    // ticks down, and a pool that has run out ends the draw rather than
+    // repeating itself: there are ten sets of three numbers from one to three,
+    // and ten is the honest answer to a request for twenty.
+    if (drawn === null || seen.has(drawn.key)) {
+      misses += 1;
+      continue;
+    }
+    seen.add(drawn.key);
+    problems.push({
+      prompt: drawn.prompt,
+      answer: drawn.answer,
+      ...(drawn.answers ? { answers: drawn.answers } : {}),
+      ...workspace,
+    });
+    misses = 0;
+  }
+  return problems;
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const TITLE: Record<StatisticStyle, string> = {
+  mean: "Finding the mean",
+  median: "Finding the median",
+  mode: "Finding the mode",
+  range: "Finding the range",
+  all: "Mean, median, mode and range",
+};
+
+const INSTRUCTION: Record<StatisticStyle, string> = {
+  mean: "Write the mean of each set of numbers.",
+  median: "Write the median of each set of numbers.",
+  mode: "Write the mode of each set of numbers.",
+  range: "Write the range of each set of numbers.",
+  all: "Write the mean, median, mode and range of each set.",
+};
+
+const titleOf = (config: StatisticsConfig): string =>
+  TITLE[config.style] ?? TITLE.all;
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: StatisticsConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions:
+      config.instructions ?? INSTRUCTION[config.style] ?? INSTRUCTION.all,
+  };
+}
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * How many numbers are in a set is the half of the difficulty the title leaves
+ * off — and, on an even-sized set, it is a different question rather than a
+ * harder one: the median lands between two numbers rather than on one.
+ */
+export function describeStatistics(config: StatisticsConfig): string {
+  const size = clamp(config.size, SIZES.min, SIZES.max);
+  return [
+    titleOf(config),
+    `sets of ${size}`,
+    `numbers to ${bounds(config.range).max}`,
+  ].join(" — ");
+}
+
+export function buildStatisticsSheet(
+  config: StatisticsConfig,
+  seed: number,
+): Sheet {
+  const items = statisticsProblems(config, seed);
+  const { columns } = statisticsLayout(config);
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is actually on the page, not out of what was asked for: a
+      // sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf: items.length },
+    },
+    blocks: [{ kind: "problems", columns, items }],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const STATISTICS_SHEET: SheetSpec<StatisticsConfig> = {
+  id: "statistics",
+  label: "Mean, median and mode",
+  world: SHEET_WORLD,
+  build: buildStatisticsSheet,
+  // The whole of the answer-key mechanism: all four statistics were worked out
+  // from the set when the problem was built, so a key prints what is already
+  // there rather than summarising the numbers a second time.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeStatistics,
+};

--- a/src/engine/sheets/maths/wordproblems.test.ts
+++ b/src/engine/sheets/maths/wordproblems.test.ts
@@ -1,0 +1,495 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { PROBLEM_GAP } from "../layout";
+import type {
+  MarginSize,
+  Paper,
+  PaperSize,
+  Problem,
+  WordProblemConfig,
+  WordTopic,
+} from "../types";
+
+import {
+  MAX_TEXT,
+  WORD_PROBLEMS_SHEET,
+  WORD_TEMPLATES,
+  wordLayout,
+  wordStories,
+} from "./wordproblems";
+
+/**
+ * Word problems, and the two things that can be wrong with one.
+ *
+ * **The answer.** Nothing here checks the generator against the generator: the
+ * numbers are read back out of the printed *sentence*, in the order they appear
+ * in it, and the answer is worked out again by a formula written down in this
+ * file — one per template, by hand, from what the story says. A template whose
+ * text and answer drifted apart fails, and so does one whose sentence stopped
+ * printing a number it depends on. Division is a search by repeated addition;
+ * there is no `/` anywhere below.
+ *
+ * The formulae are keyed by template id, and the suite refuses to run unless
+ * there is exactly one for every template the family ships (`WORD_TEMPLATES`).
+ * That is the part that matters over time: a twenty-first template cannot reach
+ * paper without somebody writing down, separately, what its answer ought to be.
+ *
+ * **The reading.** The other half of the story (§11) is that a page must not
+ * read as generated, so the variety is asserted rather than hoped for: every
+ * problem on a mixed page comes from a different template, every template the
+ * family holds actually appears on some page, and every sentence is a sentence —
+ * a capital, a question mark, and no gap where a name should be.
+ */
+
+/* ── Arithmetic, from repeated addition ──────────────────────────────────── */
+
+/** `a` added to itself `b` times — the only multiplication in this file. */
+function multiply(a: number, b: number): number {
+  const [each, times] = a > b ? [a, b] : [b, a];
+  let total = 0;
+  for (let step = 0; step < times; step += 1) total += each;
+  return total;
+}
+
+/** How many `b`s make `a`, counted up. Throws rather than round. */
+function divide(a: number, b: number): number {
+  if (b <= 0 || a < 0) throw new Error(`${a} ÷ ${b} is not a counting sum`);
+  let total = 0;
+  let how = 0;
+  while (total < a) {
+    total += b;
+    how += 1;
+  }
+  if (total !== a) throw new Error(`${a} ÷ ${b} is not a whole number`);
+  return how;
+}
+
+const least = (values: number[]): number =>
+  values.reduce((low, value) => (value < low ? value : low));
+
+const most = (values: number[]): number =>
+  values.reduce((high, value) => (value > high ? value : high));
+
+/* ── What each story's answer ought to be ────────────────────────────────── */
+
+/**
+ * One formula per template, over the numbers the sentence prints, in order.
+ *
+ * Written from the *story* rather than from the generator — "the temperature
+ * was `n0` and fell `n1`, so it is `n0 − n1`" — which is what makes this a check
+ * rather than a copy. Every one of them is spelled out, including the ones that
+ * look too obvious to be worth writing: the obvious ones are where a sign goes
+ * missing.
+ */
+const CHECKS: Record<string, (n: number[]) => number> = {
+  /* Integers. */
+  temperature: (n) => n[0] - n[1],
+  height: (n) => n[0] - n[1],
+  points: (n) => n[0] - n[1],
+  // The floor is printed as a negative number, so the sum is an addition.
+  lift: (n) => n[0] + n[1],
+
+  /* Rate. */
+  speed: (n) => divide(n[0], n[1]),
+  boxes: (n) => divide(n[1], n[0]),
+  recipe: (n) => multiply(n[0], divide(n[2], n[1])),
+  reading: (n) => multiply(divide(n[0], n[1]), n[2]),
+
+  /* Percent. */
+  score: (n) => divide(multiply(n[0], 100), n[1]),
+  share: (n) => divide(multiply(n[0], n[1]), 100),
+  left: (n) => divide(multiply(n[0], 100 - n[1]), 100),
+  increase: (n) => divide(multiply(n[0], 100 + n[1]), 100),
+
+  /* Equations. */
+  think: (n) => divide(n[2] - n[1], n[0]),
+  gave: (n) => n[0] + n[1],
+  shared: (n) => multiply(n[0], n[1]),
+  consecutive: (n) => divide(n[0] - 1, 2),
+
+  /* Averages. */
+  games: (n) => divide(n[0] + n[1] + n[2] + n[3], 4),
+  total: (n) => multiply(n[0], n[1]),
+  spread: (n) => most(n) - least(n),
+  equally: (n) => divide(n[0] + n[1] + n[2], 3),
+};
+
+/** The numbers a story prints, in the order it prints them. */
+const numbersIn = (text: string): number[] =>
+  (text.match(/−?\d+/g) ?? []).map((written) =>
+    Number(written.replace(/−/g, "-")),
+  );
+
+/* ── Configs ───────────────────────────────────────────────────────────── */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const EVERY_TOPIC: WordTopic[] = [
+  "integers",
+  "rate",
+  "percent",
+  "equation",
+  "average",
+];
+
+const config = (over: Partial<WordProblemConfig> = {}): WordProblemConfig => ({
+  kind: "word-problems",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  topics: EVERY_TOPIC,
+  range: { min: 2, max: 20 },
+  count: 8,
+  columns: 2,
+  ...over,
+});
+
+/** Every shape the family can print: each topic on its own, and mixed. */
+const EVERY_SHAPE: Array<Partial<WordProblemConfig>> = [
+  {},
+  ...EVERY_TOPIC.map((topic) => ({ topics: [topic] })),
+  { topics: ["integers", "equation"] as WordTopic[] },
+  { range: { min: 1, max: 9 } },
+  { range: { min: 5, max: 40 } },
+  { workspace: false },
+  { columns: 1 },
+];
+
+const SEEDS = [0, 1, 2, 7, 4242];
+
+/** The one block a word-problem sheet has, narrowed for the reader. */
+function problemsOf(over: Partial<WordProblemConfig>, seed: number): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+const everyStory = function* (
+  shapes: Array<Partial<WordProblemConfig>> = EVERY_SHAPE,
+) {
+  for (const shape of shapes) {
+    for (const seed of SEEDS) {
+      const stories = wordStories(config(shape), seed);
+      expect(stories.length, JSON.stringify(shape)).toBeGreaterThan(0);
+      for (const story of stories) yield story;
+    }
+  }
+};
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the word-problem family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("word-problems")).toBe(WORD_PROBLEMS_SHEET);
+    expect(sheetSpec("word-problems").label).toBe("Word problems");
+  });
+
+  it("names the sheet after its topic, and a mixed sheet after none", () => {
+    expect(describeSheet(config({ topics: ["percent"] }))).toBe(
+      "Word problems: percentages",
+    );
+    expect(describeSheet(config({ topics: ["integers", "rate"] }))).toBe(
+      "Word problems — integers, ratio and rate",
+    );
+  });
+
+  it("tells a child what to do with a page of sentences", () => {
+    expect(buildSheet(config(), 1).header.instructions).toBe(
+      "Read each problem and write the answer.",
+    );
+  });
+
+  it("marks the sheet out of what is on it", () => {
+    const sheet = buildSheet(config({ count: 6 }), 3);
+    const block = sheet.blocks[0];
+    expect(block.kind === "problems" && block.items.length).toBe(
+      sheet.header.score?.outOf,
+    );
+  });
+});
+
+/* ── The answer key (§20) ──────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("has a formula of its own for every template that ships", () => {
+    // The check that keeps the rest of this file honest over time: a new
+    // template cannot reach paper until somebody has written down, separately,
+    // what its answer ought to be.
+    expect([...WORD_TEMPLATES].sort()).toEqual(Object.keys(CHECKS).sort());
+  });
+
+  it("answers every story the way its sentence says it should", () => {
+    for (const story of everyStory()) {
+      const check = CHECKS[story.id];
+      expect(check, `no check for ${story.id}`).toBeDefined();
+      expect(
+        Number(story.answer.replace(/−/g, "-")),
+        `${story.id}: ${story.text} → ${story.answer}`,
+      ).toBe(check(numbersIn(story.text)));
+    }
+  });
+
+  it("prints a story's answer as a number and nothing else", () => {
+    for (const story of everyStory()) {
+      expect(story.answer, story.text).toMatch(/^−?\d+$/);
+    }
+  });
+
+  it("prints the answers only when the sheet is a key", () => {
+    const sheet = buildSheet(config(), 5);
+    const key = answerKey(config(), 5);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    for (const shape of EVERY_SHAPE) {
+      expect(answerKey(config(shape), 11).blocks).toEqual(
+        buildSheet(config(shape), 11).blocks,
+      );
+    }
+  });
+});
+
+/* ── How the page reads (§11) ──────────────────────────────────────────── */
+
+describe("a page that does not read as generated", () => {
+  it("uses a different template for every problem on a mixed page", () => {
+    // Twelve templates drawn at random out of twenty give the same one twice on
+    // most pages, and two stories with one skeleton and two names is exactly
+    // what a reader notices first.
+    for (const seed of SEEDS) {
+      // As many as the page holds, which is eight of the twenty templates.
+      const stories = wordStories(config({ count: 12 }), seed);
+      expect(stories.length).toBeGreaterThanOrEqual(8);
+      expect(new Set(stories.map((story) => story.id)).size).toBe(
+        stories.length,
+      );
+    }
+  });
+
+  it("asks about the topics it was given and no others", () => {
+    for (const topic of EVERY_TOPIC) {
+      for (const seed of SEEDS) {
+        const stories = wordStories(config({ topics: [topic] }), seed);
+        expect(stories.length).toBeGreaterThan(0);
+        for (const story of stories) expect(story.topic).toBe(topic);
+      }
+    }
+  });
+
+  it("ships no template that never gets printed", () => {
+    const seen = new Set<string>();
+    for (const seed of [0, 1, 2, 3, 4, 5, 6, 7]) {
+      for (const topic of EVERY_TOPIC) {
+        for (const story of wordStories(
+          config({ topics: [topic], count: 8 }),
+          seed,
+        )) {
+          seen.add(story.id);
+        }
+      }
+    }
+    expect([...seen].sort()).toEqual([...WORD_TEMPLATES].sort());
+  });
+
+  it("writes a whole sentence every time", () => {
+    for (const story of everyStory()) {
+      // A capital at the front, a question at the end, and nothing in the
+      // middle that gives away that it came out of a template.
+      expect(story.text[0], story.text).toBe(story.text[0].toUpperCase());
+      expect(story.text.endsWith("?"), story.text).toBe(true);
+      expect(story.text, story.text).not.toMatch(/undefined|NaN|\{|\}|_/);
+      expect(story.text, story.text).not.toMatch(/ {2}/);
+    }
+  });
+
+  it("keeps every story inside the length the layout reserved for it", () => {
+    // The row is declared, not measured (§4): a story longer than the cap is a
+    // row taller than the page allowed for, which is the last problem printed
+    // on a second sheet of paper.
+    for (const story of everyStory()) {
+      expect(story.text.length, story.text).toBeLessThanOrEqual(MAX_TEXT);
+    }
+  });
+
+  it("varies the names, so a page is not one child's whole day", () => {
+    const names = new Set(
+      wordStories(config({ count: 12 }), 3).flatMap(
+        (story) => story.text.match(/^[A-Z][a-z]+/) ?? [],
+      ),
+    );
+    expect(names.size).toBeGreaterThan(3);
+  });
+});
+
+/* ── Bounds (§20) ──────────────────────────────────────────────────────── */
+
+describe("what may be on the page", () => {
+  it("gives every problem exactly one place to write the answer", () => {
+    for (const [, problem] of everyProblem()) {
+      expect(problem.prompt.split("_").length - 1).toBe(0);
+      expect(problem.answers).toBeUndefined();
+    }
+  });
+
+  it("leaves room to work in unless the sheet says not to", () => {
+    // A word problem is the one sheet where the working is most of the task,
+    // so the space is there unless a parent turns it off.
+    expect(problemsOf({}, 1)[0].workspace).toBeGreaterThan(0);
+    expect(problemsOf({ workspace: false }, 1)[0].workspace).toBeUndefined();
+  });
+
+  it("tells the same story twice on no sheet at all", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const asked = problemsOf(shape, seed).map((problem) => problem.prompt);
+        expect(new Set(asked).size, JSON.stringify(shape)).toBe(asked.length);
+      }
+    }
+  });
+
+  it("prints nothing rather than something wrong when the ask is impossible", () => {
+    // A sheet with no topic on it has nothing to write about. An empty sheet is
+    // the honest answer, and the builder's job to prevent (PRINT13).
+    expect(problemsOf({ topics: [] }, 1)).toEqual([]);
+    expect(problemsOf({ topics: ["algebra" as WordTopic] }, 1)).toEqual([]);
+  });
+});
+
+const everyProblem = function* (
+  shapes: Array<Partial<WordProblemConfig>> = EVERY_SHAPE,
+): Generator<[Partial<WordProblemConfig>, Problem]> {
+  for (const shape of shapes) {
+    for (const seed of SEEDS) {
+      const problems = problemsOf(shape, seed);
+      expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+      for (const problem of problems) yield [shape, problem];
+    }
+  }
+};
+
+/* ── Determinism, and the three features it buys (§7) ──────────────────── */
+
+describe("(config, seed)", () => {
+  it("builds the same sheet twice", () => {
+    for (const shape of EVERY_SHAPE) {
+      for (const seed of SEEDS) {
+        const once = buildSheet(config(shape), seed);
+        const twice = buildSheet(config(shape), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("draws the same problems for a seed as it did the day it shipped", () => {
+    expect(
+      wordStories(config({ count: 3 }), 7).map((story) => [
+        story.text,
+        story.answer,
+      ]),
+    ).toEqual(GOLDEN);
+  });
+
+  it("makes variants A, B and C genuinely different sets of problems", () => {
+    for (const shape of EVERY_SHAPE) {
+      const [a, b, c] = [0, 1, 2].map((offset) =>
+        problemsOf({ ...shape, count: 6 }, 100 + offset).map(
+          (problem) => problem.prompt,
+        ),
+      );
+      for (const [one, other] of [
+        [a, b],
+        [a, c],
+        [b, c],
+      ]) {
+        expect(one, JSON.stringify(shape)).not.toEqual(other);
+        const shared = one.filter((asked) => other.includes(asked)).length;
+        expect(shared, JSON.stringify(shape)).toBe(0);
+      }
+    }
+  });
+});
+
+/* ── Capacity (§20) ────────────────────────────────────────────────────── */
+
+describe("how much fits", () => {
+  const SIZES: PaperSize[] = ["letter", "a4", "legal"];
+  const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
+
+  it("never prints more problems than the paper holds", () => {
+    for (const size of SIZES) {
+      for (const margin of MARGINS) {
+        for (const fontPt of [12, 18]) {
+          for (const shape of EVERY_SHAPE) {
+            const over = { ...shape, paper: paper({ size, margin }), fontPt };
+            const problems = problemsOf({ ...over, count: 200 }, 8);
+            const { box, columns, row } = wordLayout(config(over));
+            const rows = Math.ceil(problems.length / columns);
+            const used = rows * row + Math.max(0, rows - 1) * PROBLEM_GAP.y;
+            expect(used, `${size}/${margin}/${fontPt}pt`).toBeLessThanOrEqual(
+              box.height,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("reserves more lines for bigger type and for a narrower column", () => {
+    // The one row in the shop counted in lines of text, so the two things that
+    // decide how many lines there are have to reach it.
+    expect(wordLayout(config({ fontPt: 18 })).lines).toBeGreaterThan(
+      wordLayout(config({ fontPt: 12 })).lines,
+    );
+    expect(wordLayout(config({ columns: 2 })).lines).toBeGreaterThan(
+      wordLayout(config({ columns: 1 })).lines,
+    );
+  });
+
+  it("does not throw the page away either", () => {
+    const { perPage } = wordLayout(config());
+    expect(perPage).toBeGreaterThanOrEqual(8);
+  });
+
+  it("honours the count and the columns it was given", () => {
+    expect(problemsOf({ count: 6 }, 1).length).toBe(6);
+    for (const columns of [1, 2]) {
+      const block = buildSheet(config({ columns }), 1).blocks[0];
+      expect(block.kind === "problems" && block.columns).toBe(columns);
+    }
+    // Never three: a sentence set in a third of a page is a paragraph.
+    const wide = buildSheet(config({ columns: 4 }), 1).blocks[0];
+    expect(wide.kind === "problems" && wide.columns).toBe(2);
+  });
+});
+
+/**
+ * What one sheet came out as on the day this shipped.
+ *
+ * Recorded rather than computed — it is proved right by the assertions above,
+ * and what this holds is that it does not silently *change*.
+ */
+const GOLDEN: Array<[string, string]> = [
+  [
+    "Three friends have 19, 12 and 8 shells. If they share them equally, how many does each one get?",
+    "13",
+  ],
+  [
+    "Maya reads 16 pages in 8 days. At that rate, how many pages will Maya read in 3 days?",
+    "6",
+  ],
+  [
+    "A train travels 72 miles to the mountains in 8 hours. How far does it go in one hour?",
+    "9",
+  ],
+];

--- a/src/engine/sheets/maths/wordproblems.ts
+++ b/src/engine/sheets/maths/wordproblems.ts
@@ -1,0 +1,752 @@
+/**
+ * Word problems, from templates.
+ *
+ * The one place in the maths set where generated *text* is read by a person.
+ * Everywhere else a template failure is a sum that looks odd; here it is a page
+ * that reads as machinery, and a parent who notices stops trusting the rest of
+ * the shop. §11 says it plainly: ship fewer templates rather than repetitive
+ * ones. So there are twenty, four to a topic, and each one draws its own cast —
+ * a different child, a different thing being counted — because a page of four
+ * templates wearing eight names reads as eight questions and a page of one
+ * template wearing eight names reads as a form letter.
+ *
+ * **Every number a story uses is printed in it, as digits.** Not for the child's
+ * sake — for the key's. The suite reads the numbers back out of the sentence in
+ * the order they appear and works the answer out with its own arithmetic, per
+ * template, so a template whose story and answer disagree fails. A number
+ * spelled out in words would be a number the check could not see, which is why
+ * "four games" is the phrase and `4` is never the word.
+ *
+ * **No money.** Prices belong to `money.ts`, which has a currency switch,
+ * because a British child counting dollars is being asked a question about a
+ * foreign country. Everything here is counted in things, miles, pages and
+ * points, which mean the same thing everywhere.
+ *
+ * **The row is declared, not measured (§4)** — and a story is the one problem in
+ * the shop long enough for that to be a real reservation rather than a
+ * formality. `MAX_TEXT` is the cap every template is held to by the suite, and
+ * the layout reserves the lines that cap needs at the column width and type size
+ * the sheet is actually set in.
+ */
+import { between, mulberry32, shuffled } from "@/engine/random";
+
+import type {
+  Mil,
+  Problem,
+  Sheet,
+  SheetOptions,
+  WordProblemConfig,
+  WordTopic,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import {
+  PROBLEM_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches, points } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import { signedText } from "./exact";
+
+/* ── What a story takes on the page ───────────────────────────────────────
+   Declared, not measured (§4).                                              */
+
+/**
+ * The longest a story may be, in characters.
+ *
+ * A cap rather than a measurement, because the layout has to know how tall a
+ * row is before a single problem has been drawn — and because the alternative
+ * is a page whose last row is decided by whichever template happened to come
+ * out longest. The suite holds every template to it.
+ */
+export const MAX_TEXT = 150;
+
+/**
+ * How wide an average character is, as a fraction of the body size.
+ *
+ * The one estimate in the whole of the sheet engine, and it is deliberately
+ * generous: half an em is wider than the average of Nunito's lower case, so the
+ * reservation errs towards a line of air at the bottom of the page rather than
+ * towards a row below the bottom margin. Print is the whole of the output path
+ * (§10), so the two errors are not the same size.
+ */
+const CHAR_EM = 0.55;
+
+/** The ruled blank a story is answered in — `.sheet__slot`, in this unit. */
+const SLOT = inches(0.8);
+
+/** Blank space to work a story out in. On unless a config turns it off. */
+const WORKSPACE = inches(0.55);
+
+/**
+ * Two columns, and never three. A story is a sentence and a half, and a
+ * sentence set in a third of a page is a paragraph.
+ */
+const MAX_COLUMNS = 2;
+
+/** As `arithmetic.ts` — see the note there on why a budget rather than a proof. */
+const MISS_BUDGET = 500;
+
+/* ── The cast ──────────────────────────────────────────────────────────────
+   Names, things and places, drawn per problem. This is what stops four
+   templates from reading as four templates: the arithmetic repeats twenty
+   times on a page, and the reader has to not notice.                        */
+
+const NAMES = [
+  "Ava",
+  "Ben",
+  "Chloe",
+  "Diego",
+  "Emma",
+  "Finn",
+  "Grace",
+  "Hugo",
+  "Isla",
+  "Jonah",
+  "Kira",
+  "Leo",
+  "Maya",
+  "Noah",
+  "Priya",
+  "Ravi",
+  "Sofia",
+  "Theo",
+];
+
+const THINGS = [
+  "stickers",
+  "marbles",
+  "conkers",
+  "pencils",
+  "cards",
+  "shells",
+  "beads",
+  "buttons",
+  "acorns",
+  "counters",
+];
+
+const PLACES = [
+  "the chess club",
+  "the swimming club",
+  "the school choir",
+  "the art club",
+  "the running club",
+];
+
+/**
+ * Somewhere a temperature belongs.
+ *
+ * A separate list from the clubs, because "the temperature in the art club" is
+ * the sort of sentence that tells a reader immediately that nobody wrote it.
+ */
+const SPOTS = [
+  "the mountains",
+  "the valley",
+  "the harbour",
+  "the forest",
+  "the city",
+];
+
+type Cast = { name: string; thing: string; place: string; spot: string };
+
+/* ── Drawing a story ───────────────────────────────────────────────────── */
+
+export type WordStory = {
+  /** Which template made it — the suite's way of knowing what to check. */
+  id: string;
+  topic: WordTopic;
+  text: string;
+  answer: string;
+};
+
+type Range = { min: number; max: number };
+
+type Template = {
+  id: string;
+  topic: WordTopic;
+  draw(
+    range: Range,
+    cast: Cast,
+    rand: () => number,
+  ): { text: string; answer: string } | null;
+};
+
+/** The percentages a child is taught to do in their head. */
+const PERCENTS = [5, 10, 20, 25, 40, 50, 60, 75];
+
+const pick = <T>(items: readonly T[], rand: () => number): T =>
+  items[Math.floor(rand() * items.length)];
+
+/** A small number, for the times a story counts hours, days or friends. */
+const few = (range: Range, rand: () => number): number =>
+  between(2, Math.max(2, Math.min(9, range.max)), rand);
+
+const story = (text: string, answer: number | string) => ({
+  text,
+  answer: typeof answer === "number" ? signedText(answer) : answer,
+});
+
+/**
+ * The twenty templates.
+ *
+ * Each draws the numbers it needs, prints every one of them in its sentence,
+ * and returns the answer worked out from the same numbers — or `null` when what
+ * came out is not a question with a whole answer, which is the rejection every
+ * generated family in the shop is built on.
+ */
+const TEMPLATES: Template[] = [
+  /* ── Integers ───────────────────────────────────────────────────────── */
+  {
+    id: "temperature",
+    topic: "integers",
+    draw: (range, cast, rand) => {
+      const noon = between(range.min, range.max, rand);
+      const fall = between(range.min, range.max * 2, rand);
+      return story(
+        `The temperature in ${cast.spot} was ${noon}°C at noon. By midnight it had fallen ${fall} degrees. What was the temperature then?`,
+        noon - fall,
+      );
+    },
+  },
+  {
+    id: "height",
+    topic: "integers",
+    draw: (range, cast, rand) => {
+      const above = between(range.min, range.max, rand);
+      const down = between(range.min, range.max * 2, rand);
+      return story(
+        `${cast.name} is ${above} m above sea level and walks ${down} m down into a valley. How many metres above sea level is ${cast.name} now?`,
+        above - down,
+      );
+    },
+  },
+  {
+    id: "points",
+    topic: "integers",
+    draw: (range, cast, rand) => {
+      const had = between(range.min, range.max, rand);
+      const lost = between(range.min, range.max * 2, rand);
+      return story(
+        `${cast.name} had ${had} points and then lost ${lost} in one round. How many points does ${cast.name} have now?`,
+        had - lost,
+      );
+    },
+  },
+  {
+    id: "lift",
+    topic: "integers",
+    draw: (range, cast, rand) => {
+      const below = between(1, Math.max(1, Math.min(6, range.max)), rand);
+      const up = between(range.min, range.max, rand);
+      return story(
+        `${cast.name} gets into a lift on floor ${signedText(-below)} and rides up ${up} floors. Which floor does ${cast.name} get out on?`,
+        up - below,
+      );
+    },
+  },
+
+  /* ── Rate ───────────────────────────────────────────────────────────── */
+  {
+    id: "speed",
+    topic: "rate",
+    draw: (range, cast, rand) => {
+      const hours = few(range, rand);
+      const each = between(Math.max(2, range.min), range.max, rand);
+      return story(
+        `A train travels ${each * hours} miles to ${cast.spot} in ${hours} hours. How far does it go in one hour?`,
+        each,
+      );
+    },
+  },
+  {
+    id: "boxes",
+    topic: "rate",
+    draw: (range, cast, rand) => {
+      const boxes = few(range, rand);
+      const each = between(Math.max(2, range.min), range.max, rand);
+      return story(
+        `${boxes} boxes hold ${each * boxes} ${cast.thing} altogether. How many ${cast.thing} are in one box?`,
+        each,
+      );
+    },
+  },
+  {
+    id: "recipe",
+    topic: "rate",
+    draw: (range, cast, rand) => {
+      const cups = between(1, Math.max(1, Math.min(6, range.max)), rand);
+      const made = few(range, rand);
+      const by = between(2, 5, rand);
+      return story(
+        `${cast.name} uses ${cups} cups of flour to make ${made} muffins. How many cups are needed for ${made * by} muffins?`,
+        cups * by,
+      );
+    },
+  },
+  {
+    id: "reading",
+    topic: "rate",
+    draw: (range, cast, rand) => {
+      const days = few(range, rand);
+      const each = between(Math.max(2, range.min), range.max, rand);
+      const more = few(range, rand);
+      if (more === days) return null;
+      return story(
+        `${cast.name} reads ${each * days} pages in ${days} days. At that rate, how many pages will ${cast.name} read in ${more} days?`,
+        each * more,
+      );
+    },
+  },
+
+  /* ── Percent ────────────────────────────────────────────────────────── */
+  {
+    id: "score",
+    topic: "percent",
+    draw: (range, cast, rand) => {
+      const outOf = between(range.min, range.max, rand) * 4;
+      const percent = pick(PERCENTS, rand);
+      // Only the pairs that land on a whole number of marks: a test scored
+      // 17.5 out of 25 is a question nobody set.
+      if ((outOf * percent) % 100 !== 0) return null;
+      return story(
+        `${cast.name} scored ${(outOf * percent) / 100} out of ${outOf} in a spelling test. What percentage is that?`,
+        percent,
+      );
+    },
+  },
+  {
+    id: "share",
+    topic: "percent",
+    draw: (range, cast, rand) => {
+      const total = between(range.min, range.max, rand) * 4;
+      const percent = pick(PERCENTS, rand);
+      if ((total * percent) % 100 !== 0) return null;
+      return story(
+        `There are ${total} children in ${cast.place}, and ${percent}% of them are left-handed. How many is that?`,
+        (total * percent) / 100,
+      );
+    },
+  },
+  {
+    id: "left",
+    topic: "percent",
+    draw: (range, cast, rand) => {
+      const total = between(range.min, range.max, rand) * 4;
+      const percent = pick(PERCENTS, rand);
+      if ((total * percent) % 100 !== 0) return null;
+      return story(
+        `A library has ${total} books and ${percent}% of them are out on loan. How many can ${cast.name} still find on the shelf?`,
+        (total * (100 - percent)) / 100,
+      );
+    },
+  },
+  {
+    id: "increase",
+    topic: "percent",
+    draw: (range, cast, rand) => {
+      const total = between(range.min, range.max, rand) * 4;
+      const percent = pick(PERCENTS, rand);
+      if ((total * percent) % 100 !== 0) return null;
+      return story(
+        `There were ${total} members in ${cast.place} and the number grew by ${percent}%. How many members are there now?`,
+        (total * (100 + percent)) / 100,
+      );
+    },
+  },
+
+  /* ── Equations ──────────────────────────────────────────────────────── */
+  {
+    id: "think",
+    topic: "equation",
+    draw: (range, cast, rand) => {
+      const by = few(range, rand);
+      const number = between(range.min, range.max, rand);
+      const plus = between(range.min, range.max, rand);
+      return story(
+        `${cast.name} thinks of a number, multiplies it by ${by} and then adds ${plus}. The answer is ${by * number + plus}. What was the number?`,
+        number,
+      );
+    },
+  },
+  {
+    id: "gave",
+    topic: "equation",
+    draw: (range, cast, rand) => {
+      const away = between(range.min, range.max, rand);
+      const left = between(range.min, range.max, rand);
+      return story(
+        `${cast.name} had some ${cast.thing}. After giving ${away} away, there are ${left} left. How many were there to start with?`,
+        away + left,
+      );
+    },
+  },
+  {
+    id: "shared",
+    topic: "equation",
+    draw: (range, cast, rand) => {
+      const friends = few(range, rand);
+      const each = between(Math.max(2, range.min), range.max, rand);
+      return story(
+        `${cast.name} shares a jar of ${cast.thing} equally between ${friends} friends. Each one gets ${each}. How many were in the jar?`,
+        friends * each,
+      );
+    },
+  },
+  {
+    id: "consecutive",
+    topic: "equation",
+    draw: (range, cast, rand) => {
+      const smaller = between(range.min, range.max, rand);
+      return story(
+        `${cast.name} thinks of two whole numbers next to each other. They add up to ${smaller + smaller + 1}. What is the smaller one?`,
+        smaller,
+      );
+    },
+  },
+
+  /* ── Averages ───────────────────────────────────────────────────────── */
+  {
+    id: "games",
+    topic: "average",
+    draw: (range, cast, rand) => {
+      const scores = fourThatShare(range, 4, rand);
+      if (scores === null) return null;
+      const [a, b, c, d] = scores;
+      return story(
+        `${cast.name} scored ${a}, ${b}, ${c} and ${d} points in four games. What was the mean score?`,
+        (a + b + c + d) / 4,
+      );
+    },
+  },
+  {
+    id: "total",
+    topic: "average",
+    draw: (range, cast, rand) => {
+      const how = few(range, rand);
+      const mean = between(Math.max(2, range.min), range.max, rand);
+      return story(
+        `${cast.name} writes down ${how} numbers with a mean of ${mean}. What is the total of the ${how} numbers?`,
+        how * mean,
+      );
+    },
+  },
+  {
+    id: "spread",
+    topic: "average",
+    draw: (range, cast, rand) => {
+      const times = [0, 1, 2, 3].map(() =>
+        between(range.min, range.max * 2, rand),
+      );
+      const [least, most] = [Math.min(...times), Math.max(...times)];
+      // Four times that are all the same have no range worth asking for.
+      if (most === least) return null;
+      return story(
+        `${cast.name}'s times were ${times.slice(0, 3).join(", ")} and ${times[3]} seconds. What is the range of the times?`,
+        most - least,
+      );
+    },
+  },
+  {
+    id: "equally",
+    topic: "average",
+    draw: (range, cast, rand) => {
+      const shares = fourThatShare(range, 3, rand);
+      if (shares === null) return null;
+      const [a, b, c] = shares;
+      return story(
+        `Three friends have ${a}, ${b} and ${c} ${cast.thing}. If they share them equally, how many does each one get?`,
+        (a + b + c) / 3,
+      );
+    },
+  },
+];
+
+/**
+ * Numbers that share out exactly between `how` of them.
+ *
+ * The last one is what makes it work: the others are drawn and it is whatever
+ * the total needs, which is how every mean in the shop is built (see
+ * `statistics.ts`). It is checked back into the range afterwards, because a
+ * story about a child scoring −3 points is not a story about averages.
+ */
+function fourThatShare(
+  range: Range,
+  how: number,
+  rand: () => number,
+): number[] | null {
+  const drawn = Array.from({ length: how - 1 }, () =>
+    between(range.min, range.max, rand),
+  );
+  const mean = between(range.min, range.max, rand);
+  const last = mean * how - drawn.reduce((sum, value) => sum + value, 0);
+  if (last < range.min || last > range.max) return null;
+  return [...drawn, last];
+}
+
+/* ── The pool ──────────────────────────────────────────────────────────────
+   Sanitised once, because it comes from outside this build: a config in a
+   bookmarked URL may name a topic twice, or one this build has never heard
+   of.                                                                       */
+
+const TOPICS: WordTopic[] = [
+  "integers",
+  "rate",
+  "percent",
+  "equation",
+  "average",
+];
+
+function topicsOf(config: WordProblemConfig): WordTopic[] {
+  const asked = (config.topics ?? []).filter((topic) => TOPICS.includes(topic));
+  return asked.length > 0 ? [...new Set(asked)] : [];
+}
+
+function bounds(range: { min: number; max: number }): Range {
+  const min = Math.max(1, Math.floor(range?.min ?? 1));
+  return { min, max: Math.max(min, Math.floor(range?.max ?? 1)) };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/**
+ * How many problems the paper holds, and how wide a column of them is.
+ *
+ * The row is the only one in the shop counted in *lines of text*: a story is as
+ * long as it is, and how many lines that wraps onto depends on the column and
+ * the type size together. Arithmetic still — there is no DOM here (§4) — and
+ * `MAX_TEXT` is what makes it arithmetic rather than a guess.
+ */
+export function wordLayout(config: WordProblemConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  lines: number;
+  perPage: number;
+} {
+  // Against the header the sheet will print, not the one the config holds, and
+  // `true` for the score box because a sheet of problems is marked out of them.
+  const box = sheetBlockBox(headerOf(config), true);
+  const columns = clamp(config.columns, 1, MAX_COLUMNS);
+  const cell = columnWidth(box, columns, PROBLEM_GAP.x);
+
+  const character = Math.max(1, points(config.fontPt * CHAR_EM));
+  // The slot is paid for in characters, because it sits on the same wrapping
+  // line the story ends on and pushes it along like any other word.
+  const room = MAX_TEXT + Math.ceil(SLOT / character);
+  const perLine = Math.max(1, Math.floor(cell / character));
+  const lines = Math.max(1, Math.ceil(room / perLine));
+  const row =
+    lines * answerLine(config.fontPt) + (spacious(config) ? WORKSPACE : 0);
+
+  return {
+    box,
+    columns,
+    cell,
+    row,
+    lines,
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
+  };
+}
+
+/** Working space, which a word problem has unless it is turned off. */
+const spacious = (config: WordProblemConfig): boolean =>
+  config.workspace !== false;
+
+/**
+ * Every story on the sheet, in the order they are printed.
+ *
+ * Exported alongside the problems because a story carries the id of the
+ * template that made it, and that is what lets the suite check each one against
+ * arithmetic of its own — see the note at the top of this file. The page itself
+ * never shows an id.
+ */
+export function wordStories(
+  config: WordProblemConfig,
+  seed: number,
+): WordStory[] {
+  const { perPage } = wordLayout(config);
+  // The count is a request, not a promise: a count that overruns is a second
+  // sheet out of the printer with two problems on it.
+  const wanted = clamp(config.count, 0, perPage);
+
+  const rand = mulberry32(seed);
+  const pool = TEMPLATES.filter((template) =>
+    topicsOf(config).includes(template.topic),
+  );
+  const range = bounds(config.range);
+  const seen = new Set<string>();
+  const out: WordStory[] = [];
+  if (pool.length === 0) return out;
+
+  // Shuffled and then walked in order, rather than drawn each time. This is the
+  // whole of "a page that doesn't read as generated": twelve templates picked at
+  // random from twenty give the same one twice on most pages, and two stories
+  // with the same skeleton and different names is exactly what a reader notices
+  // first. Walking a shuffled list gives a different template every time until
+  // there are no more, and only then starts round again.
+  const order = shuffled(pool, rand);
+  let at = 0;
+
+  let misses = 0;
+  while (out.length < wanted && misses < MISS_BUDGET) {
+    const template = order[at % order.length];
+    at += 1;
+    const cast = {
+      name: pick(NAMES, rand),
+      thing: pick(THINGS, rand),
+      place: pick(PLACES, rand),
+      spot: pick(SPOTS, rand),
+    };
+    const drawn = template.draw(range, cast, rand);
+    // Not a question with a whole answer, too long for the row the layout
+    // reserved, or the same numbers as one already on the page. Either way the
+    // budget ticks down and a pool that has run out ends the draw.
+    const key =
+      drawn === null ? null : `${template.id}:${numbersIn(drawn.text)}`;
+    if (drawn === null || key === null || seen.has(key)) {
+      misses += 1;
+      continue;
+    }
+    if (drawn.text.length > MAX_TEXT) {
+      misses += 1;
+      continue;
+    }
+    seen.add(key);
+    out.push({ id: template.id, topic: template.topic, ...drawn });
+    misses = 0;
+  }
+  return out;
+}
+
+/**
+ * What makes two stories the same story: the template and its numbers.
+ *
+ * The cast is deliberately not part of it. Two children counting different
+ * things through the same arithmetic is the same question twice, and a child
+ * who has done one has done the other.
+ */
+const numbersIn = (text: string): string =>
+  (text.match(/−?\d+/g) ?? []).join(":");
+
+/** The stories as they are printed: a sentence, and a blank on the end. */
+export function wordProblems(
+  config: WordProblemConfig,
+  seed: number,
+): Problem[] {
+  const extras = spacious(config) ? { workspace: WORKSPACE } : {};
+  return wordStories(config, seed).map((one) => ({
+    prompt: one.text,
+    answer: one.answer,
+    ...extras,
+  }));
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const TOPIC_NAME: Record<WordTopic, string> = {
+  integers: "integers",
+  rate: "ratio and rate",
+  percent: "percentages",
+  equation: "equations",
+  average: "averages",
+};
+
+/**
+ * "Word problems: percentages" — the phrase a parent says out loud.
+ *
+ * A sheet drawing on more than one topic is not named after any of them,
+ * because it is not about any of them: it is the mixed sheet, and naming it
+ * after whichever was listed first would be a title that is wrong most of the
+ * time.
+ */
+function titleOf(config: WordProblemConfig): string {
+  const pool = topicsOf(config);
+  return pool.length === 1
+    ? `Word problems: ${TOPIC_NAME[pool[0]]}`
+    : "Word problems";
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * A generated family names its own sheet, so `config.title` is an override and
+ * is usually absent — which makes it the wrong thing to reserve space against.
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: WordProblemConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? titleOf(config),
+    instructions:
+      config.instructions ?? "Read each problem and write the answer.",
+  };
+}
+
+/**
+ * One line naming what the sheet holds, in the terms a parent chose it by.
+ *
+ * Which topics are on the page is the whole of whether a sheet matches the
+ * lesson, and it is exactly what the title of a mixed sheet leaves off.
+ */
+export function describeWordProblems(config: WordProblemConfig): string {
+  const pool = topicsOf(config);
+  if (pool.length <= 1) return titleOf(config);
+  return `${titleOf(config)} — ${pool.map((topic) => TOPIC_NAME[topic]).join(", ")}`;
+}
+
+export function buildWordProblemSheet(
+  config: WordProblemConfig,
+  seed: number,
+): Sheet {
+  const items = wordProblems(config, seed);
+  const { columns } = wordLayout(config);
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is actually on the page, not out of what was asked for: a
+      // sheet that says "/ 20" over eighteen problems is wrong twice.
+      score: { outOf: items.length },
+    },
+    blocks: [{ kind: "problems", columns, items }],
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const WORD_PROBLEMS_SHEET: SheetSpec<WordProblemConfig> = {
+  id: "word-problems",
+  label: "Word problems",
+  world: SHEET_WORLD,
+  build: buildWordProblemSheet,
+  // The whole of the answer-key mechanism: every story's answer was worked out
+  // from the same numbers the sentence was printed from, so a key prints what is
+  // already there rather than reading the story back.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeWordProblems,
+};
+
+/** Every template this build can print, for the suite that checks each one. */
+export const WORD_TEMPLATES: string[] = TEMPLATES.map(
+  (template) => template.id,
+);

--- a/src/engine/sheets/plane.ts
+++ b/src/engine/sheets/plane.ts
@@ -1,0 +1,116 @@
+/**
+ * The coordinate plane, and where a point sits on it.
+ *
+ * Here rather than inside the family that first drew one, for the reason
+ * `fractionart.ts` and `clockface.ts` are: a plane is now the question on two
+ * different sheets — reading coordinates, and reading a slope off a graph — and
+ * a second copy of "how many squares wide is it, and where do the axes cross"
+ * would be a second answer to the question the layout arithmetic already asked.
+ * The height a family reserves and the drawing the renderer makes come from one
+ * place, which is the whole of the bargain in §4.
+ *
+ * Nothing here knows what a problem is. It is squares, an origin, and the
+ * arithmetic that turns a pair of coordinates into a position on the ruling.
+ */
+import type { Box } from "./layout";
+import { inches } from "./paper";
+import type { GridMark, GridSpec, Mil } from "./types";
+
+/** The biggest a square is drawn, and how much of the page a plane may take. */
+const GRID_CELL = inches(0.4);
+const GRID_SHARE = 0.55;
+
+/**
+ * How far the axes run from the origin, in each of the two shapes.
+ *
+ * A four-quadrant plane runs less far each way for the same paper, because it
+ * has twice as much of everything to draw.
+ */
+const QUADRANT_SPAN = 10;
+const FOUR_QUADRANT_SPAN = 8;
+
+export type Plane = {
+  /** How far the axes run from nought. */
+  span: number;
+  /** Whether the plane has negative coordinates on it. */
+  negative: boolean;
+  grid: GridSpec;
+};
+
+/**
+ * The grid a coordinate sheet is drawn on.
+ *
+ * A first-quadrant plane keeps one square of margin below and to the left of the
+ * axes, which is where the numbers along them go: the drawing is exactly as wide
+ * as its squares say it is (§4), so a numeral outside the grid is a numeral off
+ * the edge of the drawing.
+ *
+ * `quadrants` is a number rather than a union because it arrives from outside
+ * this build — a bookmarked URL, a sheet saved in March — and anything that is
+ * not four has to resolve to a plane rather than throw.
+ */
+export function planeOf(quadrants: number, box: Box): Plane {
+  const negative = Math.floor(quadrants) === 4;
+  const span = negative ? FOUR_QUADRANT_SPAN : QUADRANT_SPAN;
+  const pad = negative ? span : 1;
+  const columns = span + pad;
+  const rows = span + pad;
+  const cell = Math.max(
+    1,
+    Math.min(
+      GRID_CELL,
+      Math.floor(box.width / columns),
+      Math.floor((box.height * GRID_SHARE) / rows),
+    ),
+  );
+  return {
+    span,
+    negative,
+    grid: {
+      kind: "coordinate",
+      columns,
+      rows,
+      cell,
+      origin: { column: pad, row: span },
+      // What is on the plane, as against what the ruling runs to. On a
+      // first-quadrant plane the padding square outside the axes is where the
+      // numerals go, not a column of −1: this is what stops one being printed
+      // there, on the sheet that promised no negative numbers at all.
+      axis: { min: negative ? -span : 0, max: span },
+    },
+  };
+}
+
+/** How much page a plane takes, which is what the problems under it do not get. */
+export const planeHeight = (plane: Plane): Mil =>
+  plane.grid.rows * plane.grid.cell;
+
+/** The smallest coordinate a point may have: −span, or one on a quarter plane. */
+export const planeFloor = (plane: Plane): number =>
+  plane.negative ? -plane.span : 1;
+
+/** Where a point sits on the plane, in squares from the top-left of the grid. */
+export const markAt = (
+  plane: Plane,
+  x: number,
+  y: number,
+  label: string,
+): GridMark => ({
+  column: (plane.grid.origin?.column ?? 0) + x,
+  row: (plane.grid.origin?.row ?? 0) - y,
+  label,
+});
+
+/** A, B, C … the letters a point is called by. */
+const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+/**
+ * The letter the nth point on a plane is called by, starting round again at A.
+ *
+ * Here rather than in either family, now that two of them name points: reading
+ * coordinates and reading a slope off a graph both letter their dots, and the
+ * wrap is the part worth writing once — a plane with twenty-seven points on it
+ * is not a sheet anybody would print, and a blank label is not a question.
+ */
+export const letterAt = (index: number): string =>
+  LETTERS[index % LETTERS.length];

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -885,6 +885,186 @@ export type GeometryConfig = SheetOptions & {
   workspace?: boolean;
 };
 
+/* ── Integers ──────────────────────────────────────────────────────────────
+   Where a number stops being an amount of something. Everything above this
+   line is a count a child could put on the table; here −7 is a direction as
+   much as a quantity, and the sign is the whole of what is being taught — a
+   key that had 7 − 9 as 2 would be marked right by a parent reading quickly,
+   which is the failure this family has to make impossible.                   */
+
+/**
+ * What the sheet asks for.
+ *
+ * `arithmetic` is the four operations over positive and negative whole numbers;
+ * `order` is one expression with several operations in it and the rule that
+ * decides which is done first; `powers` is exponents and the roots that undo
+ * them.
+ */
+export type IntegerStyle = "arithmetic" | "order" | "powers";
+
+/** Which operations are on the page. `both` shuffles all four together. */
+export type IntegerOperation =
+  "add" | "subtract" | "multiply" | "divide" | "both";
+
+export type IntegerConfig = SheetOptions & {
+  kind: "integers";
+  style: IntegerStyle;
+  /** Ignored by the two styles that have no operation to choose. */
+  operation: IntegerOperation;
+  /**
+   * How big the numbers get, sign aside.
+   *
+   * The *size* of what a child sees, because a range with a minus sign at one
+   * end of it is a range nobody says out loud: a parent asks for "numbers to
+   * twenty", and whether one of them is negative is the switch below rather
+   * than the bottom of the range.
+   */
+  range: { min: number; max: number };
+  /**
+   * Whether a minus sign may appear on a number at all. On unless turned off,
+   * because this is the integers family — but an order-of-operations sheet
+   * without them is a real lesson, and it is the one a year younger.
+   */
+  negatives?: boolean;
+  /** Order of operations only: how many operations the expression holds. */
+  terms?: number;
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  /** Blank space under every problem, to work in. */
+  workspace?: boolean;
+};
+
+/* ── Pre-algebra ───────────────────────────────────────────────────────────
+   The family where the answer is not a number at all. `x = 5` is a sentence,
+   `x > −4` is every number past a point, and a slope is a pair of numbers that
+   only means something written the smallest way. Which is why nothing here is
+   checked by evaluating the generator's own arithmetic: an equation's answer
+   is checked by putting it back in, and an inequality's by trying numbers.   */
+
+/**
+ * What the sheet asks for.
+ *
+ * `expression` evaluates a rule at a value or collects like terms; `equation`
+ * and `inequality` solve for the letter, in one step or two; `slope` is rise
+ * over run from a pair of written points; `graph` is the same question read off
+ * a coordinate plane, which is where a child meets it first.
+ */
+export type AlgebraStyle =
+  "expression" | "equation" | "inequality" | "slope" | "graph";
+
+export type PreAlgebraConfig = SheetOptions & {
+  kind: "prealgebra";
+  style: AlgebraStyle;
+  /**
+   * Equations and inequalities: one step, or two.
+   *
+   * The switch this family turns on, the way regrouping is the switch on an
+   * addition sheet. `x + 7 = 12` is undone by one move and `3x + 4 = 19` by
+   * two, and they are a term apart in the year rather than a harder version of
+   * the same question.
+   */
+  steps?: number;
+  /** How big the numbers get, sign aside — as on an integers sheet. */
+  range: { min: number; max: number };
+  /**
+   * Whether a negative number may appear, in the question or in the answer.
+   *
+   * More than a difficulty here: dividing an inequality by a negative turns it
+   * round, which is the single most-missed step in the whole of pre-algebra and
+   * the reason this family exists on paper rather than in a race.
+   */
+  negatives?: boolean;
+  /** The graph style only: one quadrant, or all four. */
+  quadrants?: number;
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  /** Blank space under every problem, to work in. */
+  workspace?: boolean;
+};
+
+/* ── Ratio, proportion and rate ────────────────────────────────────────────
+   Three names for one idea: two numbers whose *relationship* is the answer.
+   `12 : 18` and `2 : 3` are the same ratio and only one of them is marked
+   right, which is the bargain `exact.ts` already struck for fractions — so
+   this family reduces with the same greatest common divisor and never divides
+   a float.                                                                   */
+
+/**
+ * What the sheet asks for. `simplify` writes a ratio the smallest way;
+ * `proportion` fills the gap in a pair that scale together; `rate` is the
+ * amount for one of something, which is the form of it a shopper uses.
+ */
+export type RatioStyle = "simplify" | "proportion" | "rate";
+
+export type RatioConfig = SheetOptions & {
+  kind: "ratio";
+  style: RatioStyle;
+  /** How big the numbers in a ratio get, ends included. */
+  range: { min: number; max: number };
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  /** Blank space under every problem, to work in. */
+  workspace?: boolean;
+};
+
+/* ── Statistics ────────────────────────────────────────────────────────────
+   The one maths family whose question is a *set* rather than a sum, and the
+   one where the commonest generator bug is invisible: a set with two modes has
+   two right answers, and a set of an even size has a median between two of its
+   numbers rather than at one of them. Both print as a confident wrong key.   */
+
+/**
+ * What the sheet asks for. `all` is the four of them from one set of numbers,
+ * which is how the topic is set in every textbook that teaches it.
+ */
+export type StatisticStyle = "mean" | "median" | "mode" | "range" | "all";
+
+export type StatisticsConfig = SheetOptions & {
+  kind: "statistics";
+  style: StatisticStyle;
+  /**
+   * How many numbers are in each set.
+   *
+   * Not a difficulty dial so much as a choice of question: an even-sized set
+   * has its median between two numbers, which is the lesson a five-number set
+   * cannot teach.
+   */
+  size: number;
+  /** The numbers the set is drawn from, ends included. */
+  range: { min: number; max: number };
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  /** Blank space under every problem, to work in. */
+  workspace?: boolean;
+};
+
+/* ── Word problems ─────────────────────────────────────────────────────────
+   The one place in the maths set where generated *text* is read by a person.
+   Everywhere else a template failure is a sum that looks odd; here it is a page
+   that reads as machinery, and a parent stops trusting the rest of the shop. So
+   the rule from §11 is the rule here: fewer templates rather than repetitive
+   ones, and the suite counts the variety rather than hoping for it.          */
+
+/** Which lessons the problems are about — a pool, so a page can mix them. */
+export type WordTopic =
+  "integers" | "rate" | "percent" | "equation" | "average";
+
+export type WordProblemConfig = SheetOptions & {
+  kind: "word-problems";
+  topics: WordTopic[];
+  /** How big the numbers in a story get, ends included. */
+  range: { min: number; max: number };
+  /** How many problems to ask for. Capped at what the page holds. */
+  count: number;
+  columns: number;
+  /** Blank space under every problem, to work in. On by default here. */
+  workspace?: boolean;
+};
+
 /**
  * Anything a saved sheet can hold. Narrow on `kind` — and only in index.ts,
  * which is the one module that knows the whole union.
@@ -899,4 +1079,9 @@ export type SheetConfig =
   | MoneyConfig
   | TimeConfig
   | MeasureConfig
-  | GeometryConfig;
+  | GeometryConfig
+  | IntegerConfig
+  | PreAlgebraConfig
+  | RatioConfig
+  | StatisticsConfig
+  | WordProblemConfig;


### PR DESCRIPTION
Closes #53.

Five new sheet families that carry the Print Shop past long division and up to
eighth grade: **integers**, **pre-algebra**, **ratio/proportion/unit rate**,
**statistics** and **templated word problems**.

## Why these are different from the sheets already there

Every family before this one had the property that a wrong answer looks wrong.
These are the first where a right answer and a wrong answer are the same digits
— `7 − 9` is `2` or `−2` depending only on what a child has been taught, and
both read as plausible to a parent marking a column. So the sign is not
formatting here, it is the answer: numbers are signed integers from the moment
they are drawn, and the only two places a minus is ever written are `signedText`
and `factorText` in `exact.ts` (U+2212, never a hyphen).

## What each family generates

- **Integers** — the four operations, order of operations across twelve
  templates at two or three operations, powers and the roots that undo them. A
  negative operand is bracketed, because `7 + −4` is two operators in a row.
  Turning negatives off means the intermediate results too, so `(4 − 9) × 3` is
  a rejection at draw time rather than a surprise on the page.
- **Pre-algebra** — expressions evaluated and collected, one- and two-step
  equations and inequalities over six forms, slope from a pair of points, and
  slope read off a coordinate plane. Every equation is built *from* its
  solution, so there is nothing to solve and nothing to solve wrongly. The sign
  flip when an inequality is divided by a negative lives in exactly one
  function. Algebra folds the sign into the operator (`3x − 4`, never
  `3x + (−4)`) — the opposite convention to the integers sheet, and correct on
  both.
- **Ratio, proportion, unit rate** — a ratio is built by scaling a pair already
  in lowest terms, a proportion's gap moves between all four places, and a rate
  is built from the amount for one so the division comes out exact.
- **Statistics** — mean, median, mode, range, and all four from one set. A mode
  is *constructed* rather than hoped for (a two-mode set has two right
  answers), an even-sized median is written out in halves, and a set whose
  total doesn't divide is thrown away rather than printing a decimals sheet in
  disguise.
- **Word problems** — twenty templates, four to a topic, each drawing its own
  cast. Templates are walked in shuffled order rather than drawn, so twelve
  problems on a page come from twelve different templates; drawing at random
  out of twenty repeats on most pages, and two stories sharing a skeleton is
  the first thing a reader notices. No money in any of them — prices belong to
  `money.ts` and its currency switch.

## Structural changes

- `sheets/plane.ts` — the coordinate plane moves out of `geometry.ts`, because
  it is now the question on a pre-algebra sheet as well as a geometry one, and
  a second copy of "how many squares, and where do the axes cross" would be a
  second answer to what the layout arithmetic already settled.
- `exact.ts` gains `MINUS`, `signedText` and `factorText` — the single place
  signed numbers are rendered.

## How the answer keys are verified

The suites never check a generator against itself. An equation is verified by
substitution, an inequality by trying forty numbers either side of the
boundary, an expression by a precedence-aware parser reading the *printed*
line, a slope by cross-multiplication against the points with lowest terms
proved by factor search, a mean by multiplying back, a median in halves, a mode
by a tally that must have one winner, and every word problem by a formula
written down separately per template — with a test that refuses to pass unless
every shipped template has one.

Twenty deliberate mutations were tried against the suites — a difference the
wrong way round, a dividend one divisor out, a cube only squared, a missing
bracket, an expression worked left to right, an inequality that never turns
round, run over rise, points plotted the other way round, an unreduced ratio, a
unit rate one out, an even median rounded down, a mode named on a tie, a mean
floored, a range that is only the largest, a story missing a number it needs —
and all twenty fail at least one test.

## Second commit: a sheet that says what is on it

Three ways a page could disagree with its own heading, all the same mistake —
a number the generator clamped and the naming did not:

- Statistics sizes a set once, in `sizeOf`, read by both the draw and the
  catalog line. A mode set needs every value but the repeated one distinct, so
  a range of one to three cannot fill a set of nine however long it draws; it
  now comes down to the size that can actually be built instead of truncating
  quietly under "sets of 9", and stops burning five hundred draws a problem.
- Order of operations clamps both ends of its range. The ceiling moved the top
  only, so a range starting above twelve inverted and `between(20, 12)` drew
  thirteen to nineteen — neither the ask nor the cap.
- `stepsOf` and `termsOf` are the one place those are clamped, so five steps
  drawn as two is also named "Two-step equations". These configs come back from
  bookmarks and from sheets saved months ago, so the numbers in them are not to
  be trusted.

Each is covered by an assertion that fails without it.

## Scope

Registers five families in `sheets/index.ts` and nothing more — no catalog
pages and no builder wiring, which are PRINT10 and PRINT13. Nothing routes to
these yet.

## Validation

`npm run type-check`, `npm run lint`, `npm run test:unit` (627 passing across
29 files), `npm run build` (static, 45 pages) and the browser smoke test all
pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
