### PR TITLE
PRINT12: the four controls an option panel is made of

### DIFF
--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -1,0 +1,58 @@
+import type { InputHTMLAttributes } from "react";
+
+/**
+ * A tick box, for options that stack.
+ *
+ * Not a `Toggle`, and the difference isn't cosmetic. A switch is a setting
+ * that acts the moment it moves — sound on, sound off — and there is usually
+ * one of them. A checkbox is a statement about a thing being built: "include
+ * negatives", "print an answer key". Several sit in one panel, several are on
+ * at once, and none of them do anything until the thing is rebuilt. Reaching
+ * for the wrong one tells a parent the wrong story about what just happened.
+ *
+ * The native box is kept, not redrawn. `accent-color` recolours it to the
+ * world's `--go` while leaving the platform's own checkmark, its
+ * `:focus-visible` ring (base.css draws that for every real control) and its
+ * behaviour under forced colours intact. A hand-drawn box has to reproduce all
+ * three, and the tick is the one glyph a custom box always draws worse.
+ *
+ * The label is structural — the `<input>` sits inside the `<label>`, as in
+ * `Field` — so there is no `htmlFor`/`id` pair to keep in step and the hit
+ * target is the whole row rather than the box. `hint` sits inside the label
+ * too, which makes it part of the announced name: a phrase, not a paragraph.
+ */
+export interface CheckboxProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "onChange" | "checked" | "type"
+> {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  label: string;
+  /** A quiet second line under the label. Keep it to a phrase. */
+  hint?: string;
+}
+
+export function Checkbox({
+  checked,
+  onChange,
+  label,
+  hint,
+  className = "checkbox",
+  ...rest
+}: CheckboxProps) {
+  return (
+    <label className={className}>
+      <input
+        type="checkbox"
+        className="checkbox__box"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        {...rest}
+      />
+      <span className="checkbox__text">
+        {label}
+        {hint ? <span className="checkbox__hint">{hint}</span> : null}
+      </span>
+    </label>
+  );
+}

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -20,10 +20,17 @@ import type { InputHTMLAttributes } from "react";
  * `Field` — so there is no `htmlFor`/`id` pair to keep in step and the hit
  * target is the whole row rather than the box. `hint` sits inside the label
  * too, which makes it part of the announced name: a phrase, not a paragraph.
+ * For the same reason this one does *not* go in a `Field`: that would put a
+ * `<label>` around a `<label>`, and the name a browser then computes is
+ * anyone's guess. It brings its own.
+ *
+ * `className` replaces the default rather than adding to it, matching `Input`
+ * and `Select` — but note that the default is what carries the 44px row, so a
+ * caller who overrides it owns the hit target from then on.
  */
 export interface CheckboxProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
-  "onChange" | "checked" | "type"
+  "onChange" | "checked" | "type" | "aria-label" | "aria-labelledby"
 > {
   checked: boolean;
   onChange: (next: boolean) => void;

--- a/src/components/ui/NumberStepper.tsx
+++ b/src/components/ui/NumberStepper.tsx
@@ -21,9 +21,17 @@ import { Button } from "./Button";
  * **What is typed is held until it is committed.** Clamping on every keystroke
  * means typing "12" into a field whose minimum is 5 snaps to 5 at the "1" and
  * takes the caret with it. So a keystroke only reaches the caller once it is
- * already a legal value; anything else lives in a draft until blur or Enter,
- * where it is clamped. `ClockPicker` does this by hand for the race clock —
- * this is that behaviour, moved somewhere it can be reused.
+ * already the value a commit would produce; anything else lives in a draft
+ * until blur or Enter, where `commitValue` clamps it and snaps it to the step
+ * grid. `ClockPicker` does this by hand for the race clock — this is that
+ * behaviour, moved somewhere it can be reused.
+ *
+ * **At a bound the button is `aria-disabled`, not `disabled`.** The real
+ * attribute would be the tidier markup and the worse control: the browser
+ * blurs a disabled element, so a keyboard user pressing − down to the minimum
+ * has focus fall to `<body>` mid-interaction and the next Tab restarts at the
+ * top of the page. `aria-disabled` announces the same thing, keeps the stop in
+ * the tab order, and `nudge` makes the press a no-op.
  */
 export interface NumberStepperProps {
   /** The accessible name of the number itself, e.g. "Problems". */
@@ -61,21 +69,22 @@ export function NumberStepper({
   // mid-edit and what the person typed wins over what the caller holds.
   const [draft, setDraft] = useState<string | null>(null);
 
-  const clamp = (n: number) => Math.min(max, Math.max(min, n));
-
+  // `value` and not the draft, which is correct because blur fires — and React
+  // flushes that discrete update — before the button's click, so by the time a
+  // press lands the typed number has already been committed.
   const nudge = (delta: number) => {
+    const next = Math.min(max, Math.max(min, value + delta));
     setDraft(null);
-    onChange(clamp(value + delta));
+    // A press at the bound reaches here because the button stayed focusable;
+    // there is simply nowhere left to go, so the caller is not told anything.
+    if (next !== value) onChange(next);
   };
 
   const commit = () => {
     if (draft === null) return;
-    const parsed = Number(draft);
-    // An empty box or a typo is not a number to keep — fall back to the value
-    // that was already there rather than to zero, which the minimum would then
-    // silently turn into something else again.
+    const next = commitValue(draft, value, min, max, step);
     setDraft(null);
-    if (draft.trim() !== "" && Number.isFinite(parsed)) onChange(clamp(parsed));
+    if (next !== value) onChange(next);
   };
 
   return (
@@ -84,7 +93,8 @@ export function NumberStepper({
         variant="bare"
         className="stepper__btn"
         aria-label={decreaseLabel}
-        disabled={disabled || value <= min}
+        disabled={disabled}
+        aria-disabled={value <= min || undefined}
         onClick={() => nudge(-step)}
       >
         −
@@ -103,11 +113,13 @@ export function NumberStepper({
           onChange={(event) => {
             const text = event.target.value;
             setDraft(text);
+            // Only when what is typed already *is* what a commit would
+            // produce. A half-typed "1" below the minimum, or an off-grid
+            // "12.5", waits for blur instead of fighting the caret.
             const parsed = Number(text);
             if (
               text.trim() !== "" &&
-              Number.isFinite(parsed) &&
-              parsed === clamp(parsed)
+              commitValue(text, value, min, max, step) === parsed
             ) {
               onChange(parsed);
             }
@@ -127,11 +139,38 @@ export function NumberStepper({
         variant="bare"
         className="stepper__btn"
         aria-label={increaseLabel}
-        disabled={disabled || value >= max}
+        disabled={disabled}
+        aria-disabled={value >= max || undefined}
         onClick={() => nudge(step)}
       >
         +
       </Button>
     </span>
   );
+}
+
+/**
+ * What a draft typed into the box should become — the only real decision in
+ * this module, and exported so it can be tested as a function rather than as
+ * an interaction the project has no DOM to simulate.
+ *
+ * Returns `current` for anything that isn't a number to keep, so an empty box
+ * or a typo falls back to the value already there rather than to zero, which
+ * the minimum would then silently turn into something else again.
+ */
+export function commitValue(
+  draft: string,
+  current: number,
+  min: number,
+  max: number,
+  step: number,
+): number {
+  const parsed = Number(draft);
+  if (draft.trim() === "" || !Number.isFinite(parsed)) return current;
+  const clamp = (n: number) => Math.min(max, Math.max(min, n));
+  // Snapped to the grid `step` describes, measured from `min` and not from
+  // zero: a stepper from 5 to 60 by 5 offers 5, 10, 15 — never 23, and never
+  // the 12.5 that "a small whole number" promised it would not hand back.
+  // Clamped a second time because rounding up from the last cell can overshoot.
+  return clamp(min + Math.round((clamp(parsed) - min) / step) * step);
 }

--- a/src/components/ui/NumberStepper.tsx
+++ b/src/components/ui/NumberStepper.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+
+import { Button } from "./Button";
+
+/**
+ * A small whole number, with two big targets and a box you can type in.
+ *
+ * Both halves earn their place. The − and + are what a child or a thumb uses,
+ * and they are the reason this isn't a bare `Input type="number"`: the native
+ * spinner arrows are a few pixels tall and are hidden here (`appearance:
+ * textfield`) because they promise a target that isn't one. The box is what a
+ * parent uses, because nobody presses + thirty times to reach 40.
+ *
+ * The `<input>` is real rather than a `role="spinbutton"` span, which buys the
+ * name, the value, the range and the arrow keys from the platform instead of
+ * from three key handlers. It carries `aria-label` and the two buttons carry
+ * their own names, so a group of steppers in one panel never announces as
+ * "increase, increase, increase". Sit it in a `FieldSet`, not a `Field`: a
+ * `<label>` names the *first* control it contains, which here is the − button.
+ *
+ * **What is typed is held until it is committed.** Clamping on every keystroke
+ * means typing "12" into a field whose minimum is 5 snaps to 5 at the "1" and
+ * takes the caret with it. So a keystroke only reaches the caller once it is
+ * already a legal value; anything else lives in a draft until blur or Enter,
+ * where it is clamped. `ClockPicker` does this by hand for the race clock —
+ * this is that behaviour, moved somewhere it can be reused.
+ */
+export interface NumberStepperProps {
+  /** The accessible name of the number itself, e.g. "Problems". */
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  step?: number;
+  /**
+   * Printed after the number, inside the box: "pt", "cm". Decorative — if the
+   * unit is load-bearing, it belongs in `label` too ("Type size in points"),
+   * because that is what gets announced.
+   */
+  unit?: string;
+  disabled?: boolean;
+  /** Overrides for the button names, when "Decrease problems" reads oddly. */
+  decreaseLabel?: string;
+  increaseLabel?: string;
+}
+
+export function NumberStepper({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+  unit,
+  disabled = false,
+  decreaseLabel = `Decrease ${label.toLowerCase()}`,
+  increaseLabel = `Increase ${label.toLowerCase()}`,
+}: NumberStepperProps) {
+  // `null` means "showing the committed value". Any string means the field is
+  // mid-edit and what the person typed wins over what the caller holds.
+  const [draft, setDraft] = useState<string | null>(null);
+
+  const clamp = (n: number) => Math.min(max, Math.max(min, n));
+
+  const nudge = (delta: number) => {
+    setDraft(null);
+    onChange(clamp(value + delta));
+  };
+
+  const commit = () => {
+    if (draft === null) return;
+    const parsed = Number(draft);
+    // An empty box or a typo is not a number to keep — fall back to the value
+    // that was already there rather than to zero, which the minimum would then
+    // silently turn into something else again.
+    setDraft(null);
+    if (draft.trim() !== "" && Number.isFinite(parsed)) onChange(clamp(parsed));
+  };
+
+  return (
+    <span className="stepper">
+      <Button
+        variant="bare"
+        className="stepper__btn"
+        aria-label={decreaseLabel}
+        disabled={disabled || value <= min}
+        onClick={() => nudge(-step)}
+      >
+        −
+      </Button>
+      <span className="stepper__field">
+        <input
+          type="number"
+          inputMode="numeric"
+          className="stepper__input u-mono"
+          aria-label={label}
+          value={draft ?? String(value)}
+          min={min}
+          max={max}
+          step={step}
+          disabled={disabled}
+          onChange={(event) => {
+            const text = event.target.value;
+            setDraft(text);
+            const parsed = Number(text);
+            if (
+              text.trim() !== "" &&
+              Number.isFinite(parsed) &&
+              parsed === clamp(parsed)
+            ) {
+              onChange(parsed);
+            }
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") event.currentTarget.blur();
+          }}
+          onBlur={commit}
+        />
+        {unit ? (
+          <span className="stepper__unit u-mono" aria-hidden="true">
+            {unit}
+          </span>
+        ) : null}
+      </span>
+      <Button
+        variant="bare"
+        className="stepper__btn"
+        aria-label={increaseLabel}
+        disabled={disabled || value >= max}
+        onClick={() => nudge(step)}
+      >
+        +
+      </Button>
+    </span>
+  );
+}

--- a/src/components/ui/Range.tsx
+++ b/src/components/ui/Range.tsx
@@ -9,20 +9,38 @@ import type { InputHTMLAttributes } from "react";
  * control that suits it is the one you can sweep while watching the page
  * change. Anything that wants an exact value typed in wants the stepper.
  *
- * The readout beside it is `aria-hidden` on purpose. A range input announces
- * its own value on every change, so a live number next to it is either
- * duplicate speech or, worse, speech that arrives out of order — it is there
- * for the eyes only. `format` exists because the number a slider carries is
- * rarely the number a person reads: 14 is "14 pt", 625 is "⅝ in".
+ * `format` exists because the number a slider carries is rarely the number a
+ * person reads: 14 is "14 pt", 625 is "⅝ in". That string goes to both halves
+ * of the audience — the readout for the eyes, `aria-valuetext` for the
+ * announcement — so nobody is left with the raw number while everyone else
+ * reads the formatted one. The readout itself is `aria-hidden` precisely
+ * because `aria-valuetext` already carries it: rendering it twice is duplicate
+ * speech or, worse, speech that arrives out of order. With no `format` there
+ * is nothing to add, the attribute is left off, and the platform's own
+ * announcement of the raw number stands.
  *
  * Everything the platform gives a range is kept: arrow keys by `step`,
  * Page Up/Down by a larger stride, Home and End to the ends, and the focus
  * ring base.css draws for every real control. `label` is required, because a
  * slider with no name announces as a number belonging to nothing.
  */
+/**
+ * The name and the spoken value are computed from `label` and `format`, so
+ * they are taken out of the passthrough rather than left where a caller could
+ * spread them back over the top of the two things this doc block calls
+ * non-negotiable.
+ */
 export interface RangeProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,
-  "onChange" | "value" | "type" | "min" | "max" | "step"
+  | "onChange"
+  | "value"
+  | "type"
+  | "min"
+  | "max"
+  | "step"
+  | "aria-label"
+  | "aria-labelledby"
+  | "aria-valuetext"
 > {
   /** The accessible name. Repeat the visible label if there is one. */
   label: string;
@@ -52,6 +70,7 @@ export function Range({
         type="range"
         className="range__input"
         aria-label={label}
+        aria-valuetext={format ? format(value) : undefined}
         value={value}
         min={min}
         max={max}

--- a/src/components/ui/Range.tsx
+++ b/src/components/ui/Range.tsx
@@ -1,0 +1,67 @@
+import type { InputHTMLAttributes } from "react";
+
+/**
+ * A slider, for a number nobody has an exact answer for.
+ *
+ * The distinction against `NumberStepper` is what the number means. "How many
+ * problems" has a right answer a parent already knows and will type; "how big
+ * is the type" does not — it is judged by looking at the result, so the
+ * control that suits it is the one you can sweep while watching the page
+ * change. Anything that wants an exact value typed in wants the stepper.
+ *
+ * The readout beside it is `aria-hidden` on purpose. A range input announces
+ * its own value on every change, so a live number next to it is either
+ * duplicate speech or, worse, speech that arrives out of order — it is there
+ * for the eyes only. `format` exists because the number a slider carries is
+ * rarely the number a person reads: 14 is "14 pt", 625 is "⅝ in".
+ *
+ * Everything the platform gives a range is kept: arrow keys by `step`,
+ * Page Up/Down by a larger stride, Home and End to the ends, and the focus
+ * ring base.css draws for every real control. `label` is required, because a
+ * slider with no name announces as a number belonging to nothing.
+ */
+export interface RangeProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "onChange" | "value" | "type" | "min" | "max" | "step"
+> {
+  /** The accessible name. Repeat the visible label if there is one. */
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  step?: number;
+  /** How the value reads beside the slider. Defaults to the bare number. */
+  format?: (value: number) => string;
+}
+
+export function Range({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+  format,
+  className = "range",
+  ...rest
+}: RangeProps) {
+  return (
+    <span className={className}>
+      <input
+        type="range"
+        className="range__input"
+        aria-label={label}
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(event) => onChange(Number(event.target.value))}
+        {...rest}
+      />
+      <span className="range__value u-mono" aria-hidden="true">
+        {format ? format(value) : value}
+      </span>
+    </span>
+  );
+}

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -30,6 +30,14 @@ export type SegmentedOption<T extends string> = {
   /** What sits in the pill. A word, or a symbol like "×". */
   label: string;
   /**
+   * A glyph shown before the label — "×", "÷". Give one and the label becomes
+   * the word that hides under 560px (`.segmented__word`), because the symbol
+   * is still there to identify the pill; without one there is nothing to fall
+   * back to and the label always shows. It is decorative, `aria-hidden`: what
+   * gets announced is `title` if there is one, otherwise the label.
+   */
+  symbol?: string;
+  /**
    * The full name, for when `label` is a symbol. Becomes both the hover
    * tooltip and the announced name — a "×" left to a screen reader's own
    * judgement is read differently by every one of them.
@@ -96,10 +104,15 @@ export function SegmentedControl<T extends string>({
               aria-label={option.title}
               onChange={() => onChange(option.value)}
             />
-            {/* Deliberately unclassed: `.segmented__word` is the word that
-                hides beside a symbol under 560px, which is a decision for the
-                screen that pairs the two, not for every label in the row. */}
-            <span>{option.label}</span>
+            {option.symbol ? (
+              <span aria-hidden="true">{option.symbol}</span>
+            ) : null}
+            {/* `.segmented__word` hides under 560px, so it is worn only when a
+                symbol is there to take the pill's place. A row of words that
+                all vanished at once would be a row of empty pills. */}
+            <span className={option.symbol ? "segmented__word" : undefined}>
+              {option.label}
+            </span>
             {option.hint ? (
               <span className="segmented__hint">{option.hint}</span>
             ) : null}

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -1,0 +1,111 @@
+import { useId } from "react";
+
+/**
+ * One choice out of a handful, as a row of pills.
+ *
+ * This is what the app reaches for instead of a dropdown, and the reason is
+ * age: every option is on screen at once, so a five-year-old picks by pointing
+ * at the one they want rather than opening a list, reading it and remembering
+ * what was in it. `Select` exists for the long lists where that stops working.
+ *
+ * **Radios, not buttons.** The screens that grew this pattern each built it
+ * from `<Button pressed>`, which announces as a row of unrelated toggles and
+ * tabs through one stop per option. Real radios sharing a `name` are announced
+ * as "one of four", move with the arrow keys and skip to the chosen one with a
+ * single Tab — none of which is worth hand-rolling when the platform ships it.
+ * The inputs are visually hidden (not `display: none`, which would remove them
+ * from the tab order); the `<label>` around each one is the pill, and it wears
+ * the focus ring on their behalf.
+ *
+ * The group needs a name of its own or a screen reader reads four choices
+ * belonging to nothing, so `label` is required. Inside a `FieldSet` that will
+ * repeat the legend, which is the right kind of redundant.
+ *
+ * `T` flows through to `onChange`, so a caller keyed on a union — a paper
+ * size, an operation — gets that union back rather than a bare string. It is a
+ * type parameter and not an import: the kit stays domain-free.
+ */
+export type SegmentedOption<T extends string> = {
+  value: T;
+  /** What sits in the pill. A word, or a symbol like "×". */
+  label: string;
+  /**
+   * The full name, for when `label` is a symbol. Becomes both the hover
+   * tooltip and the announced name — a "×" left to a screen reader's own
+   * judgement is read differently by every one of them.
+   */
+  title?: string;
+  /** A quiet second line under the label, for a choice that needs a word. */
+  hint?: string;
+  disabled?: boolean;
+};
+
+export interface SegmentedControlProps<T extends string> {
+  /** Names the group. Required — see the doc block. */
+  label: string;
+  value: T;
+  onChange: (value: T) => void;
+  options: SegmentedOption<T>[];
+  /** The tighter, monospaced row used where the labels are short. */
+  slim?: boolean;
+  className?: string;
+}
+
+export function SegmentedControl<T extends string>({
+  label,
+  value,
+  onChange,
+  options,
+  slim = false,
+  className,
+}: SegmentedControlProps<T>) {
+  // One `name` per mounted control, so two segmented rows on the same panel
+  // are two groups. `useId` is stable across the server render and the client
+  // one, which a counter or a random string would not be.
+  const name = useId();
+
+  return (
+    <div
+      className={["segmented", slim ? "segmented--slim" : "", className]
+        .filter(Boolean)
+        .join(" ")}
+      role="radiogroup"
+      aria-label={label}
+    >
+      {options.map((option) => {
+        const on = option.value === value;
+        return (
+          <label
+            key={option.value}
+            className={[
+              "segmented__btn",
+              option.hint ? "segmented__btn--stack" : "",
+              on ? "is-on" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            title={option.title}
+          >
+            <input
+              className="segmented__radio"
+              type="radio"
+              name={name}
+              value={option.value}
+              checked={on}
+              disabled={option.disabled}
+              aria-label={option.title}
+              onChange={() => onChange(option.value)}
+            />
+            {/* Deliberately unclassed: `.segmented__word` is the word that
+                hides beside a symbol under 560px, which is a decision for the
+                screen that pairs the two, not for every label in the row. */}
+            <span>{option.label}</span>
+            {option.hint ? (
+              <span className="segmented__hint">{option.hint}</span>
+            ) : null}
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/kit.test.tsx
+++ b/src/components/ui/kit.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import { Checkbox } from "./Checkbox";
-import { NumberStepper } from "./NumberStepper";
+import { NumberStepper, commitValue } from "./NumberStepper";
 import { Range } from "./Range";
 import { SegmentedControl } from "./SegmentedControl";
 
@@ -94,6 +94,33 @@ describe("SegmentedControl", () => {
     expect(html).toContain('title="Multiplication"');
     expect(html).toContain("×");
   });
+
+  it("only lets the word hide when a symbol is left holding the pill", () => {
+    // `.segmented__word` is the under-560px hide. On its own a label would
+    // leave an empty pill behind, so the class is worn only beside a symbol.
+    const withSymbol = render(
+      <SegmentedControl
+        label="Operation"
+        value="mul"
+        onChange={() => {}}
+        options={[
+          { value: "mul", label: "Multiply", symbol: "×", title: "Multiply" },
+        ]}
+      />,
+    );
+    expect(withSymbol).toContain('<span aria-hidden="true">×</span>');
+    expect(withSymbol).toContain('class="segmented__word">Multiply');
+
+    const wordOnly = render(
+      <SegmentedControl
+        label="Paper"
+        value="a4"
+        onChange={() => {}}
+        options={options}
+      />,
+    );
+    expect(wordOnly).not.toContain("segmented__word");
+  });
 });
 
 describe("Range", () => {
@@ -117,13 +144,31 @@ describe("Range", () => {
     expect(html).toContain("14 pt");
   });
 
-  it("hides the readout from the screen reader that already has it", () => {
-    // A range announces its own value on every change. A live number beside it
-    // is either duplicate speech or speech in the wrong order.
+  it("says the formatted value rather than the number behind it", () => {
+    // The whole reason `format` exists is that 14 reads as "14 pt" and 625 as
+    // "⅝ in". Hiding the readout without this leaves a screen-reader user with
+    // the raw slider number in exactly the case the formatting was for.
+    const html = render(
+      <Range
+        label="Type size"
+        value={14}
+        onChange={() => {}}
+        min={8}
+        max={24}
+        format={(pt) => `${pt} pt`}
+      />,
+    );
+    expect(html).toContain('aria-valuetext="14 pt"');
+  });
+
+  it("hides the readout only because aria-valuetext carries it", () => {
+    // Unformatted, there is nothing to add: the attribute is left off so the
+    // platform's own announcement stands rather than being restated.
     const html = render(
       <Range label="Columns" value={3} onChange={() => {}} min={1} max={6} />,
     );
     expect(html).toContain('aria-hidden="true"');
+    expect(html).not.toContain("aria-valuetext");
   });
 });
 
@@ -151,15 +196,72 @@ describe("NumberStepper", () => {
     expect(html).toContain('aria-label="Increase problems"');
   });
 
-  it("stops offering a direction it can't go", () => {
-    expect(stepper({ value: 5 })).toContain("disabled");
-    expect(stepper({ value: 60 })).toContain("disabled");
-    expect(stepper()).not.toContain("disabled");
+  it("marks the direction it can't go without taking the focus with it", () => {
+    // Which button says it is out of road matters, so the assertion is
+    // positional: disabling both, or the wrong one, would pass a bare
+    // `toContain("disabled")`.
+    const atMin = stepper({ value: 5 });
+    expect(atMin).toMatch(
+      /aria-label="Decrease problems"[^>]*aria-disabled="true"/,
+    );
+    expect(atMin).not.toMatch(
+      /aria-label="Increase problems"[^>]*aria-disabled/,
+    );
+
+    const atMax = stepper({ value: 60 });
+    expect(atMax).toMatch(
+      /aria-label="Increase problems"[^>]*aria-disabled="true"/,
+    );
+    expect(atMax).not.toMatch(
+      /aria-label="Decrease problems"[^>]*aria-disabled/,
+    );
+
+    expect(stepper()).not.toContain("aria-disabled");
+
+    // And never the real attribute for a bound: a browser blurs a disabled
+    // element, so a keyboard user pressing − to the minimum would land on
+    // <body> and Tab would restart at the top of the page. The caller's own
+    // `disabled` is a different thing and stays real.
+    expect(atMin).not.toContain(" disabled");
+    expect(stepper({ disabled: true })).toContain(" disabled");
   });
 
   it("prints a unit without letting it into the value", () => {
     const html = stepper({ label: "Type size in points", unit: "pt" });
     expect(html).toContain(">pt<");
     expect(html).toContain('value="20"');
+  });
+});
+
+/**
+ * The draft/commit rule, tested as a function.
+ *
+ * There is no jsdom here, so the state machine is only reachable as the pure
+ * decision it was extracted into — which is the half worth protecting anyway:
+ * what a box holding "12.5", "abc" or "300" should hand the caller.
+ */
+describe("commitValue", () => {
+  const commit = (draft: string, current = 20, step = 1) =>
+    commitValue(draft, current, 5, 60, step);
+
+  it("keeps what was there when the box says nothing usable", () => {
+    expect(commit("")).toBe(20);
+    expect(commit("   ")).toBe(20);
+    expect(commit("abc")).toBe(20);
+  });
+
+  it("clamps rather than refusing", () => {
+    expect(commit("3")).toBe(5);
+    expect(commit("300")).toBe(60);
+    expect(commit("40")).toBe(40);
+  });
+
+  it("snaps to the step grid, measured from the minimum", () => {
+    // "A small whole number" is the module's first line; 12.5 is not one.
+    expect(commit("12.5")).toBe(13);
+    // Grid of 5 from a minimum of 5: 5, 10, 15 … so 23 is not an option.
+    expect(commit("23", 20, 5)).toBe(25);
+    // Rounding up off the last cell is clamped back inside the bound.
+    expect(commit("59", 20, 5)).toBe(60);
   });
 });

--- a/src/components/ui/kit.test.tsx
+++ b/src/components/ui/kit.test.tsx
@@ -1,0 +1,165 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { Checkbox } from "./Checkbox";
+import { NumberStepper } from "./NumberStepper";
+import { Range } from "./Range";
+import { SegmentedControl } from "./SegmentedControl";
+
+/**
+ * What the four option-panel primitives owe an assistive technology.
+ *
+ * These assertions all have the same shape, because the design decision they
+ * are protecting is the same one: **every primitive is a real control.** A
+ * radio group built from `<Button pressed>`, a spinbutton built from a span,
+ * a slider built from a draggable div — each of them looks identical on screen
+ * and each of them costs the keyboard, the announced role and the announced
+ * value. So the test does not simulate a key press; it checks that the element
+ * which receives one is the element the platform already knows how to drive.
+ *
+ * The other half is naming. A control announces as "checkbox" whether or not
+ * anyone said what it is for, so an unnamed one fails silently in exactly the
+ * place nobody looks — which is why `label` is required on three of the four
+ * and asserted here rather than trusted.
+ */
+
+const render = (node: React.ReactElement) => renderToStaticMarkup(node);
+
+describe("Checkbox", () => {
+  it("is a real checkbox inside its label, so the row is the hit target", () => {
+    const html = render(
+      <Checkbox
+        checked
+        onChange={() => {}}
+        label="Include negatives"
+        hint="Answers below zero"
+      />,
+    );
+    expect(html).toContain("<label");
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain("checked");
+    expect(html).toContain("Include negatives");
+    expect(html).toContain("Answers below zero");
+  });
+
+  it("says when it is off, rather than leaving the attribute out", () => {
+    const html = render(
+      <Checkbox checked={false} onChange={() => {}} label="Answer key" />,
+    );
+    expect(html).not.toContain("checked");
+  });
+});
+
+describe("SegmentedControl", () => {
+  const options = [
+    { value: "letter" as const, label: "Letter" },
+    { value: "a4" as const, label: "A4" },
+    { value: "legal" as const, label: "Legal", disabled: true },
+  ];
+
+  it("is one named radio group, not a row of unrelated toggles", () => {
+    const html = render(
+      <SegmentedControl
+        label="Paper"
+        value="a4"
+        onChange={() => {}}
+        options={options}
+      />,
+    );
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain('aria-label="Paper"');
+
+    // Three radios sharing one name is what makes them one group: arrow keys
+    // move between them and Tab treats the set as a single stop.
+    const names = [...html.matchAll(/name="([^"]+)"/g)].map((m) => m[1]);
+    expect(names.length).toBe(3);
+    expect(new Set(names).size).toBe(1);
+    expect(html.match(/type="radio"/g)?.length).toBe(3);
+    expect(html.match(/checked/g)?.length).toBe(1);
+    expect(html).toContain("disabled");
+  });
+
+  it("gives a symbol its words", () => {
+    // "×" is read as "times" by one screen reader and "multiplication sign" by
+    // another; `title` is what settles it, and it doubles as the tooltip.
+    const html = render(
+      <SegmentedControl
+        label="Operation"
+        value="mul"
+        onChange={() => {}}
+        options={[{ value: "mul", label: "×", title: "Multiplication" }]}
+      />,
+    );
+    expect(html).toContain('aria-label="Multiplication"');
+    expect(html).toContain('title="Multiplication"');
+    expect(html).toContain("×");
+  });
+});
+
+describe("Range", () => {
+  it("is a real slider, named, bounded and stepped", () => {
+    const html = render(
+      <Range
+        label="Type size"
+        value={14}
+        onChange={() => {}}
+        min={8}
+        max={24}
+        step={2}
+        format={(pt) => `${pt} pt`}
+      />,
+    );
+    expect(html).toContain('type="range"');
+    expect(html).toContain('aria-label="Type size"');
+    expect(html).toContain('min="8"');
+    expect(html).toContain('max="24"');
+    expect(html).toContain('step="2"');
+    expect(html).toContain("14 pt");
+  });
+
+  it("hides the readout from the screen reader that already has it", () => {
+    // A range announces its own value on every change. A live number beside it
+    // is either duplicate speech or speech in the wrong order.
+    const html = render(
+      <Range label="Columns" value={3} onChange={() => {}} min={1} max={6} />,
+    );
+    expect(html).toContain('aria-hidden="true"');
+  });
+});
+
+describe("NumberStepper", () => {
+  const stepper = (props: Partial<Parameters<typeof NumberStepper>[0]> = {}) =>
+    render(
+      <NumberStepper
+        label="Problems"
+        value={20}
+        onChange={() => {}}
+        min={5}
+        max={60}
+        {...props}
+      />,
+    );
+
+  it("is a real number field between two named buttons", () => {
+    const html = stepper();
+    expect(html).toContain('type="number"');
+    expect(html).toContain('aria-label="Problems"');
+    expect(html).toContain('value="20"');
+    // Named after the thing they change, so a panel of steppers doesn't
+    // announce as "increase, increase, increase".
+    expect(html).toContain('aria-label="Decrease problems"');
+    expect(html).toContain('aria-label="Increase problems"');
+  });
+
+  it("stops offering a direction it can't go", () => {
+    expect(stepper({ value: 5 })).toContain("disabled");
+    expect(stepper({ value: 60 })).toContain("disabled");
+    expect(stepper()).not.toContain("disabled");
+  });
+
+  it("prints a unit without letting it into the value", () => {
+    const html = stepper({ label: "Type size in points", unit: "pt" });
+    expect(html).toContain(">pt<");
+    expect(html).toContain('value="20"');
+  });
+});

--- a/src/components/ui/kit.tsx
+++ b/src/components/ui/kit.tsx
@@ -17,6 +17,14 @@ export { Input, type InputProps } from "./Input";
 export { TextArea, type TextAreaProps } from "./TextArea";
 export { Field, FieldSet } from "./Field";
 export { Select, type SelectOption, type SelectProps } from "./Select";
+export { Checkbox, type CheckboxProps } from "./Checkbox";
+export {
+  SegmentedControl,
+  type SegmentedControlProps,
+  type SegmentedOption,
+} from "./SegmentedControl";
+export { Range, type RangeProps } from "./Range";
+export { NumberStepper, type NumberStepperProps } from "./NumberStepper";
 
 export function Avatar({
   profile,
@@ -87,6 +95,13 @@ export function Stat({ value, label }: { value: ReactNode; label: string }) {
   );
 }
 
+/**
+ * A switch: one setting, on or off, acting the moment it moves.
+ *
+ * `Checkbox` is the other half of this pair and the choice between them is
+ * about consequence, not looks — see its doc block. A switch that only takes
+ * effect when something else is pressed is lying about itself.
+ */
 export function Toggle({
   checked,
   onChange,

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -260,6 +260,110 @@
   outline-offset: 3px;
 }
 
+/* ── Checkbox ──────────────────────────────────────────────────────────────
+   The native box, resized and recoloured — see Checkbox.tsx for why it isn't
+   redrawn. `accent-color` is doing the theming, which means the tick, the
+   fill, the focus ring and forced-colours mode all remain the platform's job.
+
+   The row is the hit target, not the box: the <input> sits inside the <label>,
+   so 1.35rem of checkbox is backed by a 2.75rem line of clickable label.      */
+
+.checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--gap-2);
+  min-height: 2.75rem;
+  padding: 0.4rem 0;
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox__box {
+  flex: none;
+  width: 1.35rem;
+  height: 1.35rem;
+  /* Optically centred against the first line of the label rather than its box,
+     which is what stops a two-line label pushing the tick down with it. */
+  margin-top: 0.15em;
+  accent-color: var(--go);
+  cursor: pointer;
+}
+
+.checkbox:has(.checkbox__box:disabled) {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.checkbox__text {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.checkbox__hint {
+  font-size: var(--step--2);
+  color: var(--chalk-dim);
+}
+
+/* ── Range ─────────────────────────────────────────────────────────────────
+   A slider big enough to grab. The thumb is styled per engine because there is
+   no standard pseudo-element for it yet; both branches say the same thing, and
+   the track heights have to match or the thumb sits off-centre in one of them. */
+
+.range {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-2);
+}
+
+.range__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  /* Tall enough to hit; the visible track is the 0.5rem drawn inside it. */
+  height: 2.2rem;
+  appearance: none;
+  background: none;
+  cursor: pointer;
+}
+
+.range__input::-webkit-slider-runnable-track {
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--ink-600);
+}
+
+.range__input::-moz-range-track {
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--ink-600);
+}
+
+.range__input::-webkit-slider-thumb {
+  appearance: none;
+  width: 1.6rem;
+  height: 1.6rem;
+  /* (track − thumb) ÷ 2, which is what centres a thumb on a WebKit track. */
+  margin-top: -0.55rem;
+  border-radius: 50%;
+  background: var(--go);
+  border: 2px solid var(--go-ink);
+}
+
+.range__input::-moz-range-thumb {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  background: var(--go);
+  border: 2px solid var(--go-ink);
+}
+
+.range__value {
+  flex: none;
+  min-width: 3.5ch;
+  text-align: right;
+  font-size: var(--step--1);
+  color: var(--chalk-soft);
+}
+
 /* ── Badges ────────────────────────────────────────────────────────────── */
 
 .badge {

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -150,6 +150,36 @@
   opacity: 0.75;
 }
 
+/* The <SegmentedControl> form of the same row: each pill is a <label> around a
+   radio, so the cursor and the focus ring the browser gives a <button> have to
+   be said out loud. The input is clipped rather than `display: none` — it still
+   has to take focus and answer the arrow keys, which is the whole reason the
+   primitive uses radios (see SegmentedControl.tsx). */
+
+label.segmented__btn {
+  cursor: pointer;
+  user-select: none;
+}
+
+.segmented__radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+}
+
+.segmented__btn:has(.segmented__radio:focus-visible) {
+  outline: 3px solid var(--go);
+  outline-offset: 3px;
+}
+
+.segmented__btn:has(.segmented__radio:disabled) {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .segmented--slim .segmented__btn {
   padding: 0.3em 0.75em;
   font-family: var(--font-mono);

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -157,6 +157,7 @@
    primitive uses radios (see SegmentedControl.tsx). */
 
 label.segmented__btn {
+  position: relative; /* the clipped radio below is positioned against this */
   cursor: pointer;
   user-select: none;
 }

--- a/src/styles/screens.css
+++ b/src/styles/screens.css
@@ -452,7 +452,12 @@
    in a box you can type into (<NumberStepper>). The buttons either side are the
    same `.stepper__btn`, so the two forms sit at the same size on a panel.      */
 
-.stepper__btn:disabled {
+/* Both spellings dim the same way. <NumberStepper> marks a button that has hit
+   its bound with `aria-disabled` rather than `disabled`, so that the button
+   keeps focus instead of dumping a keyboard user on <body> (see its doc
+   block) — the look must not depend on which of the two it is.              */
+.stepper__btn:disabled,
+.stepper__btn[aria-disabled="true"] {
   opacity: 0.4;
   cursor: default;
 }

--- a/src/styles/screens.css
+++ b/src/styles/screens.css
@@ -448,6 +448,53 @@
   text-align: center;
 }
 
+/* `.stepper__value` is a number you read; `.stepper__field` is the same number
+   in a box you can type into (<NumberStepper>). The buttons either side are the
+   same `.stepper__btn`, so the two forms sit at the same size on a panel.      */
+
+.stepper__btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.stepper__field {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  border: 1.5px solid var(--hairline);
+  background: var(--ink-900);
+}
+
+.stepper__field:focus-within {
+  border-color: var(--accent);
+}
+
+.stepper__input {
+  /* Fixed at four digits plus a caret, so the row never jumps as it counts. */
+  width: 4.5ch;
+  border: none;
+  background: none;
+  font-size: var(--step-1);
+  font-weight: 700;
+  text-align: center;
+  /* The two buttons are the affordance. The native spinners are three pixels
+     tall, which promises a target that is not one. */
+  appearance: textfield;
+}
+
+.stepper__input::-webkit-outer-spin-button,
+.stepper__input::-webkit-inner-spin-button {
+  appearance: none;
+  margin: 0;
+}
+
+.stepper__unit {
+  font-size: var(--step--1);
+  color: var(--chalk-dim);
+}
+
 /* ── Top bar ───────────────────────────────────────────────────────────── */
 
 .topbar {


### PR DESCRIPTION
Closes #56.

## What

Adds the four kit primitives the printable-sheet builder (PRINT13) needs, so feature code has something to compose instead of hand-rolling native controls:

| Primitive | Built on | Why that and not the obvious shortcut |
| --- | --- | --- |
| `Checkbox` | native `<input type="checkbox">` + `accent-color` | the tick, the focus ring and forced-colours mode stay the platform's job |
| `SegmentedControl` | radios sharing a `useId()` name | arrow keys, one tab stop for the set, announced as "one of four" — not four unrelated toggles |
| `Range` | native `<input type="range">` | real slider role and value, `aria-valuetext` carrying the formatted readout |
| `NumberStepper` | `<input type="number">` between two big targets | range and arrow keys from the platform, not from three key handlers |

Each lives in its own module under `src/components/ui/`, carries a doc block saying what it is for and what it deliberately does not do, and is re-exported from `kit.tsx` — still the single import path.

## Why it looks like this

The one decision here, made four times: **a control that only looks accessible isn't one.** A radio group built from `<Button pressed>`, a spinbutton built from a span, a slider built from a draggable div — each renders identically and each costs the keyboard, the announced role and the announced value.

Two consequences worth calling out:

- **Naming is required, not offered.** A control announces as "checkbox" whether or not anyone said what it is for, so an unnamed one fails silently where nobody looks. `label` is mandatory on three of the four, and a stepper's buttons are named after the number they move so a panel of them doesn't read as "increase, increase, increase".
- **`NumberStepper` never disables the button holding focus.** Reaching the minimum by keyboard would blur the element under the user and drop focus to `<body>`, restarting the next Tab at the top of the page. Bounds are announced with `aria-disabled` and `nudge` no-ops instead; the dimmed look is unchanged because the CSS matches both spellings.

Typed input is decided by `commitValue`, a pure exported function that clamps, snaps to the `step` grid measured from `min`, and falls back to the value already there for an empty box or a typo — so a field documented as "a small whole number" can't commit `12.5`.

## Hit targets

The youngest player is five: a 1.35rem tick box backed by a 2.75rem row of clickable label; a 1.6rem thumb in a 2.2rem track; the existing 2.4rem `.stepper__btn`. The visually-hidden radios are clipped rather than `display: none` because they still have to take focus — the pill wears the ring for them via `:has()`.

## Boundaries

Nothing imports a service, a game or an engine value. `SegmentedControl` is generic in `T extends string`, so a caller keyed on a union gets that union back from `onChange` without the kit ever learning what a paper size is. `rawControlsAllowlist` and `maxLinesAllowlist` were already drained to zero by KIT01–KIT04, so there was no entry left for these to retire — the native-controls ban keeps its zero exceptions.

## Tests

`src/components/ui/kit.test.tsx` covers keyboard operation and labelling for each primitive, the stepper's bound behaviour with positional disabled assertions (an implementation that disabled *both* buttons would have passed the old one), and `commitValue` as the state machine it became.

## Out of scope

The builder itself — PRINT13.

## Validation

`npm run type-check`, `npm run lint`, `npm run test:unit` (677 passing), `npm run build` (static, 67 pages) and the browser smoke test all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
