### PR TITLE
PRINT10: a maths catalog where the page is the worksheet

### DIFF
--- a/src/engine/sheets/maths/decimals.test.ts
+++ b/src/engine/sheets/maths/decimals.test.ts
@@ -359,6 +359,36 @@ describe("the answer key", () => {
     }
   });
 
+  it("spreads a page over the percentages rather than over one of them", () => {
+    // The other half of "the answer comes out whole", and the half a draw can
+    // satisfy while printing nonsense: `p% of n` is whole for some pairs and
+    // 100% of *every* number, so a draw that made a pair and then rejected it
+    // put the identity on nearly half the page — and "100% of 63" is a question
+    // a child answers by copying it out. Counted over forty sheets rather than
+    // inside one, because three of a kind on one page is luck and a quarter of
+    // every page is a bias.
+    const seen = new Map<string, number>();
+    let total = 0;
+    for (let seed = 0; seed < 40; seed += 1) {
+      for (const problem of problemsOf(
+        { style: "percent", range: PERCENT_RANGE, count: 12 },
+        seed,
+      )) {
+        const percent = /^(\d+)%/.exec(problem.prompt)?.[1] ?? "";
+        seen.set(percent, (seen.get(percent) ?? 0) + 1);
+        total += 1;
+      }
+    }
+    expect(total).toBeGreaterThan(400);
+    // The identity is not a calculation, so it is not on a sheet of them.
+    expect(seen.has("100")).toBe(false);
+    // Most of the list, rather than the three that divide a hundred best.
+    expect(seen.size).toBeGreaterThan(8);
+    for (const [percent, count] of seen) {
+      expect(count / total, `${percent}%`).toBeLessThan(0.25);
+    }
+  });
+
   it("prints the answers only when the sheet is a key", () => {
     const sheet = buildSheet(config(), 5);
     const key = answerKey(config(), 5);
@@ -645,10 +675,10 @@ const GOLDEN = {
     ["15.09 − 14.63 =", "0.46"],
   ],
   percent: [
-    ["100% of 143 =", "143"],
+    ["5% of 20 =", "1"],
+    ["90% of 140 =", "126"],
+    ["40% of 85 =", "34"],
     ["40% of 55 =", "22"],
-    ["15% of 80 =", "12"],
-    ["25% of 112 =", "28"],
   ],
   convert: [
     ["0.07 = _%", "7"],

--- a/src/engine/sheets/maths/decimals.ts
+++ b/src/engine/sheets/maths/decimals.ts
@@ -98,6 +98,17 @@ const MULTIPLIER = { min: 2, max: 9 };
 const PERCENTS = [5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100];
 
 /**
+ * The percentages a sheet takes *of an amount*, which is the list above without
+ * the identity on it.
+ *
+ * "100% of 63" is 63, and a child who has read the question has already written
+ * the answer. It stays in `PERCENTS` because `100% = 1.00` is a fair conversion
+ * to ask for — a whole is a hundred per cent is the thing being converted — and
+ * it comes out here because it is not a calculation to do.
+ */
+const AMOUNT_PERCENTS = PERCENTS.filter((percent) => percent !== 100);
+
+/**
  * The denominators a conversion sheet uses.
  *
  * Only fractions that *stop* — a third is 0.333… and there is no number of
@@ -244,17 +255,34 @@ function written(
   return { key, prompt: `${operands[0]} ${sign} ${operands[1]} =`, answer };
 }
 
-/** "25% of 80 =", and only when the answer comes out whole. */
+/**
+ * "25% of 80 =", with the amount drawn to suit the percent.
+ *
+ * The percent is chosen first and the amount is then walked in the steps that
+ * keep the answer whole, rather than both being drawn freely and the pair
+ * rejected when it isn't. That is not a saving, it is the difference between a
+ * varied page and a page of one question: a percent divides a hundred well or
+ * badly, and 5% comes out whole of one number in twenty while 50% does of one
+ * in two — so a rejecting draw prints the friendliest percents over and over
+ * and leaves the rest of the list off the sheet almost entirely. Choosing the
+ * percent first gives every one of them the same share of the page.
+ */
 function drawPercent(config: DecimalConfig, rand: () => number): Drawn | null {
-  const percent = PERCENTS[Math.floor(rand() * PERCENTS.length)];
+  const percent = AMOUNT_PERCENTS[Math.floor(rand() * AMOUNT_PERCENTS.length)];
   const { min, max } = bounds(config.range);
-  const amount = between(min, max, rand);
-  const part = percent * amount;
-  if (amount <= 0 || part % 100 !== 0) return null;
+  // How far apart the amounts are that this percent comes out whole from: every
+  // fourth number for a quarter, every second for a half, every twentieth for
+  // 5%. A range with none of them in it is a request with no answers in it, and
+  // an empty draw is the honest reply — the miss budget above ends the page.
+  const step = 100 / gcd(100, percent);
+  const first = Math.ceil(Math.max(min, 1) / step);
+  const last = Math.floor(max / step);
+  if (first > last) return null;
+  const amount = between(first, last, rand) * step;
   return {
     key: `percent:${percent}:${amount}`,
     prompt: `${percent}% of ${amount} =`,
-    answer: String(part / 100),
+    answer: String((percent * amount) / 100),
   };
 }
 

--- a/src/engine/sheets/maths/fractions.test.ts
+++ b/src/engine/sheets/maths/fractions.test.ts
@@ -525,6 +525,24 @@ describe("what may be on the page", () => {
     }
   });
 
+  it("asks one equivalence once, whichever side the blank is on", () => {
+    // The repeat the prompt does not show: `1/5 = 3/_` and `1/5 = _/15` are two
+    // sentences and one fact, so a page with both on it has given a child one
+    // problem fewer than it claims to hold — they work the first out and copy
+    // the second. Read off the printed page rather than off the key, which is
+    // where a child reads it.
+    for (const seed of SEEDS) {
+      const problems = problemsOf({ style: "equivalent", count: 12 }, seed);
+      expect(problems.length).toBeGreaterThan(0);
+      const facts = problems.map((problem) => {
+        const [left, right] = problem.prompt.split(" = ");
+        const filled = right.replace("_", problem.answer);
+        return `${left} = ${filled}`;
+      });
+      expect(new Set(facts).size, facts.join(", ")).toBe(facts.length);
+    }
+  });
+
   it("prints the whole small pool rather than repeating itself", () => {
     // Halves and quarters make three naming problems — 1/2, 1/4 and 3/4 — and
     // three is what a parent should get rather than twelve problems with the

--- a/src/engine/sheets/maths/fractions.ts
+++ b/src/engine/sheets/maths/fractions.ts
@@ -203,7 +203,13 @@ function drawEquivalent(pool: number[], rand: () => number): Drawn | null {
   if (value === null || value.d * by > MAX_SCALED_DENOMINATOR) return null;
   const scaled = { n: value.n * by, d: value.d * by };
   return {
-    key: `equivalent:${value.n}:${value.d}:${by}:${top ? "n" : "d"}`,
+    // Folded on the equivalence rather than on the blank, exactly as an
+    // identifying picture folds on the value it shows: `1/5 = 3/_` and
+    // `1/5 = _/15` are one fact asked from two sides, and a child who has just
+    // worked out that 1/5 is 3/15 does not do the second one again — they copy
+    // it. The engine would not see a repeat; the child does, which is the only
+    // vote that counts.
+    key: `equivalent:${value.n}:${value.d}:${by}`,
     prompt: top
       ? `${value.n}/${value.d} = _/${scaled.d}`
       : `${value.n}/${value.d} = ${scaled.n}/_`,

--- a/src/engine/sheets/maths/integers.test.ts
+++ b/src/engine/sheets/maths/integers.test.ts
@@ -235,6 +235,9 @@ const EVERY_SHAPE: Array<Partial<IntegerConfig>> = [
   { style: "order", terms: 3 },
   { style: "order", negatives: false },
   { style: "order", terms: 3, negatives: false, range: { min: 2, max: 9 } },
+  // The sheet the catalog prints: the rule, a term before exponents.
+  { style: "order", powers: false },
+  { style: "order", terms: 3, negatives: false, powers: false },
   { style: "powers" },
   { style: "powers", negatives: false },
   { style: "powers", range: { min: 2, max: 7 } },
@@ -305,6 +308,43 @@ describe("the integers family", () => {
     expect(buildSheet(config({ style: "order" }), 1).header.instructions).toBe(
       "Work out each answer. Brackets first, then powers, then × and ÷.",
     );
+  });
+
+  it("takes the squares off an order sheet, and says so at the top of it", () => {
+    // Two lessons on one page: a child taught which operation binds tightest is
+    // usually a term away from meeting exponents, and `3² + 10 × 2` is four
+    // problems they cannot start. The instruction line moves with the switch,
+    // because a sheet that told them to do powers first and then printed none
+    // is teaching them to look for a step that is not there.
+    expect(
+      buildSheet(
+        config({ style: "order", powers: false }),
+        1,
+      ) //
+      .header.instructions,
+    ).toBe("Work out each answer. Brackets first, then × and ÷, then + and −.");
+
+    for (const terms of [2, 3]) {
+      for (const seed of SEEDS) {
+        const shape = { style: "order" as const, terms, powers: false };
+        const problems = problemsOf({ ...shape, count: 9 }, seed);
+        expect(problems.length, JSON.stringify(shape)).toBeGreaterThan(0);
+        for (const problem of problems) {
+          expect(problem.prompt, problem.prompt).not.toContain("²");
+        }
+      }
+    }
+
+    // And the sheet that did not ask still has them, at both lengths — the rule
+    // as it is taught is brackets, powers, then × and ÷.
+    const squared = [2, 3]
+      .flatMap((terms) =>
+        SEEDS.flatMap((seed) =>
+          problemsOf({ style: "order", terms, count: 12 }, seed),
+        ),
+      )
+      .filter((problem) => problem.prompt.includes("²"));
+    expect(squared.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/engine/sheets/maths/integers.ts
+++ b/src/engine/sheets/maths/integers.ts
@@ -109,6 +109,15 @@ const pick = <T>(items: readonly T[], rand: () => number): T =>
 const signed = (config: IntegerConfig): boolean => config.negatives !== false;
 
 /**
+ * Whether an order-of-operations sheet may put a square on the page.
+ *
+ * On unless refused, because the rule is taught with powers in it. Turned off
+ * it is the same rule a year earlier — and the sheet says so, because the
+ * instruction line is written from this too.
+ */
+const powered = (config: IntegerConfig): boolean => config.powers !== false;
+
+/**
  * One number of the size the config asked for, with its sign drawn separately.
  *
  * The range counts magnitudes — "numbers to twenty" is what a parent says, and
@@ -274,6 +283,13 @@ type Template = {
   id: string;
   /** How many operations it holds, which is what `terms` chooses between. */
   ops: number;
+  /**
+   * Whether the line it prints has a square in it, which is what `powers`
+   * chooses between. Declared rather than read back off the printed text: the
+   * template knows, and a sheet that decided by looking for a `²` would be one
+   * regex away from a page a child cannot start.
+   */
+  squared?: true;
   draw(pull: () => number, rand: () => number): Expression | null;
 };
 
@@ -351,6 +367,7 @@ const TEMPLATES: Template[] = [
   {
     id: "square-add",
     ops: 2,
+    squared: true,
     draw: (pull, rand) => {
       const [a, b] = [pull(), pull()];
       const plus = rand() < 0.5;
@@ -407,6 +424,7 @@ const TEMPLATES: Template[] = [
   {
     id: "square-times",
     ops: 3,
+    squared: true,
     draw: (pull) => {
       const [a, b, c] = [pull(), pull(), pull()];
       return {
@@ -452,7 +470,13 @@ function drawExpression(
   rand: () => number,
 ): Drawn | null {
   const wanted = termsOf(config);
-  const pool = TEMPLATES.filter((one) => one.ops === wanted);
+  // Filtered before the draw rather than rejected after it, so a sheet with the
+  // squares off is the same page of expressions with two templates fewer rather
+  // than a page that spends its budget printing what it then throws away.
+  const pool = TEMPLATES.filter(
+    (one) => one.ops === wanted && (powered(config) || one.squared !== true),
+  );
+  if (pool.length === 0) return null;
   const template = pick(pool, rand);
   const { min, max } = bounds(config.range);
   // Both ends, because the cap moves the top: a range that started above it
@@ -605,6 +629,23 @@ const INSTRUCTION: Record<IntegerStyle, string> = {
 };
 
 /**
+ * The same line for an order sheet with the squares turned off.
+ *
+ * The instruction has to describe the page it is printed at the top of. A sheet
+ * that told a child to do powers first and then printed none is teaching them
+ * to look for a step that is not there — and one that printed them without
+ * saying so is worse. So `powers` moves both, from here.
+ */
+const ORDER_WITHOUT_POWERS =
+  "Work out each answer. Brackets first, then × and ÷, then + and −.";
+
+/** What the sheet tells a child to do, which is a function of what is on it. */
+function instructionOf(config: IntegerConfig): string {
+  if (config.style === "order" && !powered(config)) return ORDER_WITHOUT_POWERS;
+  return INSTRUCTION[config.style] ?? INSTRUCTION.arithmetic;
+}
+
+/**
  * The header this sheet will actually print.
  *
  * A generated family names its own sheet, so `config.title` is an override and
@@ -618,10 +659,7 @@ function headerOf(config: IntegerConfig): SheetOptions {
     fontPt: config.fontPt,
     fields: config.fields,
     title: config.title ?? titleOf(config),
-    instructions:
-      config.instructions ??
-      INSTRUCTION[config.style] ??
-      INSTRUCTION.arithmetic,
+    instructions: config.instructions ?? instructionOf(config),
   };
 }
 

--- a/src/engine/sheets/share.test.ts
+++ b/src/engine/sheets/share.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeSharedSheet, type SharedSheet } from "./share";
+import type { MultiplicationConfig } from "./types";
+
+/**
+ * The link a catalog page hands to the builder.
+ *
+ * Nothing here checks the encoder against the encoder. Every assertion works
+ * backwards from the string that ships: it is decoded with the platform's own
+ * `atob` rather than with a matching decoder written beside the encoder, which
+ * is what makes "a parent who follows this link gets this sheet" a property of
+ * the output rather than of a pair of functions that agree with each other.
+ */
+
+const config: MultiplicationConfig = {
+  kind: "multiplication",
+  paper: { size: "letter", orientation: "portrait", margin: "normal" },
+  fontPt: 12,
+  fields: ["name", "date"],
+  operation: "multiply",
+  style: "standard",
+  form: "horizontal",
+  tables: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  factors: { min: 1, max: 12 },
+  count: 30,
+  columns: 3,
+};
+
+/** base64url back to the object, the way a reader with no code would do it. */
+function decode(payload: string): SharedSheet {
+  const base64 = payload.replaceAll("-", "+").replaceAll("_", "/");
+  const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "="));
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes)) as SharedSheet;
+}
+
+describe("a shared sheet", () => {
+  it("comes back as the sheet that was shared", () => {
+    const shared = { config, seed: 7 };
+    expect(decode(encodeSharedSheet(shared))).toEqual(shared);
+  });
+
+  it("says which one of the sheets that config makes was meant", () => {
+    // §7: "another sheet like this one" is `seed + 1`, so a link that dropped
+    // the seed would offer that by accident to everybody who followed it.
+    expect(decode(encodeSharedSheet({ config, seed: 41 })).seed).toBe(41);
+  });
+
+  it("uses only characters that survive a URL", () => {
+    // Base64url's whole point: no `+`, no `/`, no `=` for something in the
+    // middle of a link to re-encode or a reader to mistype.
+    expect(encodeSharedSheet({ config, seed: 0 })).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("carries a title somebody typed in their own language", () => {
+    // `btoa` speaks in code units below 256, so anything past ASCII has to be
+    // UTF-8 before it gets there — a parent who titled a sheet "Répétition"
+    // would otherwise get an exception instead of a link.
+    const titled = { ...config, title: "Répétition — 7×8" };
+    expect(
+      decode(encodeSharedSheet({ config: titled, seed: 1 })).config,
+    ).toEqual(titled);
+  });
+
+  it("holds nothing about the child the sheet is for", () => {
+    // §1. The name line is printed blank and filled in by hand; a shared link
+    // is the surface where that would otherwise leak, and there is nowhere in
+    // a config to put one.
+    const payload = decode(encodeSharedSheet({ config, seed: 3 }));
+    expect(JSON.stringify(payload)).not.toMatch(/name"\s*:\s*"[^"]/);
+  });
+});

--- a/src/engine/sheets/share.ts
+++ b/src/engine/sheets/share.ts
@@ -1,0 +1,55 @@
+/**
+ * A sheet, as something that fits in a link.
+ *
+ * §14 settles the mechanism: the builder's config lives in the URL fragment,
+ * `#s=<base64url(JSON)>`. That is a static site's whole sharing story — there
+ * is no server to hold a saved configuration and hand back a short id, so the
+ * configuration *is* the id — and it costs nothing: a fragment is never sent to
+ * a server at all, which is the same promise §1 makes about everything else
+ * here.
+ *
+ * It buys three things at once. A catalog page can offer "change what is on
+ * this sheet" as an ordinary link, a configured sheet can be passed round a
+ * class group, and a bug report is reproducible because the report carries the
+ * sheet rather than a description of it.
+ *
+ * The seed travels with the config for the reason §7 gives: a sheet is
+ * reproducible from its URL only if the URL says which one of the infinitely
+ * many sheets that config makes was meant. Without it, a parent who followed a
+ * link would get the same *kind* of sheet and different problems, which is a
+ * feature (`seed + 1`) offered by accident.
+ *
+ * **A child's name is never in here.** The name line is printed blank and
+ * filled in by hand (§1), there is nowhere in a `SheetConfig` to put one, and a
+ * shared link is exactly the surface where that would otherwise leak.
+ *
+ * Only the encoder lives here. Reading one of these back is the builder's job,
+ * and it is a different job: a payload that arrives from outside this build is
+ * untrusted input — length-capped, validated against the spec, and falling back
+ * to defaults rather than throwing — which is a guard with nothing to guard
+ * until there is something to open it in.
+ */
+import type { SheetConfig } from "./types";
+
+/** What a link carries: which sheet, and which one of them. */
+export type SharedSheet = { config: SheetConfig; seed: number };
+
+/**
+ * The payload half of `#s=…` — base64url, so it survives a URL, an email and a
+ * printed page without being escaped into something a reader can't retype.
+ *
+ * Base64url rather than plain base64 for the usual three characters: `+` and
+ * `/` are legal in a fragment but travel badly through anything that re-encodes
+ * a link, and `=` padding is noise a decoder can restore for itself. The bytes
+ * are UTF-8 first, because `btoa` speaks in code units below 256 and a title
+ * somebody typed in another language would otherwise throw.
+ */
+export function encodeSharedSheet(shared: SharedSheet): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(shared));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -928,6 +928,18 @@ export type IntegerConfig = SheetOptions & {
   negatives?: boolean;
   /** Order of operations only: how many operations the expression holds. */
   terms?: number;
+  /**
+   * Order of operations only: whether an expression may have a square in it.
+   *
+   * On unless turned off, because "brackets, powers, then × and ÷" is the rule
+   * as it is taught. But powers are their own lesson and their own style here,
+   * and a child who has met the rule a term before they meet exponents cannot
+   * start `3² + 10 × 2` — so a sheet that asks for the rule without them is the
+   * same lesson a year earlier, exactly as `negatives` above is. The printed
+   * instruction follows the switch: a sheet with no squares on it does not tell
+   * a child to do powers first.
+   */
+  powers?: boolean;
   /** How many problems to ask for. Capped at what the page holds. */
   count: number;
   columns: number;

--- a/src/pages/printables/[topic].astro
+++ b/src/pages/printables/[topic].astro
@@ -1,0 +1,226 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { answerKey, buildSheet } from "@/engine/sheets";
+import {
+  MATHS_SEED,
+  MATHS_SHEETS,
+  builderHref,
+  mathsShelf,
+  pathFor,
+  type MathsSheet,
+} from "./_maths";
+
+/**
+ * One prerendered maths worksheet per topic — and the page is the worksheet.
+ *
+ * The shape §8 describes and the shape `[...slug].astro` already built for
+ * paper, applied to the family that is actually searched for: "free printable
+ * multiplication worksheets" is one of the largest queries in education, and a
+ * parent who lands here gets prose that answers it, the sheet itself directly
+ * under it as HTML, and nothing to click. ⌘P produces usable paper because the
+ * sheet IS the page, not a download link on it.
+ *
+ * **Two sheets, not one.** The worksheet and its answer key print as
+ * consecutive pages, which is what `break-after: page` in sheet.css was written
+ * for — the CSS names "a sheet and its answer key" in as many words. A key is
+ * the single most expected feature of a worksheet site and the most commonly
+ * done badly, and it costs nothing here: `answerKey` prints the answers the
+ * build already computed rather than working them out a second time, so the key
+ * cannot disagree with the sheet it belongs to. The two `<article>`s stay
+ * adjacent siblings on purpose — `print.css` breaks on `.sheet + .sheet` as
+ * well, and an element between them would take that second guarantee away.
+ *
+ * **No client directive on `SheetView`, ever.** `@astrojs/react` renders a
+ * component with no `client:*` to HTML at build time, so these pages ship zero
+ * JavaScript — the whole SEO argument of §2, and the reason a sheet is HTML
+ * rather than a canvas or a PDF. `Sheet.test.tsx` holds every page in this
+ * directory to it, against the source and against `dist/`.
+ *
+ * **Everything that is not a sheet carries `.no-print`.** `@page` cannot be
+ * scoped to a class, so the zeroed page margin a sheet needs applies to the
+ * prose as well and it would print off the edge. Hiding the article is the
+ * right way round rather than merely the easy one: printing this page means
+ * printing the worksheet on it.
+ *
+ * A separate route file from paper's `[...slug].astro` rather than a branch
+ * inside it. The two share a URL prefix and nothing else — a ruling comes on
+ * two stocks and has no answers, a worksheet has answers and one stock — and
+ * the slugs are disjoint, which `_maths.test.ts` asserts so that the two
+ * patterns can never both claim a path.
+ */
+
+type Props = { sheet: MathsSheet };
+
+export function getStaticPaths() {
+  return MATHS_SHEETS.map((sheet) => ({
+    params: { topic: sheet.slug },
+    props: { sheet },
+  }));
+}
+
+const { sheet } = Astro.props;
+
+const printed = buildSheet(sheet.config, MATHS_SEED);
+const key = answerKey(sheet.config, MATHS_SEED);
+
+const title = `${sheet.keyword} | School Skills`;
+const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const url = `https://schoolskills.app${pathFor(sheet)}`;
+
+const strands = mathsShelf();
+const strand = strands.find((group) => group.id === sheet.strand)!;
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    name: sheet.heading,
+    description,
+    url,
+    learningResourceType: "Worksheet",
+    educationalUse: "Practice",
+    teaches: sheet.teaches,
+    typicalAgeRange: sheet.ages,
+    isAccessibleForFree: true,
+    inLanguage: "en",
+  }}
+>
+  <header class="hero wrap no-print">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      {strand.label}
+    </p>
+    <h1 class="hero__title">{sheet.heading}</h1>
+    <p class="hero__lead">{sheet.lead}</p>
+    <p class="aside">
+      The sheet below <strong>is</strong> the printout, and the page behind it is
+      <strong> the answer key</strong>. Press{" "}
+      <strong>&#8984;P</strong> &mdash; <strong>Ctrl+P</strong> on Windows &mdash;
+      and everything but the paper disappears. Nothing here needs choosing first.
+      To keep a copy instead, pick <em>Save as PDF</em> in the print dialog and your
+      browser writes one.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  {
+    /*
+      The sheets, outside `.wrap` deliberately. A wrap adds an inline padding
+      that print.css cannot take back off, and a sheet printed a centimetre in
+      from where it says it is has the wrong geometry everywhere at once. The
+      key is a sibling of the sheet, with nothing between them — see the note
+      above on why that adjacency is load-bearing.
+    */
+  }
+  <div class="sheet-frame">
+    <SheetView sheet={printed} />
+    <SheetView sheet={key} />
+  </div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">What is on this sheet</h2>
+    <div class="prose">
+      {sheet.notes.map((note) => <p>{note}</p>)}
+      <p>
+        The answers were worked out when the problems were, so the key is the
+        same page with the answers drawn in rather than a second attempt at the
+        same questions &mdash; there is no way for the two to disagree. The
+        number in the footer is the seed the sheet was built from: it is printed
+        so that the identical sheet can be had again next week, rather than one
+        that merely looks like it.
+      </p>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Change what is on it</h2>
+    <div class="prose">
+      <p>
+        This page is one sheet out of a family that can print thousands, and the
+        settings behind it &mdash; how many problems, how big the numbers get,
+        how they are laid out, whether there is room to work &mdash; are all
+        switches. The link below carries this sheet&rsquo;s own settings, so the
+        bench opens on exactly the page above rather than on a blank one.
+      </p>
+      <p class="aside">
+        The bench is still being installed. Until it opens, the link is worth
+        having anyway: it holds the whole configuration in the address bar, so
+        it can be bookmarked or sent to somebody now and opened when it lands.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href={builderHref(sheet)}>
+        Open this sheet in the builder
+      </a>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">The same facts, on screen</h2>
+    <div class="prose">
+      <p>{sheet.play}</p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/flash-cards">Race the flash cards</a>
+    </div>
+    {
+      sheet.tables && (
+        <>
+          <h3 class="h2 h2--next">Every table this sheet uses</h3>
+          <p class="h2__sub">
+            One page each, with the full table on it and something true about
+            that number rather than filler.
+          </p>
+          <nav class="stones" aria-label="Times tables">
+            {sheet.tables.map((table) => (
+              <a class="stone" href={`/multiplication/${table}-times-table`}>
+                {table}&times;
+              </a>
+            ))}
+          </nav>
+        </>
+      )
+    }
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Every maths sheet</h2>
+    <p class="h2__sub">
+      {MATHS_SHEETS.length} topics, each one a page like this one &mdash; the sheet,
+      its answer key, and no account to print either.
+    </p>
+    {
+      strands.map((group) => (
+        <>
+          <h3 class="h2 h2--next">{group.label}</h3>
+          <p class="h2__sub">{group.blurb}</p>
+          <nav class="stones" aria-label={group.label}>
+            {group.sheets.map((candidate) => (
+              <a
+                class="stone"
+                href={pathFor(candidate)}
+                aria-current={
+                  candidate.slug === sheet.slug ? "page" : undefined
+                }
+              >
+                {candidate.short}
+              </a>
+            ))}
+          </nav>
+        </>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables/math">All the maths sheets</a>
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/_maths.test.ts
+++ b/src/pages/printables/_maths.test.ts
@@ -1,0 +1,229 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet } from "@/engine/sheets";
+import type { Block } from "@/engine/sheets/types";
+
+import { PAPER_SHEETS, STOCKS, pathFor as paperPath } from "./_catalog";
+import {
+  MATHS_SEED,
+  MATHS_SHEETS,
+  STRANDS,
+  builderHref,
+  mathsShelf,
+  pathFor,
+} from "./_maths";
+
+/**
+ * The catalog, held to the three things a catalog page has to be.
+ *
+ * **It has to be a worksheet.** Every entry here is prerendered as the page a
+ * parent lands on (§8), so an entry whose config produces an empty page is a
+ * URL in the sitemap with nothing on it — the thin-content failure `Base.astro`
+ * argues against, arrived at from the other direction.
+ *
+ * **It has to be curated.** The engine can generate millions of these. The
+ * checks below are what "curated" means when it is not a promise: no two
+ * entries print the same sheet, no two answer the same query, and every one of
+ * them carries prose somebody wrote rather than a template that was filled in.
+ *
+ * **It has to be reachable.** Every slug in the sitemap, every slug distinct
+ * from paper's — two route patterns claiming one path is a build error, and a
+ * missing URL is the failure nobody notices, because the site still builds,
+ * still deploys and still looks right.
+ */
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/** Everything on the page that a child writes an answer on. */
+function problemsOf(blocks: Block[]) {
+  return blocks.flatMap((block) =>
+    block.kind === "problems" ? block.items : [],
+  );
+}
+
+describe("the maths catalog", () => {
+  it("is bounded, and every slug is a route somebody could type", () => {
+    // Not a style rule. A slug is the URL, the head term and the file on disk
+    // at once, so a capital letter or a stray space here is a 404 that only
+    // shows up in production.
+    for (const sheet of MATHS_SHEETS) {
+      expect(sheet.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+    expect(new Set(MATHS_SHEETS.map((sheet) => sheet.slug)).size).toBe(
+      MATHS_SHEETS.length,
+    );
+  });
+
+  it("never claims a path that paper already prints on", () => {
+    // `[topic].astro` and `[...slug].astro` are two patterns over one prefix.
+    // They only coexist because the paths they emit are disjoint; the day they
+    // are not, Astro has two routes for one URL and picks one of them.
+    const paper = new Set(
+      PAPER_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => `/printables/${paperPath(sheet, stock)}`),
+      ),
+    );
+    for (const sheet of MATHS_SHEETS) {
+      expect(paper.has(pathFor(sheet))).toBe(false);
+    }
+  });
+
+  it("answers a different query on every page", () => {
+    // Two pages written to the same term compete with each other and neither
+    // wins — which is the shape a permutation farm takes before it is one.
+    const fields = ["keyword", "heading", "name", "short"] as const;
+    for (const field of fields) {
+      const values = MATHS_SHEETS.map((sheet) => sheet[field]);
+      expect(new Set(values).size, `duplicate ${field}`).toBe(values.length);
+    }
+  });
+
+  it("prints a different sheet on every page", () => {
+    // The other half of the same test, from the paper's side: two slugs whose
+    // configs are identical are one worksheet with two URLs, whatever the prose
+    // around them says.
+    const configs = MATHS_SHEETS.map((sheet) => JSON.stringify(sheet.config));
+    expect(new Set(configs).size).toBe(configs.length);
+  });
+
+  it("carries prose on every page rather than a filled-in template", () => {
+    for (const sheet of MATHS_SHEETS) {
+      expect(sheet.notes.length, sheet.slug).toBeGreaterThanOrEqual(2);
+      // A sentence and a half is the shortest thing that can say something
+      // true about one sheet and not about the one beside it.
+      for (const note of sheet.notes) {
+        expect(note.length, sheet.slug).toBeGreaterThan(200);
+      }
+      expect(sheet.lead.length, sheet.slug).toBeGreaterThan(80);
+      expect(sheet.summary.length, sheet.slug).toBeGreaterThan(40);
+      // The `LearningResource` block on the page is built from these two.
+      expect(sheet.teaches, sheet.slug).not.toBe("");
+      expect(sheet.ages, sheet.slug).toMatch(/^Ages /);
+    }
+  });
+
+  it("shelves every sheet exactly once", () => {
+    const shelved = mathsShelf().flatMap((strand) => strand.sheets);
+    expect(shelved).toHaveLength(MATHS_SHEETS.length);
+    expect(mathsShelf().every((strand) => strand.sheets.length > 0)).toBe(true);
+    expect(STRANDS).toHaveLength(mathsShelf().length);
+  });
+
+  it("only cross-links to times-table pages that exist", () => {
+    // /multiplication/[table]-times-table is built for 1 to 12 and nothing
+    // else, so a 13 here is a link into a 404 on a page whose whole job is to
+    // be found.
+    for (const sheet of MATHS_SHEETS) {
+      for (const table of sheet.tables ?? []) {
+        expect(table, sheet.slug).toBeGreaterThanOrEqual(1);
+        expect(table, sheet.slug).toBeLessThanOrEqual(12);
+      }
+    }
+  });
+});
+
+describe("the sheet on a catalog page", () => {
+  it("has something on it", () => {
+    for (const sheet of MATHS_SHEETS) {
+      const built = buildSheet(sheet.config, MATHS_SEED);
+      expect(built.blocks.length, sheet.slug).toBeGreaterThan(0);
+      // Marked out of what is actually on the page, so this is also the check
+      // that the page is not a header and a footer with nothing between them.
+      expect(built.header.score?.outOf, sheet.slug).toBeGreaterThan(0);
+      expect(built.header.title, sheet.slug).not.toBe("");
+    }
+  });
+
+  it("asks for no more than the paper holds", () => {
+    // A count is a request, not a promise: the families cap it at what fits.
+    // A page that asked for thirty and got twenty-nine is fine; the failure
+    // this catches is prose that says "thirty" over a sheet of nine.
+    for (const sheet of MATHS_SHEETS) {
+      const problems = problemsOf(buildSheet(sheet.config, MATHS_SEED).blocks);
+      const asked = "count" in sheet.config ? sheet.config.count : 0;
+      if (asked > 0) expect(problems.length, sheet.slug).toBe(asked);
+    }
+  });
+
+  it("is the same sheet on every build", () => {
+    // §7, and the reason these pages can be prerendered at all: a crawler that
+    // comes back next month has to read the page it indexed, and a parent has
+    // to be able to print the same sheet again next week.
+    for (const sheet of MATHS_SHEETS) {
+      expect(JSON.stringify(buildSheet(sheet.config, MATHS_SEED))).toBe(
+        JSON.stringify(buildSheet(sheet.config, MATHS_SEED)),
+      );
+    }
+  });
+
+  it("prints an answer key that is the same sheet with the answers shown", () => {
+    for (const sheet of MATHS_SHEETS) {
+      const built = buildSheet(sheet.config, MATHS_SEED);
+      const key = answerKey(sheet.config, MATHS_SEED);
+      expect(built.answers, sheet.slug).toBe(false);
+      expect(key.answers, sheet.slug).toBe(true);
+      expect(key.footer.note, sheet.slug).toBe("Answer key");
+      // The same questions, not a second set of them — the key is the sheet
+      // with `answers` flipped, so nothing it prints can disagree with what
+      // the child was asked.
+      expect(JSON.stringify(key.blocks), sheet.slug).toBe(
+        JSON.stringify(built.blocks),
+      );
+      for (const problem of problemsOf(key.blocks)) {
+        expect(problem.answer.length, sheet.slug).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("the link into the builder", () => {
+  it("opens the bench on the sheet that was printed", () => {
+    for (const sheet of MATHS_SHEETS) {
+      const href = builderHref(sheet);
+      expect(href.startsWith("/printables/make#s=")).toBe(true);
+
+      const payload = href.slice("/printables/make#s=".length);
+      const base64 = payload.replaceAll("-", "+").replaceAll("_", "/");
+      const shared = JSON.parse(
+        atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")),
+      );
+      expect(shared).toEqual({ config: sheet.config, seed: MATHS_SEED });
+    }
+  });
+});
+
+describe("the sitemap", () => {
+  /*
+   * §20's last line, against the file that actually shipped.
+   *
+   * The catalog is the largest crawlable surface this site has, and a URL
+   * missing from the sitemap is the failure nobody notices — nothing breaks,
+   * the page is simply never submitted. `astro.config.mjs` filters the sitemap
+   * from the world registry, which means a change there can silently take a
+   * whole directory out; this is the assertion that it hasn't.
+   *
+   * Skipped when there is no `dist/`, exactly as the built-output check in
+   * Sheet.test.tsx is. CI builds before it runs the suite.
+   */
+  it("carries every maths slug and the hub", () => {
+    const file = `${ROOT}/dist/sitemap-0.xml`;
+    if (!existsSync(file)) return; // `npm run build` hasn't run yet.
+
+    const xml = readFileSync(file, "utf8");
+    const found = new Set(
+      [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) =>
+        new URL(match[1]).pathname.replace(/\/$/, ""),
+      ),
+    );
+
+    expect(found.has("/printables/math")).toBe(true);
+    for (const sheet of MATHS_SHEETS) {
+      expect(found.has(pathFor(sheet)), sheet.slug).toBe(true);
+    }
+    // And the builder still isn't in it: it is an island and carries noindex.
+    expect(found.has("/printables/make")).toBe(false);
+  });
+});

--- a/src/pages/printables/_maths.ts
+++ b/src/pages/printables/_maths.ts
@@ -1,0 +1,806 @@
+/**
+ * The maths sheets the Print Shop has set, and the words that go round them.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data three
+ * pages share — `[topic].astro`, which prerenders one worksheet per entry,
+ * `math.astro`, which is the subject hub, and `index.astro`, which lists the
+ * strands — rather than a route of its own. `_catalog.ts` is the same file for
+ * paper, and the two are deliberately separate: a ruling and a set of problems
+ * have almost nothing to say about each other.
+ *
+ * **The slugs are curated; the sheets are generated.** §8 is explicit about
+ * why, and this is the family where it stops being theoretical. The engine can
+ * make every combination of thirteen families, five or six styles each, two
+ * forms, three currencies and any range of numbers — millions of pages, every
+ * one of them plausible and none of them written for. That is a doorway-page
+ * farm, and the `noindex` reasoning in `Base.astro` is already this codebase
+ * arguing against it. So: twenty-one slugs, each one a phrase a parent actually
+ * types, each with two paragraphs that are true of that sheet and of no other,
+ * and everything else reached by the builder — which is where *choosing*
+ * belongs.
+ *
+ * **One stock, unlike paper.** Every entry in `_catalog.ts` is printed on
+ * Letter and on A4 because a ⅝ rule scaled to fit is no longer a ⅝ rule. Long
+ * division has no such measurement: a printer that shrinks the page by four per
+ * cent gives a slightly smaller sum and the same right answer. So a maths sheet
+ * is one route, and a parent on A4 prints it exactly as it stands.
+ */
+import { encodeSharedSheet } from "@/engine/sheets/share";
+import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
+import type { HeaderField, Paper, SheetConfig } from "@/engine/sheets/types";
+
+/** How the hub groups the shelf: five strands of school maths, in order. */
+export type MathsStrand =
+  "adding" | "tables" | "parts" | "measuring" | "algebra";
+
+export type MathsSheet = {
+  /** The route under /printables, and the head term it is written to answer. */
+  slug: string;
+  /** How it is listed on a hub. */
+  name: string;
+  /** How it is labelled in the row of neighbouring sheets. A few words. */
+  short: string;
+  /** The page's `<h1>`. */
+  heading: string;
+  /** The query this page exists to answer, in the words a parent types. */
+  keyword: string;
+  /** One sentence of what is on the sheet. Used in the description and hubs. */
+  summary: string;
+  /** The lead paragraph: what the sheet asks for, stated plainly. */
+  lead: string;
+  /** Two things that are true of this sheet and not of the one beside it. */
+  notes: string[];
+  /** For the `LearningResource` block. */
+  teaches: string;
+  ages: string;
+  strand: MathsStrand;
+  /**
+   * The times-table pages whose facts this sheet drills, where any.
+   *
+   * The internal-linking win §8 calls significant and free, and it is only
+   * offered where it is honest: a long division leans on the tables it divides
+   * by, an equivalent-fractions sheet leans on nothing of the sort, and a row
+   * of twelve links on a page about fractions would be a nav bar rather than a
+   * cross-reference.
+   */
+  tables?: number[];
+  /** What the race does with the same facts, in one sentence that is true. */
+  play: string;
+  /** The sheet itself. Prerendered at build time — this IS the page (§8). */
+  config: SheetConfig;
+};
+
+/**
+ * The seed every catalog sheet is built from, and it never moves.
+ *
+ * `buildSheet(config, seed)` is deterministic (§7), so a fixed seed is what
+ * makes these pages stable: the same twenty-four sums are in the HTML on every
+ * build, a crawler that comes back next month reads the page it indexed, and a
+ * parent who printed this sheet in March can print the identical one in June.
+ * The footer prints the number, so the sheet is reproducible from the paper as
+ * well as from the URL. A different sheet with the same settings is `seed + 1`,
+ * which is what the builder is for.
+ */
+export const MATHS_SEED = 1;
+
+/** Every sheet here is Letter portrait — see the note at the top of the file. */
+const PAPER: Paper = {
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+};
+
+/**
+ * Printed blank, always, and the reason there is no third field.
+ *
+ * A worksheet asks for a name because a teacher has thirty of them to hand
+ * back. Nothing here holds one (§1): these are two ruled lines on paper and
+ * there is nowhere in a config to put a value for either.
+ */
+const FIELDS: HeaderField[] = ["name", "date"];
+
+/** What every catalog sheet shares: the stock, the type size, the two lines. */
+const SHEET = {
+  paper: PAPER,
+  fontPt: DEFAULT_FONT_PT,
+  fields: FIELDS,
+} as const;
+
+/** The twelve tables, which is what a fact sheet draws from unless it says so. */
+const ALL_TABLES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+/**
+ * The denominators a fraction sheet draws from.
+ *
+ * Halves through twelfths, skipping sevenths, ninths and elevenths — the ones a
+ * primary child meets on a clock, in a recipe and on a ruler. A pool rather
+ * than a range, because "sevenths" is a choice somebody makes and 2 to 12 is
+ * not.
+ */
+const DENOMINATORS = [2, 3, 4, 5, 6, 8, 10, 12];
+
+export const MATHS_SHEETS: MathsSheet[] = [
+  /* ── Adding and taking away ─────────────────────────────────────────── */
+  {
+    slug: "addition-worksheets",
+    name: "Addition facts to 20",
+    short: "Addition",
+    heading: "Addition worksheets",
+    keyword: "Free printable addition worksheets",
+    summary:
+      "Twenty-four addition facts with both numbers up to 20, written along the line, and an answer key on the second page.",
+    lead: "The first sheet in the shop: two numbers up to twenty, added along a line, twenty-four of them to a page. Nothing has to be chosen before it prints, and the answers are already on the second page.",
+    notes: [
+      "Both numbers go up to twenty, which means some of the answers run past it: sums like 14 + 9 are drawn from the same pool as 4 + 9. That is deliberate and it is the whole of what makes a facts sheet worth doing twice: the sums that cross ten are the ones a child counts on their fingers for longest, and they are the ones that have to become recall rather than arithmetic.",
+      "No problem appears twice, and the pairs are not in order, so a child cannot get the fourth answer from the third. That sounds obvious and it is the thing most generated worksheets get wrong — a page of sums drawn at random from a small pool repeats itself surprisingly often, and a child who spots the repeat has been given fewer problems than the page claims to hold.",
+    ],
+    teaches: "Addition facts to 20",
+    ages: "Ages 5–8",
+    strand: "adding",
+    play: "The Grid deals these same facts as timed cards, and keeps the ones that come out slow in a practice deck of their own.",
+    config: {
+      ...SHEET,
+      kind: "arithmetic",
+      operation: "add",
+      style: "standard",
+      form: "horizontal",
+      range: { min: 1, max: 20 },
+      count: 24,
+      columns: 3,
+      regrouping: "either",
+    },
+  },
+  {
+    slug: "subtraction-worksheets",
+    name: "Subtraction facts to 20",
+    short: "Subtraction",
+    heading: "Subtraction worksheets",
+    keyword: "Free printable subtraction worksheets",
+    summary:
+      "Twenty-four subtraction facts within 20, none of them going below zero, with the answer key on the second page.",
+    lead: "Taking away, within twenty, twenty-four to a page. Nothing on this sheet drops below zero — a child who has not met negative numbers should not find one waiting in question nine.",
+    notes: [
+      "Subtraction is the same fact read backwards, and that is worth saying out loud while a child works: 15 − 7 is the question “seven and what makes fifteen?”, which most children can answer a year before they can take away. If a sum stalls, turning it round is usually faster than counting back.",
+      "Negative answers are off, not absent — the engine will produce them, and the builder has the switch. They belong on the integers sheet, where the minus sign is the lesson rather than an accident of which number happened to be drawn first.",
+    ],
+    teaches: "Subtraction facts within 20",
+    ages: "Ages 5–8",
+    strand: "adding",
+    play: "The Grid drills subtraction as timed cards alongside the other three operations, so a fact that stalls on paper can be practised on screen.",
+    config: {
+      ...SHEET,
+      kind: "arithmetic",
+      operation: "subtract",
+      style: "standard",
+      form: "horizontal",
+      range: { min: 1, max: 20 },
+      count: 24,
+      columns: 3,
+      regrouping: "either",
+    },
+  },
+  {
+    slug: "addition-with-regrouping-worksheets",
+    name: "2-digit addition with regrouping",
+    short: "Regrouping",
+    heading: "Addition with regrouping worksheets",
+    keyword: "Free printable addition with regrouping worksheets",
+    summary:
+      "Sixteen two-digit sums stacked in columns, every one of them carrying, with room to work and an answer key.",
+    lead: "Two-digit numbers stacked in columns, with a rule under them and space to write the carry. Every sum on this page regroups — that is the setting, not the luck of the draw.",
+    notes: [
+      "The week a child learns to carry is the week they need a page where carrying happens every time. A mixed sheet teaches something else by accident: that most sums do not carry, so the ones that do can be treated as the odd case. Here all sixteen carry somewhere — sometimes out of the units, sometimes out of the tens — so the question is never whether to carry but where.",
+      "The sums are stacked rather than written along a line, because the algorithm being practised is a layout as much as an arithmetic. Ones under ones, tens under tens, the answer under the rule — the commonest wrong answer at this age is a right sum written in the wrong column, and squared paper is worth printing alongside this if that is what keeps happening.",
+    ],
+    teaches: "Two-digit column addition with carrying",
+    ages: "Ages 6–9",
+    strand: "adding",
+    play: "The Grid does not stack sums — it deals facts. It is the sheet to run when the columns are fine but the number bonds inside them are slow.",
+    config: {
+      ...SHEET,
+      kind: "arithmetic",
+      operation: "add",
+      style: "standard",
+      form: "vertical",
+      range: { min: 10, max: 99 },
+      count: 16,
+      columns: 4,
+      regrouping: "always",
+    },
+  },
+
+  /* ── Times tables ───────────────────────────────────────────────────── */
+  {
+    slug: "multiplication-worksheets",
+    name: "Multiplication facts, 1 to 12",
+    short: "Multiplication",
+    heading: "Multiplication worksheets",
+    keyword: "Free printable multiplication worksheets",
+    summary:
+      "Thirty multiplication facts drawn from the whole twelve-by-twelve table, mixed, with the answer key on the second page.",
+    lead: "Thirty facts from the full twelve-by-twelve table, shuffled rather than in order, thirty to a page. The mixed set is the test; the single tables are twelve pages of their own, linked below.",
+    notes: [
+      "A sheet of the seven times table in order can be answered by adding seven each time, which is a real skill and not the one being tested. Mixed is what proves recall: nothing on this page can be got from the answer above it, and the facts are drawn from all twelve tables so 12 × 8 turns up as often as 2 × 3.",
+      "7 × 8 and 8 × 7 count as one fact here, and only one of them will be on the page. They are the same product asked from two sides, and a sheet that printed both would be giving a child twenty-nine problems and a freebie — the same fold the record book makes when it decides which facts a child actually knows.",
+    ],
+    teaches: "Multiplication facts to 12 × 12",
+    ages: "Ages 7–11",
+    strand: "tables",
+    tables: ALL_TABLES,
+    play: "The Grid is this sheet with a clock on it: the same twelve tables as timed cards, raced against your own best run.",
+    config: {
+      ...SHEET,
+      kind: "multiplication",
+      operation: "multiply",
+      style: "standard",
+      form: "horizontal",
+      tables: ALL_TABLES,
+      factors: { min: 1, max: 12 },
+      count: 30,
+      columns: 3,
+    },
+  },
+  {
+    slug: "division-worksheets",
+    name: "Division facts, 1 to 12",
+    short: "Division",
+    heading: "Division worksheets",
+    keyword: "Free printable division worksheets",
+    summary:
+      "Thirty division facts, every one of them a times-table fact read backwards, with an answer key.",
+    lead: "Thirty divisions with whole-number answers, drawn from the same twelve tables as the multiplication sheet and read the other way round. Nothing here divides by zero and nothing leaves a remainder.",
+    notes: [
+      "Every question on this page is a table fact asked backwards: 56 ÷ 7 is “seven times what makes fifty-six?”. A child who knows their tables can answer all thirty, and a child who cannot answer them has been told exactly which table to go back to — which is what a division sheet is diagnostically good for.",
+      "Unlike multiplication, division does not fold. 56 ÷ 7 and 56 ÷ 8 are two different questions with two different answers, so both may appear on one page, and that is not a repeat. It is the same distinction the game makes when it decides what counts as one fact and what counts as two.",
+    ],
+    teaches: "Division facts to 144 ÷ 12",
+    ages: "Ages 8–11",
+    strand: "tables",
+    tables: ALL_TABLES,
+    play: "The Grid deals division as its own deck, so the table a child is slow to divide by can be raced rather than re-printed.",
+    config: {
+      ...SHEET,
+      kind: "multiplication",
+      operation: "divide",
+      style: "standard",
+      form: "horizontal",
+      tables: ALL_TABLES,
+      factors: { min: 1, max: 12 },
+      count: 30,
+      columns: 3,
+    },
+  },
+  {
+    slug: "multiplication-chart",
+    name: "Blank multiplication chart",
+    short: "Chart",
+    heading: "Multiplication chart",
+    keyword: "Free printable multiplication chart",
+    summary:
+      "A blank twelve-by-twelve grid with the headers printed, to be filled in — and the completed chart on the second page.",
+    lead: "The twelve-by-twelve square with its headers printed and its hundred and forty-four squares empty. Filling one in is a lesson; the finished chart on the second page is the wall chart.",
+    notes: [
+      "A chart a child fills in is worth more than a chart they are handed, and it is the same piece of paper. Working across a row is counting in that number; working down a column is the same facts from the other side; and the squares that stay empty longest are a map of exactly which tables to practise.",
+      "The completed grid is the second page, so one print gives both. It is worth pinning up: the diagonal from 1 to 144 is the square numbers, the grid is symmetrical about it — which is 7 × 8 and 8 × 7 being one fact, drawn — and the half above the diagonal is the only half anybody has to learn.",
+    ],
+    teaches: "The multiplication table to 12 × 12",
+    ages: "Ages 7–11",
+    strand: "tables",
+    tables: ALL_TABLES,
+    play: "The Grid is the same twelve-by-twelve square with a clock on it — the squares that stay blank longest here are the decks to race there.",
+    config: {
+      ...SHEET,
+      kind: "multiplication",
+      operation: "multiply",
+      style: "grid",
+      form: "horizontal",
+      tables: ALL_TABLES,
+      factors: { min: 1, max: 12 },
+      count: 0,
+      columns: 1,
+    },
+  },
+  {
+    slug: "long-division-worksheets",
+    name: "Long division, 3-digit by 1-digit",
+    short: "Long division",
+    heading: "Long division worksheets",
+    keyword: "Free printable long division worksheets",
+    summary:
+      "Nine long divisions set in the bracket, three digits by one, with room to work and no remainders.",
+    lead: "Three-digit numbers divided by one digit, set in the bracket with the quotient written along the top, and blank space under each one to bring the digits down into. Every answer comes out exactly.",
+    notes: [
+      "No remainders on this sheet. A remainder is a change of question rather than a harder version of the same one, and a child who has not been taught what to do with the two left over has been set an impossible problem rather than a stretching one. The builder has the switch for the week that changes.",
+      "The working is the exercise here, not the answer, which is why each problem gets a band of blank paper under it rather than a ruled line. The answer key shows the quotient; if it disagrees with what a child got, the place to look is the column the first digit came down into.",
+    ],
+    teaches: "Long division without remainders",
+    ages: "Ages 9–12",
+    strand: "tables",
+    tables: [2, 3, 4, 5, 6, 7, 8, 9],
+    play: "A long division is a stack of table facts with subtraction in between. The Grid drills both halves, which is usually where it actually goes wrong.",
+    config: {
+      ...SHEET,
+      kind: "multiplication",
+      operation: "divide",
+      style: "long",
+      form: "vertical",
+      tables: ALL_TABLES,
+      factors: { min: 1, max: 12 },
+      digits: { into: 3, by: 1 },
+      remainders: false,
+      count: 9,
+      columns: 3,
+      workspace: true,
+    },
+  },
+
+  /* ── Parts of a number ──────────────────────────────────────────────── */
+  {
+    slug: "fraction-worksheets",
+    name: "Adding and subtracting fractions",
+    short: "Fractions",
+    heading: "Fraction worksheets",
+    keyword: "Free printable fraction worksheets",
+    summary:
+      "Twelve fractions added and taken away, like and unlike denominators mixed, with every answer in its lowest terms.",
+    lead: "Twelve additions and subtractions over halves, thirds, quarters and up to twelfths — some pairs sharing a denominator, some not — with space to work and an answer key that has already been simplified.",
+    notes: [
+      "Adding quarters to quarters and adding quarters to thirds are a week apart in the classroom, and this page has both, because telling them apart is the skill. The first thing to do with each problem is not to add anything: it is to look at the two bottom numbers and decide whether there is a common denominator to find.",
+      "Every answer on the key is in its lowest terms. That is the part a generated worksheet usually gets wrong — 2/8 and 1/4 are the same value and only one of them is marked right — so the arithmetic here is done in whole numbers and reduced by a greatest common divisor rather than by rounding a decimal that was never exact.",
+    ],
+    teaches: "Adding and subtracting fractions",
+    ages: "Ages 9–12",
+    strand: "parts",
+    play: "Fractions are not in the games yet. What is underneath them — the times tables that find a common denominator — is, in The Grid.",
+    config: {
+      ...SHEET,
+      kind: "fractions",
+      style: "arithmetic",
+      operation: "both",
+      denominators: DENOMINATORS,
+      pairing: "either",
+      count: 12,
+      columns: 2,
+      workspace: true,
+    },
+  },
+  {
+    slug: "equivalent-fractions-worksheets",
+    name: "Equivalent fractions",
+    short: "Equivalent",
+    heading: "Equivalent fractions worksheets",
+    keyword: "Free printable equivalent fractions worksheets",
+    summary:
+      "Sixteen pairs of fractions with one number missing from the second — the same value written another way.",
+    lead: "One fraction, then the same value written with a different bottom number and one of the two numbers left blank. Sixteen to a page, and an answer key.",
+    notes: [
+      "This is the sheet that makes everything after it possible. A child who can see that 3/4 and 6/8 are one number, written twice, can add unlike fractions, simplify an answer and compare two fractions without a calculator; a child who cannot is doing all three by a rule they will forget over a summer.",
+      "Whatever you do to the top you do to the bottom — but only multiplying and dividing, never adding. That is worth saying while the sheet is being worked, because 3/4 and 4/5 look convincingly like the same fraction with one added to each half, and every child tries it once.",
+    ],
+    teaches: "Equivalent fractions",
+    ages: "Ages 8–11",
+    strand: "parts",
+    play: "Not in the games. The nearest thing on screen is the times tables in The Grid, which is what the scaling on this sheet is made of.",
+    config: {
+      ...SHEET,
+      kind: "fractions",
+      style: "equivalent",
+      operation: "add",
+      denominators: DENOMINATORS,
+      pairing: "either",
+      count: 16,
+      columns: 2,
+    },
+  },
+  {
+    slug: "decimal-worksheets",
+    name: "Adding and subtracting decimals",
+    short: "Decimals",
+    heading: "Decimal worksheets",
+    keyword: "Free printable decimal worksheets",
+    summary:
+      "Twelve two-place decimals added and taken away in columns, with the points lined up and an answer key.",
+    lead: "Two-place decimals stacked in columns so the points sit under one another, added and taken away, twelve to a page. Every value prints to the same number of places, which is what makes the column line up.",
+    notes: [
+      "Lining up the decimal points is the whole lesson, and it is why these are stacked rather than written along a line. A child adding 4.70 and 12.05 as though they were 470 and 1205 gets the digits right and the answer ten times too big, and a page where the points are already in a column makes that mistake visible rather than mysterious.",
+      "Nothing here was worked out in floating point. 0.1 + 0.2 is not 0.3 in a computer, and a worksheet generator that adds decimals the obvious way prints an answer key with 0.30000000000000004 in it — or, worse, silently rounds and prints a key that is wrong in the last place. These sums are done in whole hundredths and the point is put back at the end.",
+    ],
+    teaches: "Adding and subtracting decimals",
+    ages: "Ages 9–12",
+    strand: "parts",
+    play: "Not in the games. The number bonds under a decimal column are, in The Grid.",
+    config: {
+      ...SHEET,
+      kind: "decimals",
+      style: "standard",
+      operation: "both",
+      form: "vertical",
+      places: 2,
+      range: { min: 0, max: 50 },
+      count: 12,
+      columns: 3,
+    },
+  },
+  {
+    slug: "percentage-worksheets",
+    name: "Percentages of an amount",
+    short: "Percentages",
+    heading: "Percentage worksheets",
+    keyword: "Free printable percentage worksheets",
+    summary:
+      "Twelve percentages of an amount, in the sizes a shop actually uses, with an answer key.",
+    lead: "Twelve questions of the form “what is 25% of 80?”, using the percentages that turn up in real life rather than the ones that happen to be easy to generate, with room to work.",
+    notes: [
+      "A percentage is a fraction with a hundred underneath it, and the fastest route through most of these is to say that out loud: 25% is a quarter, 10% is a tenth, and 15% is a tenth plus half of it. A child who reaches for a formula on 50% of 60 has learnt the wrong thing about percentages.",
+      "The amounts run from ten to two hundred, which is roughly the range a price tag, a test score and a recipe live in. That matters more than it sounds — the whole reason this topic is on the syllabus is that it is the one piece of school arithmetic an adult uses weekly.",
+    ],
+    teaches: "Finding a percentage of an amount",
+    ages: "Ages 10–13",
+    strand: "parts",
+    play: "Not in the games. The tables that make 25% of 80 a one-step question are, in The Grid.",
+    config: {
+      ...SHEET,
+      kind: "decimals",
+      style: "percent",
+      operation: "multiply",
+      form: "horizontal",
+      places: 2,
+      range: { min: 10, max: 200 },
+      count: 12,
+      columns: 2,
+      workspace: true,
+    },
+  },
+  {
+    slug: "money-worksheets",
+    name: "Adding and subtracting money",
+    short: "Money",
+    heading: "Money worksheets",
+    keyword: "Free printable money worksheets",
+    summary:
+      "Twelve amounts of money added and taken away in columns, in dollars, with an answer key.",
+    lead: "Dollars and cents stacked in columns, added and taken away — the arithmetic a till does — twelve to a page. Pounds and euros are the same sheet with a different symbol, one switch away in the builder.",
+    notes: [
+      "Money is a two-place decimal wearing a symbol, which is exactly why it is taught before decimals in most classrooms: a child who cannot say what 0.05 means can usually tell you what five cents is. If the decimals sheet is going badly, this one is often the way back into it.",
+      "Every answer prints with both places, so $4.50 is not $4.5. That is a small thing on screen and a real one on paper — writing money with one figure after the point is the commonest mark lost on this topic, and a key that did it too would be teaching the mistake.",
+    ],
+    teaches: "Adding and subtracting money",
+    ages: "Ages 7–10",
+    strand: "parts",
+    play: "Not in the games. The addition facts underneath the cents column are, in The Grid.",
+    config: {
+      ...SHEET,
+      kind: "money",
+      currency: "usd",
+      operation: "both",
+      form: "vertical",
+      range: { min: 0, max: 40 },
+      count: 12,
+      columns: 3,
+    },
+  },
+
+  /* ── Measuring the world ────────────────────────────────────────────── */
+  {
+    slug: "telling-time-worksheets",
+    name: "Telling the time to five minutes",
+    short: "Telling time",
+    heading: "Telling time worksheets",
+    keyword: "Free printable telling time worksheets",
+    summary:
+      "Twelve clock faces with the hands drawn on, to be read to the nearest five minutes, with an answer key.",
+    lead: "Twelve dials with both hands on them and a line beside each one to write the time. Everything lands on a five-minute mark — the numerals a child counts round in fives.",
+    notes: [
+      "The hour hand is the one that gets read wrong, and this sheet does not help by cheating it: at twenty-five to four it is drawn most of the way round to four, exactly where it would be on a real clock, rather than parked on the three. A child who has only seen dials where the short hand points straight at a numeral is being taught something that is not true of any clock in the house.",
+      "Five minutes is the middle of five settings. O'clock, half past and the quarters come first; the minute-by-minute dial comes later, and it is a genuinely harder sheet rather than the same one with more clocks. The builder moves between them without changing anything else about the page.",
+    ],
+    teaches: "Reading an analog clock to five minutes",
+    ages: "Ages 6–9",
+    strand: "measuring",
+    play: "Not in the games — a clock face is a picture rather than a card to type an answer to, which is why it is paper.",
+    config: {
+      ...SHEET,
+      kind: "time",
+      style: "read",
+      step: 5,
+      count: 12,
+      columns: 4,
+    },
+  },
+  {
+    slug: "measurement-conversion-worksheets",
+    name: "Metric unit conversion",
+    short: "Measures",
+    heading: "Measurement conversion worksheets",
+    keyword: "Free printable measurement conversion worksheets",
+    summary:
+      "Fifteen metric conversions across length, mass and capacity, with an answer key.",
+    lead: "Millimetres to centimetres, grams to kilograms, millilitres to litres — fifteen conversions to a page, mixed across the three things a child measures. Imperial units are the same sheet, one switch away.",
+    notes: [
+      "Every conversion here is exact and every one of them is a power of ten, which is the argument for the metric system in one page of arithmetic: converting is moving the point, and the only thing to get right is which way. Nothing on this sheet converts between the two systems — metres into feet is an approximation, and it is a different lesson.",
+      "The three quantities are mixed rather than blocked, deliberately. A page of nothing but length lets a child work out the multiplier once and apply it fourteen times; a mixed page asks the actual question every time, which is what a test does.",
+    ],
+    teaches: "Converting metric units of length, mass and capacity",
+    ages: "Ages 8–12",
+    strand: "measuring",
+    play: "Not in the games. The times tables that turn 3.5 kg into grams are, in The Grid.",
+    config: {
+      ...SHEET,
+      kind: "measure",
+      style: "convert",
+      system: "metric",
+      quantities: ["length", "mass", "capacity"],
+      range: { min: 1, max: 20 },
+      count: 15,
+      columns: 3,
+    },
+  },
+  {
+    slug: "area-worksheets",
+    name: "Area of rectangles and triangles",
+    short: "Area",
+    heading: "Area worksheets",
+    keyword: "Free printable area worksheets",
+    summary:
+      "Nine shapes drawn to scale with their sides labelled, to find the area of, with an answer key.",
+    lead: "Nine rectangles and triangles, each drawn with its measurements written on the sides it needs, and a line to write the area on. Perimeter is the same shapes asked the other way, one switch away in the builder.",
+    notes: [
+      "The drawing agrees with the labels. A shape marked 8 by 3 is drawn eight units by three units, at one scale for the whole figure — which sounds like the minimum and is the thing worksheets get wrong most often. A rectangle labelled 8 by 3 and drawn 8 by 4 teaches a child that the picture is decoration and the numbers are the question, which is the opposite of what a geometry sheet is for.",
+      "A triangle carries a base and a height and nothing else. The sloping side is left unlabelled on purpose: the commonest mistake in this topic is multiplying the two numbers that happen to be printed, and a sheet that offered a third number would be inviting it.",
+    ],
+    teaches: "Area of rectangles and triangles",
+    ages: "Ages 8–12",
+    strand: "measuring",
+    play: "Not in the games. The multiplication under every area is, in The Grid.",
+    config: {
+      ...SHEET,
+      kind: "geometry",
+      style: "area",
+      system: "metric",
+      range: { min: 2, max: 12 },
+      count: 9,
+      columns: 3,
+    },
+  },
+
+  /* ── Numbers, algebra and data ──────────────────────────────────────── */
+  {
+    slug: "integers-worksheets",
+    name: "Positive and negative numbers",
+    short: "Integers",
+    heading: "Integers worksheets",
+    keyword: "Free printable integers worksheets",
+    summary:
+      "Twenty questions over positive and negative whole numbers, with an answer key that has the signs right.",
+    lead: "Twenty questions where the numbers may be negative and the answer certainly may be — the four operations over the integers, with room to work.",
+    notes: [
+      "The sign is the whole of what is being taught, so it is the whole of what has to be marked. 7 − 9 is −2, and a key that printed 2 would be read as correct by a parent going quickly down the page. That is the failure this family is written to make impossible: every answer here is checked by an independent path rather than by re-running the arithmetic that produced it.",
+      "A minus sign is doing two different jobs here and it is worth naming both while working: it says which side of zero a number is on, and it says take away. Once a child can read −7 as a place rather than as an instruction, subtracting one stops being a rule to memorise.",
+    ],
+    teaches: "Arithmetic with positive and negative integers",
+    ages: "Ages 10–13",
+    strand: "algebra",
+    play: "Not in the games — the race deals whole positive facts. The recall it builds is what makes the sign the only thing left to think about here.",
+    config: {
+      ...SHEET,
+      kind: "integers",
+      style: "arithmetic",
+      operation: "both",
+      range: { min: 1, max: 12 },
+      count: 20,
+      columns: 3,
+    },
+  },
+  {
+    slug: "order-of-operations-worksheets",
+    name: "Order of operations",
+    short: "Order",
+    heading: "Order of operations worksheets",
+    keyword: "Free printable order of operations worksheets",
+    summary:
+      "Twelve expressions with three operations each, brackets included, and no negative numbers in the way.",
+    lead: "Twelve expressions with three operations in each — brackets, then multiplying and dividing, then adding and taking away — with space to work down the page a step at a time.",
+    notes: [
+      "Every number on this sheet is positive, on purpose. Order of operations and negative numbers are two lessons, and a page that asked for both would tell you a child had got it wrong without telling you which of the two they had got wrong. The integers sheet is where the signs come in.",
+      "The rule is not really a rule about left and right; it is about which operations bind their neighbours tightest. Writing each line out underneath the last — one operation resolved per line — is slower and it is what turns this from a page of tricks into a page of arithmetic. That is why there is room under each expression rather than a slot beside it.",
+    ],
+    teaches: "Order of operations",
+    ages: "Ages 10–13",
+    strand: "algebra",
+    play: "Not in the games. Each individual step on this page is a fact The Grid deals.",
+    config: {
+      ...SHEET,
+      kind: "integers",
+      style: "order",
+      operation: "both",
+      range: { min: 1, max: 12 },
+      negatives: false,
+      terms: 3,
+      count: 12,
+      columns: 2,
+      workspace: true,
+    },
+  },
+  {
+    slug: "one-step-equations-worksheets",
+    name: "One-step equations",
+    short: "Equations",
+    heading: "One-step equations worksheets",
+    keyword: "Free printable one-step equations worksheets",
+    summary:
+      "Sixteen equations solved by a single move, with an answer key checked by substitution.",
+    lead: "Sixteen equations with a single operation to undo — x + 7 = 12, 9x = 54, x/12 = 4 — with a line for the answer on each and a key that has been checked by putting the answer back in.",
+    notes: [
+      "One step, not two, and the difference is a term of the school year rather than a difficulty slider. x + 7 = 12 is undone by a single move; 3x + 4 = 19 needs two of them in the right order, and a child who meets the second before the first tends to learn a procedure rather than the idea underneath it.",
+      "The idea underneath it is that an equation is a pair of scales. Whatever is done to one side is done to the other, and the letter is only ever a number that has not been said yet. Every answer here is checked by substituting it back into the original equation rather than by trusting the arithmetic that produced it.",
+    ],
+    teaches: "Solving one-step linear equations",
+    ages: "Ages 10–13",
+    strand: "algebra",
+    play: "Not in the games. Undoing an equation is a fact recalled backwards, which is exactly what The Grid's division decks drill.",
+    config: {
+      ...SHEET,
+      kind: "prealgebra",
+      style: "equation",
+      steps: 1,
+      range: { min: 1, max: 12 },
+      negatives: false,
+      count: 16,
+      columns: 2,
+    },
+  },
+  {
+    slug: "ratio-and-proportion-worksheets",
+    name: "Ratio and proportion",
+    short: "Ratio",
+    heading: "Ratio and proportion worksheets",
+    keyword: "Free printable ratio and proportion worksheets",
+    summary:
+      "Twelve proportions with one number missing from the pair, with an answer key in whole numbers.",
+    lead: "Twelve pairs of ratios that scale together with one of the four numbers left out — 3 : 12 as 5 : ? — with space to work and an answer key.",
+    notes: [
+      "A proportion is two ratios saying the same thing at different sizes, which is the maths behind a recipe doubled, a map's scale and a price per kilo. The question to ask of each pair is what the first was multiplied by to get the second, and the answer is always the same multiplier on both halves.",
+      "Everything here comes out in whole numbers. A ratio is only in its lowest terms one way — 12 : 18 and 2 : 3 are the same ratio and only one is marked right — so the arithmetic is done with a greatest common divisor rather than by dividing a decimal that would not have come out exactly.",
+    ],
+    teaches: "Ratio, proportion and scaling",
+    ages: "Ages 10–13",
+    strand: "algebra",
+    play: "Not in the games. The multiplication and division either side of a proportion are, in The Grid.",
+    config: {
+      ...SHEET,
+      kind: "ratio",
+      style: "proportion",
+      range: { min: 1, max: 12 },
+      count: 12,
+      columns: 2,
+      workspace: true,
+    },
+  },
+  {
+    slug: "mean-median-mode-worksheets",
+    name: "Mean, median, mode and range",
+    short: "Averages",
+    heading: "Mean, median, mode and range worksheets",
+    keyword: "Free printable mean median mode and range worksheets",
+    summary:
+      "Four sets of numbers, each with all four averages asked for, and an answer key that handles an even-sized set properly.",
+    lead: "Four sets of six numbers, with the mean, the median, the mode and the range asked for each time — the four of them from one set, which is how the topic is set in every textbook that teaches it.",
+    notes: [
+      "Every set here has an even number of values, so the median falls between two of them and has to be averaged rather than pointed at. That is the case a five-number set cannot teach and the one an exam always asks, and it is also where a generated worksheet usually prints a confident wrong answer.",
+      "Each set has exactly one mode. A set with two most-common values has two right answers, and a key that named one of them would mark a correct child wrong — so the numbers on this page are drawn until there is a single answer to give.",
+    ],
+    teaches: "Mean, median, mode and range",
+    ages: "Ages 10–13",
+    strand: "algebra",
+    play: "Not in the games. The adding and dividing inside every mean is, in The Grid.",
+    config: {
+      ...SHEET,
+      kind: "statistics",
+      style: "all",
+      size: 6,
+      range: { min: 1, max: 20 },
+      count: 4,
+      columns: 2,
+      workspace: true,
+    },
+  },
+  {
+    slug: "math-word-problems",
+    name: "Word problems",
+    short: "Word problems",
+    heading: "Math word problems",
+    keyword: "Free printable math word problems",
+    summary:
+      "Six worded problems across rates, percentages, averages and equations, with room to work and an answer key.",
+    lead: "Six short problems written as sentences rather than sums, over the topics a middle-school year covers — a rate, a percentage, an average, an equation to set up — with space under each to work.",
+    notes: [
+      "The hard part of a word problem is never the arithmetic; it is deciding which arithmetic. So there is room under each one to write the sum out before doing it, and the answer key gives the number rather than the method, because the method is the bit worth talking about at the table.",
+      "There are few enough templates here that they stay readable and are not padded out with more. A generated word problem that reads as machinery is worse than no word problem at all — a parent stops trusting the rest of the shop over it — which is why this is the one family in the Print Shop deliberately kept small.",
+    ],
+    teaches: "Solving worded arithmetic problems",
+    ages: "Ages 9–13",
+    strand: "algebra",
+    play: "Not in the games. Once the sum is written down, it is a fact — and facts are what The Grid is for.",
+    config: {
+      ...SHEET,
+      kind: "word-problems",
+      topics: ["integers", "rate", "percent", "equation", "average"],
+      range: { min: 2, max: 20 },
+      count: 6,
+      columns: 1,
+      workspace: true,
+    },
+  },
+];
+
+/** What each strand is called on a hub, in the order they are listed. */
+export const STRANDS: Array<{
+  id: MathsStrand;
+  label: string;
+  blurb: string;
+}> = [
+  {
+    id: "adding",
+    label: "Adding and taking away",
+    blurb: "The facts underneath everything else, and the columns after them.",
+  },
+  {
+    id: "tables",
+    label: "Times tables",
+    blurb:
+      "Multiplication and division, from the twelve tables to the bracket.",
+  },
+  {
+    id: "parts",
+    label: "Parts of a number",
+    blurb: "Fractions, decimals, percentages and money — one idea, four ways.",
+  },
+  {
+    id: "measuring",
+    label: "Measuring the world",
+    blurb: "Clocks, units and shapes: the maths that is about something.",
+  },
+  {
+    id: "algebra",
+    label: "Numbers, algebra and data",
+    blurb: "Signs, letters standing for numbers, and what a set is doing.",
+  },
+];
+
+/** The route a maths sheet prints at. One stock — see the note at the top. */
+export function pathFor(sheet: MathsSheet): string {
+  return `/printables/${sheet.slug}`;
+}
+
+/**
+ * The builder, opened on this sheet.
+ *
+ * §14: the config lives in the fragment, so "change what is on it" is an
+ * ordinary link on a static site rather than a lookup on a server that isn't
+ * there. The seed goes with it, so what the bench opens on is the sheet that
+ * was printed rather than another one like it.
+ */
+export function builderHref(sheet: MathsSheet): string {
+  const payload = encodeSharedSheet({ config: sheet.config, seed: MATHS_SEED });
+  return `/printables/make#s=${payload}`;
+}
+
+/**
+ * The shelf, grouped — the shape every page lists it in.
+ *
+ * Written once because the hub, the subject page and each sheet's row of
+ * neighbours would otherwise have to be kept in step by hand, and the failure
+ * would be silent: a topic added here and shown on one page but not the others
+ * still builds, still deploys, and still looks right.
+ */
+export function mathsShelf(): Array<{
+  id: MathsStrand;
+  label: string;
+  blurb: string;
+  sheets: MathsSheet[];
+}> {
+  return STRANDS.map((strand) => ({
+    ...strand,
+    sheets: MATHS_SHEETS.filter((sheet) => sheet.strand === strand.id),
+  }));
+}

--- a/src/pages/printables/_maths.ts
+++ b/src/pages/printables/_maths.ts
@@ -186,7 +186,7 @@ export const MATHS_SHEETS: MathsSheet[] = [
     heading: "Addition with regrouping worksheets",
     keyword: "Free printable addition with regrouping worksheets",
     summary:
-      "Sixteen two-digit sums stacked in columns, every one of them carrying, with room to work and an answer key.",
+      "Sixteen two-digit sums stacked in columns, every one of them carrying, with an answer key on the second page.",
     lead: "Two-digit numbers stacked in columns, with a rule under them and space to write the carry. Every sum on this page regroups — that is the setting, not the luck of the draw.",
     notes: [
       "The week a child learns to carry is the week they need a page where carrying happens every time. A mixed sheet teaches something else by accident: that most sums do not carry, so the ones that do can be treated as the odd case. Here all sixteen carry somewhere — sometimes out of the units, sometimes out of the tens — so the question is never whether to carry but where.",
@@ -572,7 +572,7 @@ export const MATHS_SHEETS: MathsSheet[] = [
     keyword: "Free printable integers worksheets",
     summary:
       "Twenty questions over positive and negative whole numbers, with an answer key that has the signs right.",
-    lead: "Twenty questions where the numbers may be negative and the answer certainly may be — the four operations over the integers, with room to work.",
+    lead: "Twenty questions where the numbers may be negative and the answer certainly may be — the four operations over the integers, mixed rather than blocked, so the sign has to be read every time.",
     notes: [
       "The sign is the whole of what is being taught, so it is the whole of what has to be marked. 7 − 9 is −2, and a key that printed 2 would be read as correct by a parent going quickly down the page. That is the failure this family is written to make impossible: every answer here is checked by an independent path rather than by re-running the arithmetic that produced it.",
       "A minus sign is doing two different jobs here and it is worth naming both while working: it says which side of zero a number is on, and it says take away. Once a child can read −7 as a place rather than as an instruction, subtracting one stops being a rule to memorise.",
@@ -598,10 +598,10 @@ export const MATHS_SHEETS: MathsSheet[] = [
     heading: "Order of operations worksheets",
     keyword: "Free printable order of operations worksheets",
     summary:
-      "Twelve expressions with three operations each, brackets included, and no negative numbers in the way.",
+      "Twelve expressions with three operations each, brackets included, and no negative numbers or powers in the way.",
     lead: "Twelve expressions with three operations in each — brackets, then multiplying and dividing, then adding and taking away — with space to work down the page a step at a time.",
     notes: [
-      "Every number on this sheet is positive, on purpose. Order of operations and negative numbers are two lessons, and a page that asked for both would tell you a child had got it wrong without telling you which of the two they had got wrong. The integers sheet is where the signs come in.",
+      "Every number on this sheet is positive and none of them is squared, on purpose. Order of operations, negative numbers and powers are three lessons, and a page that asked for more than one of them at a time would tell you a child had got it wrong without telling you which of the three they had got wrong. The integers sheet is where the signs come in, and squares and cubes are a setting of their own in the builder.",
       "The rule is not really a rule about left and right; it is about which operations bind their neighbours tightest. Writing each line out underneath the last — one operation resolved per line — is slower and it is what turns this from a page of tricks into a page of arithmetic. That is why there is room under each expression rather than a slot beside it.",
     ],
     teaches: "Order of operations",
@@ -615,6 +615,11 @@ export const MATHS_SHEETS: MathsSheet[] = [
       operation: "both",
       range: { min: 1, max: 12 },
       negatives: false,
+      // The lesson on this page is which operation binds tightest, and the
+      // child who is set it is a term away from meeting exponents. The sheet's
+      // own instruction line follows the switch, so what is printed at the top
+      // of the page and what is on it are one decision.
+      powers: false,
       terms: 3,
       count: 12,
       columns: 2,

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -1,6 +1,7 @@
 ---
 import Content from "@/layouts/Content.astro";
 import { STOCKS, pathFor, shelf } from "./_catalog";
+import { MATHS_SHEETS, mathsShelf, pathFor as mathsPath } from "./_maths";
 
 /**
  * The Print Shop's front door.
@@ -15,8 +16,9 @@ import { STOCKS, pathFor, shelf } from "./_catalog";
  * It lists what exists and nothing else. A shelf of links to sheets that
  * haven't been built is the thin-content pattern Base.astro's `noindex` block
  * already argues against, and a catalog page here is meant to BE the worksheet
- * — real prerendered HTML a parent can print without touching anything. The
- * first family fills it: every ruling in §5, on both stocks.
+ * — real prerendered HTML a parent can print without touching anything. Two
+ * families fill it: every ruling in §5 on both stocks, and the curated maths
+ * topics of §8, each of which prints its own answer key.
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
@@ -25,6 +27,7 @@ const description =
 /** Listed on the default stock; each sheet page carries the link to its twin. */
 const letter = STOCKS[0];
 const groups = shelf();
+const strands = mathsShelf();
 ---
 
 <Content
@@ -67,11 +70,41 @@ const groups = shelf();
   <section class="band band--tight wrap">
     <h2 class="h2">On the shelf now</h2>
     <p class="h2__sub">
-      Paper, in every ruling. Each of these is a page that is itself the sheet
-      &mdash; open it, press print, and that is the whole of it. Every one comes
-      on both stocks, because a ruling shrunk to fit the paper in the tray is no
-      longer the ruling you chose.
+      Two families: maths worksheets, each with its answer key on the page
+      behind it, and paper in every ruling. Each of these is a page that is
+      itself the sheet &mdash; open it, press print, and that is the whole of
+      it. The paper comes on both stocks, because a ruling shrunk to fit
+      whatever is in the tray is no longer the ruling you chose.
     </p>
+
+    <h3 class="h2 h2--next">Maths worksheets</h3>
+    <p class="h2__sub">
+      {MATHS_SHEETS.length} topics, from adding to twenty through to word problems.
+      Every one prints its answer key as the second page.
+    </p>
+    {
+      strands.map((strand) => (
+        <nav class="stones" aria-label={strand.label}>
+          {strand.sheets.map((sheet) => (
+            <a class="stone" href={mathsPath(sheet)}>
+              {sheet.short}
+            </a>
+          ))}
+        </nav>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta" href="/printables/math">All the maths sheets</a>
+    </div>
+
+    {
+      /*
+        Paper keeps its groups and its one-line summaries; maths gets a row of
+        links and a hub. Not an inconsistency — a ruling is chosen by reading
+        what makes it different from the ruling beside it, and a worksheet is
+        chosen by recognising the name of the topic.
+      */
+    }
     {
       groups.map((group) => (
         <>
@@ -120,16 +153,15 @@ const groups = shelf();
       <h2 class="h2">What the press is being set for</h2>
       <p class="h2__sub">
         The Print Shop is opening a family at a time, and this page lists what
-        exists rather than what is planned. Paper is open. What is on it is
-        next.
+        exists rather than what is planned. Paper and maths are open.
+        Handwriting is next.
       </p>
       <div class="prose">
         <p>
-          The order it opens in: the paper above, then the maths sheets with
-          their answer keys, then handwriting and copywork &mdash; passages from
-          the public domain, Scripture among them &mdash; then spelling,
-          phonics, and the charts, certificates and planners that are simply
-          blank forms.
+          The order it opens in: the paper and the maths sheets above, then
+          handwriting and copywork &mdash; passages from the public domain,
+          Scripture among them &mdash; then spelling, phonics, and the charts,
+          certificates and planners that are simply blank forms.
         </p>
         <p>
           The one it is really being built for comes with the sheet builder:

--- a/src/pages/printables/math.astro
+++ b/src/pages/printables/math.astro
@@ -1,0 +1,182 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { MATHS_SHEETS, mathsShelf, pathFor } from "./_maths";
+
+/**
+ * The maths subject hub — one of the three §8 names, and the first to exist.
+ *
+ * It is a listing rather than a sheet, which makes it the one page in this
+ * corner that isn't itself printable, and that is the right split: nobody
+ * searches for "printable list of maths worksheets". What it is for is the two
+ * jobs a hub does — giving a parent who arrived on `/printables/area-worksheets`
+ * somewhere to go next, and giving the twenty-one topic pages a crawlable
+ * parent that says what they have in common.
+ *
+ * It lists what exists and nothing else. A shelf of links to sheets that
+ * haven't been built is the thin-content pattern `Base.astro`'s `noindex` block
+ * already argues against, and every link here is a page that prints today.
+ *
+ * **"Math" in the URL and the title, "maths" in the copy.** Deliberate, and the
+ * only place on the site the two meet. The route and the `<title>` are read by
+ * a search engine and by somebody typing a query, and that phrase is "math
+ * worksheets" for most of this audience; the prose is written in the same voice
+ * as every other page here. Changing the route later would be the one-way door
+ * §8 warns about, and changing the voice would be a worse trade than the
+ * inconsistency.
+ */
+const title =
+  "Free printable math worksheets, with answer keys | School Skills";
+const description =
+  "Printable maths worksheets with the answer key on the second page: addition, times tables, long division, fractions, decimals, money, time, area, integers and word problems. Free, no account, and nothing to download.";
+
+const strands = mathsShelf();
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Printable math worksheets",
+    description,
+    url: "https://schoolskills.app/printables/math",
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    hasPart: MATHS_SHEETS.map((sheet) => ({
+      "@type": "LearningResource",
+      name: sheet.heading,
+      url: `https://schoolskills.app${pathFor(sheet)}`,
+      learningResourceType: "Worksheet",
+      teaches: sheet.teaches,
+      typicalAgeRange: sheet.ages,
+      isAccessibleForFree: true,
+    })),
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Maths
+    </p>
+    <h1 class="hero__title">Printable maths worksheets</h1>
+    <p class="hero__lead">
+      {MATHS_SHEETS.length} sheets, from adding to twenty through to word problems,
+      each one a page that prints as it stands with the answer key behind it. Nothing
+      to download, no account, and no email address for the file.
+    </p>
+    <p class="hero__note">Free &middot; answer keys &middot; no download</p>
+  </header>
+
+  {
+    /*
+      What exists, first — before the page explains itself. Somebody who came
+      looking for long division should be one link from long division, and the
+      argument for how these sheets are made reads better after you have seen
+      one than before.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">On the shelf now</h2>
+    <p class="h2__sub">
+      Each of these is a page that is itself the worksheet &mdash; open it,
+      press print, and that is the whole of it. The second page out of the
+      printer is the answer key.
+    </p>
+    {
+      strands.map((strand) => (
+        <>
+          <h3 class="h2 h2--next">{strand.label}</h3>
+          <p class="h2__sub">{strand.blurb}</p>
+          <div class="prose">
+            <ul>
+              {strand.sheets.map((sheet) => (
+                <li>
+                  <a href={pathFor(sheet)}>{sheet.name}</a> &mdash;{" "}
+                  {sheet.summary}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      ))
+    }
+  </section>
+
+  <div class="wrap"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Every sheet has an answer key</h2>
+    <div class="prose">
+      <p>
+        It is the second page, on every one of these, and it is not a second
+        attempt at the questions. The answers are worked out at the moment the
+        problems are, and the key is the same page with them drawn in &mdash; so
+        a key cannot disagree with the sheet it belongs to, which is the way
+        this most often goes wrong elsewhere.
+      </p>
+      <p>
+        The arithmetic behind them is exact rather than approximate. Decimals
+        and money are added as whole hundredths rather than as floating-point
+        numbers, so no key here has 0.30000000000000004 on it or a rounded last
+        place. Fractions and ratios are reduced with a greatest common divisor,
+        so an answer is in its lowest terms rather than merely equal to the
+        right one. A set of numbers is redrawn until it has a single mode, and
+        an even-sized set gets a median between two values rather than at one of
+        them. Each of those is a way a generated worksheet prints a confident
+        wrong answer, and each of them is a test in this repository.
+      </p>
+      <p>
+        No problem is repeated on a page, either. A sheet drawn at random from a
+        small pool of facts repeats itself surprisingly often, and a child who
+        spots the repeat has been given fewer problems than the page claims to
+        hold.
+      </p>
+    </div>
+  </section>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">A worksheet here is a web page</h2>
+      <p class="h2__sub">
+        Not a PDF, not a picture of a worksheet, and nothing to download.
+      </p>
+      <div class="prose">
+        <p>
+          A sheet is real text and real lines laid out in real inches, so
+          printing one is <em>File &rarr; Print</em> on the page you are already looking
+          at. If you want to keep a copy, choose <em>Save as PDF</em> in the print
+          dialog and your browser writes one for you.
+        </p>
+        <p>
+          That rules out the usual toll gates: no reader to install, no email
+          address for the download, no watermark, no file that turns out to be
+          the first page of twelve. It also means the problems are real text
+          &mdash; they reflow on a phone if you are only checking what is on the
+          sheet, they can be read aloud by a screen reader, and the printer
+          renders them at its own resolution rather than at the screen&rsquo;s.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">The same facts, on screen</h2>
+    <div class="prose">
+      <p>
+        Paper and practice go together here. The times tables on these sheets
+        are the twelve levels of <a href="/flash-cards">The Grid</a>, where the
+        same facts are dealt as timed cards and the ones that come out slow get
+        a practice deck of their own &mdash; and each table has{" "}
+        <a href="/multiplication/7-times-table">a page of its own</a> with the full
+        table on it.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/flash-cards">Race the flash cards</a>
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>


### PR DESCRIPTION
Closes #54.

A parent searching "free printable multiplication worksheets" lands on a page that *is* the worksheet. Twenty-one prerendered maths sheets under `/printables/<slug>`, plus a subject hub at `/printables/math`.

## What changed

**The page is the sheet.** Each catalog page carries a real `<h1>`, two paragraphs of prose true of that sheet and no other, and the sheet itself directly under it as prerendered HTML. Nothing to configure, nothing to click — ⌘P produces usable paper. The worksheet and its answer key print as consecutive pages, which is what `break-after: page` in `sheet.css` was already written for. `answerKey` prints the answers the build already computed rather than recomputing them, so a key cannot disagree with the sheet it belongs to.

**Curated, and the file says why.** The engine can generate millions of these — thirteen families, five or six styles each, two forms, three currencies, any number range — which is a doorway-page farm, the exact thing the `noindex` doc block in `Base.astro` already argues against. `_maths.ts` names twenty-one phrases a parent actually types. The suite holds that line rather than the comment: no two entries share a keyword, heading or config; every entry carries prose longer than a template would reach; every sheet must build with something on it.

**One stock, unlike paper.** Long division has no ruling measurement, so a maths sheet is one route rather than Letter + A4. That halves the set and keeps maths slugs disjoint from paper's — asserted, because `[topic].astro` and `[...slug].astro` are two patterns over one prefix and only coexist while their paths never collide.

**The builder link is §14 arriving early.** `encodeSharedSheet` puts the config and its seed in the fragment as base64url, so "change what is on this sheet" is an ordinary link on a static site. The seed travels along because a sheet is reproducible from its URL only if the URL says *which* of the infinitely many sheets that config makes was meant. Only the encoder ships — reading one back is untrusted input and belongs with the bench that opens it.

**Cross-links both ways.** Each sheet page links to the game; the four whose facts are table facts link to the twelve `/multiplication/N-times-table` pages; `/printables` lists the maths shelf beside the paper one and moves maths from "next" to "open".

## Correctness fixes found in review

Four findings, all the same failure in different clothes — a catalog page is *itself* the worksheet, so prose a paragraph away from being true is prose printed on the paper it contradicts.

- **Order of operations is one lesson at a time.** The lead named the rule without powers while four of twelve expressions had squares in them, and the sheet's own instruction line said "then powers" directly beneath prose that didn't. `IntegerConfig` gains `powers` — the switch `negatives` already is. The square templates are filtered from the pool before the draw and the instruction line is written from the same flag, so what's printed at the top and what's on the sheet are one decision.
- **A percentage sheet was 42% the identity.** `drawPercent` drew a percent and an amount and discarded the pair unless it came out whole — and 100 is the only percent whole of *every* number, so it was systematically over-drawn: five of twelve questions were `100% of N`, four consecutive, while the page's note discussed 10% and 15% that appeared nowhere. The percent is now chosen first and the amount walked in steps that keep it whole; the identity is off the list for this style.
- **One equivalence, asked once.** The fractions dedup key carried which side the blank was on, so `1/5 = 3/_` and `1/5 = _/15` were two problems to the engine and one fact to the child — on a hub claiming without qualification that no problem repeats on a page. Now folded on the equivalence.
- **"With room to work"** appears only where a config actually sets the workspace flag.

## Acceptance criteria

- [x] Curated `/printables/<slug>` pages, one per maths topic, real `<h1>`, genuine prose, sheet as prerendered HTML
- [x] Each page links into the builder preloaded with its config, cross-links to neighbouring sheets, links to `/multiplication/N-times-table` and the game
- [x] `/printables/math` subject hub
- [x] Title, description, canonical and structured data (`LearningResource`) on every page; every slug in the sitemap — asserted against the file that shipped, plus the negative that `/printables/make` still isn't
- [x] Slug set curated and bounded — no permutation farm
- [x] Zero JavaScript, verified against `dist/` (`Sheet.test.tsx` now covers twenty-one more pages)

## Validation

`type-check`, `lint`, `test:unit` (648 passing), `build` (67 pages, 62 sitemap URLs), and the browser smoke test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
