### PR TITLE
PRINT13: the bench, where a sheet gets made

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -679,13 +679,24 @@ of the 300-line cap — which is the right pressure for a screen like this.
 
 ```
 src/games/printshop/
-  App.tsx            mount, routing between picker and editor
+  App.tsx            mount, and what goes where
+  useBuilder.ts      the config, the seed, and the URL they live in
+  defaults.ts        what the bench opens on, per family
   Picker.tsx         choose a family (the catalog, in-app)
-  Editor.tsx         the option panel for the chosen family
+  PageOptions.tsx    the options every sheet has, whatever is on it
   Preview.tsx        the sheet, scaled, on the press-room ground
-  PrintBar.tsx       print · variants · answer key · save
+  PrintBar.tsx       print · variants · answer key · share
+  SavedSheets.tsx    My Sheets, through services/sheets.ts
+  options/index.tsx  the registry — the one place `kind` is narrowed
+  options/parts.tsx  choice · range · sizing · pool
   options/*.tsx      one panel per family
 ```
+
+Built as it stands, with two names moved from this sketch: the per-family panel
+is `options/*.tsx` alone (there is no `Editor` wrapping it), and what was going
+to be `Editor.tsx` turned out to be `PageOptions.tsx` — the options that belong
+to no family. The reading half of `#s=` lives in `engine/sheets/share.ts` beside
+the encoder rather than in the builder, because the two are one format.
 
 **Live preview**, scaled with `transform: scale()` inside a dark frame. Debounce
 regeneration; a sheet with 200 problems is cheap but not free.

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -227,6 +227,57 @@ try {
   await page.waitForTimeout(900);
   check("the shared link reopens the same sheet", page.url() === shared);
 
+  /*
+   * Where the paper actually lands on the paper.
+   *
+   * Print is the whole output path here (§10) — there is no PDF render to
+   * notice a problem in first — and the failure mode is invisible on screen by
+   * construction: the preview is a separate, scaled copy, so a bench that
+   * indents or offsets the *print* copy looks perfect right up until the
+   * printer runs. It cost 18px off the right edge of Letter and a second sheet
+   * of paper once already.
+   *
+   * The assertion is the whole contract in two numbers. `print.css` zeroes the
+   * `@page` margin because the sheet owns its own geometry, so a correctly
+   * printed sheet starts at 0,0 — the same box a catalog page gives it, which
+   * is measured here too rather than assumed. Anything between the sheet and
+   * the page box shows up as a non-zero offset and nothing else does.
+   */
+  log("\n7. The printed sheet is the paper, not a sheet inside a layout");
+  await page.emulateMedia({ media: "print" });
+  await page.waitForTimeout(400);
+  const benchBox = await page
+    .locator(".print-only .sheet")
+    .first()
+    .boundingBox();
+  check(
+    "the builder's printed sheet starts at the corner of the page",
+    benchBox !== null &&
+      Math.round(benchBox.x) === 0 &&
+      Math.round(benchBox.y) === 0,
+    JSON.stringify(benchBox),
+  );
+  // 8.5in at 96dpi. A sheet that measures anything else has had a transform or
+  // a scale leak onto it, which is a ⅝ rule that prints as something else.
+  check(
+    "and is 8.5in wide, unscaled",
+    benchBox !== null && Math.round(benchBox.width) === 816,
+    JSON.stringify(benchBox),
+  );
+
+  await page.goto(`${BASE}/printables/lined-paper`, {
+    waitUntil: "networkidle",
+  });
+  const catalogBox = await page.locator(".sheet").first().boundingBox();
+  check(
+    "a catalog page puts the same sheet in the same place",
+    catalogBox !== null &&
+      Math.round(catalogBox.x) === 0 &&
+      Math.round(catalogBox.y) === 0,
+    JSON.stringify(catalogBox),
+  );
+  await page.emulateMedia({ media: null });
+
   log(
     `\nconsole errors: ${errors.length ? errors.slice(0, 5).join(" | ") : "none"}`,
   );

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -49,12 +49,12 @@ try {
     .getByRole("button", { name: /add a player/i })
     .first()
     .click();
-  await page.waitForSelector(".sheet__panel", { timeout: 8000 });
+  await page.waitForSelector(".modal__panel", { timeout: 8000 });
   // The name field carries no explicit type, and age is a −/+ stepper
   // rather than a number input — so target the panel, not input types.
-  await page.locator(".sheet__panel input").first().fill("Smoke");
+  await page.locator(".modal__panel input").first().fill("Smoke");
   await page.getByRole("button", { name: /^add player$/i }).click();
-  await page.waitForSelector(".sheet__panel", {
+  await page.waitForSelector(".modal__panel", {
     state: "detached",
     timeout: 8000,
   });
@@ -178,6 +178,54 @@ try {
     "profile still listed after reload",
     (await page.getByText("Smoke").count()) > 0,
   );
+
+  /*
+   * The second island, and the second thing that writes to that database.
+   *
+   * Worth walking for the same reason the race is: the builder is a config in
+   * the address bar, a sheet built from it in the browser, and a record in the
+   * `sheets` store — three things that type-check perfectly and fail on first
+   * click. The reload at the end is the one that matters, because it proves the
+   * URL is genuinely the save file rather than something that only looks right
+   * while the state is still in memory.
+   */
+  log("\n6. The bench builds a sheet, and the URL is the save file");
+  await page.goto(`${BASE}/printables/make`, { waitUntil: "networkidle" });
+  await page.waitForSelector(".bench", { timeout: 15000 });
+  await page.waitForTimeout(900);
+  check(
+    "a sheet is on the bench",
+    (await page.locator(".preview .sheet__problem").count()) > 0,
+  );
+  check("the config is in the fragment", /#s=/.test(page.url()), page.url());
+
+  await page.locator(".saved input").fill("Smoke sheet");
+  await page.getByRole("button", { name: /save to my sheets/i }).click();
+  await page.waitForTimeout(800);
+  const savedSheets = await page.evaluate(async () => {
+    const db = await new Promise((res) => {
+      const r = indexedDB.open("schoolskills");
+      r.onsuccess = () => res(r.result);
+    });
+    return new Promise((res) => {
+      const tx = db
+        .transaction("sheets", "readonly")
+        .objectStore("sheets")
+        .getAll();
+      tx.onsuccess = () => res(tx.result.map((s) => s.name));
+    });
+  });
+  check(
+    "sheet saved to IndexedDB",
+    savedSheets.includes("Smoke sheet"),
+    JSON.stringify(savedSheets),
+  );
+
+  const shared = page.url();
+  await page.reload({ waitUntil: "networkidle" });
+  await page.waitForSelector(".bench", { timeout: 15000 });
+  await page.waitForTimeout(900);
+  check("the shared link reopens the same sheet", page.url() === shared);
 
   log(
     `\nconsole errors: ${errors.length ? errors.slice(0, 5).join(" | ") : "none"}`,

--- a/src/components/PlayerEditor.tsx
+++ b/src/components/PlayerEditor.tsx
@@ -76,7 +76,10 @@ export default function PlayerEditor({ profile, onClose, onDeleted }: Props) {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  async function save(event: React.FormEvent) {
+  // `SyntheticEvent` rather than `FormEvent`, which React's own types now mark
+  // deprecated on the grounds that it "doesn't actually exist" — a submit is a
+  // plain synthetic event, and that is all this needs from it.
+  async function save(event: React.SyntheticEvent) {
     event.preventDefault();
     if (!name.trim() || saving) return;
     setSaving(true);
@@ -120,14 +123,14 @@ export default function PlayerEditor({ profile, onClose, onDeleted }: Props) {
 
   return (
     <div
-      className="sheet"
+      className="modal"
       role="dialog"
       aria-modal="true"
       aria-label={isNew ? "Add a player" : `Edit ${profile.name}`}
     >
       <Scrim onClose={onClose} label="Close without saving" />
       <form
-        className="sheet__panel panel anim-pop"
+        className="modal__panel panel anim-pop"
         onSubmit={save}
         style={{ "--accent": color } as React.CSSProperties}
       >
@@ -215,10 +218,10 @@ export default function PlayerEditor({ profile, onClose, onDeleted }: Props) {
           </div>
         </FieldSet>
 
-        <div className="sheet__actions">
+        <div className="modal__actions">
           {!isNew &&
             (confirmingDelete ? (
-              <div className="sheet__confirm">
+              <div className="modal__confirm">
                 <span>Remove {profile.name} and all their races?</span>
                 <Button
                   variant="danger"

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -1338,6 +1338,27 @@ describe("print isolation", () => {
     }
   });
 
+  it("takes the builder's own layout out from under the sheet", () => {
+    // `.no-print` empties the bench's columns; it does not remove them. A print
+    // copy left inside a live two-column grid prints indented by the bench's
+    // padding and a row down from where the preview was — on Letter, 18px off
+    // the right edge of the paper and a full-page sheet onto a second one. It
+    // cannot be seen on screen, because the preview is a separate scaled copy.
+    //
+    // The smoke run measures the real box in a browser, which is the only place
+    // that can. This is the fast half: the two lines that make it possible.
+    const css = read(join(ROOT, "src/styles/printshop.css"));
+    const print = css.slice(css.indexOf("@media print"));
+    expect(print).toMatch(/\.bench\s*\{[^}]*display:\s*block/);
+    expect(print).toMatch(/\.bench\s*\{[^}]*padding:\s*0/);
+    expect(print).toMatch(/\.bench\s*\{[^}]*max-width:\s*none/);
+
+    // And the column itself, not only the two controls inside it — an empty
+    // grid item still occupies the row above the paper.
+    const app = read(join(ROOT, "src/games/printshop/App.tsx"));
+    expect(app).toMatch(/className="bench__paper[^"]*\bno-print\b/);
+  });
+
   it("breaks pages where a reader would expect it to", () => {
     const css = read(join(ROOT, "src/styles/sheet.css"));
     expect(css).toContain("break-after: page");

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -1391,24 +1391,45 @@ describe("the zero-JavaScript property", () => {
   /*
    * The same property, against the built output.
    *
-   * Two things would show up in `dist/` if a sheet were ever hydrated: an
-   * `<astro-island>` naming the renderer, and the renderer's own class names
-   * inside a JavaScript chunk. Neither is there while every mount is
-   * directive-free — which is the point, and is why this passes before the
-   * first catalog page exists and keeps passing after PRINT03 adds one.
+   * An `<astro-island>` is the one thing that would show up in `dist/` if a
+   * sheet were ever hydrated, and it is the whole tell: an island is how a
+   * component's JavaScript reaches a page at all, so a page that prints a sheet
+   * and carries no island has shipped no renderer, whatever is in the chunks
+   * beside it.
+   *
+   * This used to scan every JavaScript chunk for the renderer's class names.
+   * That stopped being the property once the builder landed — `/printables/make`
+   * hydrates a `SheetView` on purpose, so the classes are legitimately in a
+   * chunk now — and scanning them would have to grow an exception, which is the
+   * point at which a test stops meaning anything. What matters was never "the
+   * renderer is nowhere in the bundle": it is "no page that IS a sheet needs
+   * JavaScript to be one", which is what this asserts and what §2 claims.
    */
-  it("ships no sheet renderer in the built JavaScript", () => {
+  it("ships no sheet renderer to a page that is a sheet", () => {
     const dist = join(ROOT, "dist");
     if (!existsSync(dist)) return; // `npm run build` hasn't run yet.
 
-    for (const script of filesUnder(join(dist, "_astro"), [".js"])) {
-      expect(read(script)).not.toContain("sheet__glyph");
-      expect(read(script)).not.toContain("sheet__blocks");
-    }
+    let checked = 0;
     for (const page of filesUnder(dist, [".html"])) {
       const html = read(page);
       if (!/class="[^"]*\bsheet\b/.test(html)) continue;
       expect(html).not.toContain("astro-island");
+      checked += 1;
     }
+    // Guards the guard: a rename of `.sheet` would otherwise turn this into a
+    // loop over nothing that passes for the wrong reason.
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  it("is hydrated on the builder, which is why the builder is noindex", () => {
+    const builder = join(ROOT, "dist/printables/make/index.html");
+    if (!existsSync(builder)) return;
+
+    const html = read(builder);
+    // The exception, stated rather than implied. The bench has to run the
+    // renderer — a live preview is the whole feature — and the page pays for it
+    // with `noindex` rather than by pretending to be crawlable content.
+    expect(html).toContain("astro-island");
+    expect(html).toMatch(/<meta name="robots" content="[^"]*noindex/);
   });
 });

--- a/src/components/sheet/Sheet.tsx
+++ b/src/components/sheet/Sheet.tsx
@@ -32,7 +32,7 @@ import { BlockView } from "./blocks";
 import type { SheetMetrics } from "./metrics";
 import { SheetFoot } from "./SheetFoot";
 import { SheetHead } from "./SheetHead";
-import { inch, pt } from "./units";
+import { DASH_CUT, HEAVY, inch, pt } from "./units";
 
 export function SheetView({ sheet }: { sheet: Sheet }) {
   const page = pageSize(sheet.paper);
@@ -49,6 +49,12 @@ export function SheetView({ sheet }: { sheet: Sheet }) {
       // rather than a different kind of sheet — and a stylesheet that wants to
       // mark up the answers can reach it either way.
       data-answers={sheet.answers ? "true" : undefined}
+      // The same reasoning twice more. A face and a boxed answer place are how
+      // this sheet is drawn rather than what is on it, so both are one
+      // attribute here and one rule in sheet.css — where a font stack belongs
+      // anyway — instead of a class threaded down through every block.
+      data-font={sheet.font}
+      data-answer-box={sheet.answerBox ? "true" : undefined}
       style={
         {
           "--sheet-w": inch(page.width),
@@ -59,6 +65,7 @@ export function SheetView({ sheet }: { sheet: Sheet }) {
       }
     >
       <PageSize paper={sheet.paper} />
+      {sheet.cutLines && <CutLines paper={sheet.paper} />}
       <SheetHead header={sheet.header} />
       <div className="sheet__blocks">
         {/* Indexed keys: a block has no identity of its own, the list is
@@ -87,6 +94,55 @@ export function SheetView({ sheet }: { sheet: Sheet }) {
  * A `<style>` element, not a script. It costs nothing at run time and keeps the
  * page free of JavaScript.
  */
+/**
+ * Where to cut, drawn over the paper rather than in the flow.
+ *
+ * The `cutline` block is the other way of saying this and the two are not
+ * interchangeable: a block is a row in the document that takes a quarter of an
+ * inch a family had to reserve for it, which is why only a family can emit one.
+ * This is the parent's switch (§17), so it has to cost nothing — an overlay
+ * takes no height at all, which is the only reason `cutLines` can be an option
+ * every family shares without any of them re-doing their capacity arithmetic.
+ *
+ * Both halves of the page, always. Cutting once down the middle and cutting
+ * into quarters are the 2-up and 4-up layouts of §17, and which one a parent
+ * wanted is a decision they make with the scissors — a guide that is not
+ * followed costs nothing, and a guide that is missing costs a re-print.
+ */
+function CutLines({ paper }: { paper: Paper }) {
+  const { width, height } = pageSize(paper);
+  return (
+    <svg
+      className="sheet__ink sheet__cuts"
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label="Cut along these lines"
+    >
+      {/* HEAVY and the long dash for the same reason `Cutline` uses them: a cut
+          line is read before it is used, and it must not be mistaken for a rule
+          to write on. */}
+      <line
+        className="sheet__rule sheet__rule--cut"
+        x1={0}
+        x2={width}
+        y1={height / 2}
+        y2={height / 2}
+        strokeWidth={HEAVY}
+        strokeDasharray={DASH_CUT}
+      />
+      <line
+        className="sheet__rule sheet__rule--cut"
+        x1={width / 2}
+        x2={width / 2}
+        y1={0}
+        y2={height}
+        strokeWidth={HEAVY}
+        strokeDasharray={DASH_CUT}
+      />
+    </svg>
+  );
+}
+
 function PageSize({ paper }: { paper: Paper }) {
   if (paper.size === "letter" && paper.orientation === "portrait") return null;
   const { width, height } = pageSize(paper);

--- a/src/components/ui/kit.tsx
+++ b/src/components/ui/kit.tsx
@@ -199,7 +199,7 @@ export function usePrefersReducedMotion() {
 }
 
 /**
- * The dimmed backdrop behind a sheet, as a real control.
+ * The dimmed backdrop behind a modal, as a real control.
  *
  * It was a <div onClick> in the original, which is mouse-only: no focus, no
  * Enter/Space, invisible to a screen reader. Rendering a button gives all of
@@ -216,7 +216,7 @@ export function Scrim({
   return (
     <button
       type="button"
-      className="sheet__scrim"
+      className="modal__scrim"
       aria-label={label}
       onClick={onClose}
     />

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -69,13 +69,39 @@ export function listSheets(): SheetSpec[] {
 }
 
 /**
+ * The presentation half of `SheetOptions`, copied onto what a family built.
+ *
+ * Here rather than in fifteen `build` functions for the reason `chrome.ts`
+ * gives for living on its own: every family would otherwise write the same
+ * three lines, and the sixteenth one added would be the one that forgot. It is
+ * safe to do it after the fact because none of the three changes a length —
+ * the face is set in points, a bordered slot is the same line box as a ruled
+ * one, and the cut guides are drawn over the paper rather than in the flow —
+ * so nothing here can make a sheet the layout arithmetic already fitted stop
+ * fitting.
+ *
+ * A family that has already said something wins, which is what keeps this a
+ * default rather than an override: `UNKNOWN_SHEET` sets nothing and gets the
+ * parent's choices, and a family that one day sets its own is not quietly
+ * undone from out here.
+ */
+function present(config: SheetConfig, sheet: Sheet): Sheet {
+  return {
+    ...sheet,
+    font: sheet.font ?? config.font,
+    answerBox: sheet.answerBox ?? config.answerBox,
+    cutLines: sheet.cutLines ?? config.cutLines,
+  };
+}
+
+/**
  * Build a sheet. Deterministic in `(config, seed)`, which is the mechanism
  * behind three of the features in §7 rather than one: an answer key is the
  * same build, "another sheet like this one" is `seed + 1`, and a sheet is
  * reproducible from a shared URL because the seed is in it.
  */
 export function buildSheet(config: SheetConfig, seed: number): Sheet {
-  return sheetSpec(config.kind).build(config, seed);
+  return present(config, sheetSpec(config.kind).build(config, seed));
 }
 
 /**
@@ -87,7 +113,7 @@ export function buildSheet(config: SheetConfig, seed: number): Sheet {
  */
 export function answerKey(config: SheetConfig, seed: number): Sheet {
   const spec = sheetSpec(config.kind);
-  return spec.key(spec.build(config, seed));
+  return present(config, spec.key(spec.build(config, seed)));
 }
 
 /** One line naming what a config prints, for the catalog and the record. */

--- a/src/engine/sheets/paper.ts
+++ b/src/engine/sheets/paper.ts
@@ -119,6 +119,18 @@ export const DEFAULT_PAPER: Paper = {
  */
 export const DEFAULT_FONT_PT = 12;
 
+/**
+ * How far the body size may be moved, in points.
+ *
+ * Eight is the smallest a child is asked to read on paper and thirty-six is
+ * about one line of a Letter page, so the pair is the honest limit of "larger
+ * type as a first-class option rather than a zoom hack" (§17) rather than a
+ * guess. It lives here beside the default because both the builder's stepper
+ * and the guard on a config arriving from a URL have to agree about it, and two
+ * copies would eventually not.
+ */
+export const FONT_PT = { min: 8, max: 36 } as const;
+
 /** The sheet of paper itself, with landscape already applied. */
 export function pageSize(paper: Paper): { width: Mil; height: Mil } {
   const stock = own(PAPERS, paper.size, PAPERS.letter);

--- a/src/engine/sheets/share.test.ts
+++ b/src/engine/sheets/share.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { encodeSharedSheet, type SharedSheet } from "./share";
+import {
+  MAX_SHARE_PAYLOAD,
+  decodeSharedSheet,
+  encodeSharedSheet,
+  type SharedSheet,
+} from "./share";
 import type { MultiplicationConfig } from "./types";
 
 /**
@@ -69,5 +74,98 @@ describe("a shared sheet", () => {
     // a config to put one.
     const payload = decode(encodeSharedSheet({ config, seed: 3 }));
     expect(JSON.stringify(payload)).not.toMatch(/name"\s*:\s*"[^"]/);
+  });
+});
+
+/**
+ * The other half: what the builder does with whatever is after `#s=`.
+ *
+ * A fragment is untrusted input — it is whatever was in the address bar — and
+ * the failure being guarded against is not a stolen secret but a builder that
+ * throws on load and shows a parent a blank page instead of a worksheet. So
+ * every case below asserts the same thing in a different costume: it answers,
+ * and it answers with something a sheet can be built from.
+ */
+describe("reading a shared sheet back", () => {
+  const encoded = (shared: unknown) => encodeSharedSheet(shared as SharedSheet);
+
+  it("returns the sheet that was shared", () => {
+    const shared = { config, seed: 7 };
+    expect(decodeSharedSheet(encodeSharedSheet(shared))).toEqual(shared);
+  });
+
+  it("answers null rather than throwing on anything that isn't one", () => {
+    // Not base64, not JSON, not an object, no config, no kind — five ways of
+    // saying "whatever that was, the encoder did not write it".
+    for (const payload of [
+      "",
+      "!!!!",
+      encoded(42),
+      encoded({ seed: 1 }),
+      encoded({ config: {}, seed: 1 }),
+      encoded({ config, seed: "soon" }),
+      encoded({ config, seed: -1 }),
+      encoded({ config, seed: 1.5 }),
+    ]) {
+      expect(decodeSharedSheet(payload)).toBeNull();
+    }
+  });
+
+  it("caps how much it will decode", () => {
+    expect(decodeSharedSheet("A".repeat(MAX_SHARE_PAYLOAD + 1))).toBeNull();
+  });
+
+  it("replaces a paper size it has never heard of rather than carrying it", () => {
+    // The whole point of rebuilding the shared half rather than checking it: a
+    // config saying `size: "foolscap"` reaches `pageSize` on the very next
+    // line, and a preview that threw there is a bench that never opens.
+    const shared = decodeSharedSheet(
+      encoded({
+        config: { ...config, paper: { size: "foolscap", orientation: 7 } },
+        seed: 1,
+      }),
+    );
+    expect(shared?.config.paper).toEqual({
+      size: "letter",
+      orientation: "portrait",
+      margin: "normal",
+    });
+  });
+
+  it("holds the type size inside what a sheet can be set at", () => {
+    const huge = decodeSharedSheet(
+      encoded({ config: { ...config, fontPt: 4000 }, seed: 1 }),
+    );
+    expect(huge?.config.fontPt).toBe(36);
+  });
+
+  it("keeps the family's own fields", () => {
+    // Deliberately untouched: every family already treats its config as
+    // untrusted, because a config from a saved sheet always could be. Two
+    // validators would be one too many, and the second one goes stale.
+    const shared = decodeSharedSheet(encodeSharedSheet({ config, seed: 2 }));
+    expect((shared?.config as MultiplicationConfig).tables).toEqual(
+      config.tables,
+    );
+  });
+
+  it("prints no line the sheet did not ask for", () => {
+    // §1 from the reading end. A payload naming a field this build doesn't have
+    // gets none of it, and the three real ones come back in the printed order
+    // however they were written down.
+    const shared = decodeSharedSheet(
+      encoded({
+        config: { ...config, fields: ["class", "parent", "name", "name"] },
+        seed: 1,
+      }),
+    );
+    expect(shared?.config.fields).toEqual(["name", "class"]);
+  });
+
+  it("clips a title long enough to be an essay", () => {
+    const shared = decodeSharedSheet(
+      encoded({ config: { ...config, title: "x".repeat(500) }, seed: 1 }),
+    );
+    expect(shared?.config.title).toHaveLength(120);
   });
 });

--- a/src/engine/sheets/share.ts
+++ b/src/engine/sheets/share.ts
@@ -23,13 +23,26 @@
  * filled in by hand (§1), there is nowhere in a `SheetConfig` to put one, and a
  * shared link is exactly the surface where that would otherwise leak.
  *
- * Only the encoder lives here. Reading one of these back is the builder's job,
- * and it is a different job: a payload that arrives from outside this build is
- * untrusted input — length-capped, validated against the spec, and falling back
- * to defaults rather than throwing — which is a guard with nothing to guard
- * until there is something to open it in.
+ * Reading one back is a different job from writing one, and the harder half: a
+ * payload that arrives from outside this build is untrusted input, so the
+ * decoder is length-capped, checks what it decoded against the spec, and
+ * answers `null` rather than throwing. It sits here with the encoder because
+ * the two are one format — a guard written in the builder would be a second
+ * place the shape of `#s=` is written down, and the pair can be tested in plain
+ * Node without a browser to open a link in.
  */
-import type { SheetConfig } from "./types";
+import type {
+  HeaderField,
+  MarginSize,
+  Orientation,
+  Paper,
+  PaperSize,
+  SheetConfig,
+  SheetFont,
+  SheetOptions,
+} from "./types";
+
+import { DEFAULT_FONT_PT, FONT_PT, MARGINS, PAPERS } from "./paper";
 
 /** What a link carries: which sheet, and which one of them. */
 export type SharedSheet = { config: SheetConfig; seed: number };
@@ -52,4 +65,149 @@ export function encodeSharedSheet(shared: SharedSheet): string {
     .replaceAll("+", "-")
     .replaceAll("/", "_")
     .replace(/=+$/, "");
+}
+
+/* ── Reading one back ──────────────────────────────────────────────────────
+   Everything below treats the payload as hostile, because it is: a fragment is
+   whatever was in the address bar. The failure mode being guarded against is
+   not a stolen secret — there is nothing here to steal, and the fragment never
+   reaches a server — it is a builder that throws on load and shows a parent a
+   blank page instead of a worksheet.                                        */
+
+/**
+ * The longest payload worth decoding.
+ *
+ * A configured sheet is a few hundred characters; the biggest one this build
+ * can make — every table, every denominator, a title and an instruction — is
+ * under a thousand. Four kilobytes is room for several times that and still far
+ * too small to be worth handing to `JSON.parse` as a denial-of-service, which
+ * is the only thing a cap on a client-side decoder can buy.
+ */
+export const MAX_SHARE_PAYLOAD = 4096;
+
+/**
+ * Long enough for a real title, short enough that a URL can't carry an essay.
+ *
+ * Exported because the builder's own fields have to stop where the decoder
+ * stops. A box that accepted more than this would silently lose the tail of
+ * what somebody typed the first time the link was reopened, which is the worst
+ * of the three possible behaviours.
+ */
+export const MAX_TITLE = 120;
+export const MAX_INSTRUCTIONS = 400;
+
+const FIELDS: HeaderField[] = ["name", "date", "class"];
+const FONTS: SheetFont[] = ["print", "cursive", "dyslexic"];
+const ORIENTATIONS: Orientation[] = ["portrait", "landscape"];
+
+/** One of a known set, or the fallback. Never what the payload said. */
+function oneOf<T extends string>(value: unknown, allowed: T[], fallback: T): T {
+  return typeof value === "string" && (allowed as string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+function text(value: unknown, cap: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim().slice(0, cap);
+  return trimmed === "" ? undefined : trimmed;
+}
+
+function paperOf(value: unknown): Paper {
+  const raw = (value ?? {}) as Partial<Paper>;
+  return {
+    size: oneOf(raw.size, Object.keys(PAPERS) as PaperSize[], "letter"),
+    orientation: oneOf(raw.orientation, ORIENTATIONS, "portrait"),
+    margin: oneOf(raw.margin, Object.keys(MARGINS) as MarginSize[], "normal"),
+  };
+}
+
+/**
+ * The half of a config every family shares, rebuilt from what arrived.
+ *
+ * Rebuilt rather than checked: every field is taken from a known set or
+ * replaced, so what comes out is a `SheetOptions` whatever went in, and a
+ * payload carrying `paper: 7` produces Letter rather than an exception four
+ * modules downstream in `pageSize`.
+ *
+ * The family's own fields are passed through untouched, and that is a decision
+ * rather than an omission. Each family already treats its config as untrusted —
+ * counts are capped at what the page holds, tables are clamped, every lookup
+ * keyed by a saved string goes through `own()` — because a config from a
+ * *saved sheet* has always been able to say anything. Re-validating fifteen
+ * families' worth of fields here would be a second copy of those rules, and the
+ * second copy is the one that goes stale.
+ */
+function options(raw: Record<string, unknown>): SheetOptions {
+  // Filtered from the known list rather than from what arrived, so the order is
+  // ours and a payload asking for the name line four times gets it once.
+  const asked: unknown[] = Array.isArray(raw.fields) ? raw.fields : [];
+  const fields = FIELDS.filter((field) => asked.includes(field));
+  const fontPt = typeof raw.fontPt === "number" ? Math.round(raw.fontPt) : NaN;
+  const title = text(raw.title, MAX_TITLE);
+  const instructions = text(raw.instructions, MAX_INSTRUCTIONS);
+
+  // The four optional fields are omitted rather than written as `undefined` or
+  // `false`, so that decoding a link and re-encoding it produces the same link.
+  // A round trip that quietly grew `"answerBox":false` would make every URL a
+  // little longer each time somebody opened one and sent it on.
+  return {
+    paper: paperOf(raw.paper),
+    fontPt: Number.isFinite(fontPt)
+      ? Math.min(FONT_PT.max, Math.max(FONT_PT.min, fontPt))
+      : DEFAULT_FONT_PT,
+    fields,
+    ...(title ? { title } : {}),
+    ...(instructions ? { instructions } : {}),
+    ...(typeof raw.font === "string"
+      ? { font: oneOf(raw.font, FONTS, "print") }
+      : {}),
+    ...(raw.answerBox === true ? { answerBox: true } : {}),
+    ...(raw.cutLines === true ? { cutLines: true } : {}),
+  };
+}
+
+/**
+ * A shared sheet, or `null` if that isn't what the fragment held.
+ *
+ * `null` and not a thrown error, and not a default sheet either. The caller is
+ * the one screen that knows what to open on instead — a builder falls back to
+ * its own starting config, and telling it "there was nothing here" is a
+ * different thing from handing it a blank sheet that looks like a choice
+ * somebody made.
+ */
+export function decodeSharedSheet(payload: string): SharedSheet | null {
+  if (payload.length === 0 || payload.length > MAX_SHARE_PAYLOAD) return null;
+
+  let parsed: unknown;
+  try {
+    const padded = payload.replaceAll("-", "+").replaceAll("_", "/");
+    const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, "="));
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    // Not base64, not UTF-8, not JSON — three ways of saying the same thing:
+    // whatever is after `#s=` was not written by the encoder above.
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const shared = parsed as { config?: unknown; seed?: unknown };
+  if (typeof shared.config !== "object" || shared.config === null) return null;
+
+  const raw = shared.config as Record<string, unknown>;
+  if (typeof raw.kind !== "string" || raw.kind === "") return null;
+
+  // The seed decides *which* of the infinitely many sheets a config makes this
+  // is (§7). A fraction or a negative would still build — `mulberry32` starts
+  // with `seed >>> 0` — but it would build a different sheet than the one that
+  // was shared, which is the whole thing a link is for.
+  const seed = shared.seed;
+  if (typeof seed !== "number" || !Number.isSafeInteger(seed) || seed < 0)
+    return null;
+
+  return {
+    config: { ...raw, ...options(raw) } as SheetConfig,
+    seed,
+  };
 }

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -413,6 +413,30 @@ export type Block =
   | { kind: "cutline" }
   | { kind: "spacer"; height: Mil };
 
+/* ── Type ──────────────────────────────────────────────────────────────── */
+
+/**
+ * Which face a sheet is set in.
+ *
+ * Three names rather than a font stack, because the name is the part that has
+ * to survive: a sheet saved this term must still open on the face it was set
+ * in after the stacks behind these ids are replaced by self-hosted files
+ * (PRINT15). Until then each id resolves to whatever the reader's machine
+ * already has, which is honest — a parent who asked for a dyslexia-friendly
+ * face and has one installed gets it, and one who hasn't gets the default
+ * rather than a download.
+ *
+ * `dyslexic` is an accessibility option and not a style: §17 lists a
+ * dyslexia-friendly face beside larger type as a first-class choice rather than
+ * a zoom hack, and the reason is the same for both — the sheet stays real
+ * selectable text either way.
+ *
+ * It changes no length on the page. Every height the layout arithmetic
+ * reserves is computed from `fontPt`, in points, so swapping the face cannot
+ * push the last row onto a second sheet of paper.
+ */
+export type SheetFont = "print" | "cursive" | "dyslexic";
+
 /* ── The sheet ─────────────────────────────────────────────────────────── */
 
 /**
@@ -452,6 +476,21 @@ export type Sheet = {
    * to be able to set the type without also being given the config.
    */
   fontPt: number;
+  /**
+   * The three below are the presentation half of `SheetOptions`, carried here
+   * for exactly the reason `fontPt` is: a `Sheet` is the whole hand-off, and a
+   * renderer holding one must not also need the config it came from.
+   *
+   * No family sets them. They are copied on by `buildSheet` at the front door
+   * (index.ts), which is the same bargain `chrome.ts` struck — every family
+   * would otherwise write the same three lines, and the fifteenth one to be
+   * added would be the one that forgot.
+   */
+  font?: SheetFont;
+  /** A box round the answer place rather than a rule under it. */
+  answerBox?: boolean;
+  /** Dashed guides across the page, for a sheet that gets cut up. */
+  cutLines?: boolean;
   header: SheetHeader;
   /**
    * The flow, in order. A sheet is one document that may print over more than
@@ -486,6 +525,31 @@ export type SheetOptions = {
   title?: string;
   instructions?: string;
   fields: HeaderField[];
+  /**
+   * The face the sheet is set in. Absent is the print face, which is what a
+   * worksheet is set in unless somebody says otherwise.
+   */
+  font?: SheetFont;
+  /**
+   * A box round the answer place instead of a rule under it.
+   *
+   * The same slot either way — this decides how it is drawn, not where it is —
+   * so it can be a switch every family shares rather than a shape each one has
+   * to offer. Which is also why it costs no height: a bordered slot is the same
+   * line box as a ruled one, and the capacity arithmetic never learns about it.
+   */
+  answerBox?: boolean;
+  /**
+   * Dashed guides across the middle of the page, for a sheet that gets cut up
+   * into cards.
+   *
+   * Drawn over the paper rather than in the flow, which is the whole reason it
+   * can be a shared option: a `cutline` *block* takes a quarter of an inch the
+   * family reserved for problems, and an overlay takes none. The 2-up and 4-up
+   * card layouts of §17 are a later story; this is the guide you cut along
+   * whichever of them a sheet was laid out for.
+   */
+  cutLines?: boolean;
 };
 
 /**

--- a/src/games/flashcards/setup/DeckEditor.tsx
+++ b/src/games/flashcards/setup/DeckEditor.tsx
@@ -79,10 +79,10 @@ export function DeckEditor({
   }
 
   return (
-    <div className="sheet">
+    <div className="modal">
       <Scrim onClose={() => onClose(null)} label="Close" />
-      <div className="sheet__panel">
-        <h2 className="sheet__title u-display">
+      <div className="modal__panel">
+        <h2 className="modal__title u-display">
           {deck ? "Edit list" : "New word list"}
         </h2>
 
@@ -138,7 +138,7 @@ export function DeckEditor({
             ` — a list needs at least ${MIN_WORDS}`}
         </p>
 
-        <div className="sheet__actions">
+        <div className="modal__actions">
           <Button variant="ghost" onClick={() => onClose(null)} disabled={busy}>
             Cancel
           </Button>

--- a/src/games/printshop/App.tsx
+++ b/src/games/printshop/App.tsx
@@ -1,0 +1,103 @@
+/**
+ * The bench: pick a sheet, tune it, watch the page change, print it.
+ *
+ * A `client:only` island inside a real page, which is the opposite arrangement
+ * from the two games. A race must never have site chrome over it; the builder
+ * keeps the masthead and the footer because `print.css` hides them at exactly
+ * the moment they would cost somebody toner — see the note in make.astro.
+ *
+ * The screen is two columns and one idea. On the left, every option that
+ * changes the paper; on the right, the paper. There is no preview button and no
+ * "apply", because there is nothing to apply to: `buildSheet(config, seed)` is a
+ * pure function of the state this island holds, so the sheet on the right is not
+ * a rendering of the settings on the left, it *is* them.
+ *
+ * Nothing here reaches for storage. The saved-sheet panel calls
+ * `services/sheets`, the URL is written by `useBuilder`, and this module only
+ * decides what goes where.
+ */
+import { useMemo } from "react";
+
+import { answerKey, buildSheet } from "@/engine/sheets";
+import type { Sheet } from "@/engine/sheets/types";
+import "@/styles/printshop.css";
+
+import { FamilyOptions } from "./options";
+import { PageOptions } from "./PageOptions";
+import { Picker } from "./Picker";
+import { Preview, PrintCopy } from "./Preview";
+import { PrintBar } from "./PrintBar";
+import { SavedSheets } from "./SavedSheets";
+import { useBuilder, useDebounced } from "./useBuilder";
+
+export default function PrintShopApp() {
+  const bench = useBuilder();
+
+  // Memoised so the debounce below has something stable to hold. Without it
+  // every render would make a new object, the timer would restart on the render
+  // the timer itself caused, and the preview would rebuild forever.
+  const live = useMemo(
+    () => ({
+      config: bench.config,
+      seed: bench.seed,
+      variants: bench.variants,
+      answers: bench.answers,
+    }),
+    [bench.config, bench.seed, bench.variants, bench.answers],
+  );
+
+  // The controls are never debounced — a stepper that answered a sixth of a
+  // second late would feel broken. Only the paper is.
+  const settled = useDebounced(live);
+
+  const sheets = useMemo<Sheet[]>(() => {
+    const pages: Sheet[] = [];
+    for (let copy = 0; copy < settled.variants; copy++) {
+      // Variants are `seed + n` and nothing more elaborate (§7): the same
+      // settings, a different draw, and each one reproducible from the number
+      // printed at the foot of the page.
+      const seed = settled.seed + copy;
+      pages.push(buildSheet(settled.config, seed));
+      if (settled.answers) pages.push(answerKey(settled.config, seed));
+    }
+    return pages;
+  }, [settled]);
+
+  return (
+    <div className="bench">
+      <div className="bench__panel no-print">
+        <Picker config={bench.config} onFamily={bench.setFamily} />
+
+        <section className="bench__group">
+          <h2 className="bench__title u-display">What is on it</h2>
+          <FamilyOptions config={bench.config} set={bench.set} />
+        </section>
+
+        <section className="bench__group">
+          <h2 className="bench__title u-display">The page</h2>
+          <PageOptions config={bench.config} set={bench.set} />
+        </section>
+
+        <SavedSheets
+          config={bench.config}
+          seed={bench.seed}
+          onOpen={bench.open}
+        />
+      </div>
+
+      <div className="bench__paper">
+        <PrintBar
+          seed={bench.seed}
+          variants={bench.variants}
+          answers={bench.answers}
+          onVariants={bench.setVariants}
+          onAnswers={bench.setAnswers}
+          onReroll={bench.reroll}
+        />
+        <Preview sheets={sheets} />
+      </div>
+
+      <PrintCopy sheets={sheets} />
+    </div>
+  );
+}

--- a/src/games/printshop/App.tsx
+++ b/src/games/printshop/App.tsx
@@ -85,7 +85,11 @@ export default function PrintShopApp() {
         />
       </div>
 
-      <div className="bench__paper">
+      {/* `.no-print` on the column and not only on the two things inside it:
+          both children already carry it, but a bench column emptied by
+          `display: none` on its contents is still a column, and the print copy
+          below would lay out under it rather than at the top of the paper. */}
+      <div className="bench__paper no-print">
         <PrintBar
           seed={bench.seed}
           variants={bench.variants}

--- a/src/games/printshop/PageOptions.tsx
+++ b/src/games/printshop/PageOptions.tsx
@@ -1,0 +1,172 @@
+/**
+ * The options every sheet has, whatever is printed on it.
+ *
+ * `SheetOptions` in the engine is the same list, which is the point: these are
+ * the fields no family owns, so they sit above the family panel and stay put
+ * while a parent tries three families underneath them. Paper is even carried
+ * across a family change (see `setFamily`) — somebody who has chosen A4 has
+ * chosen it about their printer, not about long division.
+ *
+ * Every §17 option that isn't a family's own is here: type size in points, the
+ * face, Letter/A4/Legal, portrait/landscape, margins, the name line, answer
+ * boxes and cut lines.
+ */
+import {
+  Checkbox,
+  Field,
+  FieldSet,
+  Input,
+  NumberStepper,
+  TextArea,
+} from "@/components/ui/kit";
+import { FONT_PT } from "@/engine/sheets/paper";
+import { MAX_INSTRUCTIONS, MAX_TITLE } from "@/engine/sheets/share";
+import type {
+  HeaderField,
+  MarginSize,
+  Orientation,
+  PaperSize,
+  SheetFont,
+} from "@/engine/sheets/types";
+
+import { Choice, opt, type PanelProps } from "./options/parts";
+
+const SIZES = [
+  opt<PaperSize>("letter", "Letter"),
+  opt<PaperSize>("a4", "A4"),
+  opt<PaperSize>("legal", "Legal"),
+];
+
+const ORIENTATIONS = [
+  opt<Orientation>("portrait", "Portrait"),
+  opt<Orientation>("landscape", "Landscape"),
+];
+
+const MARGINS = [
+  opt<MarginSize>("none", "None"),
+  opt<MarginSize>("narrow", "Narrow"),
+  opt<MarginSize>("normal", "Normal"),
+  opt<MarginSize>("wide", "Wide"),
+];
+
+const FONTS = [
+  opt<SheetFont>("print", "Print"),
+  opt<SheetFont>("cursive", "Cursive"),
+  opt<SheetFont>("dyslexic", "Dyslexia"),
+];
+
+/** The three blanks a worksheet asks for, and the order they are printed in. */
+const FIELDS: Array<{ id: HeaderField; label: string }> = [
+  { id: "name", label: "Name" },
+  { id: "date", label: "Date" },
+  { id: "class", label: "Class" },
+];
+
+export function PageOptions({ config, set }: PanelProps) {
+  const paper = (patch: Partial<typeof config.paper>) =>
+    set({ paper: { ...config.paper, ...patch } });
+
+  const toggleField = (id: HeaderField, on: boolean) =>
+    set({
+      // Rebuilt from the canonical order rather than pushed onto the end, so
+      // ticking Class before Date still prints name, date, class.
+      fields: FIELDS.map((field) => field.id).filter((field) =>
+        field === id ? on : config.fields.includes(field),
+      ),
+    });
+
+  return (
+    <>
+      <Choice
+        label="Paper"
+        value={config.paper.size}
+        onChange={(size) => paper({ size })}
+        options={SIZES}
+      />
+      <Choice
+        label="Orientation"
+        value={config.paper.orientation}
+        onChange={(orientation) => paper({ orientation })}
+        options={ORIENTATIONS}
+      />
+      <Choice
+        label="Margins"
+        value={config.paper.margin}
+        onChange={(margin) => paper({ margin })}
+        options={MARGINS}
+      />
+
+      <FieldSet
+        legend="Type size"
+        hint="Points, as a type size is quoted on paper. Bigger type is an option here rather than something to zoom."
+      >
+        <NumberStepper
+          label="Type size in points"
+          value={config.fontPt}
+          min={FONT_PT.min}
+          max={FONT_PT.max}
+          unit="pt"
+          onChange={(fontPt) => set({ fontPt })}
+        />
+      </FieldSet>
+
+      <Choice
+        label="Face"
+        value={config.font ?? "print"}
+        onChange={(font) => set({ font })}
+        options={FONTS}
+        hint="Cursive and the dyslexia-friendly face use whatever is installed on this machine until the sheets ship their own."
+      />
+
+      <Field label="Title">
+        <Input
+          value={config.title ?? ""}
+          maxLength={MAX_TITLE}
+          placeholder="The family's own title"
+          onChange={(title) => set({ title: title || undefined })}
+        />
+      </Field>
+
+      <Field label="Instructions">
+        <TextArea
+          value={config.instructions ?? ""}
+          maxLength={MAX_INSTRUCTIONS}
+          rows={2}
+          placeholder="One line, printed under the title"
+          onChange={(instructions) =>
+            set({ instructions: instructions || undefined })
+          }
+        />
+      </Field>
+
+      <FieldSet
+        legend="Lines to fill in"
+        hint="Printed blank and filled in with a pencil. Nothing here holds a child's name — there is nowhere in a sheet to put one."
+      >
+        <span className="pool">
+          {FIELDS.map((field) => (
+            <Checkbox
+              key={field.id}
+              label={field.label}
+              checked={config.fields.includes(field.id)}
+              onChange={(on) => toggleField(field.id, on)}
+            />
+          ))}
+        </span>
+      </FieldSet>
+
+      <Checkbox
+        label="Answer boxes"
+        hint="A box round the answer place rather than a rule under it."
+        checked={config.answerBox === true}
+        onChange={(answerBox) => set({ answerBox })}
+      />
+      <Checkbox
+        label="Cut lines"
+        hint="Dashed guides across the middle of the page, for a sheet you cut up."
+        checked={config.cutLines === true}
+        onChange={(cutLines) => set({ cutLines })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/Picker.tsx
+++ b/src/games/printshop/Picker.tsx
@@ -1,0 +1,38 @@
+/**
+ * Which kind of sheet is on the bench.
+ *
+ * Built from `listSheets()` rather than from a list here, so a family added to
+ * the engine's registry appears in the picker without anybody remembering to
+ * come and say so — the same registry the catalog, the builder and a saved
+ * sheet all read.
+ *
+ * The line underneath is `describeSheet(config)`: the engine's own one-line
+ * account of what is currently set, which is also what a saved sheet is named
+ * after when a parent doesn't name it. One sentence, written once.
+ */
+import { describeSheet, listSheets } from "@/engine/sheets";
+import type { SheetConfig } from "@/engine/sheets/types";
+
+import { Choice, opt } from "./options/parts";
+
+const FAMILIES = listSheets().map((spec) => opt(spec.id, spec.label));
+
+export function Picker({
+  config,
+  onFamily,
+}: {
+  config: SheetConfig;
+  onFamily: (kind: string) => void;
+}) {
+  return (
+    <div className="picker">
+      <Choice
+        label="Sheet"
+        value={config.kind}
+        onChange={onFamily}
+        options={FAMILIES}
+      />
+      <p className="picker__line">{describeSheet(config)}</p>
+    </div>
+  );
+}

--- a/src/games/printshop/Preview.tsx
+++ b/src/games/printshop/Preview.tsx
@@ -1,0 +1,119 @@
+/**
+ * The sheet, on the press-room ground, small enough to see all of.
+ *
+ * A sheet is 8.5 inches wide and does not negotiate — that is the whole of §4 —
+ * so the only honest way to show one next to an option panel is to scale it
+ * down. `transform: scale()` and not a smaller sheet: every length on the paper
+ * stays exactly what it says it is, the type is still real selectable text, and
+ * what is on screen is the page that will come out of the printer rather than a
+ * drawing of it.
+ *
+ * The scale is measured rather than guessed, because the frame's width depends
+ * on the viewport and the sheet's on the stock: Letter portrait beside a panel
+ * on a laptop is about 0.45, A4 landscape on a phone is about 0.25, and a
+ * hard-coded number would be wrong on both.
+ *
+ * Print undoes all of it. `print.css` hides everything that isn't paper, and the
+ * rules in printshop.css take the transform back off — a scaled sheet sent to a
+ * printer is a sheet at 45% of the size it measures, which is the one bug this
+ * screen exists to prevent.
+ */
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+
+import { SheetView } from "@/components/sheet/Sheet";
+import type { Sheet } from "@/engine/sheets/types";
+
+export function Preview({ sheets }: { sheets: Sheet[] }) {
+  const stage = useRef<HTMLDivElement>(null);
+  const stack = useRef<HTMLDivElement>(null);
+  // The room there is, and the stack's own unscaled size. ResizeObserver reports
+  // layout boxes, which is exactly what is wanted here: the stack's box is what
+  // it would measure at 1:1, uncontaminated by the transform applied to it.
+  const [box, setBox] = useState({ room: 0, width: 0, height: 0 });
+
+  useEffect(() => {
+    const room = stage.current;
+    const inner = stack.current;
+    if (!room || !inner) return;
+
+    const measure = () => {
+      // The stage rather than the frame around it, because the frame has
+      // padding and `clientWidth` includes it — a sheet scaled to the padded
+      // width is a sheet a few pixels wider than the room it has.
+      const next = {
+        room: room.clientWidth,
+        width: inner.offsetWidth,
+        height: inner.offsetHeight,
+      };
+      // Same numbers, same object. The stage is measured *and* given a height,
+      // so an unguarded update would re-render once more every time the height
+      // it just set is observed coming back.
+      setBox((current) =>
+        current.room === next.room &&
+        current.width === next.width &&
+        current.height === next.height
+          ? current
+          : next,
+      );
+    };
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(room);
+    observer.observe(inner);
+    measure();
+    return () => observer.disconnect();
+  }, []);
+
+  // Never above 1. A sheet blown up past its own size on a wide monitor would be
+  // a preview that lies in the other direction.
+  const scale = box.width > 0 ? Math.min(1, box.room / box.width) : 1;
+
+  return (
+    <div className="preview no-print">
+      {/* The stage is what holds the space the scaled stack takes up. A
+          transform doesn't change layout, so without a height of its own the
+          frame would be as tall as the unscaled paper and the page would scroll
+          past the bottom of the preview by more than half its height. */}
+      <div
+        className="preview__stage"
+        ref={stage}
+        style={{ height: box.height * scale || undefined }}
+      >
+        <div
+          className="preview__stack"
+          ref={stack}
+          style={{ "--preview-scale": scale } as CSSProperties}
+        >
+          {sheets.map((sheet, index) => (
+            // Indexed keys: the stack is rebuilt whole on every change and
+            // nothing in it is stateful, so there is nothing a stable key would
+            // preserve — the same reasoning `SheetView` gives for its blocks.
+            <SheetView key={index} sheet={sheet} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The same sheets again, at full size, for the printer alone.
+ *
+ * Two renders rather than one un-scaled at print time, and it is worth being
+ * explicit about why: `transform` on an ancestor of a page box is one of the
+ * reliable ways to lose the bottom of a sheet, and print is the entire output
+ * path here (§10) — there is no PDF to notice it in first. So the preview is
+ * screen-only and this is print-only, and neither has to be undone under
+ * pressure.
+ *
+ * It costs a second copy of the markup in the DOM and nothing on paper.
+ */
+export function PrintCopy({ sheets }: { sheets: Sheet[] }) {
+  return (
+    <div className="print-only" aria-hidden="true">
+      {sheets.map((sheet, index) => (
+        <SheetView key={index} sheet={sheet} />
+      ))}
+    </div>
+  );
+}

--- a/src/games/printshop/PrintBar.tsx
+++ b/src/games/printshop/PrintBar.tsx
@@ -1,0 +1,98 @@
+/**
+ * What you do with a sheet once it is right: print it, or take a copy of it.
+ *
+ * **Print is the entire output path.** There is no PDF library here and there
+ * never will be — it would cost about 600KB and a second rendering path that
+ * drifts from the first (§10, decided) — so the browser's own dialog is the
+ * download as well as the print, and the one line of hint under the button says
+ * so in the words the dialog itself uses. A parent who wants a file and does not
+ * know that "Save as PDF" is in there will conclude the site cannot make one.
+ *
+ * The link button copies the address bar, which already holds the whole
+ * configuration: `useBuilder` rewrites `#s=` on every change, so there is
+ * nothing to build here and nothing to keep in step.
+ */
+import { useState } from "react";
+
+import { Button, Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
+
+import { MAX_VARIANTS } from "./useBuilder";
+
+export function PrintBar({
+  seed,
+  variants,
+  answers,
+  onVariants,
+  onAnswers,
+  onReroll,
+}: {
+  seed: number;
+  variants: number;
+  answers: boolean;
+  onVariants: (count: number) => void;
+  onAnswers: (on: boolean) => void;
+  onReroll: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2400);
+    } catch {
+      // Clipboard access is refused often enough — an insecure origin, a
+      // browser that wants a gesture it didn't see — that failing silently
+      // would be a button that does nothing. The URL is in the address bar
+      // either way, so the honest fallback is to say so.
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="printbar no-print">
+      <div className="printbar__row">
+        <FieldSet
+          legend="Copies"
+          hint="Each one is a different draw of the same settings."
+        >
+          <NumberStepper
+            label="Copies"
+            value={variants}
+            min={1}
+            max={MAX_VARIANTS}
+            onChange={onVariants}
+          />
+        </FieldSet>
+        <Checkbox
+          label="Answer key"
+          hint="Printed after each copy, on its own page."
+          checked={answers}
+          onChange={onAnswers}
+        />
+      </div>
+
+      <div className="printbar__actions">
+        <Button variant="go" onClick={() => window.print()}>
+          Print
+        </Button>
+        <Button variant="ghost" onClick={onReroll}>
+          Another sheet like this
+        </Button>
+        <Button variant="ghost" onClick={() => void copyLink()}>
+          {copied ? "Link copied" : "Copy link"}
+        </Button>
+      </div>
+
+      <p className="printbar__hint">
+        Choose <strong>Save as PDF</strong> in the print dialog if you want a
+        file rather than paper &mdash; that is the download, and it is the
+        browser&rsquo;s own.
+      </p>
+      <p className="printbar__seed">
+        Sheet <span className="u-mono">{seed}</span>. The number is printed at
+        the foot of the page, so this exact sheet can be had again.
+      </p>
+    </div>
+  );
+}

--- a/src/games/printshop/PrintBar.tsx
+++ b/src/games/printshop/PrintBar.tsx
@@ -18,6 +18,20 @@ import { Button, Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
 
 import { MAX_VARIANTS } from "./useBuilder";
 
+/**
+ * The button's three labels.
+ *
+ * "Copy it from the address bar" is the refusal, and it is an instruction
+ * rather than an apology: the link the button would have copied is already
+ * visible, so the one useful thing to say is where. It is held for the same
+ * 2400ms as the success, then the button goes back to offering.
+ */
+const COPY_LABEL = {
+  nothing: "Copy link",
+  copied: "Link copied",
+  refused: "Copy it from the address bar",
+} as const;
+
 export function PrintBar({
   seed,
   variants,
@@ -33,20 +47,24 @@ export function PrintBar({
   onAnswers: (on: boolean) => void;
   onReroll: () => void;
 }) {
-  const [copied, setCopied] = useState(false);
+  // What the button last did, which is the only thing it has to say. Three
+  // states rather than a boolean because the failure has to be visible: see
+  // `copyLink`.
+  const [said, setSaid] = useState<"nothing" | "copied" | "refused">("nothing");
 
   const copyLink = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2400);
+      setSaid("copied");
     } catch {
       // Clipboard access is refused often enough — an insecure origin, a
       // browser that wants a gesture it didn't see — that failing silently
       // would be a button that does nothing. The URL is in the address bar
-      // either way, so the honest fallback is to say so.
-      setCopied(false);
+      // either way, so the honest fallback is to say so, and the label is
+      // where it gets said.
+      setSaid("refused");
     }
+    window.setTimeout(() => setSaid("nothing"), 2400);
   };
 
   return (
@@ -80,7 +98,7 @@ export function PrintBar({
           Another sheet like this
         </Button>
         <Button variant="ghost" onClick={() => void copyLink()}>
-          {copied ? "Link copied" : "Copy link"}
+          {COPY_LABEL[said]}
         </Button>
       </div>
 

--- a/src/games/printshop/SavedSheets.tsx
+++ b/src/games/printshop/SavedSheets.tsx
@@ -1,0 +1,131 @@
+/**
+ * My Sheets: the worksheets this household kept.
+ *
+ * Everything here goes through `services/sheets.ts` and nothing here knows
+ * IndexedDB exists — the view calls a service, which is the boundary
+ * `eslint.config.mjs` enforces and the reason the schema, the validation and
+ * the quota handling live in one place.
+ *
+ * There is no profile picker, and that is a decision rather than an omission: a
+ * worksheet belongs to the household, not to a child (§15). The sheet made for
+ * the eldest is the sheet the next one gets, and scoping it to a profile would
+ * mean building it again for every kid at the table.
+ *
+ * A saved sheet is a config and a seed, never any paper. `buildSheet` is
+ * deterministic (§7), so a sheet kept in March prints the same problems in June
+ * — and the record has nowhere to put a child's name, which is not luck either.
+ */
+import { useCallback, useEffect, useState } from "react";
+
+import { Button, Field, Input } from "@/components/ui/kit";
+import * as sheetService from "@/services/sheets";
+import type { SavedSheet, SheetConfig } from "@/engine/sheets/types";
+
+export function SavedSheets({
+  config,
+  seed,
+  onOpen,
+}: {
+  config: SheetConfig;
+  seed: number;
+  onOpen: (config: SheetConfig, seed: number) => void;
+}) {
+  const [saved, setSaved] = useState<SavedSheet[]>([]);
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setSaved(await sheetService.all());
+      setError(null);
+    } catch {
+      // A browser blocking storage — private browsing does — is the usual
+      // cause, and it is worth saying rather than showing an empty list that
+      // looks like "you have never saved anything".
+      setError("This browser isn't letting the site save anything.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const save = async () => {
+    try {
+      // A blank name is not an error: the service names the sheet after what it
+      // prints, which is a better default than anything a hurried parent types.
+      await sheetService.create({ name, config, seed });
+      setName("");
+      await refresh();
+    } catch (err) {
+      setError(
+        err instanceof sheetService.InvalidSheet
+          ? err.message
+          : "Couldn't save that sheet.",
+      );
+    }
+  };
+
+  const forget = async (id: string) => {
+    try {
+      await sheetService.remove(id);
+      await refresh();
+    } catch {
+      setError("Couldn't remove that sheet.");
+    }
+  };
+
+  return (
+    <section className="saved no-print">
+      <h2 className="saved__title u-display">My sheets</h2>
+
+      <Field
+        label="Save this one"
+        hint="Kept on this device only. Nothing is uploaded."
+        error={error ?? undefined}
+      >
+        <Input
+          value={name}
+          maxLength={sheetService.MAX_NAME}
+          placeholder="Name it, or leave it blank"
+          blurOnEnter
+          onChange={setName}
+        />
+      </Field>
+      <Button variant="accent" size="sm" onClick={() => void save()}>
+        Save to my sheets
+      </Button>
+
+      {saved.length === 0 ? (
+        <p className="saved__empty">
+          Nothing saved yet. A saved sheet keeps its settings and its seed, so
+          it prints the same page next week.
+        </p>
+      ) : (
+        <ul className="saved__list">
+          {saved.map((sheet) => (
+            <li className="saved__item" key={sheet.id}>
+              <span className="saved__name">{sheet.name}</span>
+              <span className="saved__actions">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onOpen(sheet.config, sheet.seed)}
+                >
+                  Open
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => void forget(sheet.id)}
+                >
+                  Remove
+                </Button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -1,0 +1,193 @@
+/**
+ * What the bench opens on, for every family it can make.
+ *
+ * One config each, and each one a sheet somebody would actually print: the
+ * builder's first job is to show a page rather than a form, so switching family
+ * has to produce a finished worksheet before a single option is touched. That
+ * is the same bargain the catalog pages strike (§8) — a page that *is* the
+ * sheet — reached from the other side.
+ *
+ * It lives in the view rather than in the engine, and that is deliberate. A
+ * family's `SheetSpec` says what it can build, not what a parent probably
+ * wants; "twenty-four sums with both numbers under twenty" is an editorial
+ * judgement about children, of a piece with the copy in `_maths.ts`, and the
+ * engine has no business holding one. `deckSpec` draws the same line.
+ *
+ * Every value here is inside the range its own family clamps to, so nothing
+ * below can produce a sheet that fails to fit — the builder never opens on a
+ * page it would have to apologise for.
+ */
+import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "@/engine/sheets/paper";
+import type { SheetConfig, SheetOptions } from "@/engine/sheets/types";
+
+/**
+ * The name and date line, printed blank, always.
+ *
+ * There is nowhere in a config to put a value for either (§1), which is what
+ * makes the shared-link half of this screen safe by construction rather than by
+ * a rule somebody has to remember: a child's name is written on the paper with
+ * a pencil and never travels in a URL.
+ */
+const BASE: SheetOptions = {
+  paper: DEFAULT_PAPER,
+  fontPt: DEFAULT_FONT_PT,
+  fields: ["name", "date"],
+};
+
+/** The twelve tables, which is what a fact sheet draws from unless told less. */
+const TABLES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+/** Halves through twelfths, skipping the ones a primary child never meets. */
+const DENOMINATORS = [2, 3, 4, 5, 6, 8, 10, 12];
+
+const DEFAULTS: Record<string, SheetConfig> = {
+  blank: { ...BASE, kind: "blank", title: "Blank sheet" },
+  paper: { ...BASE, kind: "paper", rule: { style: "wide" } },
+  arithmetic: {
+    ...BASE,
+    kind: "arithmetic",
+    operation: "add",
+    style: "standard",
+    form: "horizontal",
+    range: { min: 1, max: 20 },
+    count: 24,
+    columns: 3,
+    regrouping: "either",
+  },
+  multiplication: {
+    ...BASE,
+    kind: "multiplication",
+    operation: "multiply",
+    style: "standard",
+    form: "horizontal",
+    tables: TABLES,
+    factors: { min: 1, max: 12 },
+    count: 30,
+    columns: 3,
+  },
+  fractions: {
+    ...BASE,
+    kind: "fractions",
+    style: "identify",
+    operation: "add",
+    denominators: DENOMINATORS,
+    pairing: "like",
+    model: "both",
+    count: 12,
+    columns: 2,
+  },
+  decimals: {
+    ...BASE,
+    kind: "decimals",
+    style: "standard",
+    operation: "add",
+    form: "vertical",
+    places: 2,
+    range: { min: 1, max: 20 },
+    count: 16,
+    columns: 3,
+  },
+  money: {
+    ...BASE,
+    kind: "money",
+    currency: "usd",
+    operation: "add",
+    form: "vertical",
+    range: { min: 1, max: 20 },
+    count: 16,
+    columns: 3,
+  },
+  time: {
+    ...BASE,
+    kind: "time",
+    style: "read",
+    step: 5,
+    count: 8,
+    columns: 2,
+  },
+  measure: {
+    ...BASE,
+    kind: "measure",
+    style: "convert",
+    system: "metric",
+    quantities: ["length"],
+    range: { min: 1, max: 50 },
+    count: 16,
+    columns: 2,
+  },
+  geometry: {
+    ...BASE,
+    kind: "geometry",
+    style: "area",
+    system: "metric",
+    range: { min: 2, max: 12 },
+    quadrants: 1,
+    count: 8,
+    columns: 2,
+  },
+  integers: {
+    ...BASE,
+    kind: "integers",
+    style: "arithmetic",
+    operation: "add",
+    range: { min: 1, max: 20 },
+    negatives: true,
+    terms: 3,
+    powers: true,
+    count: 20,
+    columns: 3,
+  },
+  prealgebra: {
+    ...BASE,
+    kind: "prealgebra",
+    style: "equation",
+    steps: 1,
+    range: { min: 1, max: 12 },
+    negatives: false,
+    quadrants: 1,
+    count: 16,
+    columns: 2,
+  },
+  ratio: {
+    ...BASE,
+    kind: "ratio",
+    style: "simplify",
+    range: { min: 2, max: 24 },
+    count: 16,
+    columns: 2,
+  },
+  statistics: {
+    ...BASE,
+    kind: "statistics",
+    style: "all",
+    size: 5,
+    range: { min: 1, max: 20 },
+    count: 6,
+    columns: 1,
+  },
+  "word-problems": {
+    ...BASE,
+    kind: "word-problems",
+    topics: ["integers", "rate", "average"],
+    range: { min: 2, max: 30 },
+    count: 6,
+    columns: 1,
+    workspace: true,
+  },
+};
+
+/** Where the bench opens when the address bar had nothing to say. */
+export const FIRST_SHEET = "arithmetic";
+
+/**
+ * A starting config for a family, or the first sheet's if this build has never
+ * heard of it.
+ *
+ * Never throws, for the same reason `sheetSpec` doesn't: the kind can come from
+ * a picker built out of `listSheets()`, and a family added to the registry
+ * without a default here would otherwise take the whole bench down rather than
+ * open on something.
+ */
+export function defaultConfig(kind: string): SheetConfig {
+  return Object.hasOwn(DEFAULTS, kind) ? DEFAULTS[kind] : DEFAULTS[FIRST_SHEET];
+}

--- a/src/games/printshop/options/arithmetic.tsx
+++ b/src/games/printshop/options/arithmetic.tsx
@@ -1,0 +1,102 @@
+/**
+ * Adding and taking away.
+ *
+ * Regrouping is the difficulty dial here and it is worth naming as one: it is
+ * the line between the week a child learns to add and the week they learn to
+ * carry, and it is the single most-asked-for switch on an arithmetic sheet.
+ */
+import { Checkbox } from "@/components/ui/kit";
+import type {
+  ArithmeticConfig,
+  ArithmeticForm,
+  ArithmeticOperation,
+  ArithmeticStyle,
+  Regrouping,
+} from "@/engine/sheets/types";
+
+import { Choice, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const OPERATIONS = [
+  opt<ArithmeticOperation>("add", "Add"),
+  opt<ArithmeticOperation>("subtract", "Subtract"),
+  opt<ArithmeticOperation>("both", "Both"),
+];
+
+const STYLES = [
+  opt<ArithmeticStyle>("standard", "Standard"),
+  opt<ArithmeticStyle>("missing", "Missing number"),
+  opt<ArithmeticStyle>("fact-family", "Fact family"),
+];
+
+const FORMS = [
+  opt<ArithmeticForm>("horizontal", "Along a line"),
+  opt<ArithmeticForm>("vertical", "In columns"),
+];
+
+const REGROUPING = [
+  opt<Regrouping>("either", "Either"),
+  opt<Regrouping>("never", "Never"),
+  opt<Regrouping>("always", "Always"),
+];
+
+export function ArithmeticPanel({ config, set }: PanelProps<ArithmeticConfig>) {
+  return (
+    <>
+      <Choice
+        label="Operation"
+        value={config.operation}
+        onChange={(operation) => set({ operation })}
+        options={OPERATIONS}
+      />
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      <Choice
+        label="Written"
+        value={config.form}
+        onChange={(form) => set({ form })}
+        options={FORMS}
+      />
+      <Span
+        label="Numbers"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={0}
+        max={999}
+        hint="The numbers a child sees, not the answers they reach — a sum of two numbers up to 20 can run past 20, and that is what carrying is."
+      />
+      <Choice
+        label="Regrouping"
+        value={config.regrouping}
+        onChange={(regrouping) => set({ regrouping })}
+        options={REGROUPING}
+        hint="Whether a column may carry or borrow."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+      />
+      <Checkbox
+        label="Answers may go below zero"
+        hint="Off unless asked for — a child who has not met negative numbers should not find one in question nine."
+        checked={config.negatives === true}
+        onChange={(negatives) => set({ negatives })}
+      />
+      <Checkbox
+        label="Number line under every problem"
+        checked={config.numberLine === true}
+        onChange={(numberLine) => set({ numberLine })}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/decimals.tsx
+++ b/src/games/printshop/options/decimals.tsx
@@ -1,0 +1,95 @@
+/**
+ * Decimals and percentages.
+ *
+ * Places is the difficulty dial, and column form is worth more on this sheet
+ * than anywhere else in the shop: every value prints to the same number of
+ * places, so stacking them right-aligned puts the points in a column — which is
+ * the one thing a child lining up a decimal sum has to get right.
+ */
+import { Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
+import type {
+  DecimalConfig,
+  DecimalForm,
+  DecimalOperation,
+  DecimalStyle,
+} from "@/engine/sheets/types";
+
+import { Choice, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<DecimalStyle>("standard", "Arithmetic"),
+  opt<DecimalStyle>("percent", "Percentages"),
+  opt<DecimalStyle>("convert", "Convert"),
+];
+
+const OPERATIONS = [
+  opt<DecimalOperation>("add", "Add"),
+  opt<DecimalOperation>("subtract", "Subtract"),
+  opt<DecimalOperation>("multiply", "Multiply"),
+  opt<DecimalOperation>("both", "Add and subtract"),
+];
+
+const FORMS = [
+  opt<DecimalForm>("horizontal", "Along a line"),
+  opt<DecimalForm>("vertical", "In columns"),
+];
+
+export function DecimalsPanel({ config, set }: PanelProps<DecimalConfig>) {
+  return (
+    <>
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      {config.style === "standard" && (
+        <>
+          <Choice
+            label="Operation"
+            value={config.operation}
+            onChange={(operation) => set({ operation })}
+            options={OPERATIONS}
+          />
+          <Choice
+            label="Written"
+            value={config.form}
+            onChange={(form) => set({ form })}
+            options={FORMS}
+          />
+        </>
+      )}
+      <FieldSet
+        legend="Decimal places"
+        hint="How many digits after the point — the whole of what makes one of these easy or hard."
+      >
+        <NumberStepper
+          label="Decimal places"
+          value={config.places}
+          min={1}
+          max={3}
+          onChange={(places) => set({ places })}
+        />
+      </FieldSet>
+      <Span
+        label="Whole numbers"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={0}
+        max={999}
+        hint="The whole numbers the values sit between."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/fractions.tsx
+++ b/src/games/printshop/options/fractions.tsx
@@ -1,0 +1,111 @@
+/**
+ * Fractions.
+ *
+ * `pairing` is this family's difficulty dial, the way regrouping is
+ * arithmetic's: adding quarters to quarters and adding halves to quarters are a
+ * week apart in the year rather than the same question twice. It only means
+ * something once there are two fractions in a problem, which is why it and the
+ * operation appear on the arithmetic style alone.
+ */
+import { Checkbox } from "@/components/ui/kit";
+import type {
+  Denominators,
+  FractionConfig,
+  FractionModel,
+  FractionOperation,
+  FractionStyle,
+} from "@/engine/sheets/types";
+
+import { Choice, Pool, Sizing, opt, type PanelProps } from "./parts";
+
+/** Halves through twelfths, skipping the ones a primary child never meets. */
+const DENOMINATORS = [2, 3, 4, 5, 6, 8, 10, 12];
+
+const STYLES = [
+  opt<FractionStyle>("identify", "Name it"),
+  opt<FractionStyle>("equivalent", "Equivalent"),
+  opt<FractionStyle>("simplify", "Simplify"),
+  opt<FractionStyle>("arithmetic", "Arithmetic"),
+];
+
+const OPERATIONS = [
+  opt<FractionOperation>("add", "Add"),
+  opt<FractionOperation>("subtract", "Subtract"),
+  opt<FractionOperation>("multiply", "Multiply"),
+  opt<FractionOperation>("divide", "Divide"),
+  opt<FractionOperation>("both", "Add and subtract"),
+];
+
+const PAIRING = [
+  opt<Denominators>("like", "Same"),
+  opt<Denominators>("unlike", "Different"),
+  opt<Denominators>("either", "Either"),
+];
+
+const MODELS = [
+  opt<FractionModel>("bar", "Bars"),
+  opt<FractionModel>("circle", "Circles"),
+  opt<FractionModel>("both", "Both"),
+];
+
+export function FractionsPanel({ config, set }: PanelProps<FractionConfig>) {
+  return (
+    <>
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      {config.style === "arithmetic" && (
+        <>
+          <Choice
+            label="Operation"
+            value={config.operation}
+            onChange={(operation) => set({ operation })}
+            options={OPERATIONS}
+          />
+          <Choice
+            label="Denominators"
+            value={config.pairing}
+            onChange={(pairing) => set({ pairing })}
+            options={PAIRING}
+            hint="Whether the two fractions in a problem share a bottom number."
+          />
+        </>
+      )}
+      {config.style === "identify" && (
+        <Choice
+          label="Picture"
+          value={config.model ?? "both"}
+          onChange={(model) => set({ model })}
+          options={MODELS}
+        />
+      )}
+      <Pool
+        label="Bottom numbers"
+        values={DENOMINATORS}
+        chosen={config.denominators}
+        onChange={(denominators) => set({ denominators })}
+        hint="The denominators the sheet draws from."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+      />
+      <Checkbox
+        label="Whole numbers alongside"
+        hint="2 1/4 rather than 1/4, on the page and in the answer."
+        checked={config.mixed === true}
+        onChange={(mixed) => set({ mixed })}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/geometry.tsx
+++ b/src/games/printshop/options/geometry.tsx
@@ -1,0 +1,83 @@
+/**
+ * Shapes, and the plane they are plotted on.
+ *
+ * Quadrants is the switch the coordinate style turns on, and it is a change of
+ * question rather than a harder version of one: a plane that runs from nought is
+ * counting, and a plane with four quadrants is the week negative numbers arrive.
+ * Which is why it only appears on the style that has a plane on it.
+ */
+import { Checkbox } from "@/components/ui/kit";
+import type {
+  GeometryConfig,
+  GeometryStyle,
+  UnitSystem,
+} from "@/engine/sheets/types";
+
+import { Choice, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<GeometryStyle>("area", "Area"),
+  opt<GeometryStyle>("perimeter", "Perimeter"),
+  opt<GeometryStyle>("volume", "Volume"),
+  opt<GeometryStyle>("angles", "Angles"),
+  opt<GeometryStyle>("identify", "Name the shape"),
+  opt<GeometryStyle>("coordinates", "Coordinates"),
+];
+
+const SYSTEMS = [
+  opt<UnitSystem>("metric", "Metric"),
+  opt<UnitSystem>("imperial", "Imperial"),
+];
+
+const QUADRANTS = [
+  opt("1", "One", "no negatives"),
+  opt("4", "Four", "all four"),
+];
+
+export function GeometryPanel({ config, set }: PanelProps<GeometryConfig>) {
+  return (
+    <>
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      {config.style === "coordinates" ? (
+        <Choice
+          label="Quadrants"
+          value={String(config.quadrants ?? 1)}
+          onChange={(quadrants) => set({ quadrants: Number(quadrants) })}
+          options={QUADRANTS}
+        />
+      ) : (
+        <Choice
+          label="Units"
+          value={config.system}
+          onChange={(system) => set({ system })}
+          options={SYSTEMS}
+        />
+      )}
+      <Span
+        label="Sides"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={1}
+        max={100}
+        hint="How big the measurements on a shape get."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={4}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -1,0 +1,102 @@
+/**
+ * The option panels' front door.
+ *
+ * A registry keyed by `kind`, exactly as `engine/sheets/index.ts` is, and for
+ * the same reason: looking a panel up *is* the narrowing, so there is no
+ * `switch` over `SheetConfig` here to keep in step with the union. Adding a
+ * family is a module beside this one and a line in the table.
+ *
+ * The one cast in the directory is `panel()` below, and it is worth reading
+ * before it is copied. `SheetSpec` gets into its registry for free because
+ * `build(config, seed)` only *takes* a config, and TypeScript checks method
+ * parameters bivariantly. A panel takes a config **and** a way to patch it, and
+ * those two pull in opposite directions — the config is safe to widen, the
+ * patch is safe to narrow — so no variance rule can let both through at once.
+ * The lookup is what makes it true anyway: a panel is only ever reached through
+ * the key its own `kind` is filed under.
+ */
+import type { ReactNode } from "react";
+
+import type { SheetConfig } from "@/engine/sheets/types";
+
+import { ArithmeticPanel } from "./arithmetic";
+import { DecimalsPanel } from "./decimals";
+import { FractionsPanel } from "./fractions";
+import { GeometryPanel } from "./geometry";
+import { IntegersPanel } from "./integers";
+import { MeasurePanel } from "./measure";
+import { MoneyPanel } from "./money";
+import { MultiplicationPanel } from "./multiplication";
+import { PaperPanel } from "./paper";
+import { PreAlgebraPanel } from "./prealgebra";
+import { RatioPanel } from "./ratio";
+import { StatisticsPanel } from "./statistics";
+import { TimePanel } from "./time";
+import { WordProblemsPanel } from "./wordproblems";
+import type { PanelProps } from "./parts";
+
+type FamilyPanel = (props: PanelProps) => ReactNode;
+
+/**
+ * Files a family's panel under the union, which the lookup then honours.
+ *
+ * The assertion says "this panel will only ever be given its own family's
+ * config", and the table below is what makes that true: an entry is reached by
+ * the `kind` it is keyed on and by nothing else. Written once, here, so that
+ * every panel above can stay strictly typed to its own config — a `MoneyPanel`
+ * that reached for `regrouping` still fails to compile, which is the property
+ * worth protecting.
+ *
+ * Through `unknown` because the two types genuinely do not overlap in either
+ * direction, which is TypeScript being right rather than being awkward: it
+ * cannot see the table, and the table is the whole argument. Keeping the
+ * assertion in one three-line function is what stops that argument having to be
+ * made fifteen times.
+ */
+const panel = <C extends SheetConfig>(
+  Panel: (props: PanelProps<C>) => ReactNode,
+): FamilyPanel => Panel as unknown as FamilyPanel;
+
+/**
+ * A family with nothing of its own to choose.
+ *
+ * Blank paper is the spine's own sheet — a header, a footer and nothing else —
+ * so every option it has is one of the shared ones above the panel. It is also
+ * what a `kind` this build has never heard of falls back to, which keeps the
+ * bench open on the shared options rather than blank while somebody works out
+ * why the family went missing.
+ */
+const NO_OPTIONS: FamilyPanel = () => null;
+
+const PANELS: Record<string, FamilyPanel> = {
+  blank: NO_OPTIONS,
+  paper: panel(PaperPanel),
+  arithmetic: panel(ArithmeticPanel),
+  multiplication: panel(MultiplicationPanel),
+  fractions: panel(FractionsPanel),
+  decimals: panel(DecimalsPanel),
+  money: panel(MoneyPanel),
+  time: panel(TimePanel),
+  measure: panel(MeasurePanel),
+  geometry: panel(GeometryPanel),
+  integers: panel(IntegersPanel),
+  prealgebra: panel(PreAlgebraPanel),
+  ratio: panel(RatioPanel),
+  statistics: panel(StatisticsPanel),
+  "word-problems": panel(WordProblemsPanel),
+};
+
+/**
+ * The options that belong to whichever family this config is.
+ *
+ * The own-property lookup is the same guard `sheetSpec` documents: `kind`
+ * arrives from a URL somebody may have typed, and plain `PANELS[kind]` answers
+ * `"toString"` with a function off `Object.prototype`, which is truthy, is not a
+ * panel, and would be rendered as a component one line later.
+ */
+export function FamilyOptions({ config, set }: PanelProps) {
+  const Panel = Object.hasOwn(PANELS, config.kind)
+    ? PANELS[config.kind]
+    : NO_OPTIONS;
+  return <Panel config={config} set={set} />;
+}

--- a/src/games/printshop/options/integers.tsx
+++ b/src/games/printshop/options/integers.tsx
@@ -1,0 +1,101 @@
+/**
+ * Positive and negative whole numbers, the order of operations, and powers.
+ *
+ * `negatives` is on by default here and it is still worth being able to turn
+ * off: an order-of-operations sheet without a minus sign on it is a real lesson,
+ * and it is the one a year younger. `powers` is the same argument again — the
+ * rule is taught as "brackets, powers, then × and ÷", but a child meets the rule
+ * a term before they meet exponents, and a sheet that asked for both would be an
+ * impossible page rather than a hard one.
+ */
+import { Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
+import type {
+  IntegerConfig,
+  IntegerOperation,
+  IntegerStyle,
+} from "@/engine/sheets/types";
+
+import { Choice, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<IntegerStyle>("arithmetic", "Arithmetic"),
+  opt<IntegerStyle>("order", "Order of operations"),
+  opt<IntegerStyle>("powers", "Powers and roots"),
+];
+
+const OPERATIONS = [
+  opt<IntegerOperation>("add", "Add"),
+  opt<IntegerOperation>("subtract", "Subtract"),
+  opt<IntegerOperation>("multiply", "Multiply"),
+  opt<IntegerOperation>("divide", "Divide"),
+  opt<IntegerOperation>("both", "All four"),
+];
+
+export function IntegersPanel({ config, set }: PanelProps<IntegerConfig>) {
+  const order = config.style === "order";
+
+  return (
+    <>
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      {config.style === "arithmetic" && (
+        <Choice
+          label="Operation"
+          value={config.operation}
+          onChange={(operation) => set({ operation })}
+          options={OPERATIONS}
+        />
+      )}
+      {order && (
+        <FieldSet
+          legend="Operations in each expression"
+          hint="How long the sentence is that has to be worked in the right order."
+        >
+          <NumberStepper
+            label="Operations in each expression"
+            value={config.terms ?? 3}
+            min={2}
+            max={5}
+            onChange={(terms) => set({ terms })}
+          />
+        </FieldSet>
+      )}
+      <Span
+        label="Numbers"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={1}
+        max={200}
+        hint="How big the numbers get, sign aside."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+      />
+      <Checkbox
+        label="Negative numbers"
+        checked={config.negatives !== false}
+        onChange={(negatives) => set({ negatives })}
+      />
+      {order && (
+        <Checkbox
+          label="Squares in the expression"
+          hint="Turn off for the same lesson a year earlier — the printed instruction follows the switch."
+          checked={config.powers !== false}
+          onChange={(powers) => set({ powers })}
+        />
+      )}
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/measure.tsx
+++ b/src/games/printshop/options/measure.tsx
@@ -1,0 +1,80 @@
+/**
+ * Measurement.
+ *
+ * Two systems and no conversion between them, which is why the system is a
+ * choice rather than a pool: a child converting metres into feet is doing a
+ * different lesson — an approximate one — and everything in this family is
+ * exact.
+ */
+import { Checkbox } from "@/components/ui/kit";
+import type {
+  MeasureConfig,
+  MeasureStyle,
+  Quantity,
+  UnitSystem,
+} from "@/engine/sheets/types";
+
+import { Choice, Pool, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<MeasureStyle>("convert", "Convert"),
+  opt<MeasureStyle>("compare", "Compare"),
+];
+
+const SYSTEMS = [
+  opt<UnitSystem>("metric", "Metric"),
+  opt<UnitSystem>("imperial", "Imperial"),
+];
+
+const QUANTITIES: Quantity[] = ["length", "mass", "capacity"];
+
+const QUANTITY_NAME: Record<Quantity, string> = {
+  length: "Length",
+  mass: "Weight",
+  capacity: "Capacity",
+};
+
+export function MeasurePanel({ config, set }: PanelProps<MeasureConfig>) {
+  return (
+    <>
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      <Choice
+        label="System"
+        value={config.system}
+        onChange={(system) => set({ system })}
+        options={SYSTEMS}
+      />
+      <Pool
+        label="Measuring"
+        values={QUANTITIES}
+        chosen={config.quantities}
+        onChange={(quantities) => set({ quantities })}
+        labelOf={(quantity) => QUANTITY_NAME[quantity]}
+      />
+      <Span
+        label="Amounts"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={1}
+        max={500}
+        hint="How many of the unit written on the left."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/money.tsx
+++ b/src/games/printshop/options/money.tsx
@@ -1,0 +1,78 @@
+/**
+ * Money.
+ *
+ * The currency is a switch rather than a build-time constant for the reason A4
+ * is (§4): a British child counting dollars is being asked a question about a
+ * foreign country, and the sheet is otherwise identical.
+ */
+import { Checkbox } from "@/components/ui/kit";
+import type {
+  Currency,
+  DecimalForm,
+  MoneyConfig,
+  MoneyOperation,
+} from "@/engine/sheets/types";
+
+import { Choice, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const CURRENCIES = [
+  opt<Currency>("usd", "Dollars"),
+  opt<Currency>("gbp", "Pounds"),
+  opt<Currency>("eur", "Euros"),
+];
+
+const OPERATIONS = [
+  opt<MoneyOperation>("add", "Add"),
+  opt<MoneyOperation>("subtract", "Subtract"),
+  opt<MoneyOperation>("multiply", "Multiply"),
+  opt<MoneyOperation>("both", "Add and subtract"),
+];
+
+const FORMS = [
+  opt<DecimalForm>("horizontal", "Along a line"),
+  opt<DecimalForm>("vertical", "In columns"),
+];
+
+export function MoneyPanel({ config, set }: PanelProps<MoneyConfig>) {
+  return (
+    <>
+      <Choice
+        label="Currency"
+        value={config.currency}
+        onChange={(currency) => set({ currency })}
+        options={CURRENCIES}
+      />
+      <Choice
+        label="Operation"
+        value={config.operation}
+        onChange={(operation) => set({ operation })}
+        options={OPERATIONS}
+      />
+      <Choice
+        label="Written"
+        value={config.form}
+        onChange={(form) => set({ form })}
+        options={FORMS}
+      />
+      <Span
+        label="Amounts"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={0}
+        max={999}
+        hint="The whole units the amounts sit between — dollars, pounds or euros."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/multiplication.tsx
+++ b/src/games/printshop/options/multiplication.tsx
@@ -1,0 +1,137 @@
+/**
+ * Times tables, division, and the two written methods.
+ *
+ * Two of the controls below are shown conditionally, and neither is a nicety.
+ * "Written" has nothing to decide on a multiplication square or a long form —
+ * one is a grid and the other is always stacked — and the digit pair means
+ * nothing at all to a fact sheet, which draws from the tables instead. An
+ * option that does nothing is worse than a missing one: it teaches a parent
+ * that the panel doesn't do what it says.
+ */
+import { Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
+import type {
+  MultiplicationConfig,
+  MultiplicationForm,
+  MultiplicationOperation,
+  MultiplicationStyle,
+} from "@/engine/sheets/types";
+
+import { Choice, Pool, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const TABLES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+const OPERATIONS = [
+  opt<MultiplicationOperation>("multiply", "Multiply"),
+  opt<MultiplicationOperation>("divide", "Divide"),
+  opt<MultiplicationOperation>("both", "Both"),
+];
+
+const STYLES = [
+  opt<MultiplicationStyle>("standard", "Standard"),
+  opt<MultiplicationStyle>("missing", "Missing number"),
+  opt<MultiplicationStyle>("grid", "Grid"),
+  opt<MultiplicationStyle>("long", "Long method"),
+];
+
+const FORMS = [
+  opt<MultiplicationForm>("horizontal", "Along a line"),
+  opt<MultiplicationForm>("vertical", "In columns"),
+];
+
+export function MultiplicationPanel({
+  config,
+  set,
+}: PanelProps<MultiplicationConfig>) {
+  const long = config.style === "long";
+  const digits = config.digits ?? { into: 3, by: 2 };
+
+  return (
+    <>
+      <Choice
+        label="Operation"
+        value={config.operation}
+        onChange={(operation) => set({ operation })}
+        options={OPERATIONS}
+      />
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      {config.style !== "grid" && !long && (
+        <Choice
+          label="Written"
+          value={config.form}
+          onChange={(form) => set({ form })}
+          options={FORMS}
+        />
+      )}
+
+      {long ? (
+        <FieldSet
+          legend="Digits"
+          hint="How many digits the number being worked on has, and how many the one doing the working has."
+        >
+          <span className="span">
+            <NumberStepper
+              label="Digits in the number being worked on"
+              value={digits.into}
+              min={1}
+              max={5}
+              onChange={(into) => set({ digits: { ...digits, into } })}
+            />
+            <span className="span__to" aria-hidden="true">
+              by
+            </span>
+            <NumberStepper
+              label="Digits in the number doing the working"
+              value={digits.by}
+              min={1}
+              max={3}
+              onChange={(by) => set({ digits: { ...digits, by } })}
+            />
+          </span>
+        </FieldSet>
+      ) : (
+        <>
+          <Pool
+            label="Tables"
+            values={TABLES}
+            chosen={config.tables}
+            onChange={(tables) => set({ tables })}
+            hint="One is a table to learn; several is a mixed set, which is the difference between learning a table and knowing them."
+          />
+          <Span
+            label="Multiplied by"
+            value={config.factors}
+            onChange={(factors) => set({ factors })}
+            min={0}
+            max={12}
+          />
+        </>
+      )}
+
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+      />
+
+      {long && config.operation !== "multiply" && (
+        <Checkbox
+          label="Divisions may leave a remainder"
+          hint="Off unless asked for — a remainder is a different question, not a harder one."
+          checked={config.remainders === true}
+          onChange={(remainders) => set({ remainders })}
+        />
+      )}
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/paper.tsx
+++ b/src/games/printshop/options/paper.tsx
@@ -1,0 +1,97 @@
+/**
+ * Lined, ruled, graph, dot and isometric paper.
+ *
+ * The one family whose options are the §17 line "ruling and rule size · line
+ * spacing", all three of which are the same question here: on ruled paper the
+ * spacing between the lines *is* the ruling, which is why the sizes are named
+ * by their pitch — a teacher says "we're on ⅝ paper this year", not "we're on
+ * handwriting paper at spacing four".
+ *
+ * The two extras appear only where they mean something. A midline and descender
+ * space belong to a handwriting rule and nothing else; a square belongs to the
+ * three rulings that repeat across the page as well as down it. Showing them
+ * greyed out on narrow ruled would be offering a choice that does nothing.
+ */
+import { GRID_PITCHES, RULINGS, rulingOf } from "@/engine/sheets/paper";
+import type {
+  Midline,
+  PaperConfig,
+  RuleStyle,
+  Mil,
+} from "@/engine/sheets/types";
+
+import { Checkbox } from "@/components/ui/kit";
+
+import { Choice, opt, type PanelProps } from "./parts";
+
+const STYLES = Object.values(RULINGS).map((ruling) =>
+  opt<RuleStyle>(ruling.id, ruling.label),
+);
+
+const MIDLINES = [
+  opt<Midline>("dashed", "Dashed", "the usual"),
+  opt<Midline>("solid", "Solid", "youngest"),
+  opt<Midline>("none", "None", "oldest"),
+];
+
+/** The squares of §5, labelled the way the paper is sold. */
+const SQUARES = [
+  opt("quarter-inch", "¼ in"),
+  opt("fifth-inch", "⅕ in"),
+  opt("centimetre", "1 cm"),
+  opt("half-centimetre", "5 mm"),
+];
+
+type Square = keyof typeof GRID_PITCHES;
+
+export function PaperPanel({ config, set }: PanelProps<PaperConfig>) {
+  const ruling = rulingOf(config.rule);
+  const rule = (patch: Partial<PaperConfig["rule"]>) =>
+    set({ rule: { ...config.rule, ...patch } });
+
+  // Which square is chosen, read back off the pitch rather than stored beside
+  // it: `Rule` holds a length, and a second field naming the same thing is a
+  // second thing that can disagree with it.
+  const square =
+    (Object.keys(GRID_PITCHES) as Square[]).find(
+      (key) => GRID_PITCHES[key] === config.rule.pitch,
+    ) ?? "quarter-inch";
+
+  return (
+    <>
+      <Choice
+        label="Ruling and line spacing"
+        value={config.rule.style}
+        onChange={(style) => rule({ style })}
+        options={STYLES}
+        hint="Handwriting sizes are named by the space between one set of lines and the next."
+      />
+
+      {ruling.handwriting && (
+        <>
+          <Choice
+            label="Midline"
+            value={config.rule.midline ?? "dashed"}
+            onChange={(midline) => rule({ midline })}
+            options={MIDLINES}
+          />
+          <Checkbox
+            label="Room for descenders"
+            hint="Space below the baseline for the tail of a g."
+            checked={config.rule.descender === true}
+            onChange={(descender) => rule({ descender })}
+          />
+        </>
+      )}
+
+      {ruling.grid && (
+        <Choice
+          label="Square"
+          value={square}
+          onChange={(next) => rule({ pitch: GRID_PITCHES[next] as Mil })}
+          options={SQUARES}
+        />
+      )}
+    </>
+  );
+}

--- a/src/games/printshop/options/parts.tsx
+++ b/src/games/printshop/options/parts.tsx
@@ -1,0 +1,239 @@
+/**
+ * The four shapes an option on a worksheet takes.
+ *
+ * Fifteen families ask fifteen different questions, but they ask them in almost
+ * the same four ways: pick one of a handful, set a low and a high number, say
+ * how many problems and how many columns, and tick which of a pool are in play.
+ * Writing those four once is what keeps a family's panel down to the sentences
+ * that are true of *that* family — see `arithmetic.tsx`, which is a dozen lines
+ * because everything generic about it is here.
+ *
+ * Every control is a kit primitive underneath. Nothing in this directory
+ * hand-rolls an `<input>`, a `<select>` or a `<label>`; if something is missing
+ * it goes in `src/components/ui/`, which is the rule the lint config states in
+ * its own words.
+ */
+import {
+  Checkbox,
+  FieldSet,
+  NumberStepper,
+  SegmentedControl,
+  Select,
+  type SegmentedOption,
+} from "@/components/ui/kit";
+import type { SheetConfig } from "@/engine/sheets/types";
+
+/**
+ * What a family's panel is handed.
+ *
+ * `C` is that family's own config, so a panel is checked against the fields it
+ * actually has — a `MoneyPanel` that reached for `regrouping` would not
+ * compile. The registry in index.tsx is what ties `C` back to the union, the
+ * same way `SheetSpec` does in the engine.
+ */
+export type PanelProps<C extends SheetConfig = SheetConfig> = {
+  config: C;
+  /** Patch this family's config. The bench merges it and rebuilds. */
+  set: (patch: Partial<C>) => void;
+};
+
+/** A choice, written the short way: `opt("add", "Adding")`. */
+export const opt = <T extends string>(
+  value: T,
+  label: string,
+  hint?: string,
+): SegmentedOption<T> => ({ value, label, hint });
+
+/**
+ * One choice out of several.
+ *
+ * A row of pills up to five, a dropdown beyond — which is the rule the kit's
+ * own `SegmentedControl` states: every option on screen at once is the better
+ * control right up to the point where the row wraps into a wall, and a list of
+ * twelve rulings is well past it.
+ */
+export function Choice<T extends string>({
+  label,
+  value,
+  onChange,
+  options,
+  hint,
+}: {
+  label: string;
+  value: T;
+  onChange: (value: T) => void;
+  options: SegmentedOption<T>[];
+  hint?: string;
+}) {
+  return (
+    <FieldSet legend={label} hint={hint}>
+      {options.length > 5 ? (
+        <Select
+          value={value}
+          onChange={(next) => onChange(next as T)}
+          options={options}
+          aria-label={label}
+        />
+      ) : (
+        <SegmentedControl
+          label={label}
+          value={value}
+          onChange={onChange}
+          options={options}
+          slim
+        />
+      )}
+    </FieldSet>
+  );
+}
+
+/**
+ * The low and the high of a range, as two steppers that can't cross.
+ *
+ * Clamped against each other rather than validated after the fact: a range
+ * whose bottom is above its top is not a message to show a parent, it is a
+ * state the control should not be able to reach. Every family that has one
+ * reads it as ends-included, so "1 to 20" on screen is `{ min: 1, max: 20 }`
+ * and both numbers appear on the page.
+ */
+export function Span({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  hint,
+}: {
+  label: string;
+  value: { min: number; max: number };
+  onChange: (next: { min: number; max: number }) => void;
+  min: number;
+  max: number;
+  hint?: string;
+}) {
+  return (
+    <FieldSet legend={label} hint={hint}>
+      <span className="span">
+        <NumberStepper
+          label={`${label}, lowest`}
+          value={value.min}
+          min={min}
+          max={max}
+          onChange={(next) =>
+            onChange({ min: next, max: Math.max(next, value.max) })
+          }
+        />
+        <span className="span__to" aria-hidden="true">
+          to
+        </span>
+        <NumberStepper
+          label={`${label}, highest`}
+          value={value.max}
+          min={min}
+          max={max}
+          onChange={(next) =>
+            onChange({ min: Math.min(next, value.min), max: next })
+          }
+        />
+      </span>
+    </FieldSet>
+  );
+}
+
+/**
+ * How many problems, and how many across.
+ *
+ * The one pair every generating family has, and the one place a number a parent
+ * types is knowingly a request rather than a promise: each family caps the count
+ * at what the page holds, so asking for two hundred sums on a Letter page gives
+ * as many as fit and no second page of nothing. The hint says so, because a
+ * number that silently becomes another number is worse than a smaller maximum.
+ */
+export function Sizing({
+  count,
+  columns,
+  onCount,
+  onColumns,
+  maxColumns = 6,
+}: {
+  count: number;
+  columns: number;
+  onCount: (next: number) => void;
+  onColumns: (next: number) => void;
+  maxColumns?: number;
+}) {
+  return (
+    <>
+      <FieldSet legend="Problems" hint="Capped at what fits on the page.">
+        <NumberStepper
+          label="Problems"
+          value={count}
+          min={1}
+          max={200}
+          onChange={onCount}
+        />
+      </FieldSet>
+      <FieldSet legend="Columns">
+        <NumberStepper
+          label="Columns"
+          value={columns}
+          min={1}
+          max={maxColumns}
+          onChange={onColumns}
+        />
+      </FieldSet>
+    </>
+  );
+}
+
+/**
+ * Which of a set are in play — the times tables, the denominators, the topics.
+ *
+ * A pool rather than a range, for the reason the engine gives where each one is
+ * declared: "the seven and eight times tables" is a choice somebody makes and
+ * "2 to 12" is not.
+ *
+ * The last tick cannot be removed. An empty pool is not a harder sheet, it is a
+ * sheet with nothing on it, and the honest place to refuse that is the control
+ * rather than a generator that quietly draws from everything instead.
+ */
+export function Pool<T extends string | number>({
+  label,
+  values,
+  chosen,
+  onChange,
+  labelOf = String,
+  hint,
+}: {
+  label: string;
+  values: readonly T[];
+  chosen: T[];
+  onChange: (next: T[]) => void;
+  labelOf?: (value: T) => string;
+  hint?: string;
+}) {
+  return (
+    <FieldSet legend={label} hint={hint}>
+      <span className="pool">
+        {values.map((value) => {
+          const on = chosen.includes(value);
+          return (
+            <Checkbox
+              key={String(value)}
+              label={labelOf(value)}
+              checked={on}
+              disabled={on && chosen.length === 1}
+              onChange={(next) =>
+                onChange(
+                  next
+                    ? values.filter((v) => v === value || chosen.includes(v))
+                    : chosen.filter((v) => v !== value),
+                )
+              }
+            />
+          );
+        })}
+      </span>
+    </FieldSet>
+  );
+}

--- a/src/games/printshop/options/prealgebra.tsx
+++ b/src/games/printshop/options/prealgebra.tsx
@@ -1,0 +1,89 @@
+/**
+ * Pre-algebra.
+ *
+ * Steps is the dial: `x + 7 = 12` is undone by one move and `3x + 4 = 19` by
+ * two, and they are a term apart rather than a harder version of the same
+ * question. Negatives matter more here than anywhere else in the shop —
+ * dividing an inequality by a negative turns it round, which is the single
+ * most-missed step in the whole topic.
+ */
+import { Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
+import type { AlgebraStyle, PreAlgebraConfig } from "@/engine/sheets/types";
+
+import { Choice, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<AlgebraStyle>("expression", "Expressions"),
+  opt<AlgebraStyle>("equation", "Equations"),
+  opt<AlgebraStyle>("inequality", "Inequalities"),
+  opt<AlgebraStyle>("slope", "Slope"),
+  opt<AlgebraStyle>("graph", "From a graph"),
+];
+
+const QUADRANTS = [
+  opt("1", "One", "no negatives"),
+  opt("4", "Four", "all four"),
+];
+
+export function PreAlgebraPanel({ config, set }: PanelProps<PreAlgebraConfig>) {
+  const solving = config.style === "equation" || config.style === "inequality";
+
+  return (
+    <>
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      {solving && (
+        <FieldSet
+          legend="Steps to solve"
+          hint="One move, or two. A term apart in the year."
+        >
+          <NumberStepper
+            label="Steps to solve"
+            value={config.steps ?? 1}
+            min={1}
+            max={2}
+            onChange={(steps) => set({ steps })}
+          />
+        </FieldSet>
+      )}
+      {config.style === "graph" && (
+        <Choice
+          label="Quadrants"
+          value={String(config.quadrants ?? 1)}
+          onChange={(quadrants) => set({ quadrants: Number(quadrants) })}
+          options={QUADRANTS}
+        />
+      )}
+      <Span
+        label="Numbers"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={1}
+        max={100}
+        hint="How big the numbers get, sign aside."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={4}
+      />
+      <Checkbox
+        label="Negative numbers"
+        hint="In the question or in the answer."
+        checked={config.negatives === true}
+        onChange={(negatives) => set({ negatives })}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/ratio.tsx
+++ b/src/games/printshop/options/ratio.tsx
@@ -1,0 +1,50 @@
+/**
+ * Ratio, proportion and rate — three names for one idea.
+ *
+ * The shortest panel in the shop, and honestly so: what makes one of these
+ * harder is how big the numbers are and nothing else. A style and a range is the
+ * whole of it, and inventing a fourth control to make the panel look busier
+ * would be inventing a choice that changes nothing on the paper.
+ */
+import { Checkbox } from "@/components/ui/kit";
+import type { RatioConfig, RatioStyle } from "@/engine/sheets/types";
+
+import { Choice, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<RatioStyle>("simplify", "Simplify"),
+  opt<RatioStyle>("proportion", "Proportion"),
+  opt<RatioStyle>("rate", "Rate"),
+];
+
+export function RatioPanel({ config, set }: PanelProps<RatioConfig>) {
+  return (
+    <>
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      <Span
+        label="Numbers"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={1}
+        max={200}
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={4}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/statistics.tsx
+++ b/src/games/printshop/options/statistics.tsx
@@ -1,0 +1,64 @@
+/**
+ * Mean, median, mode and range.
+ *
+ * The size of the set is not really a difficulty dial, and the hint says so: an
+ * even-sized set has its median between two numbers, which is the lesson a
+ * five-number set cannot teach at any level.
+ */
+import { Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
+import type { StatisticStyle, StatisticsConfig } from "@/engine/sheets/types";
+
+import { Choice, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<StatisticStyle>("mean", "Mean"),
+  opt<StatisticStyle>("median", "Median"),
+  opt<StatisticStyle>("mode", "Mode"),
+  opt<StatisticStyle>("range", "Range"),
+  opt<StatisticStyle>("all", "All four"),
+];
+
+export function StatisticsPanel({ config, set }: PanelProps<StatisticsConfig>) {
+  return (
+    <>
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      <FieldSet
+        legend="Numbers in each set"
+        hint="An even-sized set puts the median between two numbers, which is its own lesson."
+      >
+        <NumberStepper
+          label="Numbers in each set"
+          value={config.size}
+          min={3}
+          max={12}
+          onChange={(size) => set({ size })}
+        />
+      </FieldSet>
+      <Span
+        label="Numbers"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={0}
+        max={200}
+        hint="What the sets are drawn from."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={2}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/time.tsx
+++ b/src/games/printshop/options/time.tsx
@@ -1,0 +1,64 @@
+/**
+ * Telling the time.
+ *
+ * The step is the difficulty dial and it is the whole of it: o'clock, half past,
+ * the quarters, the numerals a child counts round in fives, and any minute
+ * there is. The names come from the engine rather than from here so the picker
+ * and the printed title cannot disagree about what a sheet is set to.
+ */
+import { Checkbox } from "@/components/ui/kit";
+import { STEP_NAME, TIME_STEPS } from "@/engine/sheets/maths/time";
+import type { TimeConfig, TimeStyle } from "@/engine/sheets/types";
+
+import { Choice, Sizing, Span, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<TimeStyle>("read", "Read the clock"),
+  opt<TimeStyle>("draw", "Draw the hands"),
+  opt<TimeStyle>("elapsed", "Time between"),
+];
+
+const STEPS = TIME_STEPS.map((step) =>
+  opt(String(step), STEP_NAME[step] ?? `to ${step} minutes`),
+);
+
+export function TimePanel({ config, set }: PanelProps<TimeConfig>) {
+  return (
+    <>
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+      <Choice
+        label="Times land"
+        value={String(config.step)}
+        onChange={(step) => set({ step: Number(step) })}
+        options={STEPS}
+      />
+      {config.style === "elapsed" && (
+        <Span
+          label="Minutes apart"
+          value={config.span ?? { min: 5, max: 120 }}
+          onChange={(span) => set({ span })}
+          min={1}
+          max={720}
+          hint="Half an hour to two hours is a different lesson from five minutes to twenty."
+        />
+      )}
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={4}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace === true}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/wordproblems.tsx
+++ b/src/games/printshop/options/wordproblems.tsx
@@ -1,0 +1,66 @@
+/**
+ * Word problems.
+ *
+ * The topics are a pool because a page that mixes them is the point: a child who
+ * knows which sum to do when the question says so is not yet doing word
+ * problems. Work space is on by default here and nowhere else — a story
+ * problem is worked out on the page, not in the margin.
+ */
+import { Checkbox } from "@/components/ui/kit";
+import type { WordProblemConfig, WordTopic } from "@/engine/sheets/types";
+
+import { Pool, Sizing, Span, type PanelProps } from "./parts";
+
+const TOPICS: WordTopic[] = [
+  "integers",
+  "rate",
+  "percent",
+  "equation",
+  "average",
+];
+
+const TOPIC_NAME: Record<WordTopic, string> = {
+  integers: "Adding and taking away",
+  rate: "Rate",
+  percent: "Percentages",
+  equation: "Equations",
+  average: "Averages",
+};
+
+export function WordProblemsPanel({
+  config,
+  set,
+}: PanelProps<WordProblemConfig>) {
+  return (
+    <>
+      <Pool
+        label="Topics"
+        values={TOPICS}
+        chosen={config.topics}
+        onChange={(topics) => set({ topics })}
+        labelOf={(topic) => TOPIC_NAME[topic]}
+        hint="Several at once is the exercise: knowing which sum to do is most of it."
+      />
+      <Span
+        label="Numbers"
+        value={config.range}
+        onChange={(range) => set({ range })}
+        min={1}
+        max={500}
+        hint="How big the numbers in a story get."
+      />
+      <Sizing
+        count={config.count}
+        columns={config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={2}
+      />
+      <Checkbox
+        label="Work space under every problem"
+        checked={config.workspace !== false}
+        onChange={(workspace) => set({ workspace })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/useBuilder.ts
+++ b/src/games/printshop/useBuilder.ts
@@ -1,0 +1,173 @@
+/**
+ * Everything the bench holds: a config, a seed, and how many copies of it.
+ *
+ * The state is deliberately small — five values — because everything else on
+ * the screen is derived from them. `buildSheet(config, seed)` is deterministic
+ * (§7), so the preview, the answer key, the variants and the shareable URL are
+ * all functions of the same five values rather than four things kept in step.
+ *
+ * **The URL is the save file.** A static site has no server to hand back a
+ * short id for a configuration, so the configuration *is* the id (§14): every
+ * change rewrites `#s=`, which makes the address bar a bookmark, a way to send
+ * a sheet to somebody, and a reproducible bug report. `replaceState` and not
+ * `pushState` — a builder that pushed a history entry per keystroke would take
+ * a hundred presses of Back to leave.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { buildSheet, describeSheet } from "@/engine/sheets";
+import { decodeSharedSheet, encodeSharedSheet } from "@/engine/sheets/share";
+import type { SheetConfig } from "@/engine/sheets/types";
+
+import { defaultConfig, FIRST_SHEET } from "./defaults";
+
+/** How long the preview waits after the last press before it redraws. */
+export const REDRAW_DELAY = 160;
+
+/** Copies of the sheet, each from its own seed. §17 asks for up to five. */
+export const MAX_VARIANTS = 5;
+
+export type Builder = {
+  config: SheetConfig;
+  seed: number;
+  variants: number;
+  /** Print the answer key after each variant. */
+  answers: boolean;
+  /** Patch the current family's config. Never changes which family it is. */
+  set: (patch: Partial<SheetConfig>) => void;
+  /** Swap family, opening on that family's own starting sheet. */
+  setFamily: (kind: string) => void;
+  /** Load a whole sheet — a shared link, or one out of My Sheets. */
+  open: (config: SheetConfig, seed: number) => void;
+  /** The same config, a different draw of it (§7). */
+  reroll: () => void;
+  setVariants: (count: number) => void;
+  setAnswers: (on: boolean) => void;
+};
+
+/**
+ * What the fragment held when the page opened, if it held a sheet.
+ *
+ * Read once, on mount, and never again: the hook rewrites `#s=` on every change
+ * from then on, so re-reading it would be reading its own handwriting.
+ *
+ * Test-built before it is trusted. `decodeSharedSheet` rebuilds the half of a
+ * config every family shares and leaves each family's own fields alone, on the
+ * grounds that a family already treats them as untrusted — so this is the belt
+ * to that pair of braces, and the one place the promise in §14 ("fall back to
+ * defaults rather than throwing") is actually kept.
+ */
+function fromHash(): { config: SheetConfig; seed: number } | null {
+  if (typeof window === "undefined") return null;
+  const match = /^#s=(.*)$/.exec(window.location.hash);
+  if (!match) return null;
+
+  const shared = decodeSharedSheet(match[1]);
+  if (!shared) return null;
+
+  try {
+    // Both halves, because a family reaches into its own config twice: once to
+    // make the page and once to say in a line what is on it. `services/sheets`
+    // guards `describeSheet` for exactly this reason, and a bench that built
+    // the paper and then threw on the caption would be no better than one that
+    // threw on the paper.
+    buildSheet(shared.config, shared.seed);
+    describeSheet(shared.config);
+  } catch {
+    return null;
+  }
+  return shared;
+}
+
+export function useBuilder(): Builder {
+  // Lazily, so the fragment is read once rather than on every render — and so
+  // the very first paint is already the shared sheet rather than the default
+  // one replaced a tick later.
+  const [state, setState] = useState(() => {
+    const shared = fromHash();
+    return {
+      config: shared?.config ?? defaultConfig(FIRST_SHEET),
+      seed: shared?.seed ?? 1,
+    };
+  });
+  const [variants, setVariants] = useState(1);
+  const [answers, setAnswers] = useState(false);
+
+  // The hash this hook last wrote. Compared before writing so that a change
+  // which happens to produce the same URL — pressing + and then − — doesn't
+  // touch the address bar at all.
+  const written = useRef<string | null>(null);
+
+  useEffect(() => {
+    const payload = encodeSharedSheet({
+      config: state.config,
+      seed: state.seed,
+    });
+    if (written.current === payload) return;
+    written.current = payload;
+    window.history.replaceState(null, "", `#s=${payload}`);
+  }, [state]);
+
+  const set = useCallback((patch: Partial<SheetConfig>) => {
+    // Cast at the one point a patch meets a union. The panels are each typed to
+    // their own family and can only produce a patch of it; what is lost here is
+    // TypeScript's ability to prove that the patch and the config are the same
+    // member, which no spread of a union can express.
+    setState((current) => ({
+      ...current,
+      config: { ...current.config, ...patch } as SheetConfig,
+    }));
+  }, []);
+
+  const setFamily = useCallback((kind: string) => {
+    // A fresh config rather than a merge. Sharing `count` and `columns` across
+    // families looks thoughtful and prints a page of six long divisions in
+    // three columns, because the numbers mean different things in each.
+    setState((current) => ({
+      ...current,
+      config: { ...defaultConfig(kind), paper: current.config.paper },
+    }));
+  }, []);
+
+  const open = useCallback((config: SheetConfig, seed: number) => {
+    setState({ config, seed });
+  }, []);
+
+  const reroll = useCallback(() => {
+    setState((current) => ({ ...current, seed: current.seed + 1 }));
+  }, []);
+
+  return {
+    config: state.config,
+    seed: state.seed,
+    variants,
+    answers,
+    set,
+    setFamily,
+    open,
+    reroll,
+    setVariants,
+    setAnswers,
+  };
+}
+
+/**
+ * A value that lags behind by `delay`, so the preview redraws once a parent has
+ * stopped rather than once per keystroke.
+ *
+ * §14 asks for this by name: a sheet of two hundred problems is cheap to build
+ * and not free, and every generator here draws-and-rejects rather than
+ * enumerating, so the cost is real at the top of a range. The controls
+ * themselves are never debounced — a stepper that answered a sixth of a second
+ * late would feel broken — only the paper is.
+ */
+export function useDebounced<T>(value: T, delay = REDRAW_DELAY): T {
+  const [settled, setSettled] = useState(value);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setSettled(value), delay);
+    return () => window.clearTimeout(timer);
+  }, [value, delay]);
+
+  return settled;
+}

--- a/src/games/race/QuitSheet.tsx
+++ b/src/games/race/QuitSheet.tsx
@@ -15,16 +15,16 @@ export function QuitSheet({
 }) {
   return (
     <div
-      className="sheet"
+      className="modal"
       role="dialog"
       aria-modal="true"
       aria-label="Quit the race"
     >
       <Scrim onClose={onKeepRacing} label="Keep racing" />
-      <div className="sheet__panel panel anim-pop">
+      <div className="modal__panel panel anim-pop">
         <h2 className="panel__title">Quit this race?</h2>
         <p className="muted">It won&apos;t be saved and no XP is earned.</p>
-        <div className="sheet__actions">
+        <div className="modal__actions">
           <Button variant="danger" size="sm" onClick={onQuit}>
             Quit
           </Button>

--- a/src/pages/printables/[topic].astro
+++ b/src/pages/printables/[topic].astro
@@ -149,9 +149,10 @@ const strand = strands.find((group) => group.id === sheet.strand)!;
         bench opens on exactly the page above rather than on a blank one.
       </p>
       <p class="aside">
-        The bench is still being installed. Until it opens, the link is worth
-        having anyway: it holds the whole configuration in the address bar, so
-        it can be bookmarked or sent to somebody now and opened when it lands.
+        The configuration travels in the address bar rather than on a server, so
+        the link can be bookmarked or sent to somebody as it stands &mdash; and
+        what they open is this sheet, down to the seed, rather than another one
+        like it.
       </p>
     </div>
     <div class="hero__actions">

--- a/src/pages/printables/make.astro
+++ b/src/pages/printables/make.astro
@@ -1,22 +1,30 @@
 ---
 import Content from "@/layouts/Content.astro";
+import PrintShopApp from "@/games/printshop/App";
+import "@/styles/index.css";
 
 /**
- * The sheet builder's route, reserved and wired before the builder exists.
+ * The sheet builder's route.
  *
  * It is `WorldInfo.island` for the paper world, which is what keeps it out of
  * the sitemap, and it carries `noindex` for the reason every island does: what
- * will render here is a `client:only` app, and a near-empty page submitted to
- * search is a thin-content signal against the whole domain. Both halves of
- * that have to be true from the first build rather than from the build the app
- * lands in — a route that is indexed for a month and then hidden is worse than
- * one that was never offered.
+ * renders here is a `client:only` app, and a near-empty page submitted to
+ * search is a thin-content signal against the whole domain. The crawlable
+ * surface of The Print Shop is the catalog — every page there *is* a sheet
+ * (§8) — and this is the screen you go to when one of those is nearly right.
  *
  * Content rather than Base, unlike the games. A race must never have site
  * chrome over it; the builder is the opposite case, because `print.css` hides
  * the masthead, the footer and everything marked `.no-print` when a sheet goes
  * to paper. So the builder can keep the site around it and lose it at exactly
  * the moment it would cost somebody toner.
+ *
+ * `index.css` — the island stylesheet — rather than only the content one,
+ * because the option panels are built out of the kit and the kit's rows,
+ * steppers and segmented pills are styled there. That is what finally settled
+ * the `.sheet` name collision recorded in sheet.css: this page is the one that
+ * loads the modal styles *and* the sheet renderer's, so the modal became
+ * `.modal`.
  */
 ---
 
@@ -26,21 +34,25 @@ import Content from "@/layouts/Content.astro";
   world="paper"
   noindex
 >
-  <header class="hero wrap">
+  <header class="hero wrap no-print">
     <p class="hero__eyebrow">
       <span class="hero__world">The Print Shop</span>
       The bench
     </p>
-    <h1 class="hero__title">The press isn&rsquo;t installed yet</h1>
+    <h1 class="hero__title">Build a sheet</h1>
     <p class="hero__lead">
-      This is where a sheet gets built: pick a family, set the ruling, the type
-      size and how many problems fit, and watch the page change as you do it. It
-      is being made now, and nothing in The Print Shop will wait on it &mdash; a
-      sheet there is a page that prints as it stands, and the bench only changes
-      what is on one.
+      Pick what is on it, set the paper, the type size and how many problems
+      fit, and watch the page change as you go. Everything happens in this
+      browser &mdash; the settings live in the address bar, so a sheet can be
+      bookmarked or passed on as an ordinary link, and nothing about your child
+      goes into either.
     </p>
-    <div class="hero__actions">
-      <a class="cta" href="/printables">Go to The Print Shop</a>
-    </div>
   </header>
+
+  <!--
+    client:only rather than client:load: the saved-sheet panel reads IndexedDB
+    on first render, so there is no meaningful server-rendered markup to
+    hydrate, and attempting SSR would throw on `indexedDB`.
+  -->
+  <PrintShopApp client:only="react" />
 </Content>

--- a/src/styles/printshop.css
+++ b/src/styles/printshop.css
@@ -1,0 +1,249 @@
+/* ── The bench ──────────────────────────────────────────────────────────────
+   The builder's own layout, and nothing else: the two columns, the option
+   groups down the left, the frame the paper is looked at in on the right, and
+   the print bar over it.
+
+   Not one colour is written down here. Every surface reads `--ink-*`,
+   `--chalk-*`, `--accent` and `--hairline`, which is what makes the whole
+   screen The Print Shop's warm graphite rather than a fifth palette — the
+   `[data-world="paper"]` block in worlds.css is the only place those are said,
+   and this file would follow it into any other world unchanged.
+
+   It arrives with the island (App.tsx imports it) rather than with a layout,
+   the same bargain sheet.css strikes: a page that renders the bench cannot
+   forget to bring the bench's stylesheet.
+
+   Everything in here is screen furniture, and every element that carries it
+   also carries `.no-print` — see the print block at the foot of the file for
+   the one exception, which is the whole point of the screen.                */
+
+.bench {
+  display: grid;
+  grid-template-columns: minmax(0, 22rem) minmax(0, 1fr);
+  gap: var(--gap-4);
+  align-items: start;
+  margin-inline: auto;
+  padding: var(--gap-4) var(--gap-3) var(--gap-5);
+  max-width: 78rem;
+}
+
+/* One column under a laptop: the paper first, because it is the thing being
+   made, and the options under it. A sheet squeezed into half of a tablet is a
+   preview nobody can read. */
+@media (width < 62rem) {
+  .bench {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .bench__paper {
+    order: -1;
+  }
+}
+
+.bench__panel {
+  display: grid;
+  gap: var(--gap-4);
+  align-content: start;
+}
+
+.bench__group {
+  display: grid;
+  gap: var(--gap-3);
+  background: linear-gradient(180deg, var(--ink-800), var(--ink-850));
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-paper);
+  padding: var(--gap-4);
+}
+
+.bench__title {
+  font-size: var(--step-1);
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--chalk);
+}
+
+.bench__paper {
+  display: grid;
+  gap: var(--gap-3);
+  position: sticky;
+  /* Under the masthead, which is the one piece of site chrome above it. */
+  top: var(--gap-3);
+}
+
+@media (width < 62rem) {
+  .bench__paper {
+    position: static;
+  }
+}
+
+/* ── The picker ─────────────────────────────────────────────────────────── */
+
+.picker {
+  display: grid;
+  gap: var(--gap-2);
+  background: linear-gradient(180deg, var(--ink-800), var(--ink-850));
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-paper);
+  padding: var(--gap-4);
+}
+
+/* `describeSheet(config)` — the engine's own line about what is set. */
+.picker__line {
+  font-size: var(--step--1);
+  color: var(--chalk-soft);
+}
+
+/* ── Two controls that only exist on this screen ────────────────────────────
+   A range is two steppers with a word between them, and a pool is a wrapped
+   row of checkboxes. Both are compositions of kit primitives rather than new
+   controls, so all that is needed here is how they sit.                     */
+
+.span {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-2);
+  flex-wrap: wrap;
+}
+
+.span__to {
+  font-size: var(--step--1);
+  color: var(--chalk-dim);
+}
+
+.pool {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-1) var(--gap-3);
+}
+
+/* ── The print bar ──────────────────────────────────────────────────────── */
+
+.printbar {
+  display: grid;
+  gap: var(--gap-2);
+  background: linear-gradient(180deg, var(--ink-800), var(--ink-850));
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-paper);
+  padding: var(--gap-3) var(--gap-4);
+}
+
+.printbar__row,
+.printbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-3);
+  flex-wrap: wrap;
+}
+
+/* The one line §17's output section is really about: print IS the download
+   here, and the words "Save as PDF" are the whole of the instruction. */
+.printbar__hint,
+.printbar__seed {
+  font-size: var(--step--1);
+  color: var(--chalk-soft);
+}
+
+.printbar__seed {
+  color: var(--chalk-dim);
+}
+
+/* ── The frame the paper is looked at in ────────────────────────────────────
+   The stage holds the room the scaled stack takes up, because a transform
+   changes what is painted and not what is laid out. Preview.tsx measures both
+   boxes and sets the height; everything else about it is here.              */
+
+.preview {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--hairline);
+  background:
+    radial-gradient(120% 90% at 50% 0%, rgb(255 255 255 / 4%), transparent 70%),
+    var(--ink-950);
+  padding: var(--gap-3);
+  overflow: hidden;
+}
+
+.preview__stage {
+  overflow: hidden;
+}
+
+.preview__stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-3);
+  width: max-content;
+  margin-inline: auto;
+  transform: scale(var(--preview-scale, 1));
+  transform-origin: top center;
+}
+
+/* ── My sheets ──────────────────────────────────────────────────────────── */
+
+.saved {
+  display: grid;
+  gap: var(--gap-2);
+  background: linear-gradient(180deg, var(--ink-800), var(--ink-850));
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-paper);
+  padding: var(--gap-4);
+}
+
+.saved__title {
+  font-size: var(--step-1);
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--chalk);
+}
+
+.saved__empty {
+  font-size: var(--step--1);
+  color: var(--chalk-dim);
+}
+
+.saved__list {
+  display: grid;
+  gap: var(--gap-1);
+  list-style: none;
+  padding-left: 0;
+}
+
+.saved__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap-2);
+  flex-wrap: wrap;
+  padding-top: var(--gap-1);
+  border-top: 1px solid var(--hairline);
+}
+
+.saved__name {
+  font-size: var(--step--1);
+  color: var(--chalk-soft);
+}
+
+.saved__actions {
+  display: flex;
+  gap: var(--gap-1);
+}
+
+/* ── Paper, and only paper ──────────────────────────────────────────────────
+   The preview is scaled, and a scaled sheet sent to a printer is a sheet at
+   45% of the size it measures — which on ⅝ handwriting paper is not a ⅝ rule
+   any more. So the sheets are rendered twice: the scaled copy for the screen,
+   this one for the printer, and neither has to be undone under pressure.
+   `print.css` hides everything carrying `.no-print`, which is the rest of this
+   file.                                                                     */
+
+.print-only {
+  display: none;
+}
+
+@media print {
+  .print-only {
+    display: block;
+  }
+}

--- a/src/styles/printshop.css
+++ b/src/styles/printshop.css
@@ -14,8 +14,9 @@
    forget to bring the bench's stylesheet.
 
    Everything in here is screen furniture, and every element that carries it
-   also carries `.no-print` — see the print block at the foot of the file for
-   the one exception, which is the whole point of the screen.                */
+   also carries `.no-print` — except the two the print block at the foot of the
+   file deals with: `.print-only`, which is the whole point of the screen, and
+   `.bench` itself, which cannot be hidden because it is what holds it.       */
 
 .bench {
   display: grid;
@@ -243,6 +244,26 @@
 }
 
 @media print {
+  /* The bench stops being a layout.
+
+     `print.css` hides everything carrying `.no-print`, but a hidden grid item
+     is still nothing laid out in a grid: left as it was, the bench indents the
+     print copy by its own `padding-inline` and drops it a row below the empty
+     column where the preview was. On Letter that is the sheet printed 18px past
+     the right edge of the paper, and a full-page sheet spilling onto a second
+     one — silently, because the two lengths that disagree are on different
+     elements. A catalog page has no bench and prints the same sheet at 0,0.
+
+     The sheet owns its own geometry (§4) and `print.css` zeroes its margin, so
+     the only correct thing between it and the page box is nothing at all. */
+  .bench {
+    display: block;
+    max-width: none;
+    margin: 0;
+    padding: 0;
+    gap: 0;
+  }
+
   .print-only {
     display: block;
   }

--- a/src/styles/screens.css
+++ b/src/styles/screens.css
@@ -237,9 +237,15 @@
   line-height: 1;
 }
 
-/* ── Sheet (modal) ─────────────────────────────────────────────────────── */
+/* ── Modal ──────────────────────────────────────────────────────────────────
+   The panel behind the player editor, the deck editor and the quit
+   confirmation. It was `.sheet` until The Print Shop arrived, and the rename is
+   recorded in the header of sheet.css: `/printables/make` is an island that
+   loads this file *and* the sheet renderer's, and two `.sheet` rules meeting
+   means an 8.5-inch-wide `position: fixed` modal. In a codebase with a print
+   shop in it, a sheet is a piece of paper.                                   */
 
-.sheet {
+.modal {
   position: fixed;
   inset: 0;
   z-index: 50;
@@ -250,8 +256,8 @@
 
 /* A real <button> (see the Scrim primitive) so the backdrop is reachable by
    keyboard, not just by mouse. These resets strip the UA button chrome so it
-   still renders as a plain dimmed sheet. */
-.sheet__scrim {
+   still renders as a plain dimmed backdrop. */
+.modal__scrim {
   position: absolute;
   inset: 0;
   display: block;
@@ -264,12 +270,12 @@
   backdrop-filter: blur(3px);
 }
 
-.sheet__scrim:focus-visible {
+.modal__scrim:focus-visible {
   outline: 2px solid var(--accent, #38bdf8);
   outline-offset: -4px;
 }
 
-.sheet__panel {
+.modal__panel {
   position: relative;
   width: min(30rem, 100%);
   max-height: 90dvh;
@@ -278,7 +284,7 @@
   gap: var(--gap-3);
 }
 
-.sheet__actions {
+.modal__actions {
   display: flex;
   gap: var(--gap-2);
   justify-content: flex-end;
@@ -288,7 +294,7 @@
   border-top: 1px solid var(--hairline);
 }
 
-.sheet__confirm {
+.modal__confirm {
   display: flex;
   align-items: center;
   gap: var(--gap-2);

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -11,14 +11,14 @@
    and every length in here is an inch, a point, or an em of a size that was
    itself set in points.
 
-   ── One name collision, recorded rather than worked around ──────────────────
-   `screens.css` already has a `.sheet`: the modal panel behind the player
-   editor and the quit confirmation. The two never meet today — that one arrives
-   with `index.css` on the game islands, this one with the renderer that uses it
-   — but `/printables/make` will be an island that loads both, and on that day
-   an 8.5in-wide `position: fixed` modal is what happens. The builder story
-   renames one of them; this note is here so it is a decision rather than a
-   surprise.
+   ── One name collision, settled ─────────────────────────────────────────────
+   `screens.css` used to have a `.sheet` of its own: the modal panel behind the
+   player editor and the quit confirmation. The two never met while this file
+   arrived with the renderer and that one with `index.css` on the game islands —
+   but `/printables/make` is an island that loads both, and on that day an
+   8.5in-wide `position: fixed` modal is what happened. So the modal was renamed
+   to `.modal` when the builder landed, which is the right way round: in a
+   codebase with a print shop in it, a sheet is a piece of paper.
 
    ── The ink ────────────────────────────────────────────────────────────────
    Black on white with no fills, by default and on purpose. A parent printing
@@ -29,6 +29,11 @@
 
 .sheet {
   --ui-scale: 1;
+
+  /* The face everything on the paper is set in, named once so the SVG blocks
+     below can be set in it too. `data-font` swaps it; see the block after the
+     ink section for what each of the three ids resolves to. */
+  --sheet-face: var(--font-body, system-ui, sans-serif);
 
   /* Overwritten inline by the renderer from the sheet's own `paper`. The
      defaults are Letter portrait at half-inch margins, which is what most of
@@ -50,9 +55,12 @@
   margin-inline: auto;
   display: flex;
   flex-direction: column;
+  /* The containing block for the cut guides, which are drawn over the paper
+     rather than in the flow so that switching them on costs no capacity. */
+  position: relative;
   /* The fallbacks are not decoration: this stylesheet arrives with the
      renderer, so it has to stand up on a page that never loaded tokens.css. */
-  font-family: var(--font-body, system-ui, sans-serif);
+  font-family: var(--sheet-face);
   font-size: var(--sheet-pt);
   line-height: 1.35;
   color: #000;
@@ -206,7 +214,48 @@
 .sheet__ink {
   display: block;
   max-width: 100%;
-  font-family: var(--font-body, system-ui, sans-serif);
+  font-family: var(--sheet-face, var(--font-body, system-ui, sans-serif));
+}
+
+/* ── The three faces (§17) ──────────────────────────────────────────────────
+   Stacks rather than files, for now and on purpose. A self-hosted set arrives
+   with the handwriting stories (PRINT15), which need real letterforms to draw
+   the trace styles from; until then each id resolves to whatever the reader's
+   machine already has and falls back to the default when it has none. That is
+   the honest version of the option: a parent who has installed a dyslexia-
+   friendly face gets it, and one who hasn't gets a readable sheet rather than a
+   download and a wait.
+
+   The `Sheet` carries the id and never the stack, so a sheet saved this term
+   opens in the *named* face once the files land, rather than in whatever this
+   list happened to say the week it was saved.                                */
+
+.sheet[data-font="cursive"] {
+  --sheet-face:
+    "Segoe Script", "Bradley Hand", "Snell Roundhand", "Lucida Handwriting",
+    cursive;
+}
+
+/* Comic Sans is in here on the evidence rather than on taste: it is one of the
+   faces dyslexia guidance actually names, for the same reason OpenDyslexic is —
+   letters that can't be mistaken for one another when they are rotated or
+   mirrored. Verdana behind it for its width and its open counters. */
+.sheet[data-font="dyslexic"] {
+  --sheet-face:
+    "OpenDyslexic", "Open Dyslexic", "Comic Sans MS", verdana, sans-serif;
+}
+
+/* ── Where to cut (§17) ─────────────────────────────────────────────────────
+   Over the paper, not in it. The overlay takes no room in the flow, which is
+   what lets a parent switch cut guides on without any family re-doing the
+   arithmetic that decided how many problems fit. `pointer-events` off so the
+   text underneath stays selectable, which is most of what §2 is about.      */
+.sheet__cuts {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 
 .sheet__rule,
@@ -324,6 +373,19 @@
   min-width: 0.8in;
   border-bottom: 0.75pt solid currentcolor;
   text-align: center;
+}
+
+/* The same slot with a box round it instead of a rule under it (§17) — which
+   is why it is drawn here rather than emitted by a family: a boxed answer is
+   how the answer place looks, not where it is, so nothing about the problem
+   changes and no family has to offer it.
+
+   No padding, deliberately. The border sits on the line box the rule already
+   occupied, so a page of boxed answers is exactly as tall as the same page of
+   ruled ones — and the capacity arithmetic, which reserved the rows before
+   anybody chose, stays right. */
+.sheet[data-answer-box] .sheet__slot {
+  border: 0.75pt solid currentcolor;
 }
 
 /* An answer, wherever it is written: in the slot at the end of a sum, in the


### PR DESCRIPTION
Closes #57.

`/printables/make` stops being a placeholder. It is now a `client:only` island
under `src/games/printshop/`: pick a sheet family, tune it, and watch the page
change before it costs anybody toner.

## The configuration is the id

On a static site there is no server to mint a share id against, so the config
*is* the id. `#s=<base64url(JSON)>` is rewritten with `replaceState` on every
change, which makes the address bar a bookmark, a way to hand a sheet to
another parent, and a reproducible bug report — all without an account.

Reading one back is the harder half and it lives beside the encoder in
`src/engine/sheets/share.ts`, because the two are one format and a guard
written in the builder would be a second place the shape of `#s=` is written
down. A fragment is whatever was in the address bar, so it is treated as
hostile: length-capped at 4KB, every shared field **rebuilt from a known set**
rather than checked, and answering `null` rather than throwing. The builder
test-builds what it decoded before trusting it, so a payload that survives the
decoder but can't produce a page still falls back to defaults instead of
showing a parent a blank screen.

**A child's name is not in the encoded config and cannot be** — there is
nowhere in a `SheetConfig` to put one. The name field is a ruled line the child
fills in by hand, and it prints blank.

## Fifteen families, fifteen panels, no switch

The option panels are a registry keyed by `kind` — the same shape `sheetSpec`
has — so there is no `switch` over the `SheetConfig` union here to keep in step
with the union as families are added. `options/parts.tsx` is the four shapes an
option takes (choice, range, sizing, pool), which is what keeps each family's
panel down to the sentences that are actually true of that family. Every module
is under the 300-line cap; nothing was added to `maxLinesAllowlist`.

## Four §17 options the engine had to grow

The face, a boxed answer place, cut guides, and the type-size bounds. All four
are shared `SheetOptions` and all four are applied by `buildSheet` at the front
door rather than by fifteen `build` functions. None of them changes a declared
height, so no family re-does its capacity arithmetic: the face is set in
points, a bordered slot is the same line box as a ruled one, and the cut guides
are drawn over the paper rather than in it.

## Print is the whole output path

The preview is scaled with a measured `transform: scale()`; the printer gets
its own unscaled copy, because a transform on an ancestor of a page box is a
reliable way to lose the bottom of a sheet. The print button carries the one
line that matters — "Save as PDF" is in the print dialog, and it is the
download. There is no PDF library and no download fallback by design.

A review finding fixed here: `.no-print` empties the bench's columns but does
not *remove* them, so the print copy was laying out as a grid item — measured
at (414, 28) in Chromium under `media=print` where a catalog page renders the
identical sheet at (0, 0). On Letter that is past the right edge of the paper.
At print time the bench now stops being a layout and the paper column carries
`.no-print` itself. It is invisible on screen by construction, so it got a test
rather than only a fix: the smoke run measures the real box in a browser
against the catalog page's, which is the only place that can.

`copyLink`'s catch also promised a fallback it did not implement. The button
now has a third label — "Copy it from the address bar" — so a refused clipboard
says where the link is instead of doing nothing.

## Also in here

- Saving to My Sheets goes through `services/sheets.ts`, per the storage
  boundary. Nothing in the island touches IndexedDB.
- Settles the `.sheet` name collision `sheet.css` has been recording since
  PRINT02. This page loads the modal styles *and* the sheet renderer's, so the
  modal became `.modal` — in a codebase with a print shop in it, a sheet is a
  piece of paper.
- `Sheet.test.tsx`'s zero-JavaScript assertion moves with the truth. It used to
  scan every chunk for the renderer's class names, which the builder
  legitimately ships now; it asserts the property §2 actually claims — no page
  that *is* a sheet needs JavaScript to be one — plus the builder as the stated
  exception, hydrated and `noindex`.
- quick-win: `PlayerEditor`'s `React.FormEvent` → `React.SyntheticEvent`,
  clearing the last `type-check` warning.

## Validation

`type-check`, `lint`, `test:unit` (687 tests), `build` (static, 67 pages) and
the browser smoke test all pass. The smoke run is load-bearing for this story —
it covers the fragment round trip, the save to IndexedDB, reopening a shared
link, and the printed geometry described above.

The three bootstraps are PRINT14, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
