### PR TITLE
PRINT14: practise what they missed

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -687,8 +687,10 @@ src/games/printshop/
   Preview.tsx        the sheet, scaled, on the press-room ground
   PrintBar.tsx       print · variants · answer key · share
   SavedSheets.tsx    My Sheets, through services/sheets.ts
+  Bootstrap.tsx      the three below — a saved list, and a paste
+  Missed.tsx         practise what they missed, through services/practice.ts
   options/index.tsx  the registry — the one place `kind` is narrowed
-  options/parts.tsx  choice · range · sizing · pool
+  options/parts.tsx  choice · range · sizing · pool · word list
   options/*.tsx      one panel per family
 ```
 
@@ -697,6 +699,13 @@ is `options/*.tsx` alone (there is no `Editor` wrapping it), and what was going
 to be `Editor.tsx` turned out to be `PageOptions.tsx` — the options that belong
 to no family. The reading half of `#s=` lives in `engine/sheets/share.ts` beside
 the encoder rather than in the builder, because the two are one format.
+
+The bootstraps arrived the same way. Which sheet family answers for which deck
+is `engine/sheets/practice.ts` — a mode and a list of fact ids in, a config
+out — because three screens ask for it and a sheet built from the same facts
+has to be the same sheet whichever door it came through. What the record book
+knows is read by `services/practice.ts`, so the island never goes near
+IndexedDB, and a child's name stops at that boundary: what crosses it is facts.
 
 **Live preview**, scaled with `transform: scale()` inside a dark frame. Debounce
 regeneration; a sheet with 200 problems is cheap but not free.

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -228,6 +228,38 @@ try {
   check("the shared link reopens the same sheet", page.url() === shared);
 
   /*
+   * The headline of the whole section, walked end to end (§14).
+   *
+   * It is the one feature that crosses every layer in the app — the record
+   * book computes it, a service reads it out of the same IndexedDB the race
+   * just wrote to, the engine turns it into a sheet, and the bench prints it —
+   * so it is exactly the kind of thing that type-checks and fails on first
+   * click. The smoke player answers correctly and quickly, so what this
+   * usually exercises is the *other* path: a child with nothing standing out
+   * still gets a sheet worth printing rather than an empty page.
+   */
+  log("\n6b. The bench starts from what the record book knows");
+  const steps = await page.locator(".bootstrap__step").count();
+  // Two at least — the missed facts and a paste. The saved-list step only
+  // appears for a household that has typed one in, which this one has not.
+  check("the bootstraps are offered", steps >= 2, `${steps} steps`);
+
+  const beforeBootstrap = page.url();
+  await page
+    .locator(".bootstrap__step")
+    .first()
+    .getByRole("button")
+    .first()
+    .click();
+  await page.waitForTimeout(900);
+  check(
+    "pressing one puts a printable sheet on the bench",
+    page.url() !== beforeBootstrap &&
+      (await page.locator(".preview .sheet__problem").count()) > 0,
+    page.url().slice(0, 60),
+  );
+
+  /*
    * Where the paper actually lands on the paper.
    *
    * Print is the whole output path here (§10) — there is no PDF render to

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -7,7 +7,6 @@ import {
   useSubject,
 } from "@/components/state/SubjectContext";
 import TopBar from "@/components/TopBar";
-import { Button } from "@/components/ui/kit";
 import { BADGES } from "@/engine/progress";
 import {
   bestRun,
@@ -28,12 +27,14 @@ import { buildDrill, deckSpec } from "@/engine/decks";
 import { WORD_MODE_PREFIX, listIdOf } from "@/engine/decks/words";
 import { TYPING_MODE_PREFIX } from "@/engine/decks/typing";
 import { WORD_LISTS_BY_ID, listWords } from "@/engine/decks/wordlists";
+import { practiceSheet } from "@/engine/sheets/practice";
 import { WORLDS } from "@/engine/worlds";
 import { sfx } from "@/services/sound";
 import { DeckSwitch, type DeckChoice } from "./progress/DeckSwitch";
 import { FactMap } from "./progress/FactMap";
 import { WordMap } from "./progress/WordMap";
 import { RecordBook, RunList } from "./progress/RecordBook";
+import { TroubleSpots } from "./progress/TroubleSpots";
 import { duration, percent } from "@/engine/format";
 
 export default function Progress() {
@@ -118,6 +119,36 @@ export default function Progress() {
   const spec = deckSpec(mode);
   /** Which world this deck is played in — and so where a drill of it starts. */
   const owner = WORLDS.find((w) => w.id === spec.world);
+  /**
+   * The same facts as a worksheet, or null where this build has no sheet for
+   * them — a typing passage is not a page of problems (§14).
+   */
+  const printable = practiceSheet(
+    mode,
+    trouble.map((fact) => fact.factId),
+  );
+  /**
+   * Race the same facts, where this app is the one they are played in. Built
+   * here beside `switcher` rather than inline in the panel below, because both
+   * are a piece of behaviour the screen hands down rather than markup.
+   */
+  const drill = ownsMode(subject, mode)
+    ? () => {
+        sfx.select();
+        navigate(`/p/${profile.id}/race`, {
+          state: {
+            config: buildDrill(
+              trouble.map((fact) => fact.factId),
+              mode,
+              {
+                inputMode: profile.age <= 6 ? "choose" : "type",
+                timeLimitMs: timeLimitForAge(profile.age),
+              },
+            ),
+          },
+        });
+      }
+    : null;
   const switcher = (
     <DeckSwitch
       choices={decks}
@@ -185,85 +216,13 @@ export default function Progress() {
         />
       )}
 
-      <section className="panel anim-rise">
-        <div className="panel__head">
-          <h2 className="panel__title">Trouble spots</h2>
-          {trouble.length > 0 &&
-            (!ownsMode(subject, mode) ? (
-              // This deck belongs to another world. The record book spans all
-              // of them, but a drill can only start where the deck lives, and
-              // handing a built config across a page load would need somewhere
-              // to put it — a link is worth more than that machinery, and the
-              // facts are listed right below either way.
-              <a className="btn btn--accent btn--sm" href={owner?.href ?? "/"}>
-                Open {owner?.name ?? "the map"}
-              </a>
-            ) : (
-              <Button
-                variant="accent"
-                size="sm"
-                onClick={() => {
-                  sfx.select();
-                  navigate(`/p/${profile.id}/race`, {
-                    state: {
-                      config: buildDrill(
-                        trouble.map((fact) => fact.factId),
-                        mode,
-                        {
-                          inputMode: profile.age <= 6 ? "choose" : "type",
-                          timeLimitMs: timeLimitForAge(profile.age),
-                        },
-                      ),
-                    },
-                  });
-                }}
-              >
-                Drill these
-              </Button>
-            ))}
-        </div>
-        {trouble.length === 0 ? (
-          <p className="muted">
-            Nothing standing out in {spec.label.toLowerCase()}. Facts land here
-            when the clock beats them, when they come out wrong, or when they
-            take longer than recall should.
-          </p>
-        ) : (
-          <>
-            <p className="muted">
-              Worst first. Answering one quickly and correctly takes it back off
-              the list.
-            </p>
-            <ul className="trouble">
-              {trouble.map((fact) => (
-                <li key={fact.factId} className="trouble__item">
-                  <span className="trouble__fact u-mono">
-                    {spec.factLabel(fact.factId)}
-                  </span>
-                  <span className="trouble__why">
-                    {fact.timeouts > 0 && (
-                      <span className="chip chip--late">
-                        ⏳ {fact.timeouts} out of time
-                      </span>
-                    )}
-                    {fact.wrong > 0 && (
-                      <span className="chip chip--wrong">
-                        ✕ {fact.wrong} wrong
-                      </span>
-                    )}
-                    {fact.slow > 0 && (
-                      <span className="chip">🐢 {fact.slow} slow</span>
-                    )}
-                  </span>
-                  <span className="trouble__avg u-mono">
-                    {(fact.avgMs / 1000).toFixed(1)}s
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
-      </section>
+      <TroubleSpots
+        trouble={trouble}
+        spec={spec}
+        drill={drill}
+        elsewhere={owner}
+        printable={printable}
+      />
 
       <div className="progress__columns">
         {/* Times tables only — a spelling list has no twelve of anything. */}

--- a/src/components/screens/progress/TroubleSpots.tsx
+++ b/src/components/screens/progress/TroubleSpots.tsx
@@ -1,0 +1,124 @@
+import type { DeckSpec } from "@/engine/decks";
+import { practiceHref } from "@/engine/sheets/practice";
+import type { SheetConfig } from "@/engine/sheets/types";
+import type { TroubleFact } from "@/engine/records";
+import type { WorldInfo } from "@/engine/worlds";
+import { Button } from "@/components/ui/kit";
+
+/**
+ * The facts worth practising, and the two things to do about them.
+ *
+ * The list itself is `troubleFacts` — ranked worst-first, and a fact drops off
+ * it as it gets learned — so this panel adds no judgement of its own. What it
+ * adds is the pair of doors: **the same list, either raced or printed**
+ * (docs/printables.md §14). A drill is a short deck of exactly these facts; a
+ * sheet is exactly these facts on paper, which is the one thing no other
+ * worksheet site can print because no other worksheet site knows what the
+ * child got wrong.
+ *
+ * Split out of `Progress.tsx` when the second door was added, which is the
+ * right seam either way: the panel is one idea, and the screen around it is a
+ * record book.
+ */
+export function TroubleSpots({
+  trouble,
+  spec,
+  drill,
+  elsewhere,
+  printable,
+}: {
+  trouble: TroubleFact[];
+  /** The deck these facts belong to — how they are named, and what it is called. */
+  spec: DeckSpec;
+  /** Race them. Null when the deck belongs to another world; see `elsewhere`. */
+  drill: (() => void) | null;
+  /**
+   * Where that deck does live. The record book spans every world, but a drill
+   * can only start where the deck is played and handing a built config across
+   * a page load would need somewhere to put it — so this is a link, and the
+   * facts are listed underneath either way.
+   */
+  elsewhere?: WorldInfo;
+  /**
+   * The same facts as a worksheet, or null where this build has no sheet for
+   * them — a typing passage is not a page of problems.
+   */
+  printable: SheetConfig | null;
+}) {
+  return (
+    <section className="panel anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Trouble spots</h2>
+        {trouble.length > 0 && (
+          <span className="panel__actions">
+            {drill ? (
+              <Button variant="accent" size="sm" onClick={drill}>
+                Drill these
+              </Button>
+            ) : (
+              <a
+                className="btn btn--accent btn--sm"
+                href={elsewhere?.href ?? "/"}
+              >
+                Open {elsewhere?.name ?? "the map"}
+              </a>
+            )}
+            {/* A link and not a handover, for the same reason the one beside it
+                is: a sheet's config *is* its id (§14), so the bench opens on
+                exactly these facts with nothing stored between the two pages —
+                and nothing about the child in the link either. */}
+            {printable && (
+              <a
+                className="btn btn--ghost btn--sm"
+                href={practiceHref(printable)}
+              >
+                Print these
+              </a>
+            )}
+          </span>
+        )}
+      </div>
+      {trouble.length === 0 ? (
+        <p className="muted">
+          Nothing standing out in {spec.label.toLowerCase()}. Facts land here
+          when the clock beats them, when they come out wrong, or when they take
+          longer than recall should.
+        </p>
+      ) : (
+        <>
+          <p className="muted">
+            Worst first. Answering one quickly and correctly takes it back off
+            the list.
+          </p>
+          <ul className="trouble">
+            {trouble.map((fact) => (
+              <li key={fact.factId} className="trouble__item">
+                <span className="trouble__fact u-mono">
+                  {spec.factLabel(fact.factId)}
+                </span>
+                <span className="trouble__why">
+                  {fact.timeouts > 0 && (
+                    <span className="chip chip--late">
+                      ⏳ {fact.timeouts} out of time
+                    </span>
+                  )}
+                  {fact.wrong > 0 && (
+                    <span className="chip chip--wrong">
+                      ✕ {fact.wrong} wrong
+                    </span>
+                  )}
+                  {fact.slow > 0 && (
+                    <span className="chip">🐢 {fact.slow} slow</span>
+                  )}
+                </span>
+                <span className="trouble__avg u-mono">
+                  {(fact.avgMs / 1000).toFixed(1)}s
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -31,6 +31,7 @@ import { TIME_SHEET } from "./maths/time";
 import { WORD_PROBLEMS_SHEET } from "./maths/wordproblems";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
 import { PAPER_SHEET } from "./templates/paper";
+import { WORDS_SHEET } from "./words/spelling";
 
 const SHEETS: Record<string, SheetSpec> = {
   [BLANK_SHEET.id]: BLANK_SHEET,
@@ -48,6 +49,7 @@ const SHEETS: Record<string, SheetSpec> = {
   [RATIO_SHEET.id]: RATIO_SHEET,
   [STATISTICS_SHEET.id]: STATISTICS_SHEET,
   [WORD_PROBLEMS_SHEET.id]: WORD_PROBLEMS_SHEET,
+  [WORDS_SHEET.id]: WORDS_SHEET,
 };
 
 /**

--- a/src/engine/sheets/maths/arithmetic.test.ts
+++ b/src/engine/sheets/maths/arithmetic.test.ts
@@ -645,3 +645,108 @@ describe("how much fits", () => {
     );
   });
 });
+
+/* ── The facts they keep missing ───────────────────────────────────────────
+   The other way into this family (docs/printables.md §14): the record book
+   hands over the fact ids it already ranked, and the sheet is those facts and
+   nothing else. Every sentence below is still verified by counting, because a
+   practice sheet with a wrong answer on it is worse than no practice sheet. */
+
+describe("the facts they keep missing", () => {
+  /** Three fact ids in the shape `decks/flashcards.ts` writes them. */
+  const MISSED = ["3:5", "7:8", "9:6"];
+
+  it("prints exactly those facts, in the order they were ranked", () => {
+    const items = problemsOf({ facts: MISSED, count: 20 }, 5);
+    expect(items.flatMap(sentences)).toEqual([
+      "3 + 5 = 8",
+      "7 + 8 = 15",
+      "9 + 6 = 15",
+    ]);
+    for (const sentence of items.flatMap(sentences)) {
+      expect(holds(sentence), sentence).toBe(true);
+    }
+  });
+
+  it("carries the id the race files each of them under", () => {
+    // The hand-off in both directions: `troubleFacts` speaks in these strings
+    // and `Problem.factId` answers in them, so neither side has to learn the
+    // other's shape.
+    expect(problemsOf({ facts: MISSED }, 5).map((p) => p.factId)) //
+      .toEqual(MISSED);
+  });
+
+  it("reads a subtraction fact back the way the deck asked it", () => {
+    // `3:5` is the pair the deck builds "8 − 3" from — the number taken away,
+    // then what is left — so the answer is the 5 that was already in the id.
+    // Getting this backwards would print "5 − 3" and drill the wrong fact.
+    const [sentence] = problemsOf(
+      { facts: ["3:5"], operation: "subtract" },
+      1,
+    ).flatMap(sentences);
+    expect(sentence).toBe("8 − 3 = 5");
+    expect(holds(sentence)).toBe(true);
+  });
+
+  it("prints them whatever the range and the regrouping say", () => {
+    // Both describe a pool to draw from, and a named sheet does not draw.
+    // Dropping a fact for carrying, or for sitting outside a range nobody
+    // chose, would print a different list from the one handed over.
+    expect(
+      problemsOf(
+        { facts: ["8:7"], range: { min: 1, max: 3 }, regrouping: "never" },
+        2,
+      ).flatMap(sentences),
+    ).toEqual(["8 + 7 = 15"]);
+  });
+
+  it("scales the number line to the facts rather than to the range", () => {
+    // A line to twenty under a sum whose answer is thirty is worse than no
+    // line: a child counts along it and runs off the end.
+    const [problem] = problemsOf(
+      { facts: ["18:14"], numberLine: true, columns: 1 },
+      3,
+    );
+    expect(problem.line?.to).toBeGreaterThanOrEqual(32);
+  });
+
+  it("says on the page, and in the record, that it is a practice sheet", () => {
+    const practice = config({ facts: MISSED });
+    const sheet = buildSheet(practice, 1);
+    // Not "Addition to 20": the sheet never saw the range, and a title
+    // claiming one would be the only untrue line on the page.
+    expect(sheet.header.title).toBe("Addition practice");
+    expect(sheet.header.score).toEqual({ outOf: 3 });
+    expect(describeSheet(practice)).toBe("Addition practice — 3 tricky facts");
+  });
+
+  it("keys them the way it keys everything else", () => {
+    const practice = config({ facts: MISSED, operation: "both" });
+    const key = answerKey(practice, 9);
+    const block = key.blocks[0];
+    if (block.kind !== "problems") throw new Error("expected problems");
+    expect(key.answers).toBe(true);
+    for (const sentence of block.items.flatMap(sentences)) {
+      expect(holds(sentence), sentence).toBe(true);
+    }
+  });
+
+  it("falls back to the ordinary sheet when nothing is standing out", () => {
+    // A child with nothing in the record book is the commonest case on a
+    // family machine rather than an error, and what they get is the sheet the
+    // range describes — which is a sheet worth printing.
+    expect(problemsOf({ facts: [] }, 4)).toEqual(problemsOf({}, 4));
+    expect(buildSheet(config({ facts: [] }), 4).header.title) //
+      .toBe("Addition to 20");
+  });
+
+  it("never prints more of them than the paper holds", () => {
+    const many: string[] = [];
+    for (let a = 1; a <= 20; a += 1) {
+      for (let b = 1; b <= 10; b += 1) many.push(`${a}:${b}`);
+    }
+    const over = { facts: many, count: many.length };
+    expect(problemsOf(over, 1).length) //
+      .toBe(arithmeticLayout(config(over)).perPage);
+  });
+});

--- a/src/engine/sheets/maths/arithmetic.ts
+++ b/src/engine/sheets/maths/arithmetic.ts
@@ -25,7 +25,7 @@
  * different sums from 1 to 3": there are six, and six is what a parent should
  * get rather than the same sum three times.
  */
-import { arithmeticFactId } from "@/engine/decks/flashcards";
+import { arithmeticFactId, factPair } from "@/engine/decks/flashcards";
 import { between, mulberry32 } from "@/engine/random";
 
 import type {
@@ -49,7 +49,7 @@ import {
 } from "../layout";
 import { NUMBER_LINE_HEIGHT, numberLine } from "../numberline";
 import { inches, points } from "../paper";
-import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
 
 /* ── What a problem takes on the page ─────────────────────────────────────
    Declared, not measured (§4), and trailing sheet.css the same way chrome.ts
@@ -140,6 +140,57 @@ function bounds(range: { min: number; max: number }): {
 } {
   const min = Math.max(0, Math.floor(range.min));
   return { min, max: Math.max(min, Math.floor(range.max)) };
+}
+
+/* ── The facts a child keeps missing ──────────────────────────────────────
+   The other way into this family (§14). A named fact is not drawn and not
+   rejected: the record book already decided which ones matter and in what
+   order, so they are printed in that order, and `range` and `regrouping` say
+   nothing about a page they did not choose.
+
+   A pair is read exactly as `decks/flashcards.ts` writes it, which is what
+   makes "print what they missed" a hand-off rather than a translation: added,
+   the two addends; subtracted, the number taken away and what is left, so the
+   fact 3:5 is 8 − 3 and the answer is the 5 that was already in it.        */
+
+/** The named facts as pairs — whole, non-negative, and in the order given. */
+function namedFacts(config: ArithmeticConfig): Array<[number, number]> {
+  return (config.facts ?? [])
+    .map(factPair)
+    .filter(
+      ([a, b]) => Number.isFinite(a) && Number.isFinite(b) && a >= 0 && b >= 0,
+    )
+    .map(([a, b]) => [Math.floor(a), Math.floor(b)] as [number, number]);
+}
+
+/** One named fact, asked the way this config asks its questions. */
+function factSum(
+  [first, second]: [number, number],
+  config: ArithmeticConfig,
+  rand: () => number,
+): Sum {
+  // The same coin the drawn path spends, and spent in the same place: a config
+  // asking for both operations decides per problem which one this is.
+  const operation =
+    config.style === "fact-family"
+      ? "add"
+      : config.operation === "both"
+        ? rand() < 0.5
+          ? "add"
+          : "subtract"
+        : config.operation;
+
+  return operation === "add"
+    ? { operation, left: first, right: second, result: first + second }
+    : // Turned back into the subtraction the fact came from: the pair is what
+      // was taken away and what was left, so the number on the page is their
+      // total. Which is also why it can never go below zero.
+      {
+        operation,
+        left: first + second,
+        right: first,
+        result: second,
+      };
 }
 
 /**
@@ -390,6 +441,20 @@ export function arithmeticProblems(
   const problems: Problem[] = [];
   const extras = sheetExtras(config, cell);
 
+  // Named facts are printed, not drawn: the list is already ranked worst-first
+  // and already de-duplicated, so there is nothing here to shuffle or reject.
+  // It runs out where it runs out, exactly as the drawn pool does — a child who
+  // is missing six facts gets six problems rather than the same six twice.
+  const named = namedFacts(config);
+  if (named.length > 0) {
+    for (const pair of named.slice(0, wanted)) {
+      const sum = factSum(pair, config, rand);
+      const slot = rand() < 0.5 ? 0 : 1;
+      problems.push(problemOf(sum, config, slot, extras));
+    }
+    return problems;
+  }
+
   let misses = 0;
   while (problems.length < wanted && misses < MISS_BUDGET) {
     const sum = drawSum(config, rand);
@@ -425,10 +490,19 @@ function sheetExtras(
   config: ArithmeticConfig,
   cell: Mil,
 ): { line?: NumberLine; workspace?: Mil } {
-  const { max } = bounds(config.range);
+  // A named-fact sheet has no range to read: the facts *are* the pool, so the
+  // line is measured against the largest number any of them puts on the page.
+  // Scaling it to `range` instead would print a line to twenty under a sum
+  // whose answer is thirty-six, which is worse than no line at all.
+  const named = namedFacts(config);
+  const max =
+    named.length > 0
+      ? Math.max(...named.map(([a, b]) => a + b))
+      : bounds(config.range).max;
   // The far end is the largest result the config can reach: two numbers from
   // the range added together, or — where nothing is added — the range itself.
-  const top = config.operation === "subtract" ? max : max * 2;
+  const top =
+    named.length > 0 || config.operation === "subtract" ? max : max * 2;
   const line = hasNumberLine(config)
     ? numberLine(config.negatives ? -max : 0, top, cell)
     : undefined;
@@ -448,6 +522,15 @@ const OPERATION_NAME = {
 
 /** "Addition to 20" — the phrase a parent says, and the one they search. */
 function titleOf(config: ArithmeticConfig): string {
+  // A sheet of named facts is not a sheet "to twenty" — it is whatever the
+  // record book handed over, and a title claiming a range it never drew from
+  // would be the one line on the page that is untrue.
+  if (namedFacts(config).length > 0) {
+    return config.style === "fact-family"
+      ? "Fact family practice"
+      : `${OPERATION_NAME[config.operation]} practice`;
+  }
+
   const { max } = bounds(config.range);
   if (config.style === "fact-family") return `Fact families to ${max}`;
   return `${OPERATION_NAME[config.operation]} to ${max}`;
@@ -496,6 +579,13 @@ export function describeArithmetic(config: ArithmeticConfig): string {
     never: "no regrouping",
     always: "with regrouping",
   };
+  // "8 tricky facts" is the race's own phrase for the same list — see
+  // `describeFlashConfig` — so a printed drill and a raced one read alike in
+  // the record book. Regrouping is left off, because it decided nothing here.
+  const named = namedFacts(config);
+  if (named.length > 0) {
+    return `${titleOf(config)} — ${named.length} tricky ${named.length === 1 ? "fact" : "facts"}`;
+  }
   return [
     titleOf(config),
     config.style === "standard" && config.form === "vertical"
@@ -529,7 +619,7 @@ export function buildArithmeticSheet(
       score: { outOf: items.length },
     },
     blocks: [{ kind: "problems", columns, items }],
-    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    footer: { credit: SHEET_CREDIT, url: gameUrl("grid"), seed },
     answers: false,
   };
 }

--- a/src/engine/sheets/maths/multiplication.test.ts
+++ b/src/engine/sheets/maths/multiplication.test.ts
@@ -927,3 +927,137 @@ describe("how much fits", () => {
     expect(divisionLines({ into: 1, by: 5 })).toBe(2);
   });
 });
+
+/* ── The facts they keep missing ───────────────────────────────────────────
+   The other way into this family (docs/printables.md §14). The record book
+   ranks the fact ids and this prints exactly those, in that order — still
+   checked by repeated addition and by the inverse, because a practice sheet
+   with a wrong answer on it is worse than no practice sheet.               */
+
+describe("the facts they keep missing", () => {
+  /** Three fact ids in the shape `decks/flashcards.ts` writes them. */
+  const MISSED = ["7:8", "6:9", "12:4"];
+
+  it("prints exactly those facts, in the order they were ranked", () => {
+    const items = problemsOf({ facts: MISSED, count: 20 }, 5);
+    expect(items.flatMap(sentences)).toEqual([
+      "7 × 8 = 56",
+      "6 × 9 = 54",
+      "12 × 4 = 48",
+    ]);
+    for (const sentence of items.flatMap(sentences)) {
+      expect(holds(sentence), sentence).toBe(true);
+    }
+  });
+
+  it("carries the id the race files each of them under", () => {
+    // The hand-off in both directions: `troubleFacts` speaks in these strings
+    // and `Problem.factId` answers in them, so neither side has to learn the
+    // other's shape.
+    expect(problemsOf({ facts: MISSED }, 5).map((p) => p.factId)) //
+      .toEqual(MISSED);
+  });
+
+  it("reads a division fact backwards, as the drill keeps it", () => {
+    // `3:7` is the pair the deck builds "21 ÷ 3" from — the divisor, then the
+    // answer — which is why 56 ÷ 7 and 56 ÷ 8 stay two facts where 7 × 8 and
+    // 8 × 7 are one.
+    const [sentence] = problemsOf(
+      { facts: ["3:7"], operation: "divide" },
+      1,
+    ).flatMap(sentences);
+    expect(sentence).toBe("21 ÷ 3 = 7");
+    expect(holds(sentence)).toBe(true);
+  });
+
+  it("never divides by zero, whatever the record book hands over", () => {
+    // A zero fact is real — 0 × 4 is a card the race asks — and it has no
+    // division. So it is asked the one way it can be asked rather than
+    // dropped or, worse, printed as "0 ÷ 0".
+    for (const seed of SEEDS) {
+      const items = problemsOf(
+        { facts: ["0:4", "0:9"], operation: "both" },
+        seed,
+      );
+      for (const sentence of items.flatMap(sentences)) {
+        expect(read(sentence).sign, sentence).toBe("×");
+        expect(holds(sentence), sentence).toBe(true);
+      }
+    }
+  });
+
+  it("prints them whatever the tables and factors say", () => {
+    // Both describe a pool to draw from, and a named sheet does not draw: a
+    // sheet of the eight facts a child keeps missing is not a sheet of the
+    // eight times table, and clipping it to `tables` would print neither.
+    expect(
+      problemsOf(
+        { facts: ["11:12"], tables: [2], factors: { min: 1, max: 3 } },
+        2,
+      ).flatMap(sentences),
+    ).toEqual(["11 × 12 = 132"]);
+  });
+
+  it("leaves a zero out of a missing-number sheet", () => {
+    // The same judgement the drawn path makes: a blank that any number would
+    // fill is not a question, and "_ × 0 = 0" is true of every number there
+    // is. Dropping it is the honest answer; printing it is a page a child
+    // cannot answer.
+    expect(
+      problemsOf({ facts: ["0:4", "7:8"], style: "missing" }, 1).map(
+        (p) => p.factId,
+      ),
+    ).toEqual(["7:8"]);
+  });
+
+  it("says on the page, and in the record, that it is a practice sheet", () => {
+    const practice = config({ facts: MISSED });
+    const sheet = buildSheet(practice, 1);
+    // Not "the 7 times table" and not "Multiplication to 12": the sheet never
+    // saw either pool, and a title claiming one would be the only untrue line
+    // on the page.
+    expect(sheet.header.title).toBe("Multiplication practice");
+    expect(sheet.header.score).toEqual({ outOf: 3 });
+    expect(describeSheet(practice)) //
+      .toBe("Multiplication practice — 3 tricky facts");
+  });
+
+  it("keys them the way it keys everything else", () => {
+    const key = answerKey(config({ facts: MISSED, operation: "both" }), 9);
+    const block = key.blocks[0];
+    if (block.kind !== "problems") throw new Error("expected problems");
+    expect(key.answers).toBe(true);
+    for (const sentence of block.items.flatMap(sentences)) {
+      expect(holds(sentence), sentence).toBe(true);
+    }
+  });
+
+  it("is ignored by the two styles that have no facts to name", () => {
+    // A square is every fact there is and a long form is not one of the
+    // twelve tables at all, so neither may quietly become a three-problem
+    // sheet because a config carried a list it has no use for.
+    const grid = config({ facts: MISSED, style: "grid" });
+    expect(buildSheet(grid, 1).blocks[0].kind).toBe("grid");
+    expect(problemsOf({ facts: MISSED, style: "long", count: 6 }, 1).length) //
+      .toBe(6);
+  });
+
+  it("falls back to the ordinary sheet when nothing is standing out", () => {
+    // A child with nothing in the record book is the commonest case on a
+    // family machine rather than an error, and what they get is the mixed
+    // sheet the tables describe — which is a sheet worth printing.
+    expect(problemsOf({ facts: [] }, 4)).toEqual(problemsOf({}, 4));
+    expect(buildSheet(config({ facts: [] }), 4).header.title) //
+      .toBe("Multiplication to 12");
+  });
+
+  it("never prints more of them than the paper holds", () => {
+    const many: string[] = [];
+    for (let a = 1; a <= 12; a += 1) {
+      for (let b = 1; b <= 12; b += 1) many.push(`${a}:${b}`);
+    }
+    const over = { facts: many, count: many.length };
+    expect(problemsOf(over, 1).length) //
+      .toBe(multiplicationLayout(config(over)).perPage);
+  });
+});

--- a/src/engine/sheets/maths/multiplication.ts
+++ b/src/engine/sheets/maths/multiplication.ts
@@ -27,7 +27,7 @@
  * height is decided by how many times a child brings a digit down. Both are in
  * `long.ts` and in `gridOf` below rather than smuggled into the problem shapes.
  */
-import { arithmeticFactId } from "@/engine/decks/flashcards";
+import { arithmeticFactId, factPair } from "@/engine/decks/flashcards";
 import { mulberry32 } from "@/engine/random";
 
 import type {
@@ -44,7 +44,7 @@ import type {
 import { sheetBlockBox } from "../chrome";
 import { PROBLEM_GAP, columnWidth, fitAcross, type Box } from "../layout";
 import { inches, points } from "../paper";
-import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
 import {
   BRACKET_EMS,
   STACK_EMS,
@@ -139,6 +139,40 @@ function poolOf(config: MultiplicationConfig): Pool {
     divide: tables.filter((table) => table > 0),
     factors: factorsOf(config),
   };
+}
+
+/* ── The facts a child keeps missing ──────────────────────────────────────
+   The other way into this family (§14), and the reason `Problem.factId`
+   exists: the record book hands over the fact ids the race already files runs
+   under, and the pairs behind them are read here exactly as
+   `decks/flashcards.ts` writes them — the table that was picked, then what it
+   was paired with. So the eight facts a child keeps missing print as the eight
+   problems they missed, in the order the record book ranked them, and neither
+   side has learned anything about the other's shape.                       */
+
+/** The named facts as (table, factor) pairs — whole, in range, in order. */
+function namedFacts(config: MultiplicationConfig): Array<[number, number]> {
+  // The two styles with no facts to name: a square is every fact there is, and
+  // a long form's numbers are not one of the twelve tables at all.
+  if (config.style === "grid" || config.style === "long") return [];
+  return (config.facts ?? [])
+    .map(factPair)
+    .filter(([table, factor]) => table >= 0 && factor >= 0)
+    .map(
+      ([table, factor]) =>
+        [Math.min(MAX_FACT, table), Math.min(MAX_FACT, factor)] as [
+          number,
+          number,
+        ],
+    )
+    .filter(
+      // The same judgement `drawFact` makes, reached from the other side: a
+      // blank that any number would fill is not a question, so a fact with a
+      // zero in it is dropped from a missing-number sheet rather than printed
+      // as one a child cannot answer.
+      ([table, factor]) =>
+        config.style !== "missing" || (table !== 0 && factor !== 0),
+    );
 }
 
 /* ── Drawing a fact ────────────────────────────────────────────────────── */
@@ -352,6 +386,29 @@ export function multiplicationProblems(
   const problems: Problem[] = [];
   const extras = config.workspace ? { workspace: WORKSPACE } : {};
 
+  // Named facts are printed, not drawn. The list arrives ranked worst-first and
+  // already folded onto one entry per fact, so there is nothing left to shuffle
+  // or reject — and it runs out where it runs out, exactly as the drawn pool
+  // does: six missed facts are six problems, not the same six twice.
+  const named = namedFacts(config);
+  if (named.length > 0) {
+    for (const [table, factor] of named.slice(0, wanted)) {
+      const asked = operationOf(config.operation, rand);
+      // Nothing is divided by zero, here or anywhere (§20). A zero fact can
+      // only be asked as a multiplication, so that is how it is asked.
+      const operation = asked === "divide" && table === 0 ? "multiply" : asked;
+      const slot = rand() < 0.5 ? 0 : 1;
+      const fact: Fact = {
+        operation,
+        table,
+        factor,
+        product: table * factor,
+      };
+      problems.push(problemOf(fact, config, slot, extras));
+    }
+    return problems;
+  }
+
   let misses = 0;
   while (problems.length < wanted && misses < MISS_BUDGET) {
     const operation = operationOf(config.operation, rand);
@@ -488,6 +545,12 @@ function titleOf(config: MultiplicationConfig): string {
   const top = topOf(config);
   if (config.style === "grid") return `Multiplication grid to ${top}`;
 
+  // A sheet of named facts is not "the 7 times table" and not "multiplication
+  // to 12" either — it is whatever the record book handed over, and a title
+  // claiming a pool it never drew from would be the one untrue line on it.
+  if (namedFacts(config).length > 0)
+    return `${MIXED_NAME[config.operation]} practice`;
+
   const tables = poolOf(config).multiply;
   if (tables.length !== 1) return `${MIXED_NAME[config.operation]} to ${top}`;
   const [table] = tables;
@@ -543,6 +606,14 @@ function headerOf(config: MultiplicationConfig): SheetOptions {
  */
 export function describeMultiplication(config: MultiplicationConfig): string {
   const digits = longDigits(config);
+  // "8 tricky facts" is the race's own phrase for the same list — see
+  // `describeFlashConfig` — so a drill that was printed and one that was raced
+  // read alike wherever the two end up beside each other.
+  const named = namedFacts(config);
+  if (named.length > 0) {
+    const facts = named.length === 1 ? "fact" : "facts";
+    return `${titleOf(config)} — ${named.length} tricky ${facts}`;
+  }
   return [
     titleOf(config),
     config.style === "long"
@@ -602,7 +673,7 @@ export function buildMultiplicationSheet(
       score: { outOf },
     },
     blocks,
-    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    footer: { credit: SHEET_CREDIT, url: gameUrl("grid"), seed },
     answers: false,
   };
 }

--- a/src/engine/sheets/practice.test.ts
+++ b/src/engine/sheets/practice.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { setCustomLists } from "@/engine/decks/words";
+import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
+
+import { buildSheet } from "./index";
+import { PRACTICE_SEED, practiceHref, practiceSheet } from "./practice";
+import { decodeSharedSheet } from "./share";
+import type { Problem } from "./types";
+
+/**
+ * The record book, as paper.
+ *
+ * The claim this module makes is narrow and total: what comes out prints
+ * *exactly* the facts that went in, in the same order, with nothing about the
+ * child anywhere in it. So the tests are about the hand-off rather than about
+ * arithmetic — the families' own suites already check that every answer is
+ * right — plus the two cases a headline feature has to survive: a child with
+ * no history, and a deck this build cannot print.
+ */
+
+const problemsOf = (mode: string, facts: string[]): Problem[] => {
+  const config = practiceSheet(mode, facts);
+  if (!config) throw new Error(`no sheet for ${mode}`);
+  const block = buildSheet(config, PRACTICE_SEED).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+};
+
+describe("a sheet of what they keep missing", () => {
+  it("prints the times-table facts the record book ranked, in order", () => {
+    const missed = ["7:8", "6:9", "12:11"];
+    expect(problemsOf("multiply", missed).map((p) => p.factId)) //
+      .toEqual(missed);
+    expect(problemsOf("multiply", missed).map((p) => p.prompt)).toEqual([
+      "7 × 8 =",
+      "6 × 9 =",
+      "12 × 11 =",
+    ]);
+  });
+
+  it("asks a division deck's facts as divisions", () => {
+    // The deck files "21 ÷ 3" under `3:7` — the divisor, then the answer — and
+    // a sheet that read the pair the other way round would drill 7 ÷ 3.
+    expect(problemsOf("divide", ["3:7"])[0].prompt).toBe("21 ÷ 3 =");
+    expect(problemsOf("subtract", ["3:5"])[0].prompt).toBe("8 − 3 =");
+    expect(problemsOf("add", ["3:5"])[0].prompt).toBe("3 + 5 =");
+  });
+
+  it("asks for each fact once, however often it was missed", () => {
+    // `troubleFacts` already folds a fact onto one entry, but a caller may
+    // hand over cards rather than facts, and a page that asked "7 × 8" three
+    // times would be a page of three problems pretending to be one of eight.
+    expect(problemsOf("multiply", ["7:8", "7:8", "6:9"]).length).toBe(2);
+  });
+
+  it("prints a spelling deck's missed words as a spelling sheet", () => {
+    const config = practiceSheet("words:dolch-1", ["because", "friend"]);
+    expect(config).toMatchObject({
+      kind: "words",
+      style: "copy",
+      words: ["because", "friend"],
+    });
+  });
+
+  it("prints a parent's own list, mirrored in from the deck service", () => {
+    // A custom list only exists in the engine because `services/decks.ts` put
+    // it there. This is the path that would break if the mirror ever stopped
+    // being loaded before a sheet was asked for.
+    setCustomLists([{ id: "custom-1", name: "Week 3", words: ["gnome"] }]);
+    expect(practiceSheet("words:custom-1", [])).toMatchObject({
+      kind: "words",
+      words: ["gnome"],
+    });
+    setCustomLists([]);
+  });
+});
+
+describe("a child with no history", () => {
+  it("still gets a sheet worth printing", () => {
+    // The commonest case on a family machine, and the one that decides whether
+    // the feature is usable at all: an empty list is not an empty sheet.
+    for (const mode of ["multiply", "divide", "add", "subtract"]) {
+      const problems = problemsOf(mode, []);
+      expect(problems.length, mode).toBeGreaterThan(10);
+      for (const problem of problems) expect(problem.answer).not.toBe("");
+    }
+  });
+
+  it("prints a whole word list when nothing has been missed in it", () => {
+    const config = practiceSheet(`words:${WORD_LISTS[0].id}`, []);
+    expect(config).toMatchObject({
+      kind: "words",
+      words: listWords(WORD_LISTS[0]),
+    });
+  });
+});
+
+describe("a deck with no sheet in this build", () => {
+  it("says so rather than printing a blank page", () => {
+    // `null` and not an empty sheet: the caller is the one that knows what to
+    // do instead — a results screen hides the button, the bench says a line.
+    expect(practiceSheet("typing:home-row", ["the", "and"])).toBeNull();
+    expect(practiceSheet("hieroglyphs", ["1:2"])).toBeNull();
+    // A list this build has never heard of, with nothing missed in it either:
+    // there are no words to print, and inventing some would be worse.
+    expect(practiceSheet("words:gone", [])).toBeNull();
+  });
+});
+
+describe("the link to the bench", () => {
+  it("carries the whole sheet, and reads back as the same one", () => {
+    const config = practiceSheet("multiply", ["7:8"])!;
+    const href = practiceHref(config);
+    expect(href.startsWith("/printables/make#s=")).toBe(true);
+    expect(decodeSharedSheet(href.split("#s=")[1])).toEqual({
+      config,
+      seed: PRACTICE_SEED,
+    });
+  });
+
+  it("has nothing about the child in it", () => {
+    // The one property this module cannot be allowed to lose, and the reason
+    // the profile stays on the service's side of the line: a config is facts,
+    // paper and type, and this link is the surface a name would leak through.
+    // `fields` is the blank rule on the paper, filled in by hand (§1) — there
+    // is nowhere here to put a value for it.
+    const config = practiceSheet("words:dolch-1", ["because"])!;
+    expect(config.fields).toEqual(["name", "date"]);
+    expect(Object.keys(config).sort()).toEqual([
+      "columns",
+      "count",
+      "fields",
+      "fontPt",
+      "gaps",
+      "kind",
+      "paper",
+      "style",
+      "times",
+      "words",
+    ]);
+    expect(Object.keys(practiceSheet("multiply", ["7:8"])!).sort()).toEqual([
+      "columns",
+      "count",
+      "factors",
+      "facts",
+      "fields",
+      "fontPt",
+      "form",
+      "kind",
+      "operation",
+      "paper",
+      "style",
+      "tables",
+    ]);
+  });
+});

--- a/src/engine/sheets/practice.ts
+++ b/src/engine/sheets/practice.ts
@@ -1,0 +1,185 @@
+/**
+ * The record book, as paper.
+ *
+ * The headline of §14 and the thing no other worksheet site can do: nobody
+ * else knows what the child got wrong. Here that is one function — a deck mode
+ * and the fact ids the record book already ranked, in, a sheet a parent can
+ * print, out — and the whole of the trick is that neither side has to learn
+ * the other's shape. `troubleFacts` speaks in `DeckSpec.drillKey`; a family
+ * turns those ids into problems through `Problem.factId`; this module is the
+ * only place that knows which family answers for which deck.
+ *
+ * It sits in the engine and not in the builder because three screens ask for
+ * it — the race results, the progress screen and the bench — and a sheet built
+ * from the same facts has to be the same sheet whichever door it came through.
+ * The counterpart is `src/games/printshop/defaults.ts`, which holds what a
+ * parent probably wants when they are choosing for themselves; this holds what
+ * the record book already decided for them.
+ *
+ * **Nothing about a child is in what comes out.** A config carries facts,
+ * paper and type — never a name, an age or a profile id — which matters more
+ * here than anywhere else in the shop, because `practiceHref` puts it in a URL
+ * (§14) and this is the one sheet built out of a child's own history.
+ */
+import { WORD_MODE_PREFIX, deckWordsOf, listIdOf } from "@/engine/decks/words";
+import { WORLDS } from "@/engine/worlds";
+
+import type { SheetConfig, SheetOptions } from "./types";
+
+import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "./paper";
+import { encodeSharedSheet } from "./share";
+
+/**
+ * What a sheet made out of the record book opens on.
+ *
+ * The same paper and the same blank name line every other sheet starts with —
+ * there is nowhere in a config to put a child's name (§1), which is exactly
+ * why this one is safe to hand round as a link.
+ */
+const BASE: SheetOptions = {
+  paper: DEFAULT_PAPER,
+  fontPt: DEFAULT_FONT_PT,
+  fields: ["name", "date"],
+};
+
+/** The twelve tables, for the sheet a child with no history gets. */
+const TABLES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+/**
+ * A full page when there is nothing in particular to practise.
+ *
+ * A named-fact sheet asks for exactly as many problems as it has facts, so
+ * this number only decides the length of the other sheet — the mixed one a
+ * child who has never raced gets, which had better be worth printing.
+ */
+const FULL_PAGE = 24;
+
+/**
+ * A sheet of exactly these facts, or `null` if this build cannot print them.
+ *
+ * `null` rather than a blank sheet, because the caller is the one that knows
+ * what to do instead: a results screen hides the button, and the bench says so
+ * in a line. Typing is the honest case — a passage is not a set of facts to
+ * print, and there is no sheet family that pretends otherwise until the
+ * copywork one lands.
+ *
+ * An empty fact list is not a failure and does not return `null`. It is what a
+ * child with no history has, and what it produces is the ordinary sheet for
+ * that deck: all twelve tables, or the whole word list. A parent who came here
+ * to print something should leave with something.
+ */
+export function practiceSheet(
+  mode: string,
+  facts: string[],
+): SheetConfig | null {
+  const named = [...new Set(facts.filter((fact) => fact !== ""))];
+  const count = named.length > 0 ? named.length : FULL_PAGE;
+
+  if (mode === "multiply" || mode === "divide") {
+    return {
+      ...BASE,
+      kind: "multiplication",
+      operation: mode,
+      style: "standard",
+      form: "horizontal",
+      tables: TABLES,
+      factors: { min: 1, max: 12 },
+      facts: named,
+      count,
+      columns: 3,
+    };
+  }
+
+  if (mode === "add" || mode === "subtract") {
+    return {
+      ...BASE,
+      kind: "arithmetic",
+      operation: mode,
+      style: "standard",
+      form: "horizontal",
+      range: { min: 1, max: 20 },
+      regrouping: "either",
+      facts: named,
+      count,
+      columns: 3,
+    };
+  }
+
+  // A word deck's fact id *is* the word — `DeckSpec.drillKey` normalises it and
+  // does nothing else — so the missed spellings are the list the sheet prints.
+  // Which is also why the two other bootstraps land on the same family: a saved
+  // deck and a pasted list are this config with the words from somewhere else.
+  if (mode.startsWith(WORD_MODE_PREFIX)) {
+    // With nothing missed yet, the whole list. The deck layer is asked for it
+    // rather than the words being looked up here, because a list may be one a
+    // parent typed in — mirrored into the engine by `services/decks.ts` — and
+    // `deckWordsOf` is where both kinds already come out the same shape.
+    const words =
+      named.length > 0
+        ? named
+        : deckWordsOf({
+            kind: "words",
+            listId: listIdOf(mode),
+            cardCount: 0,
+            inputMode: "type",
+          }).map((entry) => entry.word);
+    return words.length > 0 ? wordsSheet(words) : null;
+  }
+
+  // Typing, and any deck this build has never heard of. A passage is not a set
+  // of facts and there is no family that pretends otherwise, so the answer is
+  // "not this build" rather than a page with nothing on it. A fifth arithmetic
+  // operation would land here too, which is the right failure: it needs a line
+  // above rather than a sheet that quietly says the wrong thing.
+  return null;
+}
+
+/**
+ * A spelling sheet from a list, whoever chose it: the record book, a saved
+ * deck, or a parent's paste (§14's second and third bootstraps).
+ *
+ * Copying is the style it opens on because it is the one that works for any
+ * list at all — a word too short to take a letter out of is still a word to
+ * write three times — and the other two styles are one control away.
+ */
+export function wordsSheet(words: string[]): SheetConfig {
+  return {
+    ...BASE,
+    kind: "words",
+    style: "copy",
+    words,
+    times: 3,
+    gaps: 2,
+    count: words.length,
+    columns: 2,
+  };
+}
+
+/**
+ * The seed a sheet from the record book is built with.
+ *
+ * Fixed, so that the same facts always make the same page: a parent who prints
+ * from the results screen and then opens the same link on the laptop is
+ * looking at the sheet they printed, and the bench's own "another one like
+ * this" is still there for when they want a different draw (§7).
+ */
+export const PRACTICE_SEED = 1;
+
+/** Where the builder lives — the island in the world registry, not a literal. */
+const BENCH = WORLDS.find((world) => world.id === "paper")?.island ?? "/";
+
+/**
+ * The bench, already loaded with this sheet.
+ *
+ * A link and not a handover, which is what a static site makes cheap: the
+ * config *is* the id (§14), so a game screen can send a parent to the builder
+ * with the facts already on the paper without anything being stored, posted or
+ * kept between two pages. The fragment never leaves the browser either, which
+ * is the part that matters for a sheet built out of a child's own history.
+ */
+export function practiceHref(
+  config: SheetConfig,
+  seed = PRACTICE_SEED,
+): string {
+  return `${BENCH}#s=${encodeSharedSheet({ config, seed })}`;
+}

--- a/src/engine/sheets/spec.ts
+++ b/src/engine/sheets/spec.ts
@@ -7,7 +7,7 @@
  * what its answer is, or how to say in one line what the sheet contains. Those
  * three judgements belong to the family, and this is where it states them.
  */
-import type { World } from "@/engine/worlds";
+import { WORLDS, type World } from "@/engine/worlds";
 
 import type { Sheet, SheetConfig } from "./types";
 import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "./paper";
@@ -27,6 +27,25 @@ export const SHEET_WORLD: World = "paper";
 /** Printed small at the foot of every sheet: free traffic, and true (§16). */
 export const SHEET_URL = "schoolskills.app";
 export const SHEET_CREDIT = "Free printables and learning games";
+
+/**
+ * The same URL, pointing at the game this sheet's practice is also a race in
+ * (§16).
+ *
+ * Free traffic and genuinely useful: the child who has just done twenty
+ * problems on paper is the likeliest one to run the race, and the sheet is the
+ * only place that connection can be made — it is what they are holding.
+ *
+ * Only families that *have* a matching game print one. There is no race for
+ * long division or for the area of a trapezium, and a footer that sent a
+ * parent to the times tables from a geometry sheet would be an advert rather
+ * than a route back. The world registry is where a game's route is written
+ * down, so nothing here is a second copy of it.
+ */
+export function gameUrl(world: World): string {
+  const found = WORLDS.find((entry) => entry.id === world);
+  return found ? `${SHEET_URL}${found.href}` : SHEET_URL;
+}
 
 /**
  * `C` is the family's own config, and the registry in index.ts is what ties it

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -618,6 +618,22 @@ export type ArithmeticConfig = SheetOptions & {
    * sum may run past it. That is what carrying is.
    */
   range: { min: number; max: number };
+  /**
+   * Named facts, in the vocabulary the race already uses ("7:8") — the whole
+   * of "print exactly what they keep missing" (§14) on this family.
+   *
+   * When it has anything in it, it *is* the pool: `range` and `regrouping`
+   * stop applying, because the facts are the constraint and a sheet that
+   * dropped half of them for not carrying would not be the sheet that was
+   * asked for. Absent or empty is a sheet drawn from the range as usual, which
+   * is what a child with nothing in the record book gets.
+   *
+   * A pair is read the way `decks/flashcards.ts` builds it: added, the two
+   * addends; subtracted, the number taken away and what is left. The record
+   * book hands these over and the family turns them into problems, and neither
+   * side learns the other's shape — see `Problem.factId`.
+   */
+  facts?: string[];
   /** How many problems to ask for. Capped at what the page holds. */
   count: number;
   columns: number;
@@ -680,6 +696,22 @@ export type MultiplicationConfig = SheetOptions & {
   tables: number[];
   /** What each table is multiplied by, ends included. */
   factors: { min: number; max: number };
+  /**
+   * Named facts, in the vocabulary the race already uses ("7:8") — the whole
+   * of "print exactly what they keep missing" (§14) on this family.
+   *
+   * When it has anything in it, it *is* the pool: `tables` and `factors` stop
+   * deciding what is on the page, because a sheet of the eight facts a child
+   * keeps missing is not a sheet of the eight times table. The pair reads the
+   * way the deck builds it — the table that was picked, then what it was
+   * paired with — so a division fact is its divisor and its answer, and
+   * "56 ÷ 7" and "56 ÷ 8" stay the two questions the drill keeps apart.
+   *
+   * Ignored by the grid and the long forms, which have no facts to name: a
+   * multiplication square is every fact there is, and a three-digit long
+   * division is not one of the twelve tables at all.
+   */
+  facts?: string[];
   /** How many problems to ask for. Capped at what the page holds. */
   count: number;
   columns: number;
@@ -1141,6 +1173,53 @@ export type WordProblemConfig = SheetOptions & {
   workspace?: boolean;
 };
 
+/* ── Words ─────────────────────────────────────────────────────────────────
+   The first family whose content is not generated at all. Every sheet above
+   this line is drawn from a range or a pool the engine owns; a spelling sheet
+   is a list somebody else wrote — this week's words off a school letter, a
+   deck a parent typed in, or the words a child kept missing in the jungle —
+   and the only judgements left are how they are set on the page.
+
+   Which is why the list travels in the config rather than being named by an
+   id: a sheet has to print the same words next term after the deck it came
+   from has been deleted, exactly as a saved run outlives its deck. It is also
+   what keeps the shared-link promise intact — a word list is what a parent
+   typed, never anything the site knows about their child (§1).             */
+
+/**
+ * What the sheet asks a child to do with the list.
+ *
+ * `copy` is "write it three times", the oldest spelling exercise there is;
+ * `missing` takes letters out and leaves the gaps to fill; `test` prints
+ * numbered lines and nothing else, for a list read aloud. The wider set —
+ * ABC order, word shapes, use it in a sentence — is PRINT20's, and lands here
+ * as more of this union rather than as another family.
+ */
+export type WordSheetStyle = "copy" | "missing" | "test";
+
+export type WordsConfig = SheetOptions & {
+  kind: "words";
+  style: WordSheetStyle;
+  /**
+   * The list, in the order it was given: a spelling list is often taught in
+   * order, and `parseWords` already keeps it.
+   *
+   * There is no name for the list here on purpose. A config travels in a URL
+   * (§14), and the one thing that must never be in one is a child — so the
+   * sheet is titled after what it does, and a parent who wants their own words
+   * at the top of the page types them into `title` themselves.
+   */
+  words: string[];
+  /** `copy` only: how many times each word is written out. */
+  times: number;
+  /** `missing` only: how many letters are taken out of each word. */
+  gaps: number;
+  /** How many words to ask for. Capped at what the page holds. */
+  count: number;
+  /** `copy` and `test` only — a gapped word is a line of its own. */
+  columns: number;
+};
+
 /**
  * Anything a saved sheet can hold. Narrow on `kind` — and only in index.ts,
  * which is the one module that knows the whole union.
@@ -1160,7 +1239,8 @@ export type SheetConfig =
   | PreAlgebraConfig
   | RatioConfig
   | StatisticsConfig
-  | WordProblemConfig;
+  | WordProblemConfig
+  | WordsConfig;
 
 /* ── A sheet somebody kept ─────────────────────────────────────────────── */
 

--- a/src/engine/sheets/words/spelling.test.ts
+++ b/src/engine/sheets/words/spelling.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { answerLine } from "../layout";
+import type { Blank, Paper, Problem, WordsConfig } from "../types";
+
+import { WORDS_SHEET, gapped, wordsLayout, wordsOf } from "./spelling";
+
+/**
+ * Spelling, held to the bar the maths families set.
+ *
+ * The answers here are not arithmetic, so "verified by an independent path"
+ * means something different and just as strict: a gapped word is checked by
+ * **putting the letters back**. Reading `answers` into the underscores of
+ * `text` has to rebuild the word exactly — a test that compared the generator's
+ * gaps against the generator's answers would pass on a family that took out
+ * one letter and printed another.
+ *
+ * The rest is what a list-driven family can get wrong that a generated one
+ * cannot: dropping a word, printing one twice, or putting more of them on the
+ * page than the paper holds.
+ */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const WORDS = ["because", "thought", "friend", "people", "through"];
+
+const config = (over: Partial<WordsConfig> = {}): WordsConfig => ({
+  kind: "words",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style: "copy",
+  words: WORDS,
+  times: 3,
+  gaps: 2,
+  count: WORDS.length,
+  columns: 2,
+  ...over,
+});
+
+function problemsOf(over: Partial<WordsConfig>, seed = 1): Problem[] {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== "problems")
+    throw new Error(`expected problems, got ${block.kind}`);
+  return block.items;
+}
+
+function blanksOf(over: Partial<WordsConfig>, seed = 1): Blank[] {
+  const block = buildSheet(config({ style: "missing", ...over }), seed)
+    .blocks[0];
+  if (block.kind !== "blanks")
+    throw new Error(`expected blanks, got ${block.kind}`);
+  return block.sentences;
+}
+
+/** The word a gapped sentence came from, rebuilt by putting the letters back. */
+function refilled(blank: Blank): string {
+  let at = 0;
+  return blank.text.replaceAll("_", () => blank.answers[at++] ?? "?");
+}
+
+/* ── The registry ──────────────────────────────────────────────────────── */
+
+describe("the spelling family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("words")).toBe(WORDS_SHEET);
+    expect(sheetSpec("words").label).toBe("Spelling list");
+  });
+
+  it("names what it prints, in the terms it was chosen by", () => {
+    expect(describeSheet(config())) //
+      .toBe("Spelling practice — 5 words — written 3 times");
+    expect(describeSheet(config({ style: "missing", gaps: 1 }))) //
+      .toBe("Missing letters — 5 words — 1 letter out");
+    expect(describeSheet(config({ style: "test" }))) //
+      .toBe("Spelling test — 5 words");
+  });
+
+  it("titles the sheet and marks it out of its own words", () => {
+    const sheet = buildSheet(config(), 1);
+    expect(sheet.header.title).toBe("Spelling practice");
+    expect(sheet.header.instructions).toBe("Write each word 3 times.");
+    expect(sheet.header.score).toEqual({ outOf: 5 });
+  });
+
+  it("points back at the game that reads these words aloud", () => {
+    // §16: the child who just wrote out twenty words is the likeliest one to
+    // race them, and the sheet is the only place that link can be made.
+    expect(buildSheet(config(), 1).footer.url).toBe(
+      "schoolskills.app/spelling/play",
+    );
+  });
+});
+
+/* ── The three styles ──────────────────────────────────────────────────── */
+
+describe("writing it out", () => {
+  it("gives every word its list order and a rule for each writing", () => {
+    const items = problemsOf({ times: 4 });
+    expect(items.map((item) => item.prompt)).toEqual(WORDS);
+    for (const item of items) {
+      expect(item.answers).toEqual(Array(4).fill(item.prompt));
+      // The rules share the height the layout reserved rather than being added
+      // under it, which is what keeps the row as tall as it was declared.
+      expect(item.workspace).toBe(4 * answerLine(12));
+    }
+  });
+
+  it("holds the number of writings inside what a page can take", () => {
+    // A saved config may say anything; six writings of a word is a row taller
+    // than the family ever reserved for.
+    expect(problemsOf({ times: 99 })[0].answers).toHaveLength(5);
+    expect(problemsOf({ times: 0 })[0].answers).toHaveLength(1);
+  });
+});
+
+describe("missing letters", () => {
+  it("takes out letters it can spare, and never the first", () => {
+    // The number is a request rather than a promise, as `count` is everywhere
+    // else in the shop: a six-letter word cannot spare three letters and keep
+    // the gaps apart, and taking them anyway would print one long rule.
+    for (const gaps of [1, 2, 3]) {
+      for (const blank of blanksOf({ gaps })) {
+        expect(blank.answers.length).toBeGreaterThan(0);
+        expect(blank.answers.length).toBeLessThanOrEqual(gaps);
+        expect(blank.text.startsWith("_")).toBe(false);
+      }
+    }
+    // One letter out of a long word is a promise it can always keep.
+    expect(blanksOf({ gaps: 1 })[0].answers).toHaveLength(1);
+  });
+
+  it("never takes two letters out side by side", () => {
+    // A rendering constraint as much as a teaching one: `Blanks` reads a run
+    // of underscores as *one* gap, so "bec__se" is a single rule expecting two
+    // letters and a key that prints only the first of them.
+    for (const seed of [0, 1, 2, 3, 4, 5]) {
+      for (const gaps of [2, 3, 4]) {
+        for (const blank of blanksOf({ gaps }, seed)) {
+          expect(blank.text, blank.text).not.toContain("__");
+          // One gap, one letter to write in it — however few the word spared.
+          expect(blank.text.match(/_/g) ?? []) //
+            .toHaveLength(blank.answers.length);
+        }
+      }
+    }
+  });
+
+  it("puts back exactly the word it took the letters out of", () => {
+    // The independent path: the answers are checked against the *word*, not
+    // against the gaps the generator chose. A family that blanked one letter
+    // and answered with another passes every other test in this file.
+    for (const seed of [0, 1, 2, 99]) {
+      const blanks = blanksOf({ gaps: 2 }, seed);
+      expect(blanks.map(refilled)).toEqual(WORDS);
+    }
+  });
+
+  it("leaves a word with nothing to take out whole", () => {
+    // A single letter has no interior, and blanking it to nothing would be a
+    // question with no word in it. Printing it whole is the honest answer.
+    const [blank] = blanksOf({ words: ["a"], count: 1 });
+    expect(blank).toEqual({ text: "a", answers: [] });
+  });
+
+  it("takes different letters out for a different sheet", () => {
+    // "Another sheet like this one" is `seed + 1` here as everywhere (§7), and
+    // on this style it has to change the gaps or it changes nothing at all.
+    const first = blanksOf({ gaps: 2, words: ["thoroughly"], count: 1 }, 1);
+    const next = blanksOf({ gaps: 2, words: ["thoroughly"], count: 1 }, 2);
+    expect(first[0].text).not.toBe(next[0].text);
+  });
+
+  it("holds the number of gaps inside what a word can spare", () => {
+    expect(gapped("cat", 99, () => 0.5).answers.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("the spelling test", () => {
+  it("prints a numbered rule and nothing to copy from", () => {
+    // The words are read aloud; a sheet with them on it is a copying exercise.
+    const items = problemsOf({ style: "test" });
+    expect(items.map((item) => item.prompt)).toEqual(["", "", "", "", ""]);
+    expect(items.map((item) => item.answer)).toEqual(WORDS);
+    expect(items.every((item) => item.answers === undefined)).toBe(true);
+  });
+});
+
+/* ── The key ───────────────────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("prints the answers only when the sheet is a key", () => {
+    expect(buildSheet(config(), 3).answers).toBe(false);
+    const key = answerKey(config(), 3);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+  });
+
+  it("is the same sheet keyed, never a second generation", () => {
+    // The gaps are drawn from the seed, so a key that regenerated them would
+    // ask for one letter and answer with another.
+    const sheet = buildSheet(config({ style: "missing" }), 7);
+    const key = answerKey(config({ style: "missing" }), 7);
+    expect({ ...key, answers: false, footer: sheet.footer }).toEqual(sheet);
+  });
+});
+
+/* ── The list ──────────────────────────────────────────────────────────── */
+
+describe("the list itself", () => {
+  it("reads a saved list back safely", () => {
+    // The config comes through the same doors a deck does — a paste, a saved
+    // sheet, a link somebody was sent — and only one of those has ever been
+    // near a validator.
+    expect(
+      wordsOf(config({ words: ["  cat ", "", "cat", "Cat", "dog\tfox"] })),
+    ).toEqual(["cat", "dog fox"]);
+  });
+
+  it("keeps the order it was given", () => {
+    // A spelling list is often taught in order, and a list of missed words
+    // arrives ranked worst-first. Neither is ours to shuffle.
+    expect(wordsOf(config())).toEqual(WORDS);
+  });
+
+  it("builds the same sheet twice", () => {
+    expect(buildSheet(config({ style: "missing" }), 12)).toEqual(
+      buildSheet(config({ style: "missing" }), 12),
+    );
+  });
+
+  it("never prints more words than the paper holds", () => {
+    const many = Array.from({ length: 200 }, (_, i) => `word${i}`);
+    for (const style of ["copy", "missing", "test"] as const) {
+      const over = { style, words: many, count: many.length };
+      const { perPage } = wordsLayout(config(over));
+      const sheet = buildSheet(config(over), 1);
+      const block = sheet.blocks[0];
+      const printed =
+        block.kind === "blanks"
+          ? block.sentences.length //
+          : block.kind === "problems"
+            ? block.items.length
+            : 0;
+      expect(printed, style).toBe(perPage);
+      expect(sheet.header.score).toEqual({ outOf: perPage });
+    }
+  });
+
+  it("prints an empty list as an empty page rather than throwing", () => {
+    // A `kind` with no list behind it is a sheet somebody arrived at from a
+    // link, and the promise everywhere else in the shop holds here: it prints
+    // something, and says what it is.
+    const sheet = buildSheet(config({ words: [], count: 0 }), 1);
+    expect(sheet.header.title).toBe("Spelling practice");
+    expect(sheet.header.score).toEqual({ outOf: 0 });
+  });
+});

--- a/src/engine/sheets/words/spelling.ts
+++ b/src/engine/sheets/words/spelling.ts
@@ -1,0 +1,349 @@
+/**
+ * Spelling, from whatever list a parent already has.
+ *
+ * The first family whose content the engine does not generate. Every maths
+ * family draws from a range or a pool it owns; this one is handed a list —
+ * this week's words off a school letter, a deck typed into Word Jungle, or the
+ * words a child kept missing in the record book — and the only judgements left
+ * are how they are set on the page. Which makes it the family the three
+ * bootstraps in §14 land on: two of the three are "here is a list", and the
+ * third is the same thing with the list chosen for you.
+ *
+ * Three styles, and each one is an exercise somebody actually sets: write it
+ * three times, fill in the letters that are missing, or write it down as it is
+ * read out. The wider spelling set — ABC order, word shapes, use it in a
+ * sentence — is PRINT20's, and lands here as more of `WordSheetStyle` rather
+ * than as a second family.
+ *
+ * Everything the other families promise holds unchanged: the page comes out of
+ * `(config, seed)` and nothing else, the answers are computed when the sheet is
+ * built and the key only decides to print them, and no row is put on the page
+ * that the capacity arithmetic did not reserve room for.
+ */
+import { normaliseWord } from "@/engine/decks/words";
+import { mulberry32, shuffled } from "@/engine/random";
+
+import type {
+  Blank,
+  Block,
+  Mil,
+  Problem,
+  Sheet,
+  SheetOptions,
+  WordsConfig,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import {
+  PROBLEM_GAP,
+  WRAP_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches, points } from "../paper";
+import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
+
+/* ── What a word takes on the page ────────────────────────────────────────
+   Declared, not measured (§4). A word on a line is one line of the body type;
+   a word to be written out is that line plus the rules it is written on, which
+   wrap onto their own line inside the cell and pay the wrap gap for it.      */
+
+const ROW_EMS = 1.7;
+
+/** `.sheet__blanks` in sheet.css sets this between one sentence and the next. */
+const BLANK_GAP: Mil = inches(0.16);
+
+/** A gapped word is a line of body type, and a hair of air under it. */
+const BLANK_EMS = 1.35;
+
+/** More than three columns of words is a page nobody can write on. */
+const MAX_COLUMNS = 3;
+
+/** As many words as a parent may type into a deck — see `services/decks.ts`. */
+const MAX_WORDS = 200;
+
+/** Long enough for "onomatopoeia" twice over; short enough not to wrap. */
+const MAX_LETTERS = 24;
+
+/** How many times a word may be written out, and how many letters may go. */
+export const MAX_TIMES = 5;
+export const MAX_GAPS = 4;
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/* ── The list ──────────────────────────────────────────────────────────── */
+
+/**
+ * The words, made safe to print from whatever a saved config says.
+ *
+ * Held to the same shape `services/decks.ts` holds a typed-in list to, because
+ * this config comes through the same three doors a deck does — a parent's
+ * paste, a saved sheet, and a link somebody was sent — and only one of those
+ * has ever been near a validator. Duplicates go the way the marker sees them,
+ * so "Because" and "because" are one word on the page rather than two.
+ */
+export function wordsOf(config: WordsConfig): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of config.words ?? []) {
+    if (typeof raw !== "string") continue;
+    const word = raw.trim().replace(/\s+/g, " ").slice(0, MAX_LETTERS);
+    if (!word) continue;
+    const key = normaliseWord(word);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(word);
+    if (out.length === MAX_WORDS) break;
+  }
+  return out;
+}
+
+/* ── Taking letters out ────────────────────────────────────────────────── */
+
+/**
+ * One word with some of its letters missing, and the letters that are.
+ *
+ * Never the first one. A child reading "_at" has a word to work from and a
+ * child reading "_ _ t" has a guessing game, and the point of the exercise is
+ * the letters inside a word they can already see the shape of.
+ *
+ * **And never two in a row**, which is a rendering constraint as much as a
+ * teaching one: `Blanks` reads a run of underscores of any length as *one*
+ * gap, so "bec__se" is a single rule with two letters expected in it and an
+ * answer key that prints only the first of them. Spacing them out is what
+ * keeps one gap meaning one letter.
+ *
+ * A word with no interior letters to take — a single letter, an initial — is
+ * printed whole rather than blanked to nothing, which is the honest answer:
+ * there is nothing in it to leave out. A short word that cannot spare as many
+ * as were asked for gives up the ones it can, for the same reason.
+ */
+export function gapped(word: string, gaps: number, rand: () => number): Blank {
+  const inside = [...word]
+    .map((letter, at) => ({ letter, at }))
+    .filter(({ letter, at }) => at > 0 && /\p{L}/u.test(letter));
+
+  const wanted = clamp(gaps, 1, MAX_GAPS);
+  const at = new Set<number>();
+  const taken: Array<{ letter: string; at: number }> = [];
+  for (const letter of shuffled(inside, rand)) {
+    if (taken.length === wanted) break;
+    if (at.has(letter.at - 1) || at.has(letter.at + 1)) continue;
+    at.add(letter.at);
+    taken.push(letter);
+  }
+  if (taken.length === 0) return { text: word, answers: [] };
+
+  taken.sort((a, b) => a.at - b.at);
+  return {
+    text: [...word].map((letter, i) => (at.has(i) ? "_" : letter)).join(""),
+    answers: taken.map(({ letter }) => letter),
+  };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+const timesOf = (config: WordsConfig): number =>
+  clamp(config.times ?? 3, 1, MAX_TIMES);
+
+/** How many letters come out, said the way it reads in a sentence. */
+const gapsOf = (config: WordsConfig): string => {
+  const gaps = clamp(config.gaps ?? 2, 1, MAX_GAPS);
+  return `${gaps} ${gaps === 1 ? "letter" : "letters"}`;
+};
+
+/** How tall one word stands, the lines it is written on included. */
+function rowHeight(config: WordsConfig): Mil {
+  if (config.style === "missing") return points(config.fontPt * BLANK_EMS);
+  const body = points(config.fontPt * ROW_EMS);
+  if (config.style === "test") return body;
+  // The rules a word is copied onto wrap under it, inside the same cell, so
+  // the gap the browser puts between the two lines is reserved for here — see
+  // `WRAP_GAP`, which is that gap in the unit the arithmetic works in.
+  return body + WRAP_GAP + timesOf(config) * answerLine(config.fontPt);
+}
+
+/**
+ * How many words the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic rather than measurement, so the answer is the same in a unit test,
+ * in the build of a catalog page and in the builder's live preview (§4).
+ *
+ * A gapped word is always one column: the `blanks` block is a list of
+ * sentences down the page, and a family that asked it for two would be
+ * declaring a layout the renderer does not have.
+ */
+export function wordsLayout(config: WordsConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print rather than the one the config
+  // holds, and with the score box, because a spelling sheet is marked out of
+  // its words. Reserving for the wrong header is a last row below the bottom
+  // margin — invisible on screen, and a second sheet out of the printer.
+  const box = sheetBlockBox(headerOf(config), true);
+  const columns =
+    config.style === "missing" ? 1 : clamp(config.columns, 1, MAX_COLUMNS);
+  const row = rowHeight(config);
+  const gap = config.style === "missing" ? BLANK_GAP : PROBLEM_GAP.y;
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, gap),
+  };
+}
+
+/**
+ * The words this sheet actually prints, in the order they were given.
+ *
+ * A spelling list is often taught in order and a list of missed words arrives
+ * ranked worst-first, so neither is shuffled. The count is a request rather
+ * than a promise, the same as everywhere else: what does not fit is not
+ * printed, because print is the whole of the output path (§10).
+ */
+export function sheetWords(config: WordsConfig): string[] {
+  const { perPage } = wordsLayout(config);
+  const words = wordsOf(config);
+  return words.slice(0, clamp(config.count ?? words.length, 0, perPage));
+}
+
+/** One word, as the style asks for it. */
+function problemOf(word: string, config: WordsConfig): Problem {
+  if (config.style === "test") {
+    // Nothing to read: the word is said aloud and written on the rule, which
+    // is what a spelling test is. The key is the list, which is what makes it
+    // markable by somebody who was not the one reading it out.
+    return { prompt: "", answer: word };
+  }
+  const times = timesOf(config);
+  return {
+    prompt: word,
+    answer: word,
+    // One rule per writing, and `workspace` is the height they share rather
+    // than blank paper under them — see `Problem.answers`.
+    answers: Array.from({ length: times }, () => word),
+    workspace: times * answerLine(config.fontPt),
+  };
+}
+
+function bodyOf(
+  config: WordsConfig,
+  seed: number,
+): { blocks: Block[]; outOf: number } {
+  const words = sheetWords(config);
+  if (config.style === "missing") {
+    const rand = mulberry32(seed);
+    const sentences = words.map((word) => gapped(word, config.gaps, rand));
+    return { blocks: [{ kind: "blanks", sentences }], outOf: sentences.length };
+  }
+
+  const { columns } = wordsLayout(config);
+  return {
+    blocks: [
+      {
+        kind: "problems",
+        columns,
+        items: words.map((w) => problemOf(w, config)),
+      },
+    ],
+    outOf: words.length,
+  };
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const TITLE: Record<WordsConfig["style"], string> = {
+  copy: "Spelling practice",
+  missing: "Missing letters",
+  test: "Spelling test",
+};
+
+function instructionOf(config: WordsConfig): string {
+  switch (config.style) {
+    case "missing":
+      return "Fill in the missing letters.";
+    case "test":
+      return "Write each word as it is read out.";
+    default:
+      return `Write each word ${timesOf(config)} times.`;
+  }
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page. `config.title` is an override
+ * and is usually absent — a family names its own sheet.
+ */
+function headerOf(config: WordsConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? TITLE[config.style] ?? TITLE.copy,
+    instructions: config.instructions ?? instructionOf(config),
+  };
+}
+
+/** One line naming what the sheet holds, in the terms it was chosen by. */
+export function describeWords(config: WordsConfig): string {
+  const words = wordsOf(config);
+  return [
+    TITLE[config.style] ?? TITLE.copy,
+    `${words.length} ${words.length === 1 ? "word" : "words"}`,
+    config.style === "copy" ? `written ${timesOf(config)} times` : null,
+    config.style === "missing" ? `${gapsOf(config)} out` : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" — ");
+}
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+export function buildWordsSheet(config: WordsConfig, seed: number): Sheet {
+  const head = headerOf(config);
+  const { blocks, outOf } = bodyOf(config, seed);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is on the page rather than what was asked for: a sheet
+      // that says "/ 20" over eighteen words is wrong twice.
+      score: { outOf },
+    },
+    blocks,
+    // The jungle rather than the grid: a printed spelling list is the one sheet
+    // whose matching game is the one that reads the words aloud (§16).
+    footer: { credit: SHEET_CREDIT, url: gameUrl("jungle"), seed },
+    answers: false,
+  };
+}
+
+export const WORDS_SHEET: SheetSpec<WordsConfig> = {
+  id: "words",
+  label: "Spelling list",
+  world: SHEET_WORLD,
+  build: buildWordsSheet,
+  // The whole of the answer-key mechanism: every answer was decided when the
+  // sheet was built — which letters came out, and what goes back in — so a key
+  // cannot disagree with the sheet it belongs to.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeWords,
+};

--- a/src/games/flashcards/RaceResults.tsx
+++ b/src/games/flashcards/RaceResults.tsx
@@ -16,6 +16,7 @@ import { useWorld } from "@/components/state/useWorld";
 import { buildDrill, deckSpec, describeConfig, isTyping } from "@/engine/decks";
 import { clock, delta as formatDelta, plural } from "@/engine/format";
 import { randomSeed } from "@/engine/random";
+import { practiceHref, practiceSheet } from "@/engine/sheets/practice";
 import { sfx } from "@/services/sound";
 import { Rewards } from "@/games/race";
 import { Scoreline } from "./results/Scoreline";
@@ -135,6 +136,14 @@ export default function RaceResults() {
 
   const selfGhost = { session, profile: outcome.profileAfter, isSelf: true };
   const practiceFirst = missedFacts.length > 0;
+  /**
+   * The same facts as a worksheet (§14) — the one thing no other worksheet
+   * site can print, offered at the moment it is most obviously wanted. Null
+   * for a deck this build has no sheet family for.
+   */
+  const printable = practiceFirst
+    ? practiceSheet(session.mode, missedFacts)
+    : null;
 
   return (
     <main className="results">
@@ -216,6 +225,22 @@ export default function RaceResults() {
           <Button variant="go" onClick={practise}>
             Practise {plural(missedFacts.length, "fact")}
           </Button>
+        )}
+        {/* A new tab, which is the one place on the site that earns one: this
+            screen is the run, held in memory and gone the moment the browser
+            leaves it, so a parent who opened the print shop in it would take
+            the child's "race again" with them. The link carries the sheet in
+            its fragment — nothing is stored, and nothing about the child is in
+            it. */}
+        {printable && (
+          <a
+            className="btn btn--accent"
+            href={practiceHref(printable)}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Print these
+          </a>
         )}
         <Button
           variant={practiceFirst ? "accent" : "go"}

--- a/src/games/printshop/App.tsx
+++ b/src/games/printshop/App.tsx
@@ -22,6 +22,7 @@ import { answerKey, buildSheet } from "@/engine/sheets";
 import type { Sheet } from "@/engine/sheets/types";
 import "@/styles/printshop.css";
 
+import { Bootstrap } from "./Bootstrap";
 import { FamilyOptions } from "./options";
 import { PageOptions } from "./PageOptions";
 import { Picker } from "./Picker";
@@ -66,6 +67,12 @@ export default function PrintShopApp() {
   return (
     <div className="bench">
       <div className="bench__panel no-print">
+        {/* Above the picker, because it answers the question the picker asks:
+            a parent who came to print what their child keeps missing should not
+            have to work out which family that is. It only ever opens a sheet on
+            the bench — everything below stays in charge of it afterwards. */}
+        <Bootstrap onOpen={bench.open} />
+
         <Picker config={bench.config} onFamily={bench.setFamily} />
 
         <section className="bench__group">

--- a/src/games/printshop/Bootstrap.tsx
+++ b/src/games/printshop/Bootstrap.tsx
@@ -1,0 +1,135 @@
+/**
+ * The three ways into a sheet that is already about something (§14).
+ *
+ * Three buttons and not a wizard, because each one is a source a parent
+ * already has: the record book knows what their child keeps missing, the word
+ * lists they typed into Word Jungle are sitting in IndexedDB, and this week's
+ * spellings are on a letter they can paste. None of the three is a new kind of
+ * sheet — they all end at `bench.open(config, seed)` with a config the picker
+ * and the panels below can then tune, which is why a bootstrap is a way to
+ * start rather than a mode to be in.
+ *
+ * Everything here goes through a service. The missed facts come from
+ * `services/practice.ts` and the saved lists from `services/decks.ts`; nothing
+ * in this directory knows that IndexedDB exists, which is the boundary
+ * `eslint.config.mjs` enforces and the reason the schema lives in one place.
+ */
+import { useEffect, useState } from "react";
+
+import { Button, Field, Select } from "@/components/ui/kit";
+import { PRACTICE_SEED, wordsSheet } from "@/engine/sheets/practice";
+import type { SheetConfig } from "@/engine/sheets/types";
+import type { CustomDeck } from "@/engine/types";
+import * as deckService from "@/services/decks";
+
+import { Missed } from "./Missed";
+import { WordList } from "./options/parts";
+
+type Open = (config: SheetConfig, seed: number) => void;
+
+export function Bootstrap({ onOpen }: { onOpen: Open }) {
+  return (
+    <section className="bootstrap no-print">
+      <h2 className="bootstrap__title u-display">Start from</h2>
+      <p className="bootstrap__lead">
+        A sheet about something in particular. Every one of these opens on the
+        bench, so the style, the paper and the rest are still yours to change.
+      </p>
+      <Missed onOpen={onOpen} />
+      <FromSavedList onOpen={onOpen} />
+      <FromPaste onOpen={onOpen} />
+    </section>
+  );
+}
+
+/**
+ * A word list a parent already typed in, as paper.
+ *
+ * Nearly free, and the reason it is here rather than in a later story: the
+ * data is in IndexedDB already, parsed already, and a spelling deck is exactly
+ * a spelling sheet's content. One press turns this week's list into a
+ * worksheet; the style control beside it turns that into three of them.
+ */
+function FromSavedList({ onOpen }: { onOpen: Open }) {
+  const [decks, setDecks] = useState<CustomDeck[]>([]);
+  const [chosen, setChosen] = useState("");
+
+  useEffect(() => {
+    let live = true;
+    deckService
+      .all()
+      // Silent on failure, unlike the missed-facts panel above: this is the
+      // one of the three that a parent has no reason to expect, so a browser
+      // with no storage simply doesn't offer it rather than explaining itself
+      // twice on one screen.
+      .then((loaded) => live && setDecks(loaded))
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  if (decks.length === 0) return null;
+  const deck = decks.find((d) => d.id === chosen) ?? decks[0];
+
+  return (
+    <div className="bootstrap__step">
+      <h3 className="bootstrap__name">A list you saved</h3>
+      <Field label="Which list">
+        <Select
+          value={deck.id}
+          onChange={setChosen}
+          options={decks.map((d) => ({
+            value: d.id,
+            label: `${d.emoji} ${d.name} — ${d.words.length} words`,
+          }))}
+        />
+      </Field>
+      <Button
+        variant="accent"
+        size="sm"
+        onClick={() => onOpen(wordsSheet(deck.words), PRACTICE_SEED)}
+      >
+        Make a sheet
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Whatever the school letter says.
+ *
+ * `parseWords` has handled this paste since the day a parent could author a
+ * deck — newlines, commas, tabs and semicolons are all a word boundary — so a
+ * spelling list, a memory verse or a paragraph all arrive as a list of words
+ * without anybody reformatting anything.
+ */
+function FromPaste({ onOpen }: { onOpen: Open }) {
+  const [text, setText] = useState("");
+  const words = deckService.parseWords(text);
+
+  return (
+    <div className="bootstrap__step">
+      <h3 className="bootstrap__name">Something you paste</h3>
+      <WordList
+        label="Paste a list"
+        text={text}
+        onChange={setText}
+        rows={4}
+        hint={
+          words.length > 0
+            ? `${words.length} ${words.length === 1 ? "word" : "words"} — one a line, or separated by commas.`
+            : "This week's spellings, a verse, a paragraph. One a line, or separated by commas."
+        }
+      />
+      <Button
+        variant="accent"
+        size="sm"
+        disabled={words.length === 0}
+        onClick={() => onOpen(wordsSheet(words), PRACTICE_SEED)}
+      >
+        Make a sheet
+      </Button>
+    </div>
+  );
+}

--- a/src/games/printshop/Missed.tsx
+++ b/src/games/printshop/Missed.tsx
@@ -1,0 +1,144 @@
+/**
+ * Practise what they missed — the first of §14's three bootstraps, and the one
+ * the whole section exists for.
+ *
+ * No other worksheet site can print this page, because no other worksheet site
+ * knows what the child got wrong. Everything it needs is already computed: the
+ * record book ranks the trouble facts, `services/practice.ts` reads them
+ * through the layer that owns the schema, and `practiceSheet` turns a deck and
+ * a list of fact ids into paper. This screen only asks whose.
+ *
+ * **Nothing about a child goes any further than this component.** The picker
+ * knows their name because it has to say it; what it hands the bench is a sheet
+ * config, which carries facts and paper and nothing else — and that is what
+ * ends up in the address bar (§14).
+ *
+ * A player with no history is the normal case on a family machine, not an
+ * error state, so there is always something to print: the ordinary sheet for
+ * the deck they would have started on.
+ */
+import { useEffect, useState } from "react";
+
+import { Button, Field, Select } from "@/components/ui/kit";
+import { PRACTICE_SEED, practiceSheet } from "@/engine/sheets/practice";
+import type { SheetConfig } from "@/engine/sheets/types";
+import { loadPractice, type PracticePlayer } from "@/services/practice";
+
+/**
+ * What a child with nothing in the record book gets: the twelve tables, which
+ * is where the site itself starts (`WORLDS[0]`) and the sheet a parent who
+ * pressed this button was most likely after anyway.
+ */
+const FIRST_DECK = "multiply";
+
+export function Missed({
+  onOpen,
+}: {
+  onOpen: (config: SheetConfig, seed: number) => void;
+}) {
+  const [players, setPlayers] = useState<PracticePlayer[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [who, setWho] = useState("");
+  const [deck, setDeck] = useState("");
+
+  useEffect(() => {
+    let live = true;
+    loadPractice()
+      .then((loaded) => live && setPlayers(loaded))
+      .catch(() => {
+        // A browser blocking storage — private browsing does — is the usual
+        // cause, and it is worth saying: an empty picker otherwise reads as
+        // "this family has never played", which is a different thing.
+        if (live)
+          setError("This browser isn't letting the site read anything.");
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  // Whoever is chosen, or the first player on the device. Derived rather than
+  // stored, so the pickers are right on the first paint instead of a tick after
+  // the load — there is no state here that the data does not already decide.
+  const player = players.find((p) => p.id === who) ?? players[0];
+  // Only the decks this build can actually print. A typing level has trouble
+  // facts and no sheet family — a passage is not a set of problems — so it is
+  // left out rather than offered as a button that does nothing.
+  const sets = (player?.sets ?? []).filter(
+    (set) => practiceSheet(set.mode, set.facts) !== null,
+  );
+  const set = sets.find((s) => s.mode === deck) ?? sets[0];
+
+  const open = (mode: string, facts: string[]) => {
+    const config = practiceSheet(mode, facts);
+    // Never null for either caller — both modes come from a set this build can
+    // print, or from the fallback deck — and checked anyway, because the one
+    // thing worse than no sheet is a blank one.
+    if (config) onOpen(config, PRACTICE_SEED);
+  };
+
+  return (
+    <div className="bootstrap__step">
+      <h3 className="bootstrap__name">Practise what they missed</h3>
+      {error && <p className="bootstrap__note">{error}</p>}
+
+      {players.length > 0 && (
+        <Field label="Whose">
+          <Select
+            value={player?.id ?? ""}
+            onChange={setWho}
+            options={players.map((p) => ({ value: p.id, label: p.name }))}
+          />
+        </Field>
+      )}
+
+      {sets.length > 1 && (
+        <Field label="Which practice">
+          <Select
+            value={set?.mode ?? ""}
+            onChange={setDeck}
+            options={sets.map((s) => ({
+              value: s.mode,
+              label: `${s.label} — ${s.facts.length}`,
+            }))}
+          />
+        </Field>
+      )}
+
+      {set ? (
+        <>
+          <p className="bootstrap__facts">
+            {set.labels.map((label) => (
+              <span className="chip u-mono" key={label}>
+                {label}
+              </span>
+            ))}
+          </p>
+          <Button
+            variant="go"
+            size="sm"
+            onClick={() => open(set.mode, set.facts)}
+          >
+            Print these {set.facts.length}
+          </Button>
+        </>
+      ) : (
+        <>
+          <p className="bootstrap__note">
+            {players.length === 0
+              ? "Nobody has raced on this device yet."
+              : `Nothing standing out for ${player?.name} yet — facts land here when the clock beats them, when they come out wrong, or when they take longer than recall should.`}{" "}
+            A mixed sheet of the tables is a good place to start.
+          </p>
+          <Button
+            variant="accent"
+            size="sm"
+            onClick={() => open(FIRST_DECK, [])}
+          >
+            A mixed times-table sheet
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -17,6 +17,7 @@
  * below can produce a sheet that fails to fit — the builder never opens on a
  * page it would have to apologise for.
  */
+import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
 import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "@/engine/sheets/paper";
 import type { SheetConfig, SheetOptions } from "@/engine/sheets/types";
 
@@ -39,6 +40,15 @@ const TABLES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
 /** Halves through twelfths, skipping the ones a primary child never meets. */
 const DENOMINATORS = [2, 3, 4, 5, 6, 8, 10, 12];
+
+/**
+ * A list to open the spelling family on, from the shipped sight words.
+ *
+ * Twelve rather than the whole list, because the sheet is a starting point
+ * somebody replaces rather than the sheet they came for — and a page of forty
+ * words written three times each is a page that fits nothing else.
+ */
+const STARTER_WORDS = listWords(WORD_LISTS[0]).slice(0, 12);
 
 const DEFAULTS: Record<string, SheetConfig> = {
   blank: { ...BASE, kind: "blank", title: "Blank sheet" },
@@ -164,6 +174,20 @@ const DEFAULTS: Record<string, SheetConfig> = {
     range: { min: 1, max: 20 },
     count: 6,
     columns: 1,
+  },
+  words: {
+    ...BASE,
+    kind: "words",
+    style: "copy",
+    // A spelling family with an empty list is a page with nothing on it, and
+    // the bench's first job is to show a sheet rather than a form. So it opens
+    // on the first shipped sight-word list, which is a worksheet somebody would
+    // print unchanged — and the three bootstraps replace it in one press.
+    words: STARTER_WORDS,
+    times: 3,
+    gaps: 2,
+    count: STARTER_WORDS.length,
+    columns: 2,
   },
   "word-problems": {
     ...BASE,

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -33,6 +33,7 @@ import { RatioPanel } from "./ratio";
 import { StatisticsPanel } from "./statistics";
 import { TimePanel } from "./time";
 import { WordProblemsPanel } from "./wordproblems";
+import { WordsPanel } from "./words";
 import type { PanelProps } from "./parts";
 
 type FamilyPanel = (props: PanelProps) => ReactNode;
@@ -84,6 +85,7 @@ const PANELS: Record<string, FamilyPanel> = {
   ratio: panel(RatioPanel),
   statistics: panel(StatisticsPanel),
   "word-problems": panel(WordProblemsPanel),
+  words: panel(WordsPanel),
 };
 
 /**

--- a/src/games/printshop/options/parts.tsx
+++ b/src/games/printshop/options/parts.tsx
@@ -13,15 +13,20 @@
  * it goes in `src/components/ui/`, which is the rule the lint config states in
  * its own words.
  */
+import type { ReactNode } from "react";
+
 import {
   Checkbox,
+  Field,
   FieldSet,
   NumberStepper,
   SegmentedControl,
   Select,
+  TextArea,
   type SegmentedOption,
 } from "@/components/ui/kit";
 import type { SheetConfig } from "@/engine/sheets/types";
+import { parseWords } from "@/services/decks";
 
 /**
  * What a family's panel is handed.
@@ -148,41 +153,102 @@ export function Span({
  * at what the page holds, so asking for two hundred sums on a Letter page gives
  * as many as fit and no second page of nothing. The hint says so, because a
  * number that silently becomes another number is worse than a smaller maximum.
+ *
+ * `columns` is optional because not every family lays its items out across the
+ * page: a word with letters missing is a line of its own whatever the config
+ * says, and a stepper that could only ever be set to one is an option that does
+ * nothing — which is worse than a missing one.
  */
 export function Sizing({
+  label = "Problems",
   count,
   columns,
   onCount,
   onColumns,
   maxColumns = 6,
 }: {
+  /** What the family calls the things it is counting. */
+  label?: string;
   count: number;
-  columns: number;
+  columns?: number;
   onCount: (next: number) => void;
-  onColumns: (next: number) => void;
+  onColumns?: (next: number) => void;
   maxColumns?: number;
 }) {
   return (
     <>
-      <FieldSet legend="Problems" hint="Capped at what fits on the page.">
+      <FieldSet legend={label} hint="Capped at what fits on the page.">
         <NumberStepper
-          label="Problems"
+          label={label}
           value={count}
           min={1}
           max={200}
           onChange={onCount}
         />
       </FieldSet>
-      <FieldSet legend="Columns">
-        <NumberStepper
-          label="Columns"
-          value={columns}
-          min={1}
-          max={maxColumns}
-          onChange={onColumns}
-        />
-      </FieldSet>
+      {columns !== undefined && onColumns && (
+        <FieldSet legend="Columns">
+          <NumberStepper
+            label="Columns"
+            value={columns}
+            min={1}
+            max={maxColumns}
+            onChange={onColumns}
+          />
+        </FieldSet>
+      )}
     </>
+  );
+}
+
+/**
+ * A list of words, typed or pasted in.
+ *
+ * One box rather than a row of fields, for the reason `DeckEditor` gives about
+ * the same paste: the list is coming off a school letter or a phone
+ * screenshot, and retyping it into twelve inputs is how a parent decides not to
+ * bother. `parseWords` is what splits it — newlines, commas, tabs and
+ * semicolons all work — so a sheet takes whatever shape the letter was in.
+ *
+ * It is here rather than in the spelling panel because two screens need the
+ * same box: the panel, where the list is what the sheet is *about*, and the
+ * bootstrap, where a paste is one of the three ways to start a sheet at all
+ * (§14). Two copies would be two rules about what counts as a word.
+ */
+export function WordList({
+  label,
+  text,
+  onChange,
+  hint,
+  rows = 5,
+}: {
+  label: string;
+  text: string;
+  onChange: (text: string) => void;
+  hint?: ReactNode;
+  rows?: number;
+}) {
+  const words = parseWords(text);
+  return (
+    <Field
+      label={label}
+      hint={
+        hint ?? (
+          <>
+            One a line, or separated by commas. {words.length}{" "}
+            {words.length === 1 ? "word" : "words"} so far.
+          </>
+        )
+      }
+    >
+      <TextArea
+        value={text}
+        rows={rows}
+        spellCheck={false}
+        placeholder={"because\nthought\nfriend"}
+        onChange={onChange}
+      />
+    </Field>
   );
 }
 

--- a/src/games/printshop/options/words.tsx
+++ b/src/games/printshop/options/words.tsx
@@ -1,0 +1,92 @@
+/**
+ * A spelling list, and what the sheet asks a child to do with it.
+ *
+ * The only panel whose first control is the *content* of the sheet rather than
+ * a setting on it: every other family draws its problems from a range the
+ * engine owns, and this one is handed a list somebody else wrote. So the box
+ * comes first, and it is the same box the bootstrap pastes into — see
+ * `WordList` in parts.tsx for why there is only one of them.
+ *
+ * Two of the four steppers are conditional, and neither is a nicety. Nothing
+ * is written three times on a sheet that is only numbered lines, and nothing
+ * has letters taken out of it unless the gaps are the exercise. An option that
+ * does nothing teaches a parent that the panel doesn't do what it says.
+ */
+import { FieldSet, NumberStepper } from "@/components/ui/kit";
+import type { WordSheetStyle, WordsConfig } from "@/engine/sheets/types";
+import { MAX_GAPS, MAX_TIMES } from "@/engine/sheets/words/spelling";
+import { parseWords } from "@/services/decks";
+
+import { Choice, Sizing, WordList, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<WordSheetStyle>("copy", "Write it out"),
+  opt<WordSheetStyle>("missing", "Missing letters"),
+  opt<WordSheetStyle>("test", "Spelling test"),
+];
+
+export function WordsPanel({ config, set }: PanelProps<WordsConfig>) {
+  return (
+    <>
+      <WordList
+        label="Words"
+        // Joined back out of the config rather than held as text beside it: the
+        // config is the state (`useBuilder`), and a second copy of the list
+        // would be the one the sheet was not built from.
+        text={config.words.join("\n")}
+        onChange={(text) => {
+          const words = parseWords(text);
+          // The count follows the list unless a parent has said otherwise —
+          // "print all of them" is what a list means, and the family caps it at
+          // what the page holds anyway.
+          set({ words, count: words.length });
+        }}
+      />
+
+      <Choice
+        label="What it asks for"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+
+      {config.style === "copy" && (
+        <FieldSet legend="Times each">
+          <NumberStepper
+            label="Times each word is written"
+            value={config.times}
+            min={1}
+            max={MAX_TIMES}
+            onChange={(times) => set({ times })}
+          />
+        </FieldSet>
+      )}
+
+      {config.style === "missing" && (
+        <FieldSet
+          legend="Letters out"
+          hint="Never the first one, and never two in a row — a child needs the start of the word to work from, and one rule means one letter."
+        >
+          <NumberStepper
+            label="Letters taken out of each word"
+            value={config.gaps}
+            min={1}
+            max={MAX_GAPS}
+            onChange={(gaps) => set({ gaps })}
+          />
+        </FieldSet>
+      )}
+
+      {/* A gapped word is a line of its own, so that sheet has no columns to
+          choose — see `wordsLayout`, which is the half of this that decides. */}
+      <Sizing
+        label="Words"
+        count={config.count}
+        columns={config.style === "missing" ? undefined : config.columns}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={3}
+      />
+    </>
+  );
+}

--- a/src/services/practice.test.ts
+++ b/src/services/practice.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardResult, Profile, Session } from "@/engine/types";
+
+import { practiceFrom } from "./practice";
+
+/**
+ * The half of the practice service that decides anything.
+ *
+ * Loading needs IndexedDB and is covered against a fake one in
+ * `storage/db.test.ts`; what is worth pinning here is the judgement — whose
+ * facts, from which deck, in what order, and what a player with no history
+ * gets — because every one of those is a way the headline feature could be
+ * subtly wrong while looking right.
+ */
+
+const profile = (id: string, name: string): Profile => ({
+  id,
+  name,
+  emoji: "🦊",
+  color: "#fff",
+  age: 8,
+  soundOn: true,
+  xp: 0,
+  badges: [],
+  createdAt: `2026-01-0${id.slice(-1)}T00:00:00.000Z`,
+});
+
+const card = (over: Partial<CardResult> = {}): CardResult => ({
+  prompt: "7 × 8",
+  answer: "56",
+  given: "56",
+  ok: true,
+  ms: 1200,
+  factId: "7:8",
+  ...over,
+});
+
+let runs = 0;
+const session = (
+  profileId: string,
+  mode: string,
+  cards: CardResult[],
+): Session => ({
+  id: `s${(runs += 1)}`,
+  profileId,
+  game: "flashcards",
+  mode,
+  configKey: "k",
+  config: {
+    operation: "multiply",
+    tables: [7],
+    others: [8],
+    cardCount: cards.length,
+    inputMode: "type",
+  },
+  seed: 1,
+  finishedAt: "2026-08-01T10:00:00.000Z",
+  durationMs: cards.reduce((total, c) => total + c.ms, 0),
+  correct: cards.filter((c) => c.ok).length,
+  incorrect: cards.filter((c) => !c.ok).length,
+  bestStreak: 0,
+  xpEarned: 0,
+  ghostSessionId: null,
+  beatGhost: null,
+  cards,
+});
+
+/** Wrong three times over is a fact that lands near the top of the list. */
+const missed = (factId: string) => card({ factId, ok: false, given: "" });
+
+describe("what the record book knows they keep missing", () => {
+  it("gives every player their own facts and nobody else's", () => {
+    const players = practiceFrom(
+      [profile("p1", "Ada"), profile("p2", "Bo")],
+      [
+        session("p1", "multiply", [missed("7:8"), missed("7:8")]),
+        session("p2", "multiply", [missed("3:4"), missed("3:4")]),
+      ],
+    );
+    expect(players.map((p) => p.name)).toEqual(["Ada", "Bo"]);
+    expect(players[0].sets[0].facts).toEqual(["7:8"]);
+    expect(players[1].sets[0].facts).toEqual(["3:4"]);
+  });
+
+  it("names the facts the way the deck names them", () => {
+    // Through `DeckSpec.factLabel`, so the chips a parent reads before pressing
+    // print say exactly what the record book's trouble panel says.
+    const [player] = practiceFrom(
+      [profile("p1", "Ada")],
+      [session("p1", "divide", [missed("3:7"), missed("3:7")])],
+    );
+    expect(player.sets[0]).toMatchObject({
+      mode: "divide",
+      label: "Division",
+      facts: ["3:7"],
+      labels: ["21 ÷ 3"],
+    });
+  });
+
+  it("offers only the decks they have actually raced, worst first", () => {
+    const players = practiceFrom(
+      [profile("p1", "Ada")],
+      [
+        session("p1", "add", [missed("1:2"), missed("1:2")]),
+        session("p1", "multiply", [
+          missed("7:8"),
+          missed("7:8"),
+          missed("7:8"),
+          missed("6:9"),
+        ]),
+      ],
+    );
+    // Not the four operations and every shipped list: a switcher offering
+    // everything would bury the deck they are struggling with.
+    expect(players[0].sets.map((set) => set.mode)).toEqual(["multiply", "add"]);
+  });
+
+  it("leaves out a deck with nothing standing out in it", () => {
+    // A clean, quick run is not a trouble spot, and a set of no facts would be
+    // a button that printed an empty page.
+    const [player] = practiceFrom(
+      [profile("p1", "Ada")],
+      [session("p1", "multiply", [card(), card(), card()])],
+    );
+    expect(player.sets).toEqual([]);
+  });
+
+  it("keeps a player who has never raced in the list", () => {
+    // The commonest case on a family machine. Leaving them out would leave a
+    // parent with no way to pick the child they came to print for; the empty
+    // `sets` is what the bench turns into a sheet of the whole table.
+    expect(practiceFrom([profile("p1", "Ada")], [])).toEqual([
+      { id: "p1", name: "Ada", sets: [] },
+    ]);
+  });
+
+  it("folds a fact the deck folds, and splits one it splits", () => {
+    // Nothing here re-decides what a fact is: 7 × 8 and 8 × 7 are one practice
+    // and 21 ÷ 3 and 21 ÷ 7 are two, which is `DeckSpec.drillKey` and not this
+    // module's opinion.
+    const [player] = practiceFrom(
+      [profile("p1", "Ada")],
+      [
+        session("p1", "multiply", [missed("7:8"), missed("8:7")]),
+        session("p1", "divide", [missed("3:7"), missed("7:3")]),
+      ],
+    );
+    const facts = (mode: string) =>
+      player.sets.find((set) => set.mode === mode)?.facts;
+    expect(facts("multiply")).toEqual(["7:8"]);
+    expect(facts("divide")?.sort()).toEqual(["3:7", "7:3"]);
+  });
+});

--- a/src/services/practice.ts
+++ b/src/services/practice.ts
@@ -1,0 +1,115 @@
+import type { Profile, Session } from "@/engine/types";
+
+import { deckSpec } from "@/engine/decks";
+import { sessionsFor, troubleFacts } from "@/engine/records";
+
+import { loadHub } from "./hub";
+
+/**
+ * What the record book already knows a child keeps getting wrong.
+ *
+ * The one door between a child's history and The Print Shop, and the reason
+ * there is a service here at all: the bench is a `client:only` island with no
+ * hub around it, and a view that read the sessions itself would be reaching
+ * past the layer that owns the schema — the boundary `eslint.config.mjs`
+ * enforces. So the island asks for this and gets plain data back.
+ *
+ * **Nothing here leaves the device, and nothing here becomes a sheet.** What
+ * comes out is a list of fact ids in the deck's own vocabulary
+ * (`DeckSpec.drillKey`) plus the words to show them in; turning those into
+ * paper is `engine/sheets/practice.ts`, which never learns whose facts they
+ * were. A child's name is on this side of that line and stays here — the sheet
+ * it produces travels in a URL (docs/printables.md §14), and a name in one
+ * would be the one thing this site refuses to hold.
+ *
+ * Nothing is computed here that the record book does not already compute. The
+ * ranking, the folding of two cards onto one fact and the phrase a fact is
+ * named by are all `records.ts` and `DeckSpec`, so a sheet of trouble facts
+ * and a drill of them are the same list — printed, or raced.
+ */
+
+/** The facts a player keeps missing in one deck, worst first. */
+export type PracticeSet = {
+  /** `Session.mode` — the deck, and what `deckSpec` routes on. */
+  mode: string;
+  /** What that deck is called: "Multiplication", "Year 2 spellings". */
+  label: string;
+  /** The deck's own drill keys, in the order the record book ranked them. */
+  facts: string[];
+  /** The same facts as they read on screen — "7 × 8", or just the word. */
+  labels: string[];
+};
+
+/** One player, and every deck they have trouble in. */
+export type PracticePlayer = {
+  id: string;
+  name: string;
+  /**
+   * Worst deck first, and empty for a player with nothing standing out —
+   * which is not an error and not a reason to leave them out of the picker. A
+   * child who has never raced is the commonest case on a shared family
+   * machine, and the honest answer is a sheet of the whole table rather than
+   * a screen that says no.
+   */
+  sets: PracticeSet[];
+};
+
+/**
+ * The same computation as the progress screen's trouble panel, per deck.
+ *
+ * Pure, and exported for that reason: everything below it needs IndexedDB, and
+ * the judgement worth testing is which facts come out and in what order.
+ */
+export function practiceFrom(
+  profiles: Profile[],
+  sessions: Session[],
+): PracticePlayer[] {
+  return profiles.map((profile) => {
+    const mine = sessionsFor(sessions, profile.id);
+    // Only the decks this player has actually raced. A switcher offering every
+    // deck ever shipped would bury the one they have been struggling with.
+    const modes = [...new Set(mine.map((session) => session.mode))].sort();
+
+    const sets = modes
+      .map((mode) => {
+        // No `take`: the same eight the progress screen shows, so "drill these"
+        // and "print these" are the same list rather than two lists that
+        // happen to start the same way.
+        const trouble = troubleFacts(mine, mode);
+        const spec = deckSpec(mode);
+        return {
+          mode,
+          label: spec.label,
+          facts: trouble.map((fact) => fact.factId),
+          labels: trouble.map((fact) => spec.factLabel(fact.factId)),
+          // Not part of the set — only what orders them below. The worst deck
+          // is the one with the worst fact in it, which is the one a parent
+          // standing at the printer means.
+          worst: trouble[0]?.score ?? 0,
+        };
+      })
+      .filter((set) => set.facts.length > 0)
+      .sort((a, b) => b.worst - a.worst)
+      .map(({ mode, label, facts, labels }) => ({
+        mode,
+        label,
+        facts,
+        labels,
+      }));
+
+    return { id: profile.id, name: profile.name, sets };
+  });
+}
+
+/**
+ * Every player on this device, and what each of them keeps missing.
+ *
+ * Through `loadHub` rather than the store, for the reason the hub's own note
+ * gives: loading is also what mirrors a parent's word lists into the engine,
+ * and without that a spelling deck would come back named "Words" and its facts
+ * would be a list this build could not turn into a sheet.
+ */
+export async function loadPractice(): Promise<PracticePlayer[]> {
+  const { profiles, sessions } = await loadHub();
+  return practiceFrom(profiles, sessions);
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -88,6 +88,16 @@
   margin-bottom: var(--gap-3);
 }
 
+/* Where a panel has more than one thing to offer — drill these, or print them
+   — the pair sits together at the end of the head rather than being spread to
+   both ends of it by the flex row above. */
+.panel__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-2);
+  flex-wrap: wrap;
+}
+
 .panel__title {
   font-family: var(--font-display);
   font-weight: 800;

--- a/src/styles/printshop.css
+++ b/src/styles/printshop.css
@@ -180,6 +180,57 @@
   transform-origin: top center;
 }
 
+/* ── The three bootstraps ───────────────────────────────────────────────────
+   Three sources stacked in one card rather than three cards, because they are
+   one question — what is this sheet about? — asked three ways. The card itself
+   is the same surface `.saved` and `.picker` are; only the steps inside it are
+   new.                                                                       */
+
+.bootstrap {
+  display: grid;
+  gap: var(--gap-3);
+  background: linear-gradient(180deg, var(--ink-800), var(--ink-850));
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-paper);
+  padding: var(--gap-4);
+}
+
+.bootstrap__title {
+  font-size: var(--step-1);
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--chalk);
+}
+
+.bootstrap__lead,
+.bootstrap__note {
+  font-size: var(--step--1);
+  color: var(--chalk-dim);
+}
+
+.bootstrap__step {
+  display: grid;
+  gap: var(--gap-2);
+  justify-items: start;
+  padding-top: var(--gap-2);
+  border-top: 1px solid var(--hairline);
+}
+
+.bootstrap__name {
+  font-size: var(--step-0);
+  color: var(--chalk-soft);
+}
+
+/* The facts themselves, in the deck's own words. A parent should be able to
+   see what is about to be printed before printing it — this is the whole claim
+   the section makes, and it is worth showing rather than counting. */
+.bootstrap__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-1);
+}
+
 /* ── My sheets ──────────────────────────────────────────────────────────── */
 
 .saved {


### PR DESCRIPTION
Closes #58 — PRINT14, "practise what they missed".

## Why

This is the reason the printables section is worth building rather than being one more printables site: no other worksheet site knows what the child got wrong. The record book already ranks a profile's trouble facts to feed the drill button. This story gives those same facts a second destination — paper.

## What changed

**Three doors, one sheet.** A parent can print exactly the ranked facts from:

- the race results screen, after a run with wrong answers;
- the progress screen, beside the existing trouble-facts drill — the same list, either raced or printed;
- the bench itself, as a bootstrap with a profile picker.

All three route through one function (`src/engine/sheets/practice.ts`), because a sheet built from the same facts has to be the same sheet whichever door it came through. It hands back a config; `practiceHref` puts that config in the URL fragment, which on a static site is the whole handover — nothing stored between two pages.

**Nothing new is computed.** `troubleFacts` already ranks facts and already speaks in `DeckSpec.drillKey`; `Problem.factId` was the other half of that hand-off. So the arithmetic and multiplication fact families grow one optional field — `facts` — and when it is non-empty it *is* the pool: the named facts print in ranked order rather than being drawn and rejected, and `range` / `regrouping` / `tables` / `factors` stop deciding a page they did not choose. A pair is read exactly as `decks/flashcards.ts` writes it, so `3:5` subtracted is "8 − 3" and `3:7` divided is "21 ÷ 3". No arithmetic is re-derived here.

**A new `words` sheet family** covers the other two acceptance criteria — a saved `CustomDeck` in one click, and pasted text through `parseWords`. Same config, words from somewhere else, three styles: write it out, letters missing, or a numbered spelling test with the list on the key. Gaps are never the first letter and never two in a row, because `Blanks` reads a run of underscores as one gap and adjacent gaps would print one rule expecting two letters.

**Privacy holds by construction, not by rule.** The bench is a `client:only` island with no hub around it, so it reads through `src/services/practice.ts` rather than reaching past the layer that owns the schema. A child's name stops at that boundary — what crosses is fact ids and the deck's own words for them, and a `SheetConfig` has nowhere to put a name. The fragment never leaves the browser.

**Empty history still prints something worth printing.** At every door, an empty fact list falls back to the ordinary sheet for that deck — all twelve tables, or the whole word list — and a household that has never raced gets the mixed times-table sheet the site opens on. Covered in the unit suite, the service suite and the smoke run.

**Footers point home.** Maths and spelling sheets now carry the short URL of the game the practice is also a race in (`schoolskills.app/flash-cards`), read off the world registry rather than a second copy of the route. Families with no matching game keep the bare URL.

**Split for the cap.** `Progress.tsx` hit the 300-line component cap when the second door was added, so the trouble panel moved to `src/components/screens/progress/TroubleSpots.tsx` — one idea per module, and the right seam regardless of the cap.

## Out of scope

QR codes (as the story says).

## Validation

`type-check`, `lint`, `test:unit` (743 tests, 37 files), `build` (67 pages, static) and the browser smoke run all pass. The smoke test is load-bearing for this story since it reads a child's session history — it was extended with step 6b, which drives a bootstrap from real IndexedDB-backed history onto the bench and asserts a printable sheet comes out. Console errors: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
