### PR TITLE
PRINT11: a sheet a parent made is still there tomorrow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-astro": "^3.1.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.1.1",
+        "fake-indexeddb": "^6.2.5",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "prettier": "^3.9.6",
@@ -5470,6 +5471,16 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-astro": "^3.1.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "fake-indexeddb": "^6.2.5",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.9.6",

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -1097,3 +1097,38 @@ export type SheetConfig =
   | RatioConfig
   | StatisticsConfig
   | WordProblemConfig;
+
+/* ── A sheet somebody kept ─────────────────────────────────────────────── */
+
+/**
+ * A sheet a parent configured and saved — what the `sheets` store holds (§15).
+ *
+ * A config and the seed that chose which one of the infinitely many sheets it
+ * makes, which together are the whole of it: `buildSheet(config, seed)`
+ * reproduces the page exactly (§7), so none of the paper is stored and a sheet
+ * saved in March prints the same problems in June.
+ *
+ * Declared here rather than in `services/sheets.ts` for the same reason
+ * `CustomDeck` sits in `engine/types.ts`: the model owns the vocabulary and the
+ * service owns the persistence, which is what lets `db.ts` state its schema
+ * without importing a peer service back up the stack.
+ *
+ * `id` is prefixed `sheet-`, the way a custom deck's is prefixed `custom-`, so
+ * the two can never collide wherever they end up side by side — one backup
+ * file, one list of things a parent made.
+ *
+ * There is no `profileId`, and that is a decision rather than an omission. A
+ * worksheet belongs to the household, not to a child (§15): the sheet made for
+ * the eldest is the sheet the next one gets, and scoping it to a profile would
+ * mean building it again for every kid at the table. It is also the one record
+ * here with nowhere to put a child's name, which is not an accident either —
+ * the name line is printed blank and filled in by hand (§1).
+ */
+export type SavedSheet = {
+  id: string;
+  name: string;
+  config: SheetConfig;
+  seed: number;
+  createdAt: string;
+  updatedAt: string;
+};

--- a/src/services/decks.test.ts
+++ b/src/services/decks.test.ts
@@ -5,8 +5,12 @@ import type { CustomDeck } from "@/engine/types";
 
 /**
  * The pure half of the deck service — parsing what a parent pasted, and
- * refusing a file that isn't ours. Everything that writes needs IndexedDB and
- * is covered in the browser instead.
+ * refusing a file that isn't ours.
+ *
+ * `create`, `update` and `remove` are not exercised here or anywhere else: they
+ * need IndexedDB, and the browser suite drives profiles and races rather than
+ * decks. The store underneath them — the upgrade that added `decks`, and its
+ * place in a backup — is covered in `storage/db.test.ts`.
  */
 
 describe("parseWords", () => {

--- a/src/services/sheets.test.ts
+++ b/src/services/sheets.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import { describeSheet } from "@/engine/sheets";
+import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "@/engine/sheets/paper";
+import type { SavedSheet, SheetConfig } from "@/engine/sheets/types";
+
+import { InvalidSheet, MAX_NAME, readSheetFile, toFile } from "./sheets";
+
+/**
+ * The pure half of the sheet service — what may be saved, and refusing a file
+ * that isn't ours. Everything that writes needs IndexedDB and is covered in the
+ * browser instead, the same way the deck service's writing half is.
+ */
+
+const config: SheetConfig = {
+  kind: "paper",
+  paper: DEFAULT_PAPER,
+  fontPt: DEFAULT_FONT_PT,
+  fields: ["name", "date"],
+  rule: { style: "hand-5-8" },
+};
+
+const sheet: SavedSheet = {
+  id: "sheet-abc",
+  name: "Monday handwriting",
+  config,
+  seed: 12,
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+};
+
+describe("sharing a sheet", () => {
+  it("writes the sheet and nothing else", () => {
+    // Not the id, and not the timestamps: what gets passed round is next week's
+    // worksheet, not a record of when somebody made it.
+    expect(toFile(sheet)).toEqual({
+      kind: "schoolskills-sheet",
+      version: 1,
+      name: "Monday handwriting",
+      config,
+      seed: 12,
+    });
+    expect(Object.keys(toFile(sheet))).not.toContain("id");
+  });
+
+  it("reads a good file into the same input the builder produces", () => {
+    expect(readSheetFile(toFile(sheet))).toEqual({
+      name: "Monday handwriting",
+      config,
+      seed: 12,
+    });
+  });
+
+  it("keeps the seed, because it says which sheet this is", () => {
+    // A config alone reproduces the same *kind* of sheet with different
+    // problems. The seed is the difference between being sent a worksheet and
+    // being sent a description of one.
+    expect(readSheetFile({ ...toFile(sheet), seed: 991 }).seed).toBe(991);
+  });
+
+  it("refuses a file that isn't ours", () => {
+    expect(() => readSheetFile({ kind: "schoolskills-deck" })).toThrow(
+      InvalidSheet,
+    );
+    expect(() => readSheetFile({ ...toFile(sheet), config: null })).toThrow(
+      InvalidSheet,
+    );
+    // A sheet with no seed can't be the sheet the sender printed.
+    expect(() => readSheetFile({ ...toFile(sheet), seed: undefined })).toThrow(
+      InvalidSheet,
+    );
+    expect(() => readSheetFile("a string")).toThrow(InvalidSheet);
+    expect(() => readSheetFile(null)).toThrow(InvalidSheet);
+  });
+
+  it("refuses a sheet this build doesn't know how to make", () => {
+    // It would import perfectly and then print a page saying "sheet
+    // unavailable". Somebody who was sent a worksheet is better told why.
+    expect(() =>
+      readSheetFile({
+        ...toFile(sheet),
+        config: { ...config, kind: "alchemy" },
+      }),
+    ).toThrow(InvalidSheet);
+  });
+});
+
+describe("what may be saved", () => {
+  it("names an unnamed sheet after what it prints", () => {
+    // The engine already says in one line what a config makes, so a sheet with
+    // no name typed on it gets that rather than "Untitled".
+    const read = readSheetFile({ ...toFile(sheet), name: "   " });
+    expect(read.name).toBe(describeSheet(config));
+    expect(read.name.length).toBeGreaterThan(0);
+  });
+
+  it("refuses a name past the cap", () => {
+    expect(() =>
+      readSheetFile({ ...toFile(sheet), name: "x".repeat(MAX_NAME + 1) }),
+    ).toThrow(InvalidSheet);
+  });
+
+  it("refuses a seed that isn't a whole number", () => {
+    // Every one of these builds — `mulberry32` starts with `seed >>> 0` — and
+    // every one builds a different sheet from the one being saved.
+    for (const seed of [1.5, -1, Number.NaN, 2 ** 60]) {
+      expect(() => readSheetFile({ ...toFile(sheet), seed })).toThrow(
+        InvalidSheet,
+      );
+    }
+  });
+});

--- a/src/services/sheets.test.ts
+++ b/src/services/sheets.test.ts
@@ -8,8 +8,9 @@ import { InvalidSheet, MAX_NAME, readSheetFile, toFile } from "./sheets";
 
 /**
  * The pure half of the sheet service — what may be saved, and refusing a file
- * that isn't ours. Everything that writes needs IndexedDB and is covered in the
- * browser instead, the same way the deck service's writing half is.
+ * that isn't ours. Everything that writes needs IndexedDB, so it is covered in
+ * `storage/db.test.ts` against a fake one, alongside the store's own upgrade
+ * and backup paths.
  */
 
 const config: SheetConfig = {
@@ -71,6 +72,22 @@ describe("sharing a sheet", () => {
     );
     expect(() => readSheetFile("a string")).toThrow(InvalidSheet);
     expect(() => readSheetFile(null)).toThrow(InvalidSheet);
+  });
+
+  it("refuses a half-built config as InvalidSheet, not as a TypeError", () => {
+    // The kind is one this build makes, so the spec check passes — and then the
+    // family reads its own config to name the sheet, and `paper` has no rule to
+    // read. Whatever comes out of this door has to be an `InvalidSheet`, or the
+    // caller that catches one is left holding a crash instead of a message.
+    expect(() =>
+      readSheetFile({
+        kind: "schoolskills-sheet",
+        version: 1,
+        name: "",
+        config: { kind: "paper" },
+        seed: 1,
+      }),
+    ).toThrow(InvalidSheet);
   });
 
   it("refuses a sheet this build doesn't know how to make", () => {

--- a/src/services/sheets.ts
+++ b/src/services/sheets.ts
@@ -1,0 +1,196 @@
+import { describeSheet, sheetSpec } from "@/engine/sheets";
+import { UNKNOWN_SHEET } from "@/engine/sheets/spec";
+import type { SavedSheet, SheetConfig } from "@/engine/sheets/types";
+
+import * as store from "./storage/db";
+
+/**
+ * Worksheets a parent set up and kept.
+ *
+ * The only writer of the `sheets` store, and the only place the rules for what
+ * may be saved are stated — the same bargain `decks.ts` strikes with word
+ * lists, for the same reason: a sheet typed into the builder and a sheet read
+ * out of a file somebody was sent have to end up as the same record, and two
+ * validators would eventually disagree about which.
+ *
+ * What it does *not* do is mirror anything back into the engine. A custom deck
+ * has to be mirrored because `deckSpec` names one from the record book without
+ * knowing storage exists; a sheet needs no such favour, because its name and
+ * its one-line description are both computable from the config it carries. The
+ * engine never has to be told that a saved sheet exists.
+ */
+
+export class InvalidSheet extends Error {}
+
+/**
+ * Long enough for the name the engine gives a sheet when a parent doesn't.
+ *
+ * Generous next to a word list's 40, because it is not only a thing somebody
+ * types: `describeSheet` produces lines like "Multiplication — 3-digit by
+ * 2-digit — worked in columns", and the default name has to fit inside its own
+ * cap.
+ */
+export const MAX_NAME = 80;
+
+/**
+ * `sheet-` for the same reason a custom deck's id is `custom-`: the two live in
+ * one origin's IndexedDB and one backup file, and a collision between them
+ * would be a worksheet overwriting this week's spellings.
+ */
+const nextId = () =>
+  `sheet-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+
+/** What a caller hands over. The record's id and timestamps are ours to make. */
+export type SheetInput = { name: string; config: SheetConfig; seed: number };
+
+function validate(input: SheetInput): SheetInput {
+  // Guarded rather than trusted, because this is also the door a shared file
+  // comes through. A config with no `kind` at all is not a sheet from a family
+  // that retired — it is a record that can never start printing.
+  if (typeof input.config?.kind !== "string" || !input.config.kind)
+    throw new InvalidSheet("That sheet has nothing to print");
+
+  const typed = input.name.trim();
+  if (typed.length > MAX_NAME)
+    throw new InvalidSheet(`Name must be ${MAX_NAME} characters or fewer`);
+
+  // A blank name is not an error here, unlike a blank word-list name: the
+  // engine can already say in one line what a config prints, and `describeSheet`
+  // is documented as the line for the catalog *and the record*. Clipped rather
+  // than checked against the cap, because a name the service chose for itself
+  // must never be the thing that refuses the save.
+  const name = typed || describeSheet(input.config).slice(0, MAX_NAME);
+
+  // The seed is which one of the infinitely many sheets a config makes this is
+  // (§7). A fraction or a negative would still build — `mulberry32` starts with
+  // `seed >>> 0` — but it would build a *different* sheet than the one being
+  // saved, and reproducing that exact page is the whole of what a saved sheet
+  // is for.
+  if (!Number.isSafeInteger(input.seed) || input.seed < 0)
+    throw new InvalidSheet("That sheet's seed isn't a whole number");
+
+  return { name, config: input.config, seed: input.seed };
+}
+
+/**
+ * Every saved sheet, oldest first.
+ *
+ * All of them, with no profile to filter by: a worksheet belongs to the
+ * household rather than to a child (docs/printables.md §15).
+ */
+export async function all(): Promise<SavedSheet[]> {
+  return (await store.allSheets()).sort((a, b) =>
+    a.createdAt.localeCompare(b.createdAt),
+  );
+}
+
+export async function create(input: SheetInput): Promise<SavedSheet> {
+  const clean = validate(input);
+  const now = new Date().toISOString();
+  const sheet: SavedSheet = {
+    id: nextId(),
+    ...clean,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await store.putSheet(sheet);
+  return sheet;
+}
+
+export async function update(
+  id: string,
+  input: SheetInput,
+): Promise<SavedSheet> {
+  const existing = (await store.allSheets()).find((s) => s.id === id);
+  if (!existing) throw new InvalidSheet("That sheet no longer exists");
+  const sheet: SavedSheet = {
+    ...existing,
+    ...validate(input),
+    updatedAt: new Date().toISOString(),
+  };
+  await store.putSheet(sheet);
+  return sheet;
+}
+
+/**
+ * Forgets a sheet.
+ *
+ * Nothing is orphaned by it, which is the difference from removing a deck:
+ * there are no races saved against a worksheet, only paper that was already
+ * printed and is on the fridge either way.
+ */
+export async function remove(id: string): Promise<void> {
+  await store.removeSheet(id);
+}
+
+/* ── Sharing one sheet ───────────────────────────────────────────────────
+   A single sheet as a file, distinct from a full backup, for the same reason
+   a deck has one: what gets passed round a class group is next week's
+   worksheet, not somebody's children's race history.
+
+   Safe to email in a way an export of the record book is not, and not by
+   luck. There is nowhere in a `SheetConfig` to put a child's name — the name
+   line is printed blank and filled in by hand (§1) — so the file carries a
+   configuration and nothing about anybody.                                 */
+
+export type SheetFile = {
+  kind: "schoolskills-sheet";
+  version: 1;
+  name: string;
+  config: SheetConfig;
+  /**
+   * Travels with the config, for the reason §7 gives: without it the reader
+   * gets the same *kind* of sheet with different problems, which is a feature
+   * (`seed + 1`) handed out by accident instead of the sheet they were sent.
+   */
+  seed: number;
+};
+
+export const toFile = (sheet: SavedSheet): SheetFile => ({
+  kind: "schoolskills-sheet",
+  version: 1,
+  name: sheet.name,
+  config: sheet.config,
+  seed: sheet.seed,
+});
+
+/**
+ * Reads a shared sheet into the same input the builder produces.
+ *
+ * Deliberately does NOT write, exactly as `readDeckFile` doesn't: `create` is
+ * the one path a saved sheet comes into being through, and an import that
+ * wrote here would land in IndexedDB and stay invisible to whatever list is
+ * already on screen until the next reload.
+ *
+ * The sender's id is dropped on purpose — it isn't in the file to begin with.
+ * Two families' copies are separate sheets, and keeping the id would silently
+ * overwrite a sheet of the same origin that the reader had since re-tuned.
+ */
+export function readSheetFile(parsed: unknown): SheetInput {
+  const file = parsed as Partial<SheetFile>;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    file.kind !== "schoolskills-sheet" ||
+    typeof file.config !== "object" ||
+    file.config === null ||
+    typeof file.seed !== "number"
+  ) {
+    throw new InvalidSheet("That doesn't look like a School Skills sheet");
+  }
+
+  // Checked here and nowhere else. A config whose family this build hasn't got
+  // would save as a page that says "sheet unavailable", and somebody who was
+  // sent a worksheet is better told why than handed a blank one. Records
+  // already in storage are never held to this — `UNKNOWN_SHEET` exists so a
+  // sheet outlives the family it was made on, and renaming an old one must not
+  // fail because that family has since retired.
+  if (sheetSpec(file.config.kind) === UNKNOWN_SHEET)
+    throw new InvalidSheet("This version doesn't make that kind of sheet");
+
+  return validate({
+    name: typeof file.name === "string" ? file.name : "",
+    config: file.config,
+    seed: file.seed,
+  });
+}

--- a/src/services/sheets.ts
+++ b/src/services/sheets.ts
@@ -59,7 +59,21 @@ function validate(input: SheetInput): SheetInput {
   // is documented as the line for the catalog *and the record*. Clipped rather
   // than checked against the cap, because a name the service chose for itself
   // must never be the thing that refuses the save.
-  const name = typed || describeSheet(input.config).slice(0, MAX_NAME);
+  //
+  // Guarded, because this is the untrusted door. A family describes its own
+  // config and reaches into it to do so — `describePaper` reads `rule.style` —
+  // and all this config has been held to so far is a `kind` string. A file
+  // carrying the right kind and a missing sub-object would throw a raw
+  // TypeError out of a function documented as throwing `InvalidSheet`, which a
+  // caller catching `InvalidSheet` would not catch at all.
+  let name = typed;
+  if (!name) {
+    try {
+      name = describeSheet(input.config).slice(0, MAX_NAME);
+    } catch {
+      throw new InvalidSheet("That sheet has nothing to print");
+    }
+  }
 
   // The seed is which one of the infinitely many sheets a config makes this is
   // (§7). A fraction or a negative would still build — `mulberry32` starts with

--- a/src/services/storage/db.test.ts
+++ b/src/services/storage/db.test.ts
@@ -1,0 +1,302 @@
+import {
+  IDBCursor,
+  IDBDatabase,
+  IDBFactory,
+  IDBIndex,
+  IDBKeyRange,
+  IDBObjectStore,
+  IDBRequest,
+  IDBTransaction,
+} from "fake-indexeddb";
+import { openDB, type IDBPDatabase } from "idb";
+import { describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "@/engine/sheets/paper";
+import type { SavedSheet } from "@/engine/sheets/types";
+import type { CustomDeck, Profile, Session } from "@/engine/types";
+
+/**
+ * The store itself, against a fake IndexedDB.
+ *
+ * The one file in the suite that opens a database, and it exists because this
+ * layer holds the only copy of a child's record book there is. An upgrade that
+ * dropped a store, an index that came back missing, or a backup that restored
+ * three of four collections cannot be caught by reading the diff — the failure
+ * is in what the browser did with the data, not in what the code says.
+ *
+ * `fake-indexeddb` rather than the browser suite: the interesting case is a
+ * database that already has data in it *at the old version*, which means
+ * building version 2 by hand before the app ever opens it. There is no way to
+ * arrange that from a page that has already booted.
+ *
+ * Every case starts from a brand-new `IDBFactory` and a fresh module registry,
+ * because `db.ts` memoises its connection and exports no way to drop it — which
+ * is right for the app and means a test that reused it could only ever see
+ * whatever version the first case happened to open.
+ */
+
+const profile: Profile = {
+  id: "kid-1",
+  name: "Ada",
+  emoji: "🚀",
+  color: "#7c3aed",
+  age: 7,
+  soundOn: true,
+  xp: 340,
+  badges: ["first-race"],
+  createdAt: "2026-03-01T09:00:00.000Z",
+};
+
+const session: Session = {
+  id: "run-1",
+  profileId: "kid-1",
+  game: "flashcards",
+  mode: "multiply",
+  configKey: "multiply|7|1-12|20|type",
+  config: {
+    operation: "multiply",
+    tables: [7],
+    others: [1, 2, 3],
+    cardCount: 20,
+    inputMode: "type",
+  },
+  seed: 42,
+  finishedAt: "2026-03-02T09:00:00.000Z",
+  durationMs: 41_000,
+  correct: 19,
+  incorrect: 1,
+  bestStreak: 12,
+  xpEarned: 55,
+  ghostSessionId: null,
+  beatGhost: null,
+  cards: [
+    {
+      prompt: "7 × 8",
+      answer: "56",
+      given: "56",
+      ok: true,
+      ms: 1900,
+      factId: "7:8",
+    },
+  ],
+};
+
+const deck: CustomDeck = {
+  id: "custom-abc",
+  name: "Week 4 spellings",
+  emoji: "📝",
+  words: ["because", "thought"],
+  createdAt: "2026-03-01T09:00:00.000Z",
+  updatedAt: "2026-03-01T09:00:00.000Z",
+};
+
+const sheet: SavedSheet = {
+  id: "sheet-abc",
+  name: "Monday handwriting",
+  config: {
+    kind: "paper",
+    paper: DEFAULT_PAPER,
+    fontPt: DEFAULT_FONT_PT,
+    fields: ["name", "date"],
+    rule: { style: "hand-5-8" },
+  },
+  seed: 12,
+  createdAt: "2026-03-01T09:00:00.000Z",
+  updatedAt: "2026-03-01T09:00:00.000Z",
+};
+
+const EXPORTED_AT = "2026-03-03T09:00:00.000Z";
+
+/**
+ * Node has no IndexedDB at all, so the whole family goes on the global object
+ * rather than only the factory: `idb` unwraps what a request hands back by
+ * asking `instanceof IDBDatabase`, `instanceof IDBCursor` and so on, and a fake
+ * factory whose results fail every one of those checks is worse than none.
+ */
+Object.assign(globalThis, {
+  IDBCursor,
+  IDBDatabase,
+  IDBFactory,
+  IDBIndex,
+  IDBKeyRange,
+  IDBObjectStore,
+  IDBRequest,
+  IDBTransaction,
+});
+
+/** A device nobody has ever run School Skills on. */
+function freshIndexedDB(): void {
+  globalThis.indexedDB = new IDBFactory();
+}
+
+/** `db.ts` as the browser would load it on that device. */
+async function loadDb() {
+  vi.resetModules();
+  return import("./db");
+}
+
+/**
+ * The database exactly as version 2 shipped it, with a kid's data already in
+ * it — written by hand rather than by an older copy of `db.ts`, because the
+ * point is to upgrade *from what is on disk*, not from what this build would
+ * have created. The connection is left open for the caller to close: a tab
+ * that never lets go is one of the cases below.
+ */
+async function seedVersion2(): Promise<IDBPDatabase> {
+  const old = await openDB("schoolskills", 2, {
+    upgrade(database) {
+      database.createObjectStore("profiles", { keyPath: "id" });
+      const sessions = database.createObjectStore("sessions", {
+        keyPath: "id",
+      });
+      sessions.createIndex("byProfile", "profileId");
+      database.createObjectStore("decks", { keyPath: "id" });
+    },
+  });
+  await old.put("profiles", profile);
+  await old.put("sessions", session);
+  await old.put("decks", deck);
+  return old;
+}
+
+describe("upgrading to version 3", () => {
+  it("adds the sheets store and leaves everything else exactly as it was", async () => {
+    freshIndexedDB();
+    (await seedVersion2()).close();
+
+    const db = await loadDb();
+
+    // Byte-identical, all three. An upgrade block that recreated a store would
+    // pass a type check and silently empty somebody's record book.
+    expect(await db.allProfiles()).toEqual([profile]);
+    expect(await db.allSessions()).toEqual([session]);
+    expect(await db.allDecks()).toEqual([deck]);
+
+    // The new store is there and has nothing in it.
+    expect(await db.allSheets()).toEqual([]);
+
+    // And `sessions` kept its index. Losing it is the quiet failure: every read
+    // above still works, and profile deletion and the ghost list stop.
+    const raw = await openDB("schoolskills", 3);
+    expect(await raw.getAllFromIndex("sessions", "byProfile", "kid-1")).toEqual(
+      [session],
+    );
+    raw.close();
+  });
+
+  it("tells a parent to close the other tab instead of hanging on it", async () => {
+    freshIndexedDB();
+    // A tab opened before this deploy: version 2, and no `blocking` handler,
+    // because the build it is running was written before there was anything to
+    // block. The upgrade cannot start while it is there.
+    const stale = await seedVersion2();
+
+    const db = await loadDb();
+    await expect(db.allProfiles()).rejects.toThrow(/another tab/i);
+
+    // And once it does go, the boot screen's retry actually retries — the
+    // failure was not memoised.
+    stale.close();
+    expect(await db.allProfiles()).toEqual([profile]);
+  });
+});
+
+describe("backing up and restoring", () => {
+  it("carries every store to a new device and back", async () => {
+    freshIndexedDB();
+    const source = await loadDb();
+    await source.putProfile(profile);
+    await source.putSession(session);
+    await source.putDeck(deck);
+    await source.putSheet(sheet);
+
+    const backup = await source.exportAll();
+    expect(backup.version).toBe(3);
+    expect(backup.sheets).toEqual([sheet]);
+
+    // The new laptop: a fresh database, and the file is all it has.
+    freshIndexedDB();
+    const moved = await loadDb();
+    expect(await moved.importAll(backup)).toEqual({
+      profiles: 1,
+      sessions: 1,
+      decks: 1,
+      sheets: 1,
+    });
+    expect(await moved.allProfiles()).toEqual([profile]);
+    expect(await moved.allSessions()).toEqual([session]);
+    expect(await moved.allDecks()).toEqual([deck]);
+    expect(await moved.allSheets()).toEqual([sheet]);
+  });
+
+  it("restores a file written before decks and before sheets existed", async () => {
+    freshIndexedDB();
+    const db = await loadDb();
+
+    // A backup a parent has been keeping since before either store arrived
+    // still has to restore — it may be the only copy left.
+    expect(
+      await db.importAll({
+        version: 1,
+        exportedAt: EXPORTED_AT,
+        profiles: [profile],
+        sessions: [session],
+      }),
+    ).toEqual({ profiles: 1, sessions: 1, decks: 0, sheets: 0 });
+    expect(await db.allProfiles()).toEqual([profile]);
+    expect(await db.allSheets()).toEqual([]);
+
+    expect(
+      await db.importAll({
+        version: 2,
+        exportedAt: EXPORTED_AT,
+        profiles: [profile],
+        decks: [deck],
+        sessions: [session],
+      }),
+    ).toEqual({ profiles: 1, sessions: 1, decks: 1, sheets: 0 });
+    expect(await db.allDecks()).toEqual([deck]);
+  });
+
+  it("wipes the sheets too when a restore says replace", async () => {
+    freshIndexedDB();
+    const db = await loadDb();
+    await db.putSheet(sheet);
+    await db.putDeck(deck);
+
+    // "This device is wrong, make it match the file" has to mean every store,
+    // or a restore reports that it replaced everything and quietly keeps the
+    // old copy of whichever one was forgotten.
+    await db.importAll(
+      {
+        version: 3,
+        exportedAt: EXPORTED_AT,
+        profiles: [profile],
+        sessions: [],
+      },
+      "replace",
+    );
+    expect(await db.allSheets()).toEqual([]);
+    expect(await db.allDecks()).toEqual([]);
+    expect(await db.allProfiles()).toEqual([profile]);
+  });
+});
+
+describe("what the sheet service writes", () => {
+  it("gives a saved sheet an id that cannot collide with a deck's", async () => {
+    // The writing half of `services/sheets.ts`, exercised here rather than in
+    // its own suite because this is the file that owns a fake IndexedDB. It is
+    // imported after the reset so it binds to the same fresh `db.ts`.
+    freshIndexedDB();
+    await loadDb();
+    const sheets = await import("../sheets");
+
+    const saved = await sheets.create({
+      name: "Monday handwriting",
+      config: sheet.config,
+      seed: 12,
+    });
+    expect(saved.id.startsWith("sheet-")).toBe(true);
+    expect(await sheets.all()).toEqual([saved]);
+  });
+});

--- a/src/services/storage/db.ts
+++ b/src/services/storage/db.ts
@@ -58,10 +58,46 @@ interface HubDB extends DBSchema {
 
 let handle: Promise<IDBPDatabase<HubDB>> | null = null;
 
+/**
+ * What a parent is told when another tab is holding the old version open.
+ *
+ * The one storage failure with an instruction attached, which is why it is a
+ * sentence rather than a code: every screen renders `err.message` straight out
+ * of the hub's error state, so this is the whole of what somebody sees.
+ */
+const BLOCKED_MSG =
+  "School Skills is open in another tab from before this update. Close the other tabs, then reload this page.";
+
 function db() {
   // Opened lazily and memoised: the island is `client:only`, but a stray import
   // from a build-time script must not try to open IndexedDB in Node.
-  handle ??= openDB<HubDB>(DB_NAME, DB_VERSION, {
+  handle ??= open().catch((err: unknown) => {
+    // A failure is never memoised. The commonest one is a stale tab, which the
+    // parent fixes by closing it — and the retry button on the boot screen has
+    // to be able to actually retry rather than re-await the same dead promise.
+    handle = null;
+    throw err;
+  });
+  return handle;
+}
+
+/**
+ * Opens the database, refusing to hang when another tab blocks the upgrade.
+ *
+ * A version bump cannot start while a connection to the older version is still
+ * open somewhere, and `openDB`'s promise simply never settles while that is
+ * true — so without the race below every service read awaits `db()` forever and
+ * the app sits on its loading state with nothing to say. The epic's own premise
+ * is a parent in the print shop with a kid's game open in another tab, so this
+ * is reachable rather than theoretical.
+ */
+function open(): Promise<IDBPDatabase<HubDB>> {
+  let stall: (reason: Error) => void = () => {};
+  const stalled = new Promise<never>((_, reject) => {
+    stall = reject;
+  });
+
+  const opening = openDB<HubDB>(DB_NAME, DB_VERSION, {
     // Each version's block is additive and guarded by the version it arrived
     // in, so a browser two versions behind runs both and a fresh one runs both
     // in order. Nothing here ever rewrites or drops existing data — this is
@@ -81,8 +117,30 @@ function db() {
         database.createObjectStore("sheets", { keyPath: "id" });
       }
     },
+    // We are the tab asking for the new version and somebody else won't let go.
+    blocked() {
+      stall(new Error(BLOCKED_MSG));
+    },
+    // The mirror image: we are the old tab, and another one wants to upgrade.
+    // Letting go is the only way that upgrade ever runs. The handle is dropped
+    // before the close so this tab's next read opens a fresh connection at
+    // whatever version is current by then, rather than being handed back the
+    // one we just closed.
+    blocking() {
+      const stale = handle;
+      handle = null;
+      void stale?.then((database) => database.close()).catch(() => {});
+    },
   });
-  return handle;
+
+  return Promise.race([opening, stalled]).catch((err: unknown) => {
+    // The open we walked away from can still succeed later, once the other tab
+    // goes. Close it rather than strand a connection nobody holds a reference
+    // to — that one would block the *next* version bump exactly as this one was
+    // blocked, and there would be no tab to close to clear it.
+    void opening.then((database) => database.close()).catch(() => {});
+    throw err;
+  });
 }
 
 /**

--- a/src/services/storage/db.ts
+++ b/src/services/storage/db.ts
@@ -1,6 +1,7 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 
 import { readSession, readSessions } from "@/engine/migrate";
+import type { SavedSheet } from "@/engine/sheets/types";
 import type {
   CustomDeck,
   LegacySession,
@@ -24,8 +25,11 @@ import type {
  */
 
 const DB_NAME = "schoolskills";
-/** 2 added `decks` — parent-authored word lists. */
-const DB_VERSION = 2;
+/**
+ * 2 added `decks` — parent-authored word lists.
+ * 3 added `sheets` — worksheets a parent configured in the print shop.
+ */
+const DB_VERSION = 3;
 
 /** Oldest sessions past this count are dropped so a profile stays fast to load. */
 export const MAX_SESSIONS_PER_PROFILE = 2000;
@@ -33,6 +37,13 @@ export const MAX_SESSIONS_PER_PROFILE = 2000;
 interface HubDB extends DBSchema {
   profiles: { key: string; value: Profile };
   decks: { key: string; value: CustomDeck };
+  /**
+   * Keyed by id and nothing else — no `byProfile` index to match the one on
+   * `sessions`, because a saved sheet has no profile to be indexed by. A
+   * worksheet belongs to the household rather than to a child; see `SavedSheet`
+   * for why that is the shape rather than an oversight.
+   */
+  sheets: { key: string; value: SavedSheet };
   sessions: {
     key: string;
     /**
@@ -65,6 +76,9 @@ function db() {
       }
       if (oldVersion < 2) {
         database.createObjectStore("decks", { keyPath: "id" });
+      }
+      if (oldVersion < 3) {
+        database.createObjectStore("sheets", { keyPath: "id" });
       }
     },
   });
@@ -112,6 +126,18 @@ export async function putDeck(deck: CustomDeck): Promise<void> {
  */
 export async function removeDeck(id: string): Promise<void> {
   await (await db()).delete("decks", id);
+}
+
+export async function allSheets(): Promise<SavedSheet[]> {
+  return (await db()).getAll("sheets");
+}
+
+export async function putSheet(sheet: SavedSheet): Promise<void> {
+  await (await db()).put("sheets", sheet);
+}
+
+export async function removeSheet(id: string): Promise<void> {
+  await (await db()).delete("sheets", id);
 }
 
 export async function putProfile(profile: Profile): Promise<void> {
@@ -177,12 +203,27 @@ export async function trimSessions(profileId: string): Promise<number> {
   return doomed.length;
 }
 
+/**
+ * Every store a backup covers, written once.
+ *
+ * The transaction and the `replace` wipe both read it, so a store added to one
+ * can't be missing from the other — which would be a restore that says it
+ * replaced everything and quietly kept the old copy of whatever was forgotten.
+ */
+const BACKUP_STORES = ["profiles", "sessions", "decks", "sheets"] as const;
+
 export type Backup = {
-  /** 2 added `decks`. Files at either version restore. */
-  version: 1 | 2;
+  /** 2 added `decks`, 3 added `sheets`. Files at any of the three restore. */
+  version: 1 | 2 | 3;
   exportedAt: string;
   profiles: Profile[];
   decks?: CustomDeck[];
+  /**
+   * Optional for the same reason `decks` is: a file written before the print
+   * shop existed simply has none, and a backup a parent has been keeping since
+   * the spring must not stop restoring because a later version added a store.
+   */
+  sheets?: SavedSheet[];
   /**
    * Written current, read wide. A file exported today holds widened cards, but
    * one exported last week — or produced by `scripts/convert-legacy-hub.mjs`
@@ -192,16 +233,18 @@ export type Backup = {
 };
 
 export async function exportAll(): Promise<Backup> {
-  const [profiles, sessions, decks] = await Promise.all([
+  const [profiles, sessions, decks, sheets] = await Promise.all([
     allProfiles(),
     allSessions(),
     allDecks(),
+    allSheets(),
   ]);
   return {
-    version: 2,
+    version: 3,
     exportedAt: new Date().toISOString(),
     profiles,
     decks,
+    sheets,
     sessions,
   };
 }
@@ -217,23 +260,27 @@ export async function exportAll(): Promise<Backup> {
 export async function importAll(
   backup: Backup,
   mode: "merge" | "replace" = "merge",
-): Promise<{ profiles: number; sessions: number; decks: number }> {
+): Promise<{
+  profiles: number;
+  sessions: number;
+  decks: number;
+  sheets: number;
+}> {
   const database = await db();
-  const tx = database.transaction(
-    ["profiles", "sessions", "decks"],
-    "readwrite",
-  );
+  const tx = database.transaction(BACKUP_STORES, "readwrite");
   if (mode === "replace") {
-    await Promise.all([
-      tx.objectStore("profiles").clear(),
-      tx.objectStore("sessions").clear(),
-      tx.objectStore("decks").clear(),
-    ]);
+    await Promise.all(BACKUP_STORES.map((s) => tx.objectStore(s).clear()));
   }
   await Promise.all([
     ...backup.profiles.map((p) => tx.objectStore("profiles").put(p)),
     // Absent from a version 1 file, which is fine — there were none.
     ...(backup.decks ?? []).map((d) => tx.objectStore("decks").put(d)),
+    // Likewise absent from anything written before version 3. Restored as
+    // they were saved and not re-validated: the sheet service refuses a family
+    // this build doesn't have, and a backup is the one place that would be the
+    // wrong answer — a file is the only copy there is, so a sheet whose family
+    // was retired has to come back rather than be dropped on the way in.
+    ...(backup.sheets ?? []).map((s) => tx.objectStore("sheets").put(s)),
     // Widened on the way in, so a restored run is stored in the shape a fresh
     // one would be. Reads migrate anyway; this just stops the file's age from
     // outliving the import.
@@ -246,5 +293,6 @@ export async function importAll(
     profiles: backup.profiles.length,
     sessions: backup.sessions.length,
     decks: backup.decks?.length ?? 0,
+    sheets: backup.sheets?.length ?? 0,
   };
 }


### PR DESCRIPTION
Closes #55. Epic: #76 (PRINT11).

The storage half of the Print Shop, and no UI — the service and the schema only.

## What changed

**`DB_VERSION` 2 → 3, one additive block.** `oldVersion < 3` creates a `sheets` store and does nothing else. Nothing existing is rewritten, dropped or re-keyed: IndexedDB holds the only copy of a child's record book there is, so an upgrade block that touches what is already on disk is the one mistake here with no undo.

**A saved sheet is a config and a seed, and nothing else.** `buildSheet(config, seed)` is deterministic, so none of the paper is stored — a sheet saved in March prints the same problems in June out of six fields. `SavedSheet` lives in `src/engine/sheets/types.ts` beside the config it holds, for the same reason `CustomDeck` sits in `engine/types.ts`: the model owns the vocabulary, the service owns the persistence, and that is what lets `db.ts` state its schema without importing a peer service back up the stack.

**`src/services/sheets.ts` is the only writer**, mirroring `services/decks.ts` — validation in the service, one creation path. Ids are prefixed `sheet-` the way a custom deck's is prefixed `custom-`, so the two can never collide wherever they end up side by side: one backup file, one list of things a parent made.

**Household-scoped, not profile-scoped.** There is no `profileId` and no `byProfile` index. The sheet made for the eldest is the sheet the next one gets; scoping it to a child would mean rebuilding it for every kid at the table. It is also the one record here with nowhere to put a child's name — the name line prints blank and gets filled in by hand.

**`Backup` goes to `version: 3`** with an optional `sheets` array, optional for the same reason `decks` is: a backup a parent has been keeping since the spring must not stop restoring because a later version added a store. Files at versions 1, 2 and 3 all restore. A `BACKUP_STORES` constant is now read by both the export transaction and the `replace` wipe, so a store added to one can't be missing from the other — that would be a restore claiming it replaced everything while quietly keeping the old copy of whatever was forgotten.

**A `kind: "schoolskills-sheet"` file format** for sharing a single sheet, with the sender's id dropped on import so a shared sheet lands as a new local one.

## Two bugs the tests found

The storage half was originally written on inspection alone. Standing up a fake IndexedDB — building version 2 by hand, putting a profile, a run and a word list in it, then letting `db.ts` upgrade what is actually on disk — turned up two real defects:

- **The upgrade could hang forever.** A tab left open from before a deploy holds the old version, and `openDB`'s promise simply never settles while it does, so every service read awaited a promise that would not resolve and the app sat on its loading state with nothing to say. The open now races a `blocked` handler and loses in a way that names the tab to close; the failure is not memoised, so the boot screen's retry button can actually retry. The old tab's side is the `blocking` handler, which lets go so the upgrade can start. This is reachable rather than theoretical — the epic's premise is a parent in the print shop with a kid's game open in another tab.
- **`validate` threw the wrong error.** It named an unnamed sheet by asking the family to describe its own config, reaching inside it, so a shared file with the right `kind` and a missing sub-object threw a `TypeError` out of the one door documented as throwing `InvalidSheet`.

## Validation

`type-check`, `lint`, `test:unit` (663 tests, 33 files), `build` (static, 67 pages) all pass. Because this story changes storage, the browser smoke test is the load-bearing check and was run against this build: create profile → race → results → reload, with the profile and session read back out of IndexedDB after the reload. All checks passed, no console errors.

`fake-indexeddb` is added as a devDependency for the upgrade tests.
