### PR TITLE
PRINT16: handwriting sheets that go from tracing to writing alone

### DIFF
--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -1375,6 +1375,50 @@ describe("trace styles", () => {
     expect(new Set(sizes).size).toBe(3);
   });
 
+  it("keeps a tail out of the box without letting the ruling out of it", () => {
+    // A trace row is exactly one repeat tall, so `overflow: visible` is what
+    // stops a `g` printing with its loop cut off at the baseline. It also
+    // un-clips the row sideways, which two things rely on: the isometric
+    // ruling draws its diagonals half a side past each edge (`Ruling.tsx`) on
+    // the understanding that a viewport takes them off again, and a word wider
+    // than the declared mean advance would otherwise run past the margin.
+    //
+    // The AC names this combination — every ruling of PRINT04 with every trace
+    // style of PRINT15 — so it is the one drawn here.
+    const row = render(
+      sheet({
+        blocks: [
+          {
+            kind: "trace",
+            rule: { style: "isometric" },
+            rows: [{ cells: [{ text: "gg", style: "dotted" }] }],
+          },
+        ],
+      }),
+    );
+
+    // A second viewport inside the row's own: as wide as the row exactly, and
+    // taller than it at both ends. The overhang is vertical and only vertical.
+    const inner = /<svg x="0" y="(-?\d+)" width="(\d+)" height="(\d+)"/.exec(
+      row,
+    );
+    expect(inner, "the trace row nests a clipping viewport").not.toBeNull();
+    const [, y, width, height] = (inner ?? []).map(Number);
+    expect(y).toBeLessThan(0);
+    expect(height).toBeGreaterThan(-2 * y);
+    // The row's own box, in the same mil the viewBox is written in.
+    const outer = /viewBox="0 0 (\d+) (\d+)"/.exec(
+      row.slice(row.indexOf("sheet__ink--trace")),
+    );
+    expect(width).toBe(Number(outer?.[1]));
+
+    // And the diagonals really do run outside it, which is why the clip is
+    // load-bearing rather than decorative.
+    const diagonals = [...row.matchAll(/<line[^>]*\sx1="(-?\d+)"/g)] //
+      .map((match) => Number(match[1]));
+    expect(Math.min(...diagonals)).toBeLessThan(0);
+  });
+
   it("paints them with ink rather than with a background", () => {
     // The failure this guards is invisible on screen: a style that leaned on
     // `background` looks right in the preview and prints as nothing.

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -147,7 +147,16 @@ const EVERY_BLOCK: Block[] = [
   {
     kind: "trace",
     rule: { style: "hand-1", midline: "dashed" },
-    rows: [{ text: "cat", repeats: ["solid", "dotted", "dashed", "none"] }],
+    rows: [
+      {
+        cells: [
+          { text: "cat", style: "solid" },
+          { text: "cat", style: "dotted" },
+          { text: "cat", style: "dashed" },
+          { text: "", style: "none" },
+        ],
+      },
+    ],
   },
   {
     kind: "copywork",
@@ -1308,7 +1317,7 @@ describe("trace styles", () => {
           {
             kind: "trace",
             rule: { style: "hand-5-8", midline: "dashed", descender: true },
-            rows: [{ text: "cat", repeats: [style] }],
+            rows: [{ cells: [{ text: "cat", style }] }],
           },
         ],
       }),

--- a/src/components/sheet/Traced.tsx
+++ b/src/components/sheet/Traced.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/engine/sheets/faces";
 import { ruledLines } from "@/engine/sheets/layout";
 import { rulePitch } from "@/engine/sheets/paper";
-import type { Mil, Rule, TraceStyle } from "@/engine/sheets/types";
+import type { Mil, Rule, TraceCell, TraceStyle } from "@/engine/sheets/types";
 
 import { Ruling } from "./Ruling";
 import { inch } from "./units";
@@ -74,7 +74,12 @@ export function Glyph({
   );
 }
 
-export type TracedCell = { text: string; style: TraceStyle };
+/**
+ * The engine's own cell, not a second copy of it. A renderer that redeclared
+ * the shape would be a second place to change when a cell learns to say
+ * something new.
+ */
+export type TracedCell = TraceCell;
 
 /**
  * One repeat of a ruling with letterforms written onto it.
@@ -127,18 +132,26 @@ export function TracedRow({
   );
   const ink = traceInk(size, face);
 
-  // Every cell in a row carries the same word — that is what a tracing row is
-  // — so the row is announced once rather than four times over.
-  const said = cells.find((entry) => entry.text !== "")?.text;
+  // A row is usually one word written four times, and sometimes three letters
+  // written four times each. Either way it is announced by what is on it and
+  // not by how many places it is written in.
+  const said = [...new Set(cells.map((entry) => entry.text))]
+    .filter((text) => text !== "")
+    .join(" ");
 
   return (
     <svg
-      className="sheet__ink"
+      // The modifier is what lets a tail out of the box. An SVG viewport
+      // clips by default, and a row is exactly one repeat tall — so on a
+      // ruling with no descender space a `g` would print with its tail cut off
+      // at the baseline, which is a worse model than one drawn through the
+      // line below. See `Face.descent`, and `.sheet__ink--trace` in sheet.css.
+      className="sheet__ink sheet__ink--trace"
       width={inch(width)}
       height={inch(pitch)}
       viewBox={`0 0 ${width} ${pitch}`}
       role="img"
-      aria-label={said ?? "A line to write on"}
+      aria-label={said === "" ? "A line to write on" : said}
     >
       <Ruling rule={rule} box={metrics.box} sets={1} />
       {cells.map((entry, index) => (

--- a/src/components/sheet/Traced.tsx
+++ b/src/components/sheet/Traced.tsx
@@ -21,15 +21,21 @@ import {
   type TraceInk,
 } from "@/engine/sheets/faces";
 import { ruledLines } from "@/engine/sheets/layout";
-import { rulePitch } from "@/engine/sheets/paper";
+import { rulePitch, writingSpace } from "@/engine/sheets/paper";
 import type { Mil, Rule, TraceCell, TraceStyle } from "@/engine/sheets/types";
 
 import { Ruling } from "./Ruling";
 import { inch } from "./units";
 import type { SheetMetrics } from "./metrics";
 
-/** The three styles that are an outline rather than a filled shape. */
-const OUTLINED: TraceStyle[] = ["hollow", "dotted", "dashed"];
+/**
+ * The three styles that are an outline rather than a filled shape.
+ *
+ * Not the same set as `MODELLED` in the handwriting family, and named apart
+ * from it for that reason: `dim` is a model to write over but it is drawn
+ * filled, so it belongs to that set and not to this one.
+ */
+const STROKED: TraceStyle[] = ["hollow", "dotted", "dashed"];
 
 export function Glyph({
   text,
@@ -52,7 +58,7 @@ export function Glyph({
   // is on their own. Nothing is drawn, and the space is still reserved.
   if (style === "none" || text === "") return null;
 
-  const outlined = OUTLINED.includes(style);
+  const outlined = STROKED.includes(style);
   // Solid and dim are filled shapes with no outline to break up, and hollow is
   // the outline unbroken — so only two of the five carry a pattern.
   const dashes: Partial<Record<TraceStyle, string>> = {
@@ -94,13 +100,17 @@ export type TracedCell = TraceCell;
  * holds two quite different type sizes (`faces.ts`).
  *
  * The rule fixed here is the top line: `glyphEm` sizes the em so the tallest
- * letter stands on the baseline and reaches it. That leaves the midline as a
- * consequence rather than a second constraint, and letter bodies clear it — by
- * 0.13 of the writing space in Andika, 0.16 in OpenDyslexic, 0.01 in Playwrite
- * (`Face.xHeight`, and a test that bounds it). Two lines cannot both be exact
- * unless the face was drawn to that ruling, and a body that overshoots the
- * midline is the right way round to miss: the child still has a line to write
- * up to, which they would not if the model stopped below it.
+ * thing *on this row* stands on the baseline and reaches it. Which of the
+ * face's heights that is depends on what is written — a row of capitals is set
+ * off `capHeight` and a row with an `l` on it off `ascent`, because a capital
+ * a tenth under the top line is a smaller error than an ascender through it
+ * (`glyphHeight`). That leaves the midline as a consequence rather than a
+ * second constraint, and letter bodies clear it — by 0.13 of the writing space
+ * in Andika, 0.16 in OpenDyslexic, 0.01 in Playwrite (`Face.xHeight`, and a
+ * test that bounds it). Two lines cannot both be exact unless the face was
+ * drawn to that ruling, and a body that overshoots the midline is the right
+ * way round to miss: the child still has a line to write up to, which they
+ * would not if the model stopped below it.
  */
 export function TracedRow({
   rule,
@@ -116,36 +126,38 @@ export function TracedRow({
   const lines = ruledLines({ x: 0, y: 0, width, height: pitch }, rule);
   const face = faceOf(metrics.font);
 
+  // A row is usually one word written four times, and sometimes three letters
+  // written four times each. Either way it is announced by what is on it and
+  // not by how many places it is written in — and it is sized by what is on it
+  // for the same reason.
+  const said = [...new Set(cells.map((entry) => entry.text))]
+    .filter((text) => text !== "")
+    .join(" ");
+
   // Where the letters sit, and how big they are. A handwriting rule states
   // both; a notebook rule states only the line, so the body size fills what is
-  // left above it.
+  // left above it. The writing space comes from the engine rather than from a
+  // second subtraction here (`writingSpace`), so the size the family reserved
+  // room for and the size that gets drawn cannot drift apart.
   const baseline = lines.find((line) => line.role === "base")?.y ?? pitch;
-  const top = lines.find((line) => line.role === "top")?.y ?? 0;
   const cell = cells.length > 0 ? Math.floor(width / cells.length) : width;
   const longest = cells.reduce(
     (most, one) => Math.max(most, one.text.length),
     0,
   );
   const size = Math.min(
-    glyphEm(baseline - top, face),
+    glyphEm(writingSpace(rule), face, said),
     fittedEm(cell, longest, face),
   );
   const ink = traceInk(size, face);
 
-  // A row is usually one word written four times, and sometimes three letters
-  // written four times each. Either way it is announced by what is on it and
-  // not by how many places it is written in.
-  const said = [...new Set(cells.map((entry) => entry.text))]
-    .filter((text) => text !== "")
-    .join(" ");
-
   return (
     <svg
-      // The modifier is what lets a tail out of the box. An SVG viewport
-      // clips by default, and a row is exactly one repeat tall — so on a
-      // ruling with no descender space a `g` would print with its tail cut off
-      // at the baseline, which is a worse model than one drawn through the
-      // line below. See `Face.descent`, and `.sheet__ink--trace` in sheet.css.
+      // The modifier is what lets a tail out of the box. An SVG viewport clips
+      // by default, and a row is exactly one repeat tall — so on a ruling with
+      // no descender space a `g` would print with its tail cut off at the
+      // baseline, which is a worse model than one drawn through the line
+      // below. See `Face.descent`, and `.sheet__ink--trace` in sheet.css.
       className="sheet__ink sheet__ink--trace"
       width={inch(width)}
       height={inch(pitch)}
@@ -153,18 +165,44 @@ export function TracedRow({
       role="img"
       aria-label={said === "" ? "A line to write on" : said}
     >
-      <Ruling rule={rule} box={metrics.box} sets={1} />
-      {cells.map((entry, index) => (
-        <Glyph
-          key={`${index}-${entry.text}`}
-          text={entry.text}
-          x={index * cell}
-          y={baseline}
-          size={size}
-          style={entry.style}
-          ink={ink}
-        />
-      ))}
+      {/*
+        A second viewport, one em taller than the row at each end and exactly
+        as wide as it.
+
+        Letting the row overflow is the *vertical* concession above, and it has
+        to stay vertical. Two things run off the sides otherwise: the isometric
+        ruling deliberately draws its diagonals half a side past each edge
+        (`Ruling.tsx`) on the understanding that the viewport takes them off
+        again, and `Face.advance` is a declared mean rather than a measurement,
+        so a wide word typed into the builder — `M` is 0.876em against a
+        declared 0.506 — can run past the margin the sheet reserved.
+
+        A nested `<svg>` clips to itself whatever the outer one does, and with
+        the viewBox restating the same rectangle the coordinates inside it are
+        the coordinates outside it, so nothing here has to move. An em of slack
+        clears the deepest tail any of the three faces draws (0.52em) twice
+        over.
+      */}
+      <svg
+        x={0}
+        y={-size}
+        width={width}
+        height={pitch + 2 * size}
+        viewBox={`0 ${-size} ${width} ${pitch + 2 * size}`}
+      >
+        <Ruling rule={rule} box={metrics.box} sets={1} />
+        {cells.map((entry, index) => (
+          <Glyph
+            key={`${index}-${entry.text}`}
+            text={entry.text}
+            x={index * cell}
+            y={baseline}
+            size={size}
+            style={entry.style}
+            ink={ink}
+          />
+        ))}
+      </svg>
     </svg>
   );
 }

--- a/src/components/sheet/blocks/Trace.tsx
+++ b/src/components/sheet/blocks/Trace.tsx
@@ -2,23 +2,23 @@ import { TracedRow } from "../Traced";
 import type { BlockProps } from "./block";
 
 /**
- * Tracing rows: the same word several times across one ruled repeat, each in
- * its own style.
+ * Tracing rows: several cells across one ruled repeat, each with something
+ * written in it and a style to write it in.
  *
- * `["solid", "dotted", "dotted", "none"]` is trace → copy → write on one line,
- * which is the progression a handwriting sheet exists to walk a child through.
- * The row decides its own styles; this only draws them.
+ * A word in `["solid", "dotted", "dotted", "none"]` is trace → copy → write on
+ * one line, which is the progression a handwriting sheet exists to walk a child
+ * through; a row of three letters in that same sequence is the shape that fits
+ * an alphabet on one page. The family decides both; this only draws them.
  */
 export function Trace({ block, metrics }: BlockProps<"trace">) {
   return (
     <div className="sheet__block">
       {block.rows.map((row, index) => (
-        <div className="sheet__row" key={`${index}-${row.text}`}>
-          <TracedRow
-            rule={block.rule}
-            metrics={metrics}
-            cells={row.repeats.map((style) => ({ text: row.text, style }))}
-          />
+        <div
+          className="sheet__row"
+          key={`${index}-${row.cells[0]?.text ?? ""}`}
+        >
+          <TracedRow rule={block.rule} metrics={metrics} cells={row.cells} />
         </div>
       ))}
     </div>

--- a/src/engine/sheets/faces.test.ts
+++ b/src/engine/sheets/faces.test.ts
@@ -12,6 +12,7 @@ import {
   faceOf,
   fittedEm,
   glyphEm,
+  glyphHeight,
   traceInk,
 } from "./faces";
 import { RULINGS, rulePitch, writingSpace } from "./paper";
@@ -57,6 +58,43 @@ describe("sizing letters to a ruling", () => {
         expect(Math.abs(em * face.ascent - writing), face.family) //
           .toBeLessThanOrEqual(1);
       }
+    }
+  });
+
+  it("sizes a capital or a numeral off its own height, not off an ascender", () => {
+    // The thing a sheet of nothing but capitals gets wrong otherwise. Andika
+    // is a text face: its caps are 0.713 against a 0.791 ascender, so a page
+    // of them sized off `ascent` stops a tenth of the writing space short of
+    // the top line — on a sheet whose whole copy is "every capital starts at
+    // the top line".
+    for (const face of Object.values(FACES)) {
+      expect(glyphHeight("ABC", face), face.family).toBe(face.capHeight);
+      expect(glyphHeight("0123", face), face.family).toBe(face.figure);
+      // Neither is ever taller than the ascender, or a row would be sized off
+      // the wrong one of the three the moment the two were mixed.
+      expect(face.capHeight, face.family).toBeLessThanOrEqual(face.ascent);
+      expect(face.figure, face.family).toBeLessThanOrEqual(face.ascent);
+    }
+
+    // And it is a real difference, not a rounding of the same number: an
+    // Andika capital sheet is set a tenth larger than an Andika `Aa` one.
+    expect(glyphEm(500, FACES.print, "ABC")) //
+      .toBeGreaterThan(glyphEm(500, FACES.print, "Aa"));
+  });
+
+  it("goes back to the ascender the moment the row is mixed", () => {
+    // A row cannot put a capital and an `l` on the top line at once. The
+    // ascender wins, because a capital a tenth under the line is a smaller
+    // error than an ascender drawn through it — and an empty row has to agree
+    // with the row above it rather than resize itself.
+    for (const face of Object.values(FACES)) {
+      expect(glyphHeight("Aa", face), face.family).toBe(face.ascent);
+      expect(glyphHeight("A1a", face), face.family).toBe(face.ascent);
+      expect(glyphHeight("", face), face.family).toBe(face.ascent);
+      expect(glyphHeight("— .", face), face.family).toBe(face.ascent);
+      // Two classes with no lower-case between them take the taller of them.
+      expect(glyphHeight("A1", face), face.family) //
+        .toBe(Math.max(face.capHeight, face.figure));
     }
   });
 

--- a/src/engine/sheets/faces.test.ts
+++ b/src/engine/sheets/faces.test.ts
@@ -14,7 +14,7 @@ import {
   glyphEm,
   traceInk,
 } from "./faces";
-import { RULINGS, rulePitch, ruleLines } from "./paper";
+import { RULINGS, rulePitch, writingSpace } from "./paper";
 import type { Rule, RuleStyle, SheetFont } from "./types";
 
 const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
@@ -27,15 +27,6 @@ const HANDWRITING = Object.values(RULINGS)
     { style: ruling.id, descender: false },
     { style: ruling.id, descender: true },
   ]);
-
-/** The writing space of a rule: the top line down to the baseline. */
-function writingSpace(rule: Rule): number {
-  const lines = ruleLines(rule);
-  const base =
-    lines.find((line) => line.role === "base")?.at ?? rulePitch(rule);
-  const top = lines.find((line) => line.role === "top")?.at ?? 0;
-  return base - top;
-}
 
 describe("resolving a face", () => {
   it("answers with the face that was asked for", () => {
@@ -86,6 +77,28 @@ describe("sizing letters to a ruling", () => {
         expect(over / writing, face.family).toBeLessThanOrEqual(1 / 6);
       }
     }
+  });
+
+  it("keeps a tail in the room the ruling gives it", () => {
+    // The other end of the same question. A handwriting rule with descender
+    // space gives a third of its repeat to the tail against two thirds to the
+    // writing space, so the room below the baseline is half the writing space
+    // — which is `ascent / 2` of the em at every rule size, and the number a
+    // measured `descent` has to be checked against.
+    //
+    // Playwrite is the one face that hangs over, by 0.009 of the em: a joined
+    // script draws its loops to the full descender the file declares. Four
+    // thousandths of an inch on a ⅝ rule is the stated tolerance, and it is
+    // drawn rather than clipped — see `.sheet__ink--trace` in sheet.css.
+    for (const face of Object.values(FACES)) {
+      const room = face.ascent / 2;
+      expect(face.descent, face.family).toBeLessThanOrEqual(room + 0.01);
+      // And deep enough to be a tail at all: a `g` whose loop stopped at a
+      // twentieth of an em would be a face measured off the wrong glyph.
+      expect(face.descent, face.family).toBeGreaterThan(0.15);
+    }
+    expect(FACES.print.descent).toBeLessThan(FACES.print.ascent / 2);
+    expect(FACES.dyslexic.descent).toBeLessThan(FACES.dyslexic.ascent / 2);
   });
 
   it("never returns a size that rounds away to nothing", () => {

--- a/src/engine/sheets/faces.ts
+++ b/src/engine/sheets/faces.ts
@@ -45,18 +45,48 @@ export type Face = {
    * real ascender overshoots a declared one in most faces and it is the ink
    * that has to fit between the rules.
    *
-   * It is the *tallest ascender*, which in two of the three is a lower-case
-   * letter rather than a capital. Playwrite and OpenDyslexic draw both to the
-   * same height (caps 1.015 and 0.849 against these), so a capital lands on
-   * the top line in those. Andika's caps are 0.713 — it is a text face, not a
-   * manuscript model drawn to a ruling — so an Andika capital stops about a
-   * tenth of the writing space short of the top line: 0.039in on the default
-   * ⅝ rule with tails, 0.093in on a 1-inch one. That is the accepted
-   * tolerance, not an oversight. Sizing capitals off a per-face cap height
-   * instead would leave a row's `l` and `h` overshooting the rule by the same
-   * tenth, and a row mixing the two cannot satisfy both.
+   * It is the *tallest ascender*, which in all three is a lower-case letter —
+   * `f` in Andika, `b` in the other two. It is therefore the right number for
+   * any row that has a lower-case letter on it, and the wrong one for a row
+   * that has not: see `capHeight` and `figure` below, and `glyphHeight`, which
+   * is what picks between the three.
    */
   ascent: number;
+  /**
+   * Baseline up to the top of a capital, as a share of the em.
+   *
+   * Measured off the flat-topped capitals (`E H I L T`), which is the height
+   * the face draws a capital to; the round ones (`C G O Q S`) overshoot it by
+   * the face's own optical overshoot, exactly as they overshoot the cap line
+   * in any book — Andika by 0.012em, OpenDyslexic by 0.013em.
+   *
+   * Here because a sheet of nothing but capitals is one of the seven the shop
+   * prints, and on it the tallest thing written *is* a capital. Sized off
+   * `ascent` a capital would stop short of the top line by the difference
+   * between the two — a tenth of the writing space in Andika, which is a text
+   * face rather than a manuscript model drawn to a ruling, and 0.039in on the
+   * default ⅝ rule. The page says "every capital starts at the top line", so
+   * it has to.
+   *
+   * A row that mixes the two cannot satisfy both, and `glyphHeight` resolves
+   * that the only way round that is safe: the moment a lower-case letter is on
+   * the row, the em goes back to `ascent` and the capital rides low. An `l`
+   * through the top rule is a worse sheet than a capital a tenth under it.
+   */
+  capHeight: number;
+  /**
+   * Baseline up to the top of a numeral, as a share of the em.
+   *
+   * The same argument as `capHeight`, for the sheet of nothing but numerals.
+   * Not the same *number*, which is why it is a second field: Andika and
+   * Playwrite draw lining figures to their cap height, but OpenDyslexic's are
+   * a tenth shorter than its capitals, so one shared value would print that
+   * face's digits well under the top line.
+   *
+   * Measured off the flat-topped numerals (`1 4 5 7`), for the reason
+   * `capHeight` is measured off the flat capitals.
+   */
+  figure: number;
   /**
    * Baseline up to the top of `x`, as a share of the em.
    *
@@ -157,6 +187,8 @@ export const FACES: Record<SheetFont, Face> = {
     id: "print",
     family: "Andika",
     ascent: 0.791,
+    capHeight: 0.713,
+    figure: 0.713,
     xHeight: 0.498,
     descent: 0.239,
     advance: 0.506,
@@ -168,6 +200,8 @@ export const FACES: Record<SheetFont, Face> = {
     id: "cursive",
     family: "Playwrite US Trad",
     ascent: 1.019,
+    capHeight: 1.015,
+    figure: 1.015,
     xHeight: 0.519,
     descent: 0.519,
     advance: 0.57,
@@ -184,6 +218,8 @@ export const FACES: Record<SheetFont, Face> = {
     id: "dyslexic",
     family: "OpenDyslexic",
     ascent: 0.85,
+    capHeight: 0.847,
+    figure: 0.729,
     xHeight: 0.56,
     descent: 0.261,
     advance: 0.795,
@@ -206,14 +242,43 @@ export function faceOf(font: SheetFont | undefined): Face {
 }
 
 /**
+ * How tall the tallest thing in `text` is drawn, as a share of the em.
+ *
+ * The one judgement that decides whether a printed model reaches the top line:
+ * a face states three heights and which of them applies is a fact about what
+ * is written, not about the face. So it is read off the text itself rather
+ * than off a config — the sheet of capitals and the word "ABC" typed into the
+ * builder get the same answer, and a renderer that only has cells to look at
+ * can still ask.
+ *
+ * The classes are taken at their largest, so a row of `Aa` is sized off the
+ * ascender and not off the capital. `ascent` is also the answer for a row with
+ * none of them on it: a line of punctuation is not a reason to resize the
+ * page, and an empty row has to agree with the row above it.
+ */
+export function glyphHeight(text: string, face: Face): number {
+  let height = 0;
+  if (/[a-z]/.test(text)) height = face.ascent;
+  if (/[A-Z]/.test(text)) height = Math.max(height, face.capHeight);
+  if (/[0-9]/.test(text)) height = Math.max(height, face.figure);
+  return height > 0 ? height : face.ascent;
+}
+
+/**
  * The type size that fills a writing space, in mil.
  *
  * `writing` is the distance from the top line down to the baseline — what
  * `ruleLines` calls `top` to `base`. A notebook rule has no top line, so its
  * caller passes the whole repeat and the letters fill it.
+ *
+ * `text` is what will be written at that size, and it is what decides which of
+ * the face's three heights has to reach the top line (`glyphHeight`). Left
+ * out, the answer is the tallest letter there is — the safe end, and the right
+ * one for a caller asking "how big is this ruling" rather than "how big is
+ * this row".
  */
-export function glyphEm(writing: Mil, face: Face): Mil {
-  return Math.max(1, Math.round(writing / face.ascent));
+export function glyphEm(writing: Mil, face: Face, text = ""): Mil {
+  return Math.max(1, Math.round(writing / glyphHeight(text, face)));
 }
 
 /**

--- a/src/engine/sheets/faces.ts
+++ b/src/engine/sheets/faces.ts
@@ -72,6 +72,26 @@ export type Face = {
    */
   xHeight: number;
   /**
+   * Baseline down to the bottom of the deepest tail, as a share of the em —
+   * `p` and `q` in Andika, `g` in the other two.
+   *
+   * Recorded rather than used, exactly as `xHeight` is, and read by
+   * `faces.test.ts`. What it is checked against is the tail space of a
+   * handwriting rule, which is a third of the repeat against a writing space of
+   * two thirds (`DESCENDER_SHARE` in paper.ts) — so the room below the baseline
+   * is half the writing space, and half the writing space is `ascent / 2` of
+   * the em whatever the rule size. A tail deeper than that is drawn through the
+   * next set's top line rather than into clean paper.
+   *
+   * Andika uses 0.239 of the 0.396 it is given and OpenDyslexic 0.261 of 0.425,
+   * so both print sheets clear it comfortably. Playwrite's descenders are a
+   * whole 0.519 against 0.510, which is the one face that hangs over — by 0.009
+   * of the em, four thousandths of an inch on a ⅝ rule. That is the stated
+   * tolerance and the reason a traced row is not allowed to clip: a joined `g`
+   * with its loop cut off is a worse model than one that crosses a line.
+   */
+  descent: number;
+  /**
    * A *declared* mean advance across `a`–`z` and the space, as a share of the
    * em.
    *
@@ -138,6 +158,7 @@ export const FACES: Record<SheetFont, Face> = {
     family: "Andika",
     ascent: 0.791,
     xHeight: 0.498,
+    descent: 0.239,
     advance: 0.506,
     stroke: 0.022,
     dotted: [0, 4.5],
@@ -148,6 +169,7 @@ export const FACES: Record<SheetFont, Face> = {
     family: "Playwrite US Trad",
     ascent: 1.019,
     xHeight: 0.519,
+    descent: 0.519,
     advance: 0.57,
     // Finer than the other two, and dotted tighter. A joined script is one
     // continuous stroke, so its outline doubles back on itself down every
@@ -163,6 +185,7 @@ export const FACES: Record<SheetFont, Face> = {
     family: "OpenDyslexic",
     ascent: 0.85,
     xHeight: 0.56,
+    descent: 0.261,
     advance: 0.795,
     // The heaviest of the three, because the face is: weighted bottoms and
     // 0.099em stems can carry an outline that would fill Andika's counters.
@@ -203,6 +226,21 @@ export function glyphEm(writing: Mil, face: Face): Mil {
 export function fittedEm(width: Mil, characters: number, face: Face): Mil {
   if (characters <= 0) return Infinity;
   return Math.max(1, Math.floor(width / (characters * face.advance)));
+}
+
+/**
+ * How many characters fit across `width` at one type size — `fittedEm` read
+ * the other way round.
+ *
+ * What a passage is wrapped at. The em is fixed by the ruling on a handwriting
+ * sheet, so the question is never "how small must this be to fit" but "where
+ * does the line run out", and answering it needs no DOM: it is the same
+ * declared mean advance, divided rather than multiplied.
+ */
+export function fittedCharacters(width: Mil, em: Mil, face: Face): number {
+  const advance = em * face.advance;
+  if (advance <= 0 || width <= 0) return 1;
+  return Math.max(1, Math.floor(width / advance));
 }
 
 /** What a stroked letterform is drawn with, at one type size. */

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -31,6 +31,7 @@ import { TIME_SHEET } from "./maths/time";
 import { WORD_PROBLEMS_SHEET } from "./maths/wordproblems";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
 import { PAPER_SHEET } from "./templates/paper";
+import { HANDWRITING_SHEET } from "./writing/handwriting";
 import { WORDS_SHEET } from "./words/spelling";
 
 const SHEETS: Record<string, SheetSpec> = {
@@ -50,6 +51,7 @@ const SHEETS: Record<string, SheetSpec> = {
   [STATISTICS_SHEET.id]: STATISTICS_SHEET,
   [WORD_PROBLEMS_SHEET.id]: WORD_PROBLEMS_SHEET,
   [WORDS_SHEET.id]: WORDS_SHEET,
+  [HANDWRITING_SHEET.id]: HANDWRITING_SHEET,
 };
 
 /**

--- a/src/engine/sheets/paper.ts
+++ b/src/engine/sheets/paper.ts
@@ -317,6 +317,27 @@ export function gridPitch(rule: Rule): Mil {
 }
 
 /**
+ * The writing space of a ruling: the top line down to the baseline.
+ *
+ * The one distance a type size is set from (`glyphEm`), because it is the space
+ * the tallest letter has to stand in. A notebook rule has no top line, so its
+ * writing space is the whole repeat — you write on the line, and everything
+ * above it is the room you have.
+ *
+ * Here rather than in the family that first needed it: the trace renderer, the
+ * handwriting family and the suite that holds the faces to their files all ask
+ * the same question, and three copies of it would be three chances to disagree
+ * about where a letter sits.
+ */
+export function writingSpace(rule: Rule): Mil {
+  const lines = ruleLines(rule);
+  const pitch = rulePitch(rule);
+  const base = lines.find((line) => line.role === "base")?.at ?? pitch;
+  const top = lines.find((line) => line.role === "top")?.at ?? 0;
+  return base - top;
+}
+
+/**
  * The lines of one repeat, as offsets down from the top of it.
  *
  * A notebook rule is one line at the foot of its repeat, because you write on

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -264,13 +264,23 @@ export type Problem = {
   workspace?: Mil;
 };
 
+/** One place on a tracing row: what is written there, and how it is drawn. */
+export type TraceCell = { text: string; style: TraceStyle };
+
 export type TraceRow = {
-  text: string;
   /**
-   * One entry per repeat across the row, left to right. `["solid", "dotted",
-   * "dotted", "none"]` is the trace → copy → write progression on one line.
+   * The cells across one row, left to right. `A` in `["solid", "dotted",
+   * "dotted", "none"]` is the trace → copy → write progression for one letter,
+   * and a row holds as many of those groups as the paper is wide enough for —
+   * which is what puts a whole alphabet on one page rather than the first
+   * thirteen letters of it.
+   *
+   * The text is per cell rather than per row for that reason alone. A row of
+   * one repeated word is the commoner shape and still the easy one to write;
+   * a row that could only say one thing would have made the letters family
+   * choose between a legible rule size and the other half of the alphabet.
    */
-  repeats: TraceStyle[];
+  cells: TraceCell[];
 };
 
 export type GridSpec = {
@@ -1221,6 +1231,93 @@ export type WordsConfig = SheetOptions & {
   columns: number;
 };
 
+/* ── Handwriting ───────────────────────────────────────────────────────────
+   The family where the ruling stops being the paper and becomes the exercise.
+   Every sheet above this line could be printed a thousandth of an inch out and
+   nobody would know; here the child is being taught to write between two lines,
+   so a ⅝ rule that is not ⅝ of an inch teaches the wrong size of letter — and
+   the model they trace has to stand on the baseline and reach the top line in
+   whichever face the sheet is set in (`faces.ts`).                          */
+
+/**
+ * What is written on the sheet.
+ *
+ * `letters` and `numbers` are the two sets the engine owns outright — the
+ * alphabet and the numerals, in the order they are taught. The other two are
+ * content somebody else wrote, and they differ only in how much of it goes on
+ * one line: a word is written several times *across* a row, and a line of a
+ * passage fills the row, so its repeats run *down* the page instead.
+ *
+ * A sentence is a passage of one line. It is not a style of its own because it
+ * would be the same function with the same arguments — what makes a sentence
+ * sheet a sentence sheet is how many lines are left under it, which is
+ * `repeats`.
+ */
+export type HandwritingStyle = "letters" | "numbers" | "words" | "passage";
+
+/**
+ * Which alphabet a letter sheet writes.
+ *
+ * `both` writes each letter as a pair — `A` then `a`, `B` then `b` — rather
+ * than the capitals and then the small letters, because the pair is what a
+ * child is taught as one letter.
+ */
+export type LetterCase = "upper" | "lower" | "both";
+
+export type HandwritingConfig = SheetOptions & {
+  kind: "handwriting";
+  style: HandwritingStyle;
+  /**
+   * The paper it is written on — any ruling in §5, and the whole of what makes
+   * this family physical. Blank paper is the one that cannot work: a
+   * handwriting sheet is rows of a repeating ruling, and a ruling with no pitch
+   * has no rows. See `ruleOf` for what it resolves to instead.
+   */
+  rule: Rule;
+  /**
+   * How a model is drawn — any style in §6. `none` is a sheet with nothing to
+   * trace, which is a real sheet: the model is the solid one at the start of
+   * the row and the rest is the child's own writing.
+   */
+  trace: TraceStyle;
+  /**
+   * How many times each thing is written, the model and the empty space
+   * included.
+   *
+   * Across the row for letters, numbers and words; down the page for a
+   * passage, whose lines are too wide to sit beside each other.
+   */
+  repeats: number;
+  /**
+   * Trace → copy → write: the first is a solid model and the last is left
+   * empty, with everything between drawn in `trace`.
+   *
+   * On unless turned off, because it is what the whole sheet is for — one page
+   * that carries a child from a letter they follow to a letter they make. Off
+   * is every repeat drawn the same way, which is the sheet for a child who is
+   * still tracing and not yet ready to be left on their own.
+   */
+  progression?: boolean;
+  /** `letters` only. Absent is both cases, which is how letters are taught. */
+  letters?: LetterCase;
+  /**
+   * `words` only: the list, in the order it was given.
+   *
+   * There is no name for it here for the reason `WordsConfig.words` gives — a
+   * config travels in a URL, and the one thing that must never be in one is a
+   * child (§1).
+   */
+  words?: string[];
+  /**
+   * `passage` only: what is copied, as it should read on the page.
+   *
+   * Wrapped to the ruling by the family rather than by the renderer, because
+   * there is no DOM to measure in (§4) — a newline here is a line break the
+   * author asked for, and everything else breaks where the paper runs out.
+   */
+  text?: string;
+};
+
 /**
  * Anything a saved sheet can hold. Narrow on `kind` — and only in index.ts,
  * which is the one module that knows the whole union.
@@ -1241,7 +1338,8 @@ export type SheetConfig =
   | RatioConfig
   | StatisticsConfig
   | WordProblemConfig
-  | WordsConfig;
+  | WordsConfig
+  | HandwritingConfig;
 
 /* ── A sheet somebody kept ─────────────────────────────────────────────── */
 

--- a/src/engine/sheets/writing/handwriting.test.ts
+++ b/src/engine/sheets/writing/handwriting.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from "vitest";
+
+import { FACES, glyphEm } from "../faces";
+import { ruleCapacity, ruledLines } from "../layout";
+import { RULINGS, inches, rulePitch, toInches, writingSpace } from "../paper";
+import type {
+  HandwritingConfig,
+  Rule,
+  RuleStyle,
+  TraceRow,
+  TraceStyle,
+} from "../types";
+
+import {
+  DEFAULT_HAND_RULE,
+  HANDWRITING_SHEET,
+  MAX_REPEATS,
+  describeHandwriting,
+  handwritingLayout,
+  instructionOf,
+  traceStyles,
+  wrapPassage,
+} from "./handwriting";
+
+/**
+ * The family where the paper is the exercise.
+ *
+ * Three properties carry this sheet, and none of them can be seen by looking at
+ * a screen:
+ *
+ * **The ruling is the size it says it is.** A ⅝ rule is ⅝ of an inch under a
+ * ruler or the child is being taught the wrong size of letter. Every row is one
+ * repeat of the ruling, so that promise is the row pitch and nothing else.
+ *
+ * **The model sits on the rules.** The tallest letter stands on the baseline
+ * and reaches the top line, in whichever of the three faces the sheet is set
+ * in — which is arithmetic over proportions measured out of the font files
+ * (`faces.ts`), not a guess that happens to look right in one of them.
+ *
+ * **What is asked for is what is printed.** A page that quietly dropped `8` and
+ * `9` off a sheet of number formation is a sheet that teaches eight numerals,
+ * and nothing on screen would say so.
+ */
+
+const BASE: HandwritingConfig = {
+  kind: "handwriting",
+  paper: { size: "letter", orientation: "portrait", margin: "normal" },
+  fontPt: 12,
+  fields: ["name", "date"],
+  style: "letters",
+  rule: DEFAULT_HAND_RULE,
+  letters: "both",
+  trace: "dotted",
+  repeats: 3,
+};
+
+const config = (over: Partial<HandwritingConfig> = {}): HandwritingConfig => ({
+  ...BASE,
+  ...over,
+});
+
+/** The rows a config actually printed. */
+function rowsOf(over: Partial<HandwritingConfig> = {}): TraceRow[] {
+  const [block] = HANDWRITING_SHEET.build(config(over), 1).blocks;
+  return block?.kind === "trace" ? block.rows : [];
+}
+
+/**
+ * Everything written on a sheet, in the order a child meets it.
+ *
+ * The empty places drop out, which is what they are: a cell the child fills in
+ * carries no text at all, so that nothing announces the word they are supposed
+ * to have thought of.
+ */
+const written = (rows: TraceRow[]): string[] => [
+  ...new Set(
+    rows.flatMap((row) =>
+      row.cells.map((cell) => cell.text).filter((text) => text !== ""),
+    ),
+  ),
+];
+
+describe("what goes on a handwriting sheet", () => {
+  it("writes the whole alphabet, upper and lower, on one page", () => {
+    // The acceptance criterion, and the reason a row carries a text per cell:
+    // fifty-two rows of one letter each is four sheets of ⅝ paper, and a sheet
+    // that stopped at M would be a sheet that teaches half an alphabet.
+    const pairs = written(rowsOf({ letters: "both" }));
+    for (const letter of "ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+      expect(pairs, letter).toContain(`${letter}${letter.toLowerCase()}`);
+    }
+
+    expect(written(rowsOf({ letters: "upper" }))).toContain("Z");
+    expect(written(rowsOf({ letters: "lower" }))).toContain("z");
+    expect(written(rowsOf({ letters: "lower" }))).not.toContain("Z");
+  });
+
+  it("writes every numeral from nought to nine", () => {
+    // Ten things at four repeats each is two to a row on inch-high paper —
+    // which is the point of checking it rather than assuming it, because one
+    // more repeat drops the last two numerals off the bottom of the page.
+    const rule: Rule = { style: "hand-1", midline: "solid", descender: true };
+    const drawn = written(rowsOf({ style: "numbers", rule, repeats: 4 }));
+    for (const numeral of "0123456789") {
+      expect(drawn, numeral).toContain(numeral);
+    }
+  });
+
+  it("writes the words it was given, in the order they were given", () => {
+    const words = ["because", "thought", "friend"];
+    expect(written(rowsOf({ style: "words", words }))).toEqual(words);
+  });
+
+  it("keeps a capital and a small letter apart in a word list", () => {
+    // The one place this family parts company with the spelling sheet: a
+    // marker sees "The" and "the" as one word, and a handwriting sheet is
+    // about the shape of the letters, where they are two different exercises.
+    const words = ["The", "the", "the"];
+    expect(written(rowsOf({ style: "words", words }))).toEqual(["The", "the"]);
+  });
+
+  it("breaks a passage where the paper runs out, and nowhere else", () => {
+    const text =
+      "The quick brown fox jumps over the lazy dog.\nHandwriting is slow before it is neat.";
+    const lines = written(rowsOf({ style: "passage", text })).filter(
+      (line) => line !== "",
+    );
+    expect(lines.length).toBeGreaterThan(2);
+    // Nothing is lost and nothing is invented: the lines put back together are
+    // the passage, with the author's own break kept.
+    expect(lines.join(" ").replace(/\s+/g, " ")).toBe(
+      text.replace(/\n/g, " ").replace(/\s+/g, " "),
+    );
+  });
+
+  it("puts a passage on lines that fit the width it was measured against", () => {
+    const line = "a".repeat(9);
+    // Six words of nine letters and five spaces is fifty-nine characters; a
+    // limit of twenty takes two of them per line.
+    const wrapped = wrapPassage(`${line} ${line} ${line} ${line}`, 20);
+    expect(wrapped).toEqual([`${line} ${line}`, `${line} ${line}`]);
+    // A word longer than the whole line still gets a line rather than being
+    // dropped or cut in half.
+    expect(wrapPassage("antidisestablishmentarianism", 5)).toEqual([
+      "antidisestablishmentarianism",
+    ]);
+  });
+});
+
+describe("trace, copy, then write it alone", () => {
+  it("is a model, the tracing, and the place the child is on their own", () => {
+    expect(traceStyles(config({ repeats: 4 }))).toEqual([
+      "solid",
+      "dotted",
+      "dotted",
+      "none",
+    ]);
+  });
+
+  it("draws every repeat the same way when the progression is off", () => {
+    expect(traceStyles(config({ repeats: 3, progression: false }))).toEqual([
+      "dotted",
+      "dotted",
+      "dotted",
+    ]);
+  });
+
+  it("gives the model on its own when there is nowhere to progress to", () => {
+    expect(traceStyles(config({ repeats: 1 }))).toEqual(["solid"]);
+    expect(traceStyles(config({ repeats: 2 }))).toEqual(["solid", "none"]);
+  });
+
+  it("stops where a row stops being legible", () => {
+    expect(traceStyles(config({ repeats: 99 }))).toHaveLength(MAX_REPEATS);
+    expect(traceStyles(config({ repeats: 0 }))).toHaveLength(1);
+  });
+
+  it("runs across the row for a letter and down the page for a line", () => {
+    // The whole of the difference between the four styles: something short
+    // enough to write several times on one line does, and a line of a passage
+    // takes the next row instead.
+    const across = rowsOf({ letters: "upper", repeats: 4 });
+    expect(across[0].cells.map((cell) => cell.style)).toEqual([
+      "solid",
+      "dotted",
+      "dotted",
+      "none",
+      "solid",
+      "dotted",
+      "dotted",
+      "none",
+      "solid",
+      "dotted",
+      "dotted",
+      "none",
+    ]);
+
+    const down = rowsOf({ style: "passage", text: "One line.", repeats: 3 });
+    expect(down.map((row) => row.cells.length)).toEqual([1, 1, 1]);
+    expect(down.map((row) => row.cells[0].style)).toEqual([
+      "solid",
+      "dotted",
+      "none",
+    ]);
+  });
+
+  it("gives every row the same number of cells, short last row included", () => {
+    // A final row that divided the page between four cells instead of twelve
+    // would set its letters three times as far apart as the row above it,
+    // which looks like a mistake because it is one.
+    const rows = rowsOf({ letters: "upper", repeats: 4 });
+    const widths = new Set(rows.map((row) => row.cells.length));
+    expect(widths.size).toBe(1);
+  });
+
+  it("says what the row actually does, rather than what was asked for", () => {
+    expect(instructionOf(config({ repeats: 4 }))).toBe(
+      "Trace each letter, then write it on your own.",
+    );
+    expect(instructionOf(config({ repeats: 3, progression: false }))).toBe(
+      "Trace each letter.",
+    );
+    // Nothing to trace: a solid model and an empty place is a copying sheet,
+    // and it must not tell a child to trace something that isn't dotted.
+    expect(instructionOf(config({ trace: "none", repeats: 3 }))).toBe(
+      "Copy each letter on your own.",
+    );
+    expect(instructionOf(config({ trace: "solid", progression: false }))).toBe(
+      "Write each letter.",
+    );
+    expect(instructionOf(config({ style: "passage", repeats: 3 }))).toBe(
+      "Trace each line, then write it on the line below.",
+    );
+  });
+});
+
+/* ── Every ruling, every trace style ───────────────────────────────────────
+   The acceptance criterion in as many words: the rulings of PRINT04 and the
+   letterforms of PRINT15 are two independent choices, so all of them have to
+   work together — including the combinations nobody would print.           */
+
+const STYLES: RuleStyle[] = Object.keys(RULINGS) as RuleStyle[];
+const TRACES: TraceStyle[] = [
+  "solid",
+  "dim",
+  "hollow",
+  "dotted",
+  "dashed",
+  "none",
+];
+
+describe("every ruling with every trace style", () => {
+  it("prints something on all of them", () => {
+    for (const style of STYLES) {
+      for (const trace of TRACES) {
+        const rows = rowsOf({ rule: { style }, trace, letters: "upper" });
+        expect(rows.length, `${style} / ${trace}`).toBeGreaterThan(0);
+        expect(rows[0].cells.length, `${style} / ${trace}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("falls back to ⅝ paper when there is no ruling to write on", () => {
+    // Blank paper is the one ruling with no pitch, so a sheet ruled on it
+    // would have no rows at all — a title and an empty page. It answers with
+    // the commonest primary size instead, the way `rulingOf` answers with
+    // something that prints rather than with nothing.
+    const [block] = HANDWRITING_SHEET.build(
+      config({ rule: { style: "blank" } }),
+      1,
+    ).blocks;
+    expect(block.kind).toBe("trace");
+    if (block.kind !== "trace") return;
+    expect(block.rule).toEqual(DEFAULT_HAND_RULE);
+  });
+
+  it("never asks for more rows than the paper holds", () => {
+    // Print is the whole of the output path (§10): a row past the bottom
+    // margin is a second sheet out of the printer, and the preview would have
+    // looked right.
+    for (const style of STYLES) {
+      for (const repeats of [1, 3, MAX_REPEATS]) {
+        const rule: Rule = { style, descender: true };
+        const drawn = rowsOf({ rule, repeats, letters: "both" });
+        const { box } = handwritingLayout(config({ rule, repeats }), 1);
+        const held = ruleCapacity(
+          box.height,
+          rulePitch(rule) > 0 ? rule : DEFAULT_HAND_RULE,
+        );
+        expect(drawn.length, `${style} × ${repeats}`).toBeLessThanOrEqual(held);
+      }
+    }
+  });
+});
+
+/* ── The paper is the size it says it is ───────────────────────────────── */
+
+describe("a ⅝ rule under a ruler", () => {
+  it("repeats every five eighths of an inch, down a whole page of them", () => {
+    const rule: Rule = {
+      style: "hand-5-8",
+      midline: "dashed",
+      descender: true,
+    };
+    // A row is one repeat of the ruling and rows sit against each other, so
+    // the distance between one baseline and the next is the pitch — measured
+    // from the repeat index rather than accumulated, which is what stops a
+    // rounding error compounding down the page (`layout.ts`).
+    expect(toInches(rulePitch(rule))).toBe(0.625);
+
+    const rows = rowsOf({ rule, letters: "both" });
+    const page = ruledLines(
+      { x: 0, y: 0, width: inches(7.5), height: rows.length * rulePitch(rule) },
+      rule,
+    );
+    const bases = page.filter((line) => line.role === "base").map((l) => l.y);
+    expect(bases).toHaveLength(rows.length);
+    for (let at = 1; at < bases.length; at++) {
+      expect(bases[at] - bases[at - 1]).toBe(inches(0.625));
+    }
+  });
+
+  it("sets the model to the writing space, in whichever face it is in", () => {
+    // The em is fixed to the top line, so the tallest letter stands on the
+    // baseline and reaches it. Two faces on one rule are two type sizes, which
+    // is the reason `faces.ts` measures rather than shares a ratio.
+    const rule: Rule = {
+      style: "hand-5-8",
+      midline: "dashed",
+      descender: true,
+    };
+    const writing = writingSpace(rule);
+    const sizes = new Set<number>();
+    for (const face of Object.values(FACES)) {
+      const { em } = handwritingLayout(config({ rule, font: face.id }), 1);
+      expect(Math.abs(em * face.ascent - writing), face.family) //
+        .toBeLessThanOrEqual(1);
+      sizes.add(em);
+    }
+    expect(sizes.size).toBe(Object.keys(FACES).length);
+  });
+
+  it("fits a wider face on the same line by writing fewer of them", () => {
+    // OpenDyslexic is half as wide again as Andika, so a row of it holds
+    // fewer groups — which is a fact about the font file, not a guess, and it
+    // is why the packing is per face rather than a constant.
+    const rule: Rule = { style: "hand-5-8", descender: true };
+    const print = handwritingLayout(config({ rule, font: "print" }), 1);
+    const wide = handwritingLayout(config({ rule, font: "dyslexic" }), 1);
+    expect(wide.perRow).toBeLessThan(print.perRow);
+  });
+
+  it("writes smaller letters on smaller paper, not the same ones", () => {
+    const big = glyphEm(
+      writingSpace({ style: "hand-1", descender: true }),
+      FACES.print,
+    );
+    const small = glyphEm(writingSpace({ style: "hand-3-8" }), FACES.print);
+    expect(small).toBeLessThan(big);
+  });
+});
+
+/* ── The sheet itself ──────────────────────────────────────────────────── */
+
+describe("the sheet", () => {
+  it("is the same page on every build", () => {
+    // §7, and what lets a catalog page be prerendered: a parent who printed
+    // this in March prints the identical sheet in June.
+    for (const seed of [0, 1, 4242]) {
+      expect(JSON.stringify(HANDWRITING_SHEET.build(config(), seed))).toBe(
+        JSON.stringify(HANDWRITING_SHEET.build(config(), seed)),
+      );
+    }
+  });
+
+  it("has nothing to mark and no key to disagree with it", () => {
+    const sheet = HANDWRITING_SHEET.build(config(), 1);
+    // No score box: a handwriting sheet is not marked out of anything, and a
+    // "___ / 26" over a page of letters would be a number nobody can award.
+    expect(sheet.header.score).toBeUndefined();
+    expect(sheet.answers).toBe(false);
+    expect(HANDWRITING_SHEET.key(sheet)).toBe(sheet);
+  });
+
+  it("prints the name line blank, because it has nothing to fill it with", () => {
+    expect(HANDWRITING_SHEET.build(config(), 1).header.fields) //
+      .toEqual(["name", "date"]);
+  });
+
+  it("names itself in the terms it was chosen by", () => {
+    expect(describeHandwriting(config())).toBe(
+      'Letter practice — capitals and small letters — handwriting ⅝" — written 3 times',
+    );
+    expect(describeHandwriting(config({ style: "numbers", repeats: 4 }))).toBe(
+      'Number formation — 0 to 9 — handwriting ⅝" — written 4 times',
+    );
+  });
+
+  it("survives a config that says something this build has never heard of", () => {
+    // Every field here can arrive from a shared link or a sheet saved before a
+    // rename, so a lookup keyed on one has to answer rather than throw.
+    const stale = {
+      ...config(),
+      style: "toString",
+      letters: "constructor",
+      rule: { style: "runes" },
+    } as unknown as HandwritingConfig;
+    expect(() => HANDWRITING_SHEET.build(stale, 1)).not.toThrow();
+    expect(HANDWRITING_SHEET.build(stale, 1).blocks.length).toBe(1);
+  });
+});

--- a/src/engine/sheets/writing/handwriting.test.ts
+++ b/src/engine/sheets/writing/handwriting.test.ts
@@ -96,11 +96,14 @@ describe("what goes on a handwriting sheet", () => {
   });
 
   it("writes every numeral from nought to nine", () => {
-    // Ten things at four repeats each is two to a row on inch-high paper —
+    // Ten things at three repeats each is two to a row on inch-high paper —
     // which is the point of checking it rather than assuming it, because one
-    // more repeat drops the last two numerals off the bottom of the page.
+    // more repeat drops the last two numerals off the bottom of the page. A
+    // numeral that fills a 1-inch rule's writing space is 0.47in wide at
+    // Andika's mean advance (`Face.figure`, `Face.advance`), so four of them
+    // and their air is 3.79in and two groups no longer fit across 7.5in.
     const rule: Rule = { style: "hand-1", midline: "solid", descender: true };
-    const drawn = written(rowsOf({ style: "numbers", rule, repeats: 4 }));
+    const drawn = written(rowsOf({ style: "numbers", rule, repeats: 3 }));
     for (const numeral of "0123456789") {
       expect(drawn, numeral).toContain(numeral);
     }
@@ -228,6 +231,12 @@ describe("trace, copy, then write it alone", () => {
     expect(instructionOf(config({ trace: "solid", progression: false }))).toBe(
       "Write each letter.",
     );
+    // Nothing to copy either: `trace: "none"` with the progression off draws
+    // no model anywhere, so the sheet is blank ruled paper and must not tell a
+    // child to copy something that was never printed.
+    expect(instructionOf(config({ trace: "none", progression: false }))).toBe(
+      "Write each letter.",
+    );
     expect(instructionOf(config({ style: "passage", repeats: 3 }))).toBe(
       "Trace each line, then write it on the line below.",
     );
@@ -338,6 +347,54 @@ describe("a ⅝ rule under a ruler", () => {
       sizes.add(em);
     }
     expect(sizes.size).toBe(Object.keys(FACES).length);
+  });
+
+  it("puts a capital on the top line when a capital is the tallest thing", () => {
+    // The claim the capitals page makes and invites a reader to measure. The
+    // em is fixed to the tallest thing the sheet writes, and on a sheet of
+    // nothing but capitals that is a capital rather than an ascender — so
+    // sizing it off `ascent` would leave every capital a tenth of the writing
+    // space short of the line the page says it starts on.
+    const rule: Rule = {
+      style: "hand-3-4",
+      midline: "dashed",
+      descender: true,
+    };
+    const writing = writingSpace(rule);
+    for (const face of Object.values(FACES)) {
+      const { em } = handwritingLayout(
+        config({ rule, font: face.id, letters: "upper" }),
+        1,
+      );
+      expect(Math.abs(em * face.capHeight - writing), face.family) //
+        .toBeLessThanOrEqual(1);
+    }
+
+    // And a numeral on a sheet of nothing but numerals, which is not the same
+    // number: OpenDyslexic's digits are a tenth shorter than its capitals.
+    for (const face of Object.values(FACES)) {
+      const { em } = handwritingLayout(
+        config({ rule, font: face.id, style: "numbers" }),
+        1,
+      );
+      expect(Math.abs(em * face.figure - writing), face.family) //
+        .toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("goes back to the ascender the moment a small letter is on the row", () => {
+    // The other half of it. A row cannot put a capital and an `l` on the same
+    // line, and an ascender through the top rule is the worse of the two
+    // misses — so `Aa` is sized off the ascender and the capital rides low.
+    const rule: Rule = {
+      style: "hand-3-4",
+      midline: "dashed",
+      descender: true,
+    };
+    const both = handwritingLayout(config({ rule, letters: "both" }), 1);
+    const upper = handwritingLayout(config({ rule, letters: "upper" }), 1);
+    expect(both.em * FACES.print.ascent).toBeCloseTo(writingSpace(rule), -1);
+    expect(upper.em).toBeGreaterThan(both.em);
   });
 
   it("fits a wider face on the same line by writing fewer of them", () => {

--- a/src/engine/sheets/writing/handwriting.ts
+++ b/src/engine/sheets/writing/handwriting.ts
@@ -7,8 +7,10 @@
  * they were taught to write between two lines by somebody who will notice. So
  * everything here is geometry: the rows are one repeat of the ruling apart
  * because that is what the ruling says, and the model that sits on them is
- * sized off the face's own measured ascent (`faces.ts`) rather than off the
- * body type.
+ * sized off the face's own measured proportions (`faces.ts`) rather than off
+ * the body type — off whichever of them the tallest thing on the sheet is
+ * drawn to, so a page of capitals reaches the top line as surely as a page of
+ * `Aa` does.
  *
  * **One progression, two directions.** A row is `["solid", "dotted", "none"]` —
  * a model to trace, a trace, and the place where the child is on their own —
@@ -150,8 +152,9 @@ export function handwritingWords(config: HandwritingConfig): string[] {
  * A passage broken into lines that fit the ruling.
  *
  * The family's job rather than the renderer's, because there is nothing to
- * measure in (§4): `Copywork` renders one line of text per repeat of the
- * ruling, so where a verse breaks has to be decided here or not at all. A
+ * measure in (§4): a row is one repeat of the ruling and holds one line of a
+ * passage — `TracedRow` draws what it is handed and never rewraps it — so
+ * where a verse breaks has to be decided here or not at all. A
  * newline in the source is a break the author asked for and is kept; everything
  * else breaks at the last space before the paper runs out. A word longer than a
  * whole line gets one of its own, and `fittedEm` sets it small enough to reach
@@ -180,8 +183,20 @@ export function wrapPassage(text: string, characters: number): string[] {
 
 /* ── The progression ───────────────────────────────────────────────────── */
 
-/** The four styles that are a model to follow rather than the child's own. */
-const OUTLINED = new Set<TraceStyle>(["dim", "hollow", "dotted", "dashed"]);
+/**
+ * The four styles that are a model to follow rather than the child's own.
+ *
+ * Exported because two suites check a sheet against it and a third list would
+ * be a third chance to disagree. Named for what it means here rather than for
+ * how it is drawn: `Traced.tsx` has its own `STROKED`, which is a *different*
+ * set — `dim` is a model but it is a filled shape, not an outline.
+ */
+export const MODELLED = new Set<TraceStyle>([
+  "dim",
+  "hollow",
+  "dotted",
+  "dashed",
+]);
 
 /**
  * How each repeat of one thing is drawn: trace → copy → write.
@@ -241,6 +256,12 @@ export type HandwritingLayout = {
  * mean advance it is counted in is the face's own (`faces.ts`), because
  * OpenDyslexic is half as wide again as Andika and one shared guess would push
  * a word off the end of the line in one of them.
+ *
+ * The em is worked out against everything the sheet writes rather than against
+ * one row, and that is the conservative direction: a page of capitals is set
+ * larger than a page of `Aa` on the same ruling (`glyphHeight`), so measuring
+ * the packing off the whole page can only reserve more room per group than any
+ * one row goes on to need.
  */
 export function handwritingLayout(
   config: HandwritingConfig,
@@ -252,7 +273,7 @@ export function handwritingLayout(
   // mark out of anything.
   const box = sheetBlockBox(headerOf(config));
   const face = faceOf(config.font);
-  const em = glyphEm(writingSpace(rule), face);
+  const em = glyphEm(writingSpace(rule), face, writtenOf(config));
   const rows = ruleCapacity(box.height, rule);
   const times = traceStyles(config).length;
 
@@ -288,6 +309,16 @@ function contentOf(config: HandwritingConfig): string[] {
       return own(ALPHABETS, config.letters ?? "both", ALPHABETS.both);
   }
 }
+
+/**
+ * Every character the sheet will print, as one string.
+ *
+ * Only ever read by `glyphHeight`, which wants to know whether there is a
+ * lower-case letter, a capital or a numeral anywhere on the page — so the
+ * order it is joined in and the spaces between are beside the point.
+ */
+const writtenOf = (config: HandwritingConfig): string =>
+  config.style === "passage" ? (config.text ?? "") : contentOf(config).join("");
 
 /** The longest thing on the page, in characters. Never less than one. */
 const longestOf = (things: string[]): number =>
@@ -389,18 +420,24 @@ const NOUN: Record<HandwritingStyle, string> = {
  * sheet with nothing dotted on it never says "trace", and a sheet with no empty
  * place never promises one. The same rule the integers sheet follows when it
  * decides whether to mention powers.
+ *
+ * "Copy" needs a model as well as an empty place, which is the one that is easy
+ * to get wrong: `trace: "none"` with the progression off draws nothing at all,
+ * and a page of blank ruled lines headed "Copy each letter on your own" is
+ * asking a child to copy something that is not there.
  */
 export function instructionOf(config: HandwritingConfig): string {
   const noun = own(NOUN, config.style, NOUN.letters);
   const styles = traceStyles(config);
-  const traced = styles.some((style) => OUTLINED.has(style));
+  const traced = styles.some((style) => MODELLED.has(style));
+  const model = traced || styles.includes("solid");
   const alone = styles.includes("none");
   const where =
     config.style === "passage" ? "on the line below" : "on your own";
 
   if (traced && alone) return `Trace each ${noun}, then write it ${where}.`;
   if (traced) return `Trace each ${noun}.`;
-  if (alone) return `Copy each ${noun} ${where}.`;
+  if (model && alone) return `Copy each ${noun} ${where}.`;
   return `Write each ${noun}.`;
 }
 

--- a/src/engine/sheets/writing/handwriting.ts
+++ b/src/engine/sheets/writing/handwriting.ts
@@ -1,0 +1,494 @@
+/**
+ * Handwriting: trace it, copy it, then write it alone.
+ *
+ * The first family where the ruling is the exercise rather than the paper. A
+ * maths sheet printed a thousandth of an inch out is a maths sheet; a ⅝ rule
+ * that is not ⅝ of an inch is teaching a child the wrong size of letter, and
+ * they were taught to write between two lines by somebody who will notice. So
+ * everything here is geometry: the rows are one repeat of the ruling apart
+ * because that is what the ruling says, and the model that sits on them is
+ * sized off the face's own measured ascent (`faces.ts`) rather than off the
+ * body type.
+ *
+ * **One progression, two directions.** A row is `["solid", "dotted", "none"]` —
+ * a model to trace, a trace, and the place where the child is on their own —
+ * and that sequence is the whole of what a handwriting sheet does. Something
+ * short enough to write several times on one line runs *across* the row, and as
+ * many of them fit as the paper is wide enough for, which is what puts a whole
+ * alphabet on one page. A line of a passage fills the row on its own, so the
+ * same sequence runs *down* the page instead. Nothing else differs between the
+ * four styles.
+ *
+ * Everything the other families promise holds unchanged: the page comes out of
+ * `(config, seed)` and nothing else, and no row is put on the page that the
+ * capacity arithmetic did not reserve room for.
+ *
+ * There are no answers. A key is the same page — see the note on `key` below,
+ * which is the same one blank paper makes.
+ */
+import { faceOf, fittedCharacters, glyphEm, type Face } from "../faces";
+
+import type {
+  Block,
+  HandwritingConfig,
+  HandwritingStyle,
+  LetterCase,
+  Mil,
+  Rule,
+  Sheet,
+  SheetOptions,
+  TraceCell,
+  TraceRow,
+  TraceStyle,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import { ruleCapacity, type Box } from "../layout";
+import { own, rulePitch, rulingOf, writingSpace } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+
+/* ── What the family will and won't do ─────────────────────────────────── */
+
+/**
+ * The most times one thing is written.
+ *
+ * Eight is already a row of eight letters and a page of nothing else; past that
+ * the cells are narrower than the letters in them and the sheet stops being
+ * legible before it stops being generatable.
+ */
+export const MAX_REPEATS = 8;
+
+/** As many words as a parent may type into a deck — see `services/decks.ts`. */
+const MAX_WORDS = 200;
+
+/** Long enough for "onomatopoeia" twice over; short enough not to wrap. */
+const MAX_LETTERS = 24;
+
+/**
+ * The longest passage worth setting.
+ *
+ * The smallest ruling here holds about twenty-two lines to a page and about
+ * forty-six characters to a line, so a thousand characters is already more than
+ * any sheet can print — this is twice that, and still short enough that a config
+ * fits in a URL (§14), which is not the place for an essay.
+ */
+const MAX_TEXT = 2000;
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/**
+ * ⅝ with a dashed midline and room for a tail: the commonest primary size, and
+ * what the shop's own handwriting paper defaults to.
+ */
+export const DEFAULT_HAND_RULE: Rule = {
+  style: "hand-5-8",
+  midline: "dashed",
+  descender: true,
+};
+
+/**
+ * The paper the sheet is written on.
+ *
+ * Every ruling in §5 is legal here, notebook rules and squares included — a
+ * child asked to write a sentence on college-ruled paper is being set a real
+ * exercise. Blank paper is the only one that cannot work: a handwriting sheet
+ * is rows of a repeating ruling, and a ruling with no pitch has no rows, so a
+ * sheet on it would be a page with a title and nothing under it. It resolves to
+ * the ⅝ rule instead, which is the same promise `rulingOf` makes — answer with
+ * something that prints rather than with nothing.
+ */
+export function ruleOf(config: HandwritingConfig): Rule {
+  const rule = config.rule ?? DEFAULT_HAND_RULE;
+  return rulePitch(rule) > 0 ? rule : DEFAULT_HAND_RULE;
+}
+
+/* ── What is written ───────────────────────────────────────────────────── */
+
+const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const LOWER = "abcdefghijklmnopqrstuvwxyz";
+const NUMERALS = "0123456789";
+
+/**
+ * The alphabets, in the order they are taught.
+ *
+ * `both` is the pair written as one thing — `Aa`, then `Bb` — rather than the
+ * capitals and then the small letters. That is how a letter is introduced, and
+ * it is also the only shape in which twenty-six of them fit on one page: fifty-
+ * two rows of one letter each is four sheets of ⅝ paper.
+ */
+const ALPHABETS: Record<LetterCase, string[]> = {
+  upper: [...UPPER],
+  lower: [...LOWER],
+  both: [...UPPER].map((letter, at) => `${letter}${LOWER[at]}`),
+};
+
+/**
+ * The word list, made safe to print from whatever a saved config says.
+ *
+ * Trimmed, capped and de-duplicated, the way `wordsOf` holds a spelling list —
+ * but **case-sensitively**, which is the one difference and the reason this is
+ * not that function. A spelling marker sees "Because" and "because" as one
+ * word; a handwriting sheet is about the shape of the letters, and a capital B
+ * is a different shape from a small one.
+ */
+export function handwritingWords(config: HandwritingConfig): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of config.words ?? []) {
+    if (typeof raw !== "string") continue;
+    const word = raw.trim().replace(/\s+/g, " ").slice(0, MAX_LETTERS);
+    if (word === "" || seen.has(word)) continue;
+    seen.add(word);
+    out.push(word);
+    if (out.length === MAX_WORDS) break;
+  }
+  return out;
+}
+
+/**
+ * A passage broken into lines that fit the ruling.
+ *
+ * The family's job rather than the renderer's, because there is nothing to
+ * measure in (§4): `Copywork` renders one line of text per repeat of the
+ * ruling, so where a verse breaks has to be decided here or not at all. A
+ * newline in the source is a break the author asked for and is kept; everything
+ * else breaks at the last space before the paper runs out. A word longer than a
+ * whole line gets one of its own, and `fittedEm` sets it small enough to reach
+ * the margin — the only place on a handwriting sheet where the type is not the
+ * ruling's size, and better than a word running off the page.
+ */
+export function wrapPassage(text: string, characters: number): string[] {
+  const width = Math.max(1, characters);
+  return text.split("\n").flatMap((source) => {
+    const words = source.split(/\s+/).filter((word) => word !== "");
+    const lines: string[] = [];
+    let line = "";
+    for (const word of words) {
+      const next = line === "" ? word : `${line} ${word}`;
+      if (next.length > width && line !== "") {
+        lines.push(line);
+        line = word;
+      } else {
+        line = next;
+      }
+    }
+    if (line !== "") lines.push(line);
+    return lines;
+  });
+}
+
+/* ── The progression ───────────────────────────────────────────────────── */
+
+/** The four styles that are a model to follow rather than the child's own. */
+const OUTLINED = new Set<TraceStyle>(["dim", "hollow", "dotted", "dashed"]);
+
+/**
+ * How each repeat of one thing is drawn: trace → copy → write.
+ *
+ * The first is a solid model, the last is left empty, and everything between is
+ * the style the sheet was set in. Turning the progression off draws every
+ * repeat the same way, which is the sheet for a child who is still tracing —
+ * and asking for one repeat gives the model on its own, because a progression
+ * needs somewhere to progress to.
+ */
+export function traceStyles(config: HandwritingConfig): TraceStyle[] {
+  const times = clamp(config.repeats ?? 3, 1, MAX_REPEATS);
+  const trace = config.trace ?? "dotted";
+  if (config.progression === false) {
+    return Array.from({ length: times }, () => trace);
+  }
+  if (times === 1) return ["solid"];
+  return ["solid", ...Array.from({ length: times - 2 }, () => trace), "none"];
+}
+
+/**
+ * One cell. An empty place carries no text, so a row of nothing but empty
+ * places announces itself as a line to write on rather than as the word the
+ * child is supposed to have thought of.
+ */
+const cellOf = (text: string, style: TraceStyle): TraceCell => ({
+  text: style === "none" ? "" : text,
+  style,
+});
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+export type HandwritingLayout = {
+  rule: Rule;
+  box: Box;
+  face: Face;
+  /** The type size the ruling asks for, in mil. */
+  em: Mil;
+  /** How many repeats of the ruling the page holds. */
+  rows: number;
+  /** How many things go on one row — one, for a passage. */
+  perRow: number;
+  /** How many things the page holds altogether. */
+  perPage: number;
+};
+
+/**
+ * How much of the sheet fits, and how it is packed.
+ *
+ * Arithmetic rather than measurement, so the answer is the same in a unit test,
+ * in the build of a catalog page and in the builder's live preview (§4).
+ *
+ * `longest` is the longest thing that will be written, in characters, and it is
+ * what decides how many fit beside each other: a group takes its own width plus
+ * one character of air, so three letters written four times each is a row of
+ * twelve cells and two words written three times each is a row of six. The
+ * mean advance it is counted in is the face's own (`faces.ts`), because
+ * OpenDyslexic is half as wide again as Andika and one shared guess would push
+ * a word off the end of the line in one of them.
+ */
+export function handwritingLayout(
+  config: HandwritingConfig,
+  longest: number,
+): HandwritingLayout {
+  const rule = ruleOf(config);
+  // Against the header the sheet will print rather than the one the config
+  // holds, and with no score box: there is nothing on a handwriting sheet to
+  // mark out of anything.
+  const box = sheetBlockBox(headerOf(config));
+  const face = faceOf(config.font);
+  const em = glyphEm(writingSpace(rule), face);
+  const rows = ruleCapacity(box.height, rule);
+  const times = traceStyles(config).length;
+
+  if (config.style === "passage") {
+    // A line fills the row, so the repeats go down the page: one line takes as
+    // many rows as it is written times.
+    return {
+      rule,
+      box,
+      face,
+      em,
+      rows,
+      perRow: 1,
+      perPage: Math.floor(rows / Math.max(1, times)),
+    };
+  }
+
+  const across = fittedCharacters(box.width, em, face);
+  const perRow = Math.max(1, Math.floor(across / (times * (longest + 1))));
+  return { rule, box, face, em, rows, perRow, perPage: perRow * rows };
+}
+
+/** Everything the sheet writes, before the page has had its say. */
+function contentOf(config: HandwritingConfig): string[] {
+  switch (config.style) {
+    case "numbers":
+      return [...NUMERALS];
+    case "words":
+      return handwritingWords(config);
+    case "passage":
+      return [];
+    default:
+      return own(ALPHABETS, config.letters ?? "both", ALPHABETS.both);
+  }
+}
+
+/** The longest thing on the page, in characters. Never less than one. */
+const longestOf = (things: string[]): number =>
+  things.reduce((most, thing) => Math.max(most, thing.length), 1);
+
+/**
+ * The rows of a sheet whose things are written across the line.
+ *
+ * Every row carries the same number of cells, the last one included: a short
+ * final row left to divide the width between four cells instead of twelve
+ * would set its letters three times as far apart as the row above it, which
+ * looks like a mistake and is one.
+ */
+function rowsAcross(
+  things: string[],
+  styles: TraceStyle[],
+  perRow: number,
+): TraceRow[] {
+  const cells = perRow * styles.length;
+  const rows: TraceRow[] = [];
+  for (let at = 0; at < things.length; at += perRow) {
+    const group = things
+      .slice(at, at + perRow)
+      .flatMap((text) => styles.map((style) => cellOf(text, style)));
+    rows.push({
+      cells: [
+        ...group,
+        ...Array.from({ length: cells - group.length }, () =>
+          cellOf("", "none"),
+        ),
+      ],
+    });
+  }
+  return rows;
+}
+
+/** The rows of a passage: each line written down the page, once per style. */
+const rowsDown = (lines: string[], styles: TraceStyle[]): TraceRow[] =>
+  lines.flatMap((line) =>
+    styles.map((style) => ({ cells: [cellOf(line, style)] })),
+  );
+
+/**
+ * The one block a handwriting sheet is.
+ *
+ * One block and not two, so there is no `BLOCK_GAP` to pay for and no way for
+ * the rules under a passage to drift out of step with the rules it is written
+ * on — the blank places are rows of the same block, drawn by the same renderer
+ * off the same ruling.
+ */
+function bodyOf(config: HandwritingConfig): Block[] {
+  const styles = traceStyles(config);
+
+  if (config.style === "passage") {
+    const { box, em, face, perPage, rule } = handwritingLayout(config, 1);
+    const text = (config.text ?? "").slice(0, MAX_TEXT);
+    const lines = wrapPassage(text, fittedCharacters(box.width, em, face));
+    return [
+      { kind: "trace", rule, rows: rowsDown(lines.slice(0, perPage), styles) },
+    ];
+  }
+
+  const things = contentOf(config);
+  const { perPage, perRow, rule } = handwritingLayout(
+    config,
+    longestOf(things),
+  );
+  return [
+    {
+      kind: "trace",
+      rule,
+      rows: rowsAcross(things.slice(0, perPage), styles, perRow),
+    },
+  ];
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const TITLE: Record<HandwritingStyle, string> = {
+  letters: "Letter practice",
+  numbers: "Number formation",
+  words: "Handwriting practice",
+  passage: "Copywork",
+};
+
+/** What one thing on the page is called, in the instruction line. */
+const NOUN: Record<HandwritingStyle, string> = {
+  letters: "letter",
+  numbers: "number",
+  words: "word",
+  passage: "line",
+};
+
+/**
+ * What the child is being asked to do, read off the row rather than off the
+ * config.
+ *
+ * The four sentences follow from what `traceStyles` actually produced, so a
+ * sheet with nothing dotted on it never says "trace", and a sheet with no empty
+ * place never promises one. The same rule the integers sheet follows when it
+ * decides whether to mention powers.
+ */
+export function instructionOf(config: HandwritingConfig): string {
+  const noun = own(NOUN, config.style, NOUN.letters);
+  const styles = traceStyles(config);
+  const traced = styles.some((style) => OUTLINED.has(style));
+  const alone = styles.includes("none");
+  const where =
+    config.style === "passage" ? "on the line below" : "on your own";
+
+  if (traced && alone) return `Trace each ${noun}, then write it ${where}.`;
+  if (traced) return `Trace each ${noun}.`;
+  if (alone) return `Copy each ${noun} ${where}.`;
+  return `Write each ${noun}.`;
+}
+
+/** How the content is described in one phrase, in the terms it was chosen by. */
+function contentLabel(config: HandwritingConfig): string {
+  switch (config.style) {
+    case "numbers":
+      return "0 to 9";
+    case "words": {
+      const words = handwritingWords(config).length;
+      return `${words} ${words === 1 ? "word" : "words"}`;
+    }
+    case "passage":
+      return "a passage";
+    default:
+      switch (config.letters ?? "both") {
+        case "upper":
+          return "capitals";
+        case "lower":
+          return "small letters";
+        default:
+          return "capitals and small letters";
+      }
+  }
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page — a header the layout under-
+ * reserved for is a row of writing below the bottom margin, which on ⅝ paper
+ * is a second sheet out of the printer.
+ */
+function headerOf(config: HandwritingConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? own(TITLE, config.style, TITLE.letters),
+    instructions: config.instructions ?? instructionOf(config),
+  };
+}
+
+/** One line naming what the sheet holds, for the catalog and the record. */
+export function describeHandwriting(config: HandwritingConfig): string {
+  const styles = traceStyles(config);
+  return [
+    own(TITLE, config.style, TITLE.letters),
+    contentLabel(config),
+    rulingOf(ruleOf(config)).label.toLowerCase(),
+    `written ${styles.length} ${styles.length === 1 ? "time" : "times"}`,
+  ].join(" — ");
+}
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+export function buildHandwritingSheet(
+  config: HandwritingConfig,
+  seed: number,
+): Sheet {
+  const head = headerOf(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+    },
+    blocks: bodyOf(config),
+    // No game to point at. A handwriting sheet has no race behind it — the
+    // words on one may come from the jungle, but what is being practised is the
+    // shape of the letters and not the spelling (§16).
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const HANDWRITING_SHEET: SheetSpec<HandwritingConfig> = {
+  id: "handwriting",
+  label: "Handwriting practice",
+  world: SHEET_WORLD,
+  build: buildHandwritingSheet,
+  // Returned as-is rather than with `answers: true`, for the same reason blank
+  // paper is: there is nothing on a handwriting sheet that has a right answer,
+  // and a key indistinguishable from its sheet should also be identical to it.
+  key: (sheet) => sheet,
+  describe: describeHandwriting,
+};

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -42,13 +42,21 @@ const TABLES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 const DENOMINATORS = [2, 3, 4, 5, 6, 8, 10, 12];
 
 /**
- * A list to open the spelling family on, from the shipped sight words.
+ * The first sight words: what a first word list is made of, wherever one is
+ * needed.
  *
- * Twelve rather than the whole list, because the sheet is a starting point
- * somebody replaces rather than the sheet they came for — and a page of forty
- * words written three times each is a page that fits nothing else.
+ * Taken from the list the jungle already ships rather than typed out again, so
+ * the words a child is racing on screen are the words they are writing on
+ * paper. Twelve rather than the whole list, because a page of forty words
+ * written three times each is a page that fits nothing else — and because the
+ * sheet is a starting point somebody replaces rather than the sheet they came
+ * for.
+ *
+ * Exported because the catalog's own sight-word sheet is meant to be the sheet
+ * the bench opens on (`pages/printables/_handwriting.ts`), and two slices of
+ * the same list are two lists that can quietly stop matching.
  */
-const STARTER_WORDS = listWords(WORD_LISTS[0]).slice(0, 12);
+export const STARTER_WORDS = listWords(WORD_LISTS[0]).slice(0, 12);
 
 /**
  * A passage to open the copywork style on.

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -50,6 +50,18 @@ const DENOMINATORS = [2, 3, 4, 5, 6, 8, 10, 12];
  */
 const STARTER_WORDS = listWords(WORD_LISTS[0]).slice(0, 12);
 
+/**
+ * A passage to open the copywork style on.
+ *
+ * A pangram first, because a sentence set for handwriting is chosen for the
+ * letters it uses rather than for what it says, and this one uses all of them.
+ * The second line is there so the box arrives holding two lines: a passage is
+ * broken where the paper runs out, and a parent who has never seen that happen
+ * would not know a newline of their own is honoured.
+ */
+const PASSAGE =
+  "The quick brown fox jumps over the lazy dog.\nGood handwriting is slow before it is neat.";
+
 const DEFAULTS: Record<string, SheetConfig> = {
   blank: { ...BASE, kind: "blank", title: "Blank sheet" },
   paper: { ...BASE, kind: "paper", rule: { style: "wide" } },
@@ -188,6 +200,21 @@ const DEFAULTS: Record<string, SheetConfig> = {
     gaps: 2,
     count: STARTER_WORDS.length,
     columns: 2,
+  },
+  handwriting: {
+    ...BASE,
+    kind: "handwriting",
+    style: "letters",
+    // The ⅝ rule with a tail space, which is what a school means by
+    // "handwriting paper" — and the sheet a parent is likeliest to want first.
+    rule: { style: "hand-5-8", midline: "dashed", descender: true },
+    letters: "both",
+    trace: "dotted",
+    // Three: a model, a trace, and the place where they are on their own. Also
+    // what puts the whole alphabet on one page at this rule size.
+    repeats: 3,
+    words: STARTER_WORDS,
+    text: PASSAGE,
   },
   "word-problems": {
     ...BASE,

--- a/src/games/printshop/options/handwriting.tsx
+++ b/src/games/printshop/options/handwriting.tsx
@@ -1,0 +1,172 @@
+/**
+ * Handwriting: the ruling, the model, and how many times over.
+ *
+ * Four questions, and every one of them is on the page rather than behind a
+ * mode: which paper, what is written on it, how the model is drawn, and how
+ * many times each thing is written before the child is left on their own. The
+ * §17 line "ruling and rule size · line spacing" is the first of those, and it
+ * is the same control the paper family uses — on ruled paper the spacing
+ * between the lines *is* the ruling.
+ *
+ * What is written changes with the style and nothing else does, which is why
+ * only one content control is on screen at a time: a word list on a sheet of
+ * the alphabet is a box that does nothing, and a box that does nothing is worse
+ * than a missing one.
+ */
+import { MAX_REPEATS } from "@/engine/sheets/writing/handwriting";
+import { RULINGS, rulingOf } from "@/engine/sheets/paper";
+import type {
+  HandwritingConfig,
+  HandwritingStyle,
+  LetterCase,
+  Midline,
+  RuleStyle,
+  TraceStyle,
+} from "@/engine/sheets/types";
+
+import {
+  Checkbox,
+  Field,
+  FieldSet,
+  NumberStepper,
+  TextArea,
+} from "@/components/ui/kit";
+import { parseWords } from "@/services/decks";
+
+import { Choice, WordList, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<HandwritingStyle>("letters", "Letters"),
+  opt<HandwritingStyle>("numbers", "Numbers"),
+  opt<HandwritingStyle>("words", "Words"),
+  opt<HandwritingStyle>("passage", "Passage"),
+];
+
+const CASES = [
+  opt<LetterCase>("both", "Aa", "both cases"),
+  opt<LetterCase>("upper", "A", "capitals"),
+  opt<LetterCase>("lower", "a", "small letters"),
+];
+
+/** The five appearances of §6, plus the sheet with nothing to trace at all. */
+const TRACES = [
+  opt<TraceStyle>("dotted", "Dotted", "the usual"),
+  opt<TraceStyle>("dashed", "Dashed"),
+  opt<TraceStyle>("hollow", "Hollow"),
+  opt<TraceStyle>("dim", "Grey"),
+  opt<TraceStyle>("solid", "Solid"),
+  opt<TraceStyle>("none", "None", "a model, then empty lines"),
+];
+
+const RULES = Object.values(RULINGS).map((ruling) =>
+  opt<RuleStyle>(ruling.id, ruling.label),
+);
+
+const MIDLINES = [
+  opt<Midline>("dashed", "Dashed", "the usual"),
+  opt<Midline>("solid", "Solid", "youngest"),
+  opt<Midline>("none", "None", "oldest"),
+];
+
+export function HandwritingPanel({
+  config,
+  set,
+}: PanelProps<HandwritingConfig>) {
+  const ruling = rulingOf(config.rule);
+  const rule = (patch: Partial<HandwritingConfig["rule"]>) =>
+    set({ rule: { ...config.rule, ...patch } });
+
+  return (
+    <>
+      <Choice
+        label="What to write"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+
+      {config.style === "letters" && (
+        <Choice
+          label="Which letters"
+          value={config.letters ?? "both"}
+          onChange={(letters) => set({ letters })}
+          options={CASES}
+          hint="Both cases writes each letter as a pair — Aa, then Bb."
+        />
+      )}
+
+      {config.style === "words" && (
+        <WordList
+          label="Words"
+          text={(config.words ?? []).join("\n")}
+          onChange={(text) => set({ words: parseWords(text) })}
+        />
+      )}
+
+      {config.style === "passage" && (
+        <Field
+          label="Passage"
+          hint="Broken where the line runs out. A line break of your own is kept."
+        >
+          <TextArea
+            value={config.text ?? ""}
+            rows={4}
+            onChange={(text) => set({ text })}
+          />
+        </Field>
+      )}
+
+      <Choice
+        label="Ruling and line spacing"
+        value={config.rule.style}
+        onChange={(style) => rule({ style })}
+        options={RULES}
+        hint="Handwriting sizes are named by the space between one set of lines and the next."
+      />
+
+      {ruling.handwriting && (
+        <>
+          <Choice
+            label="Midline"
+            value={config.rule.midline ?? "dashed"}
+            onChange={(midline) => rule({ midline })}
+            options={MIDLINES}
+          />
+          <Checkbox
+            label="Room for descenders"
+            hint="Space below the baseline for the tail of a g."
+            checked={config.rule.descender === true}
+            onChange={(descender) => rule({ descender })}
+          />
+        </>
+      )}
+
+      <Choice
+        label="How the model is drawn"
+        value={config.trace}
+        onChange={(trace) => set({ trace })}
+        options={TRACES}
+      />
+
+      <FieldSet
+        legend="Times each is written"
+        hint="Capped at what the line holds."
+      >
+        <NumberStepper
+          label="Times each is written"
+          value={config.repeats}
+          min={1}
+          max={MAX_REPEATS}
+          onChange={(repeats) => set({ repeats })}
+        />
+      </FieldSet>
+
+      <Checkbox
+        label="Trace, then write it alone"
+        hint="A solid model first and an empty place last, with the tracing in between."
+        checked={config.progression !== false}
+        onChange={(progression) => set({ progression })}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/handwriting.tsx
+++ b/src/games/printshop/options/handwriting.tsx
@@ -4,9 +4,12 @@
  * Four questions, and every one of them is on the page rather than behind a
  * mode: which paper, what is written on it, how the model is drawn, and how
  * many times each thing is written before the child is left on their own. The
- * §17 line "ruling and rule size · line spacing" is the first of those, and it
- * is the same control the paper family uses — on ruled paper the spacing
- * between the lines *is* the ruling.
+ * first of those is `RulingControls`, the same control the paper family uses —
+ * literally the same one, because on ruled paper the spacing between the lines
+ * *is* the ruling and there is no version of that question specific to
+ * handwriting. All it passes is a shorter list: blank paper has no pitch, so it
+ * has no rows to write on, and offering it would name a ruling the sheet then
+ * quietly refuses (`ruleOf`).
  *
  * What is written changes with the style and nothing else does, which is why
  * only one content control is on screen at a time: a word list on a sheet of
@@ -14,13 +17,10 @@
  * than a missing one.
  */
 import { MAX_REPEATS } from "@/engine/sheets/writing/handwriting";
-import { RULINGS, rulingOf } from "@/engine/sheets/paper";
 import type {
   HandwritingConfig,
   HandwritingStyle,
   LetterCase,
-  Midline,
-  RuleStyle,
   TraceStyle,
 } from "@/engine/sheets/types";
 
@@ -33,7 +33,14 @@ import {
 } from "@/components/ui/kit";
 import { parseWords } from "@/services/decks";
 
-import { Choice, WordList, opt, type PanelProps } from "./parts";
+import {
+  Choice,
+  RULED_STYLES,
+  RulingControls,
+  WordList,
+  opt,
+  type PanelProps,
+} from "./parts";
 
 const STYLES = [
   opt<HandwritingStyle>("letters", "Letters"),
@@ -58,24 +65,10 @@ const TRACES = [
   opt<TraceStyle>("none", "None", "a model, then empty lines"),
 ];
 
-const RULES = Object.values(RULINGS).map((ruling) =>
-  opt<RuleStyle>(ruling.id, ruling.label),
-);
-
-const MIDLINES = [
-  opt<Midline>("dashed", "Dashed", "the usual"),
-  opt<Midline>("solid", "Solid", "youngest"),
-  opt<Midline>("none", "None", "oldest"),
-];
-
 export function HandwritingPanel({
   config,
   set,
 }: PanelProps<HandwritingConfig>) {
-  const ruling = rulingOf(config.rule);
-  const rule = (patch: Partial<HandwritingConfig["rule"]>) =>
-    set({ rule: { ...config.rule, ...patch } });
-
   return (
     <>
       <Choice
@@ -116,30 +109,11 @@ export function HandwritingPanel({
         </Field>
       )}
 
-      <Choice
-        label="Ruling and line spacing"
-        value={config.rule.style}
-        onChange={(style) => rule({ style })}
-        options={RULES}
-        hint="Handwriting sizes are named by the space between one set of lines and the next."
+      <RulingControls
+        rule={config.rule}
+        onChange={(patch) => set({ rule: { ...config.rule, ...patch } })}
+        options={RULED_STYLES}
       />
-
-      {ruling.handwriting && (
-        <>
-          <Choice
-            label="Midline"
-            value={config.rule.midline ?? "dashed"}
-            onChange={(midline) => rule({ midline })}
-            options={MIDLINES}
-          />
-          <Checkbox
-            label="Room for descenders"
-            hint="Space below the baseline for the tail of a g."
-            checked={config.rule.descender === true}
-            onChange={(descender) => rule({ descender })}
-          />
-        </>
-      )}
 
       <Choice
         label="How the model is drawn"

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -23,6 +23,7 @@ import { ArithmeticPanel } from "./arithmetic";
 import { DecimalsPanel } from "./decimals";
 import { FractionsPanel } from "./fractions";
 import { GeometryPanel } from "./geometry";
+import { HandwritingPanel } from "./handwriting";
 import { IntegersPanel } from "./integers";
 import { MeasurePanel } from "./measure";
 import { MoneyPanel } from "./money";
@@ -86,6 +87,7 @@ const PANELS: Record<string, FamilyPanel> = {
   statistics: panel(StatisticsPanel),
   "word-problems": panel(WordProblemsPanel),
   words: panel(WordsPanel),
+  handwriting: panel(HandwritingPanel),
 };
 
 /**

--- a/src/games/printshop/options/paper.tsx
+++ b/src/games/printshop/options/paper.tsx
@@ -1,97 +1,20 @@
 /**
  * Lined, ruled, graph, dot and isometric paper.
  *
- * The one family whose options are the §17 line "ruling and rule size · line
- * spacing", all three of which are the same question here: on ruled paper the
- * spacing between the lines *is* the ruling, which is why the sizes are named
- * by their pitch — a teacher says "we're on ⅝ paper this year", not "we're on
- * handwriting paper at spacing four".
- *
- * The two extras appear only where they mean something. A midline and descender
- * space belong to a handwriting rule and nothing else; a square belongs to the
- * three rulings that repeat across the page as well as down it. Showing them
- * greyed out on narrow ruled would be offering a choice that does nothing.
+ * The one family whose options are nothing but the ruling — so the panel is the
+ * shared `RulingControls` and not a line more. Why the sizes are named by their
+ * pitch, and why the midline, the descender space and the square appear only
+ * where they mean something, is written once beside that control in `parts.tsx`.
  */
-import { GRID_PITCHES, RULINGS, rulingOf } from "@/engine/sheets/paper";
-import type {
-  Midline,
-  PaperConfig,
-  RuleStyle,
-  Mil,
-} from "@/engine/sheets/types";
+import type { PaperConfig } from "@/engine/sheets/types";
 
-import { Checkbox } from "@/components/ui/kit";
-
-import { Choice, opt, type PanelProps } from "./parts";
-
-const STYLES = Object.values(RULINGS).map((ruling) =>
-  opt<RuleStyle>(ruling.id, ruling.label),
-);
-
-const MIDLINES = [
-  opt<Midline>("dashed", "Dashed", "the usual"),
-  opt<Midline>("solid", "Solid", "youngest"),
-  opt<Midline>("none", "None", "oldest"),
-];
-
-/** The squares of §5, labelled the way the paper is sold. */
-const SQUARES = [
-  opt("quarter-inch", "¼ in"),
-  opt("fifth-inch", "⅕ in"),
-  opt("centimetre", "1 cm"),
-  opt("half-centimetre", "5 mm"),
-];
-
-type Square = keyof typeof GRID_PITCHES;
+import { RulingControls, type PanelProps } from "./parts";
 
 export function PaperPanel({ config, set }: PanelProps<PaperConfig>) {
-  const ruling = rulingOf(config.rule);
-  const rule = (patch: Partial<PaperConfig["rule"]>) =>
-    set({ rule: { ...config.rule, ...patch } });
-
-  // Which square is chosen, read back off the pitch rather than stored beside
-  // it: `Rule` holds a length, and a second field naming the same thing is a
-  // second thing that can disagree with it.
-  const square =
-    (Object.keys(GRID_PITCHES) as Square[]).find(
-      (key) => GRID_PITCHES[key] === config.rule.pitch,
-    ) ?? "quarter-inch";
-
   return (
-    <>
-      <Choice
-        label="Ruling and line spacing"
-        value={config.rule.style}
-        onChange={(style) => rule({ style })}
-        options={STYLES}
-        hint="Handwriting sizes are named by the space between one set of lines and the next."
-      />
-
-      {ruling.handwriting && (
-        <>
-          <Choice
-            label="Midline"
-            value={config.rule.midline ?? "dashed"}
-            onChange={(midline) => rule({ midline })}
-            options={MIDLINES}
-          />
-          <Checkbox
-            label="Room for descenders"
-            hint="Space below the baseline for the tail of a g."
-            checked={config.rule.descender === true}
-            onChange={(descender) => rule({ descender })}
-          />
-        </>
-      )}
-
-      {ruling.grid && (
-        <Choice
-          label="Square"
-          value={square}
-          onChange={(next) => rule({ pitch: GRID_PITCHES[next] as Mil })}
-          options={SQUARES}
-        />
-      )}
-    </>
+    <RulingControls
+      rule={config.rule}
+      onChange={(patch) => set({ rule: { ...config.rule, ...patch } })}
+    />
   );
 }

--- a/src/games/printshop/options/parts.tsx
+++ b/src/games/printshop/options/parts.tsx
@@ -1,12 +1,16 @@
 /**
- * The four shapes an option on a worksheet takes.
+ * The shapes an option on a worksheet takes.
  *
  * Fifteen families ask fifteen different questions, but they ask them in almost
- * the same four ways: pick one of a handful, set a low and a high number, say
+ * the same few ways: pick one of a handful, set a low and a high number, say
  * how many problems and how many columns, and tick which of a pool are in play.
- * Writing those four once is what keeps a family's panel down to the sentences
- * that are true of *that* family — see `arithmetic.tsx`, which is a dozen lines
+ * Writing those once is what keeps a family's panel down to the sentences that
+ * are true of *that* family — see `arithmetic.tsx`, which is a dozen lines
  * because everything generic about it is here.
+ *
+ * `RulingControls` is the one that is a whole question rather than a shape: two
+ * families put a ruling on paper and there is only one right way to ask for
+ * one, so it lives here beside the primitives rather than twice in the panels.
  *
  * Every control is a kit primitive underneath. Nothing in this directory
  * hand-rolls an `<input>`, a `<select>` or a `<label>`; if something is missing
@@ -25,7 +29,14 @@ import {
   TextArea,
   type SegmentedOption,
 } from "@/components/ui/kit";
-import type { SheetConfig } from "@/engine/sheets/types";
+import { GRID_PITCHES, RULINGS, rulingOf } from "@/engine/sheets/paper";
+import type {
+  Midline,
+  Mil,
+  Rule,
+  RuleStyle,
+  SheetConfig,
+} from "@/engine/sheets/types";
 import { parseWords } from "@/services/decks";
 
 /**
@@ -89,6 +100,119 @@ export function Choice<T extends string>({
         />
       )}
     </FieldSet>
+  );
+}
+
+/* ── The ruling ────────────────────────────────────────────────────────────
+   Two families ask this question — the paper sheet, whose whole content is the
+   ruling, and the handwriting sheet, which is written on one — and they have
+   to ask it identically. A ruling added to §5, or a hint reworded, is one edit
+   here rather than two that can be made singly.                             */
+
+/** Every ruling in §5, in the order `RULINGS` declares them. */
+export const RULE_STYLES = Object.values(RULINGS).map((ruling) =>
+  opt<RuleStyle>(ruling.id, ruling.label),
+);
+
+/**
+ * The same list without blank paper.
+ *
+ * For a family that writes *on* the ruling: a ruling with no pitch has no rows
+ * to write on, so `ruleOf` swaps it for the ⅝ rule and the control would read
+ * "Blank" over a sheet that plainly isn't. The engine keeps that fallback for
+ * saved and shared configs; a control offering the choice at all is the part
+ * that was wrong.
+ */
+export const RULED_STYLES = RULE_STYLES.filter(
+  (option) => option.value !== "blank",
+);
+
+const MIDLINES = [
+  opt<Midline>("dashed", "Dashed", "the usual"),
+  opt<Midline>("solid", "Solid", "youngest"),
+  opt<Midline>("none", "None", "oldest"),
+];
+
+/** The squares of §5, labelled the way the paper is sold. */
+const SQUARES = [
+  opt("quarter-inch", "¼ in"),
+  opt("fifth-inch", "⅕ in"),
+  opt("centimetre", "1 cm"),
+  opt("half-centimetre", "5 mm"),
+];
+
+type Square = keyof typeof GRID_PITCHES;
+
+/**
+ * Which paper, and the two extras that only some papers have.
+ *
+ * The §17 line "ruling and rule size · line spacing", all three of which are
+ * one question: on ruled paper the spacing between the lines *is* the ruling,
+ * which is why the sizes are named by their pitch — a teacher says "we're on ⅝
+ * paper this year", not "we're on handwriting paper at spacing four".
+ *
+ * The extras appear only where they mean something. A midline and descender
+ * space belong to a handwriting rule and nothing else; a square belongs to the
+ * three rulings that repeat across the page as well as down it. Showing them
+ * greyed out on narrow ruled would be offering a choice that does nothing.
+ */
+export function RulingControls({
+  rule,
+  onChange,
+  options = RULE_STYLES,
+}: {
+  rule: Rule;
+  /** A patch onto the rule, merged by the family that owns it. */
+  onChange: (patch: Partial<Rule>) => void;
+  /** Which rulings this family can honour. Every one of them, unless said. */
+  options?: SegmentedOption<RuleStyle>[];
+}) {
+  const ruling = rulingOf(rule);
+
+  // Which square is chosen, read back off the pitch rather than stored beside
+  // it: `Rule` holds a length, and a second field naming the same thing is a
+  // second thing that can disagree with it.
+  const square =
+    (Object.keys(GRID_PITCHES) as Square[]).find(
+      (key) => GRID_PITCHES[key] === rule.pitch,
+    ) ?? "quarter-inch";
+
+  return (
+    <>
+      <Choice
+        label="Ruling and line spacing"
+        value={rule.style}
+        onChange={(style) => onChange({ style })}
+        options={options}
+        hint="Handwriting sizes are named by the space between one set of lines and the next."
+      />
+
+      {ruling.handwriting && (
+        <>
+          <Choice
+            label="Midline"
+            value={rule.midline ?? "dashed"}
+            onChange={(midline) => onChange({ midline })}
+            options={MIDLINES}
+          />
+          <Checkbox
+            label="Room for descenders"
+            hint="Space below the baseline for the tail of a g."
+            checked={rule.descender === true}
+            onChange={(descender) => onChange({ descender })}
+          />
+        </>
+      )}
+
+      {ruling.grid && (
+        <Choice
+          label="Square"
+          value={square}
+          onChange={(next) => onChange({ pitch: GRID_PITCHES[next] as Mil })}
+          options={SQUARES}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/pages/printables/_handwriting.test.ts
+++ b/src/pages/printables/_handwriting.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet } from "@/engine/sheets";
 import type { HandwritingConfig, TraceRow } from "@/engine/sheets/types";
+import { MODELLED } from "@/engine/sheets/writing/handwriting";
 
 import { PAPER_SHEETS, STOCKS, pathFor as paperPath } from "./_catalog";
 import { MATHS_SHEETS, pathFor as mathsPath } from "./_maths";
@@ -186,9 +187,7 @@ describe("the sheet on a catalog page", () => {
       expect(styles.has("solid"), `${sheet.slug} has a model`).toBe(true);
       expect(styles.has("none"), `${sheet.slug} has an empty place`).toBe(true);
       expect(
-        [...styles].some((style) =>
-          ["dim", "hollow", "dotted", "dashed"].includes(style),
-        ),
+        [...styles].some((style) => MODELLED.has(style)),
         `${sheet.slug} has something to trace`,
       ).toBe(true);
     }

--- a/src/pages/printables/_handwriting.test.ts
+++ b/src/pages/printables/_handwriting.test.ts
@@ -1,0 +1,268 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet } from "@/engine/sheets";
+import type { HandwritingConfig, TraceRow } from "@/engine/sheets/types";
+
+import { PAPER_SHEETS, STOCKS, pathFor as paperPath } from "./_catalog";
+import { MATHS_SHEETS, pathFor as mathsPath } from "./_maths";
+import {
+  HANDWRITING_GROUPS,
+  HANDWRITING_SEED,
+  HANDWRITING_SHEETS,
+  builderHref,
+  configFor,
+  handwritingShelf,
+  hrefFor,
+} from "./_handwriting";
+
+/**
+ * The handwriting catalog, held to the three things a catalog page has to be —
+ * and to the one thing only this family has to be.
+ *
+ * **It has to be a worksheet.** Every entry is prerendered as the page a parent
+ * lands on (§8), so an entry whose config produces an empty page is a URL in the
+ * sitemap with nothing on it.
+ *
+ * **It has to be curated.** No two entries print the same sheet, no two answer
+ * the same query, and every one carries prose somebody wrote.
+ *
+ * **It has to be reachable.** Every slug in the sitemap, and every slug distinct
+ * from the two catalogs that share the prefix.
+ *
+ * **And it has to print everything it promised.** A count is a request
+ * everywhere else in the shop, capped at what the page holds. Here the content
+ * is not a count but a set — the alphabet, the ten numerals, a poem — and a
+ * page that quietly dropped `y` and `z` off the bottom would teach twenty-four
+ * letters while looking exactly like a sheet that teaches twenty-six.
+ */
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+const UPPER = [..."ABCDEFGHIJKLMNOPQRSTUVWXYZ"];
+
+/** Everything the sheet writes, worked out from the config and not from the family. */
+function promised(config: HandwritingConfig): string[] {
+  switch (config.style) {
+    case "numbers":
+      return [..."0123456789"];
+    case "words":
+      return config.words ?? [];
+    case "passage":
+      return (config.text ?? "").split(/\s+/).filter((word) => word !== "");
+    default:
+      switch (config.letters ?? "both") {
+        case "upper":
+          return UPPER;
+        case "lower":
+          return UPPER.map((letter) => letter.toLowerCase());
+        default:
+          return UPPER.map((letter) => `${letter}${letter.toLowerCase()}`);
+      }
+  }
+}
+
+/** Everything that is actually printed on it, empty places dropped. */
+function printed(config: HandwritingConfig): string[] {
+  const rows = buildSheet(config, HANDWRITING_SEED).blocks.flatMap(
+    (block): TraceRow[] => (block.kind === "trace" ? block.rows : []),
+  );
+  return rows.flatMap((row) =>
+    row.cells.map((cell) => cell.text).filter((text) => text !== ""),
+  );
+}
+
+describe("the handwriting catalog", () => {
+  it("is bounded, and every slug is a route somebody could type", () => {
+    for (const sheet of HANDWRITING_SHEETS) {
+      expect(sheet.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+    expect(new Set(HANDWRITING_SHEETS.map((sheet) => sheet.slug)).size).toBe(
+      HANDWRITING_SHEETS.length,
+    );
+  });
+
+  it("never claims a path that paper or maths already prints on", () => {
+    // Three route patterns over one prefix. They only coexist because the paths
+    // they emit are disjoint; the day they are not, Astro has two routes for
+    // one URL and picks one of them.
+    const taken = new Set([
+      ...PAPER_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => `/printables/${paperPath(sheet, stock)}`),
+      ),
+      ...MATHS_SHEETS.map((sheet) => mathsPath(sheet)),
+    ]);
+    for (const sheet of HANDWRITING_SHEETS) {
+      for (const stock of STOCKS) {
+        expect(taken.has(hrefFor(sheet, stock)), sheet.slug).toBe(false);
+      }
+    }
+  });
+
+  it("answers a different query on every page", () => {
+    const fields = ["keyword", "heading", "name", "short"] as const;
+    for (const field of fields) {
+      const values = HANDWRITING_SHEETS.map((sheet) => sheet[field]);
+      expect(new Set(values).size, `duplicate ${field}`).toBe(values.length);
+    }
+  });
+
+  it("prints a different sheet on every page", () => {
+    const configs = HANDWRITING_SHEETS.map((sheet) =>
+      JSON.stringify(sheet.config),
+    );
+    expect(new Set(configs).size).toBe(configs.length);
+  });
+
+  it("carries prose on every page rather than a filled-in template", () => {
+    for (const sheet of HANDWRITING_SHEETS) {
+      expect(sheet.notes.length, sheet.slug).toBeGreaterThanOrEqual(2);
+      for (const note of sheet.notes) {
+        expect(note.length, sheet.slug).toBeGreaterThan(200);
+      }
+      expect(sheet.lead.length, sheet.slug).toBeGreaterThan(80);
+      expect(sheet.summary.length, sheet.slug).toBeGreaterThan(40);
+      expect(sheet.teaches, sheet.slug).not.toBe("");
+      expect(sheet.ages, sheet.slug).toMatch(/^Ages /);
+    }
+  });
+
+  it("shelves every sheet exactly once", () => {
+    const shelved = handwritingShelf().flatMap((group) => group.sheets);
+    expect(shelved).toHaveLength(HANDWRITING_SHEETS.length);
+    expect(handwritingShelf().every((group) => group.sheets.length > 0)) //
+      .toBe(true);
+    expect(HANDWRITING_GROUPS).toHaveLength(handwritingShelf().length);
+  });
+
+  it("covers the whole of what the story asked for", () => {
+    // Letters in both cases, numerals, words and a passage — one page each, so
+    // that "trace, then copy, then write" is a thing a parent can print rather
+    // than a thing the engine can do.
+    const styles = HANDWRITING_SHEETS.map((sheet) => sheet.config.style);
+    expect(new Set(styles)).toEqual(
+      new Set(["letters", "numbers", "words", "passage"]),
+    );
+    const cases = HANDWRITING_SHEETS.filter(
+      (sheet) => sheet.config.style === "letters",
+    ).map((sheet) => sheet.config.letters);
+    expect(new Set(cases)).toEqual(new Set(["both", "upper", "lower"]));
+  });
+});
+
+describe("the sheet on a catalog page", () => {
+  it("prints every letter, numeral, word and line it promised", () => {
+    // The check this family needs and the maths one doesn't: the content is a
+    // set rather than a count, so "as many as fit" is not an acceptable answer.
+    for (const sheet of HANDWRITING_SHEETS) {
+      for (const stock of STOCKS) {
+        const config = configFor(sheet, stock.id);
+        const on = printed(config);
+        // A passage is checked word by word, because the family decides where
+        // the lines break and the page must still hold all of the poem.
+        const words =
+          config.style === "passage"
+            ? on.flatMap((line) => line.split(/\s+/))
+            : on;
+        for (const thing of promised(config)) {
+          expect(words, `${sheet.slug} on ${stock.id}`).toContain(thing);
+        }
+      }
+    }
+  });
+
+  it("walks the child from a model to an empty line, on every page", () => {
+    // The story in one assertion. Every catalog sheet has a solid model to look
+    // at, something to trace, and a place where nobody is helping.
+    for (const sheet of HANDWRITING_SHEETS) {
+      const [block] = buildSheet(sheet.config, HANDWRITING_SEED).blocks;
+      expect(block.kind, sheet.slug).toBe("trace");
+      if (block.kind !== "trace") continue;
+      const styles = new Set(
+        block.rows.flatMap((row) => row.cells.map((cell) => cell.style)),
+      );
+      expect(styles.has("solid"), `${sheet.slug} has a model`).toBe(true);
+      expect(styles.has("none"), `${sheet.slug} has an empty place`).toBe(true);
+      expect(
+        [...styles].some((style) =>
+          ["dim", "hollow", "dotted", "dashed"].includes(style),
+        ),
+        `${sheet.slug} has something to trace`,
+      ).toBe(true);
+    }
+  });
+
+  it("has a title and an instruction on it", () => {
+    for (const sheet of HANDWRITING_SHEETS) {
+      const built = buildSheet(sheet.config, HANDWRITING_SEED);
+      expect(built.header.title, sheet.slug).not.toBe("");
+      expect(built.header.instructions, sheet.slug).toBeTruthy();
+      // Nothing to mark: there is no right answer on a handwriting sheet, so a
+      // score box would be a number nobody can award.
+      expect(built.header.score, sheet.slug).toBeUndefined();
+    }
+  });
+
+  it("is the same sheet on every build, and its own answer key", () => {
+    for (const sheet of HANDWRITING_SHEETS) {
+      expect(JSON.stringify(buildSheet(sheet.config, HANDWRITING_SEED))).toBe(
+        JSON.stringify(buildSheet(sheet.config, HANDWRITING_SEED)),
+      );
+      // The model is already printed, which is the whole exercise — so the key
+      // is the sheet, exactly as it is for blank paper.
+      expect(
+        JSON.stringify(answerKey(sheet.config, HANDWRITING_SEED)),
+        sheet.slug,
+      ).toBe(JSON.stringify(buildSheet(sheet.config, HANDWRITING_SEED)));
+    }
+  });
+});
+
+describe("the link into the builder", () => {
+  it("opens the bench on the sheet that was printed, on the right stock", () => {
+    for (const sheet of HANDWRITING_SHEETS) {
+      for (const stock of STOCKS) {
+        const href = builderHref(sheet, stock);
+        expect(href.startsWith("/printables/make#s=")).toBe(true);
+
+        const payload = href.slice("/printables/make#s=".length);
+        const base64 = payload.replaceAll("-", "+").replaceAll("_", "/");
+        const shared = JSON.parse(
+          atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")),
+        );
+        expect(shared).toEqual({
+          config: configFor(sheet, stock.id),
+          seed: HANDWRITING_SEED,
+        });
+      }
+    }
+  });
+});
+
+describe("the sitemap", () => {
+  /*
+   * A URL missing from the sitemap is the failure nobody notices — nothing
+   * breaks, the page is simply never submitted. Skipped when there is no
+   * `dist/`, exactly as the maths one is; CI builds before it runs the suite.
+   */
+  it("carries every handwriting slug, on both stocks, and the hub", () => {
+    const file = `${ROOT}/dist/sitemap-0.xml`;
+    if (!existsSync(file)) return; // `npm run build` hasn't run yet.
+
+    const xml = readFileSync(file, "utf8");
+    const found = new Set(
+      [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) =>
+        new URL(match[1]).pathname.replace(/\/$/, ""),
+      ),
+    );
+
+    expect(found.has("/printables/handwriting")).toBe(true);
+    for (const sheet of HANDWRITING_SHEETS) {
+      for (const stock of STOCKS) {
+        expect(found.has(hrefFor(sheet, stock)), sheet.slug).toBe(true);
+      }
+    }
+  });
+});

--- a/src/pages/printables/_handwriting.ts
+++ b/src/pages/printables/_handwriting.ts
@@ -1,0 +1,422 @@
+/**
+ * The handwriting sheets the Print Shop has set, and the words that go round
+ * them.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data two pages
+ * share — `handwriting/[...slug].astro`, which prerenders one sheet per entry,
+ * and `handwriting/index.astro`, which is the subject hub — rather than a route
+ * of its own. `_catalog.ts` does the same job for paper and `_maths.ts` for
+ * maths, and the three are deliberately separate: a ruling, a set of problems
+ * and a letter to trace have almost nothing to say about each other.
+ *
+ * **The slugs are curated; the sheets are generated.** §8 is explicit about why.
+ * The family can rule any of twelve papers, write four kinds of content on it in
+ * six letterforms and repeat each of them up to eight times — tens of thousands
+ * of plausible pages, none of them written for. So: seven slugs, each one a
+ * phrase a parent types, each with two paragraphs true of that sheet and of no
+ * other, and everything else reached through the builder, which is where
+ * *choosing* belongs.
+ *
+ * **Two stocks, as with paper and unlike maths.** A handwriting sheet is the one
+ * kind of worksheet whose whole content is a measurement: a ⅝ rule sent to a
+ * printer loaded with A4 is scaled to fit, and a scaled ⅝ rule is not a ⅝ rule.
+ * `@page` is a document rule, so the two cannot share a page — hence a route
+ * each, exactly as `_catalog.ts` argues.
+ */
+import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
+import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
+import { encodeSharedSheet } from "@/engine/sheets/share";
+import type {
+  HandwritingConfig,
+  HeaderField,
+  Paper,
+  PaperSize,
+} from "@/engine/sheets/types";
+
+import { STOCKS, type Stock } from "./_catalog";
+
+/** How the hub groups the shelf: what is being written, in the order it is learnt. */
+export type HandwritingGroup = "letters" | "words" | "passages";
+
+export type HandwritingSheet = {
+  /** The route under /printables/handwriting, and the head term it answers. */
+  slug: string;
+  /** How it is listed on a hub. */
+  name: string;
+  /** How it is labelled in the row of neighbouring sheets. A few words. */
+  short: string;
+  /** The page's `<h1>`. */
+  heading: string;
+  /** The query this page exists to answer, in the words a parent types. */
+  keyword: string;
+  /** One sentence of what is on the sheet. Used in the description and hubs. */
+  summary: string;
+  /** The lead paragraph: what the sheet asks for, stated plainly. */
+  lead: string;
+  /** Two things that are true of this sheet and not of the one beside it. */
+  notes: string[];
+  /** For the `LearningResource` block. */
+  teaches: string;
+  ages: string;
+  group: HandwritingGroup;
+  /** Where the words on it came from, printed under the sheet where it matters. */
+  credit?: string;
+  /** The sheet itself. Prerendered at build time — this IS the page (§8). */
+  config: HandwritingConfig;
+};
+
+/**
+ * The seed every handwriting sheet is built from, and it never moves.
+ *
+ * Nothing in this family is drawn at random — an alphabet is an alphabet — so
+ * the seed decides nothing about the page and only prints in the footer. It is
+ * still fixed and still carried into the builder link, because §7's promise is
+ * about the whole shop: the number on the paper is what gets you the identical
+ * sheet back, whichever family printed it.
+ */
+export const HANDWRITING_SEED = 1;
+
+/** Portrait, half-inch margins — the stock is the only thing that varies. */
+const paperOf = (size: PaperSize): Paper => ({
+  size,
+  orientation: "portrait",
+  margin: "normal",
+});
+
+/**
+ * Printed blank, always, and the reason there is no third field.
+ *
+ * A worksheet asks for a name because a teacher has thirty of them to hand
+ * back. Nothing here holds one (§1): these are two ruled lines on paper and
+ * there is nowhere in a config to put a value for either.
+ */
+const FIELDS: HeaderField[] = ["name", "date"];
+
+/**
+ * The first sight words, which is what a first handwriting list is made of.
+ *
+ * Taken from the list the jungle already ships rather than typed out again, so
+ * the words a child is racing on screen are the words they are writing on
+ * paper — and twelve of them, because a page of forty words written three times
+ * each is a page that holds nothing else.
+ */
+const STARTER_WORDS = listWords(WORD_LISTS[0]).slice(0, 12);
+
+/**
+ * The first verse of "The Star", Jane Taylor, 1806 — the poem everyone knows
+ * these four lines of, and public domain twice over by age.
+ *
+ * Copywork wants text somebody wrote rather than text a generator assembled: a
+ * child copying a real poem is reading it too. The line breaks are the poet's,
+ * and the family keeps them — anything longer than the paper is broken where
+ * the paper runs out and nowhere else.
+ *
+ * One verse rather than two because four lines written four times each is
+ * sixteen rows, which is what a ⅜ page holds with room to spare. Two verses at
+ * the same repeats would not fit, and the family would print seven of the eight
+ * lines — a poem with its last line missing.
+ */
+const STAR = [
+  "Twinkle, twinkle, little star,",
+  "How I wonder what you are!",
+  "Up above the world so high,",
+  "Like a diamond in the sky.",
+].join("\n");
+
+/**
+ * The four short sentences a first sentence sheet is set on.
+ *
+ * Short enough that none of them wraps on either stock — a sentence broken over
+ * two lines is still correct, but the point of this sheet is a whole sentence
+ * on one line — and between them they carry a capital, a full stop, and the
+ * word spacing that is the actual lesson.
+ */
+const SENTENCES = [
+  "The cat sat on the warm mat.",
+  "We went to the park on Friday.",
+  "My little dog can run very fast.",
+  "I can write my name by myself.",
+].join("\n");
+
+export const HANDWRITING_SHEETS: HandwritingSheet[] = [
+  /* ── Letters and numbers ────────────────────────────────────────────── */
+  {
+    slug: "letter-tracing-worksheets",
+    name: "Letter tracing — the whole alphabet",
+    short: "A to Z",
+    heading: "Letter tracing worksheets",
+    keyword: "Free printable letter tracing worksheets",
+    summary:
+      "Every letter of the alphabet as a capital and a small letter, on ⅝-inch ruled paper: a solid model, two dotted letters to trace, and an empty space to write it alone.",
+    lead: "All twenty-six letters on one page, each one written as the pair a child is taught — A then a, B then b. Every letter gets a solid model to look at, two dotted ones to trace over, and an empty space at the end where nobody is helping.",
+    notes: [
+      "The three steps on each line are the whole point of the sheet, and they are meant to be done in order. A child who traces a letter twenty times has practised following a line; a child who traces it once and then writes it from nothing has practised writing the letter. The empty space at the end of every group is where the actual learning happens, and it is why this page is worth more than a page of dotted letters twice the length.",
+      "Capitals and small letters sit together rather than on separate pages, because they are one letter with two shapes and a child meets them that way in every book they open. It also makes the difference visible: b and d are a genuine problem at this age, and having Bb and Dd on the same sheet is a better answer than practising each of them alone a week apart.",
+    ],
+    teaches: "Printing the letters of the alphabet",
+    ages: "Ages 4–7",
+    group: "letters",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "letters",
+      letters: "both",
+      rule: { style: "hand-5-8", midline: "dashed", descender: true },
+      trace: "dotted",
+      repeats: 4,
+    },
+  },
+  {
+    slug: "uppercase-letter-tracing-worksheets",
+    name: "Capital letter tracing",
+    short: "Capitals",
+    heading: "Uppercase letter tracing worksheets",
+    keyword: "Free printable uppercase letter tracing worksheets",
+    summary:
+      "The twenty-six capitals on ¾-inch handwriting paper, each traced and then written alone — the larger ruling for a hand that is still arriving.",
+    lead: "Capital letters only, on the ¾-inch ruling a lot of schools spend the first term on. Every capital starts at the top line and sits on the baseline, which is the one rule that makes a capital a capital.",
+    notes: [
+      "Capitals are usually the first letters a child writes, and not because they come first in the alphabet: every one of them is made of straight lines and simple curves that start at the top and finish at the bottom, with nothing that has to be joined and nothing that drops below the line. If handwriting is going badly, this is the page to go back to.",
+      "The ruling is a size larger than the ⅝ paper most of Year 1 works on. That is deliberate rather than a concession — a child whose fine motor control is still arriving writes large, and paper that asks them to write smaller than they can control teaches them that handwriting is something they are bad at. Drop to ⅝ when the letters stop touching the top line by accident.",
+    ],
+    teaches: "Forming capital letters",
+    ages: "Ages 4–6",
+    group: "letters",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "letters",
+      letters: "upper",
+      rule: { style: "hand-3-4", midline: "dashed", descender: true },
+      trace: "dotted",
+      repeats: 3,
+    },
+  },
+  {
+    slug: "lowercase-letter-tracing-worksheets",
+    name: "Small letter tracing",
+    short: "Small letters",
+    heading: "Lowercase letter tracing worksheets",
+    keyword: "Free printable lowercase letter tracing worksheets",
+    summary:
+      "The twenty-six small letters on ⅝-inch paper with a dashed midline and room for descenders, traced twice and then written alone.",
+    lead: "Small letters on their own, on the ⅝ paper a school usually means by “handwriting paper”. The dashed midline is where the body of a letter stops, and the space below the baseline is where the tail of a g, a y or a p goes.",
+    notes: [
+      "Small letters are harder than capitals and this sheet is where that shows. Three things are happening at once: some letters reach the top line, some stop at the dashed midline, and five of them drop below the baseline — so the paper is doing as much teaching as the letters are. That is why the descender space is on rather than off, and why the midline is dashed rather than solid.",
+      "There are two more repeats of each letter here than on the capitals sheet, because small letters need them. b and d, p and q, n and h are pairs a child mixes up for a year or more, and the fix is not explanation but enough repetitions of each that the hand stops having to decide. The empty space at the end of every line is still where it is checked.",
+    ],
+    teaches: "Forming lowercase letters",
+    ages: "Ages 5–7",
+    group: "letters",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "letters",
+      letters: "lower",
+      rule: { style: "hand-5-8", midline: "dashed", descender: true },
+      trace: "dotted",
+      repeats: 5,
+    },
+  },
+  {
+    slug: "number-tracing-worksheets",
+    name: "Number formation, 0 to 9",
+    short: "Numbers",
+    heading: "Number tracing worksheets",
+    keyword: "Free printable number tracing worksheets",
+    summary:
+      "Every numeral from 0 to 9 on ¾-inch paper with a solid midline, one to a line: a model, four dotted numbers to trace, and one written alone.",
+    lead: "The ten numerals every other number is built out of, one to a line on large ¾-inch paper. Each gets a solid model, four dotted numbers to trace, and an empty space at the end where nobody is helping.",
+    notes: [
+      "Ten symbols is the whole of it, and they are worth more practice than they usually get. Every number a child will ever write is made of these ten shapes, and a 5 started at the wrong end or a 2 drawn as a loop is a habit that survives into secondary school and slows down every sum on the page. Six goes at each is roughly what it takes for the direction to stick, which is why they get a line each rather than sharing one.",
+      "A solid midline rather than a dashed one, because a four- or five-year-old is aiming at a line rather than reading a hint. Numbers help here: unlike letters, almost all of them are the full height of the writing space, so the top line and the baseline are the two that matter and the middle one is a landmark rather than a limit on how tall a body may be.",
+    ],
+    teaches: "Writing the numerals 0 to 9",
+    ages: "Ages 4–6",
+    group: "letters",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "numbers",
+      rule: { style: "hand-3-4", midline: "solid", descender: true },
+      trace: "dotted",
+      repeats: 6,
+    },
+  },
+
+  /* ── Words ──────────────────────────────────────────────────────────── */
+  {
+    slug: "sight-word-handwriting-worksheets",
+    name: "Sight words to trace and write",
+    short: "Sight words",
+    heading: "Sight word handwriting worksheets",
+    keyword: "Free printable sight word handwriting worksheets",
+    summary:
+      "Twelve first sight words on ⅝-inch paper, each one traced once and then written from nothing — spelling and handwriting in the same three minutes.",
+    lead: "The first twelve sight words, one to a line, each with a model to read, a dotted word to trace and an empty stretch of line to write it on. The same words the jungle deals as flash cards, on paper.",
+    notes: [
+      "Writing a word out is a different exercise from writing its letters, and this is the sheet where that gap gets closed. A child who can form every letter of the alphabet can still stall at “because”, because a word needs the letters in an order, joined by spaces that are the right size, on a line that has to keep going. One word to a line is what gives them room to get all three right.",
+      "These are sight words rather than phonetic ones on purpose: they are the words that turn up most often and are least worth sounding out, so writing them is memory work as much as handwriting. If a different list is wanted — this week's spellings off a school letter, or the words a child kept missing on screen — the builder takes a typed or pasted list and prints the same sheet.",
+    ],
+    teaches: "Writing sight words by hand",
+    ages: "Ages 5–7",
+    group: "words",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "words",
+      words: STARTER_WORDS,
+      rule: { style: "hand-5-8", midline: "dashed", descender: true },
+      trace: "dotted",
+      repeats: 3,
+    },
+  },
+
+  /* ── Sentences and passages ─────────────────────────────────────────── */
+  {
+    slug: "sentence-handwriting-worksheets",
+    name: "Sentences to trace and copy",
+    short: "Sentences",
+    heading: "Sentence handwriting worksheets",
+    keyword: "Free printable sentence handwriting worksheets",
+    summary:
+      "Four short sentences on half-inch paper, each printed as a model, traced twice on the lines below, and then written on a line of its own.",
+    lead: "Four sentences a five-year-old can read, on the half-inch ruling that fits a whole sentence on a line. Each one appears four times down the page: printed to read, dotted twice to trace, and empty to write.",
+    notes: [
+      "A sentence brings in everything a letter sheet leaves out — a capital at the start, spaces between the words, and a full stop at the end — and those are the three things a child forgets first when they stop thinking about them. The model line at the top of each group is there to be looked at rather than skipped: the spacing is as much the lesson as the letters are.",
+      "Half an inch is the ruling where handwriting stops being about forming letters and starts being about writing a line without the page running out. If the sentences are being squeezed or the writing is drifting off the baseline, print the ⅝ or ¾ version from the builder instead — the sheet is identical apart from the size, which is the one thing worth changing at a time.",
+    ],
+    teaches: "Writing whole sentences by hand",
+    ages: "Ages 5–8",
+    group: "passages",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "passage",
+      text: SENTENCES,
+      rule: { style: "hand-1-2", midline: "dashed", descender: true },
+      trace: "dotted",
+      repeats: 4,
+    },
+  },
+  {
+    slug: "copywork-worksheets",
+    name: "Copywork — a poem to copy out",
+    short: "Copywork",
+    heading: "Copywork worksheets",
+    keyword: "Free printable copywork worksheets",
+    summary:
+      "A verse of “The Star” on ⅜-inch transitional paper: the line printed, two grey copies to write over, and an empty line to write it from nothing.",
+    lead: "A verse of a real poem, one line at a time. Each line is printed to read, then printed faintly twice to write over, then left as an empty ruled line. Copywork is the oldest handwriting exercise there is and still the best one once letters are formed.",
+    notes: [
+      "The faint lines are grey rather than dotted, which is the change that marks this sheet as the one after tracing. A dotted letter is a path to follow; a grey one is a shape to write over, and the pencil has to do the deciding. The empty line under each group is where it stops being a copy at all — and by then the eye has held the words long enough that the spelling has gone in as well.",
+      "The ⅜ ruling has a top line and a baseline and no midline at all. By this stage a child knows how tall a letter is and the paper stops telling them; what is left is a pair of lines to keep the writing straight, which is all an exercise book gives you. It is the last ruling before ordinary lined paper, and copying a poem onto it is a fair test of whether someone is ready for that.",
+    ],
+    teaches: "Copywork and sustained handwriting",
+    ages: "Ages 7–10",
+    group: "passages",
+    credit: "“The Star”, Jane Taylor, 1806. Public domain.",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "passage",
+      text: STAR,
+      rule: { style: "hand-3-8", midline: "none", descender: true },
+      trace: "dim",
+      repeats: 4,
+    },
+  },
+];
+
+/** What each group is called on a hub, in the order they are listed. */
+export const HANDWRITING_GROUPS: Array<{
+  id: HandwritingGroup;
+  label: string;
+  blurb: string;
+}> = [
+  {
+    id: "letters",
+    label: "Letters and numbers",
+    blurb: "The shapes everything else is built out of, one page each.",
+  },
+  {
+    id: "words",
+    label: "Words",
+    blurb: "Letters in an order, with spaces the right size between them.",
+  },
+  {
+    id: "passages",
+    label: "Sentences and copywork",
+    blurb: "A whole line at a time, once the letters are no longer the work.",
+  },
+];
+
+/** The same sheet, measured for another stock. */
+export function configFor(
+  sheet: HandwritingSheet,
+  size: PaperSize,
+): HandwritingConfig {
+  return { ...sheet.config, paper: paperOf(size) };
+}
+
+/** The route a sheet prints at, on a given stock. */
+export function pathFor(sheet: HandwritingSheet, stock: Stock): string {
+  return stock.path ? `${sheet.slug}/${stock.path}` : sheet.slug;
+}
+
+/** The whole URL, which is what a hub links to and the canonical says. */
+export const hrefFor = (sheet: HandwritingSheet, stock: Stock): string =>
+  `/printables/handwriting/${pathFor(sheet, stock)}`;
+
+/**
+ * The builder, opened on this sheet.
+ *
+ * §14: the config lives in the fragment, so "change what is on it" is an
+ * ordinary link on a static site rather than a lookup on a server that isn't
+ * there. The stock goes with it, so a parent who came from the A4 page gets the
+ * A4 sheet on the bench rather than a Letter one to set again.
+ */
+export function builderHref(sheet: HandwritingSheet, stock: Stock): string {
+  const payload = encodeSharedSheet({
+    config: configFor(sheet, stock.id),
+    seed: HANDWRITING_SEED,
+  });
+  return `/printables/make#s=${payload}`;
+}
+
+/**
+ * The shelf, grouped — the shape every page lists it in.
+ *
+ * Written once because the hub and each sheet's row of neighbours would
+ * otherwise have to be kept in step by hand, and the failure would be silent: a
+ * sheet added here and shown on one page but not the other still builds, still
+ * deploys, and still looks right.
+ */
+export function handwritingShelf(): Array<{
+  id: HandwritingGroup;
+  label: string;
+  blurb: string;
+  sheets: HandwritingSheet[];
+}> {
+  return HANDWRITING_GROUPS.map((group) => ({
+    ...group,
+    sheets: HANDWRITING_SHEETS.filter((sheet) => sheet.group === group.id),
+  }));
+}
+
+/** Letter first, then A4 — the order `_catalog.ts` sets and the reason for it. */
+export { STOCKS };

--- a/src/pages/printables/_handwriting.ts
+++ b/src/pages/printables/_handwriting.ts
@@ -23,7 +23,6 @@
  * `@page` is a document rule, so the two cannot share a page — hence a route
  * each, exactly as `_catalog.ts` argues.
  */
-import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
 import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
 import { encodeSharedSheet } from "@/engine/sheets/share";
 import type {
@@ -32,6 +31,9 @@ import type {
   Paper,
   PaperSize,
 } from "@/engine/sheets/types";
+// The same twelve words the bench opens its own sight-word sheet on. Sliced in
+// one place so the catalog page and the builder default cannot drift apart.
+import { STARTER_WORDS } from "@/games/printshop/defaults";
 
 import { STOCKS, type Stock } from "./_catalog";
 
@@ -91,16 +93,6 @@ const paperOf = (size: PaperSize): Paper => ({
  * there is nowhere in a config to put a value for either.
  */
 const FIELDS: HeaderField[] = ["name", "date"];
-
-/**
- * The first sight words, which is what a first handwriting list is made of.
- *
- * Taken from the list the jungle already ships rather than typed out again, so
- * the words a child is racing on screen are the words they are writing on
- * paper — and twelve of them, because a page of forty words written three times
- * each is a page that holds nothing else.
- */
-const STARTER_WORDS = listWords(WORD_LISTS[0]).slice(0, 12);
 
 /**
  * The first verse of "The Star", Jane Taylor, 1806 — the poem everyone knows

--- a/src/pages/printables/handwriting/[...slug].astro
+++ b/src/pages/printables/handwriting/[...slug].astro
@@ -123,11 +123,12 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
     <div class="prose">
       {sheet.notes.map((note) => <p>{note}</p>)}
       <p>
-        The rules are drawn as real strokes at real sizes, and the letters are
-        set to them: the tallest letter stands on the baseline and reaches the
-        top line, because the type size is worked out from the ruling and from
-        the font&rsquo;s own measured proportions rather than picked to look
-        about right. Put a ruler on it. The ruling is the size it says it is.
+        The rules are drawn as real strokes at real sizes, and what is written
+        is set to them: the tallest thing on a line stands on the baseline and
+        reaches the top line, whether that is an ascender, a capital or a
+        numeral. The type size is worked out from the ruling and from the
+        font&rsquo;s own measured proportions rather than picked to look about
+        right. Put a ruler on it. The ruling is the size it says it is.
       </p>
       {sheet.credit && <p class="aside">{sheet.credit}</p>}
     </div>

--- a/src/pages/printables/handwriting/[...slug].astro
+++ b/src/pages/printables/handwriting/[...slug].astro
@@ -1,0 +1,217 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { buildSheet } from "@/engine/sheets";
+import {
+  HANDWRITING_SEED,
+  HANDWRITING_SHEETS,
+  STOCKS,
+  builderHref,
+  configFor,
+  handwritingShelf,
+  hrefFor,
+  type HandwritingSheet,
+} from "../_handwriting";
+import type { Stock } from "../_catalog";
+
+/**
+ * One prerendered handwriting sheet per topic — and the page is the sheet.
+ *
+ * The shape §8 describes, applied to the family where the paper *is* the
+ * content: "free printable letter tracing worksheets" is one of the largest
+ * queries in this whole section, and a parent who lands here gets prose that
+ * answers it, the sheet itself directly under it as HTML, and nothing to click.
+ *
+ * **Two stocks, two routes — as with paper and unlike maths.** A ⅝ rule scaled
+ * to fit whatever is in the tray is no longer a ⅝ rule, and `@page` is a
+ * document rule, so Letter and A4 cannot share a page. That is also why this
+ * route is a rest pattern under `handwriting/` rather than another `[topic]`
+ * beside the maths one: a two-segment path needs a rest param, and two dynamic
+ * patterns at the same level would be two routes claiming one URL.
+ *
+ * **No answer key, and no apology for it.** There is nothing on a handwriting
+ * sheet with a right answer — the model is already printed, which is the whole
+ * exercise — so the family returns its own sheet as the key and the page prints
+ * one article rather than two.
+ *
+ * **No client directive on `SheetView`, ever.** `@astrojs/react` renders a
+ * component with no `client:*` to HTML at build time, so these pages ship zero
+ * JavaScript — the whole SEO argument of §2. `Sheet.test.tsx` holds every page
+ * in this directory to it, against the source and against `dist/`.
+ *
+ * **Everything that is not the sheet carries `.no-print`.** `@page` cannot be
+ * scoped to a class, so the zeroed page margin a sheet needs applies to the
+ * prose as well and it would print off the edge.
+ */
+
+type Props = { sheet: HandwritingSheet; stock: Stock };
+
+export function getStaticPaths() {
+  return HANDWRITING_SHEETS.flatMap((sheet) =>
+    STOCKS.map((stock) => ({
+      params: { slug: stock.path ? `${sheet.slug}/${stock.path}` : sheet.slug },
+      props: { sheet, stock },
+    })),
+  );
+}
+
+const { sheet, stock } = Astro.props;
+
+const a4 = stock.id === "a4";
+const printed = buildSheet(configFor(sheet, stock.id), HANDWRITING_SEED);
+const other = STOCKS.find((candidate) => candidate.id !== stock.id)!;
+
+const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
+const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
+const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const url = `https://schoolskills.app${hrefFor(sheet, stock)}`;
+
+const groups = handwritingShelf();
+const group = groups.find((entry) => entry.id === sheet.group)!;
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    name: heading,
+    description,
+    url,
+    learningResourceType: "Worksheet",
+    educationalUse: "Practice",
+    teaches: sheet.teaches,
+    typicalAgeRange: sheet.ages,
+    isAccessibleForFree: true,
+    inLanguage: "en",
+  }}
+>
+  <header class="hero wrap no-print">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Handwriting &middot; {group.label}
+    </p>
+    <h1 class="hero__title">{heading}</h1>
+    <p class="hero__lead">{sheet.lead}</p>
+    <p class="aside">
+      The sheet below <strong>is</strong> the printout. Press{" "}
+      <strong>&#8984;P</strong> &mdash; <strong>Ctrl+P</strong> on Windows &mdash;
+      and everything but the paper disappears. Nothing here needs choosing first.
+      To keep a copy instead, pick <em>Save as PDF</em> in the print dialog and your
+      browser writes one.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  {
+    /*
+      The sheet, outside `.wrap` deliberately. A wrap adds an inline padding
+      that print.css cannot take back off, and a sheet printed a centimetre in
+      from where it says it is has the wrong geometry everywhere at once —
+      which on this family is the whole content of the page.
+    */
+  }
+  <div class="sheet-frame">
+    <SheetView sheet={printed} />
+  </div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">What is on this sheet</h2>
+    <div class="prose">
+      {sheet.notes.map((note) => <p>{note}</p>)}
+      <p>
+        The rules are drawn as real strokes at real sizes, and the letters are
+        set to them: the tallest letter stands on the baseline and reaches the
+        top line, because the type size is worked out from the ruling and from
+        the font&rsquo;s own measured proportions rather than picked to look
+        about right. Put a ruler on it. The ruling is the size it says it is.
+      </p>
+      {sheet.credit && <p class="aside">{sheet.credit}</p>}
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Trace it, copy it, then write it alone</h2>
+    <div class="prose">
+      <p>
+        Every group on this page runs the same three steps: a solid model to
+        look at, a dotted letter to trace over, and an empty space where nobody
+        is helping. That last one is the part that teaches &mdash; tracing
+        practises following a line, and writing from nothing practises writing.
+        A sheet of nothing but dotted letters is a sheet a child can finish
+        without ever having made a letter themselves.
+      </p>
+      <p>
+        How far along that progression a sheet sits is a setting rather than a
+        different worksheet. The dotted model can be dashed, hollow, grey or
+        left off entirely; the number of repeats moves between one and eight;
+        and every ruling in the shop &mdash; the five handwriting sizes, the
+        three notebook rules, squares, dots and triangles &mdash; works with any
+        of them.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href={builderHref(sheet, stock)}>
+        Open this sheet in the builder
+      </a>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Printing it on {other.label}</h2>
+    <div class="prose">
+      <p>
+        This sheet is set for {stock.label} &mdash; {stock.size}. Paper size is
+        not a preference on a handwriting sheet: sent to a printer loaded with
+        something else, the browser shrinks the page to fit, and a ruling that
+        has been shrunk is no longer the size it was chosen for. So there is a
+        second copy of this sheet, ruled identically and measured for {
+          other.label
+        }.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href={hrefFor(sheet, other)}>The {other.label} version</a>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Every handwriting sheet</h2>
+    <p class="h2__sub">
+      {HANDWRITING_SHEETS.length} sheets, each one a page like this one. Nothing is
+      locked and nothing needs an account.
+    </p>
+    {
+      groups.map((entry) => (
+        <>
+          <h3 class="h2 h2--next">{entry.label}</h3>
+          <p class="h2__sub">{entry.blurb}</p>
+          <nav class="stones" aria-label={entry.label}>
+            {entry.sheets.map((candidate) => (
+              <a
+                class="stone"
+                href={hrefFor(candidate, stock)}
+                aria-current={
+                  candidate.slug === sheet.slug ? "page" : undefined
+                }
+              >
+                {candidate.short}
+              </a>
+            ))}
+          </nav>
+        </>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables/handwriting">
+        All the handwriting sheets
+      </a>
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/handwriting/index.astro
+++ b/src/pages/printables/handwriting/index.astro
@@ -1,0 +1,194 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import {
+  HANDWRITING_SHEETS,
+  STOCKS,
+  handwritingShelf,
+  hrefFor,
+} from "../_handwriting";
+
+/**
+ * The handwriting subject hub — the second of the three §8 names to exist.
+ *
+ * A listing rather than a sheet, which makes it one of the two pages in this
+ * corner that isn't itself printable, and that is the right split: nobody
+ * searches for "printable list of handwriting worksheets". What it is for is
+ * the two jobs a hub does — giving a parent who arrived on
+ * `/printables/handwriting/letter-tracing-worksheets` somewhere to go next, and
+ * giving the topic pages a crawlable parent that says what they have in common.
+ *
+ * It lists what exists and nothing else. Cursive is a story of its own and
+ * Scripture copywork another; neither is linked from here until it prints.
+ */
+const title =
+  "Free printable handwriting worksheets — trace, copy, write | School Skills";
+const description =
+  "Printable handwriting practice: letter tracing in upper and lower case, number formation 0–9, sight words, sentences and copywork. Every sheet traces first, then copies, then leaves an empty line. Free, no account, and nothing to download.";
+
+const groups = handwritingShelf();
+const letter = STOCKS[0];
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Printable handwriting worksheets",
+    description,
+    url: "https://schoolskills.app/printables/handwriting",
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    hasPart: HANDWRITING_SHEETS.map((sheet) => ({
+      "@type": "LearningResource",
+      name: sheet.heading,
+      url: `https://schoolskills.app${hrefFor(sheet, letter)}`,
+      learningResourceType: "Worksheet",
+      teaches: sheet.teaches,
+      typicalAgeRange: sheet.ages,
+      isAccessibleForFree: true,
+    })),
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Handwriting
+    </p>
+    <h1 class="hero__title">Printable handwriting worksheets</h1>
+    <p class="hero__lead">
+      {HANDWRITING_SHEETS.length} sheets, from the first capital letter through to
+      copying out a poem. Every one of them traces first, then copies, then leaves
+      an empty line &mdash; so one page carries a child through the whole progression.
+    </p>
+    <p class="hero__note">Free &middot; two paper sizes &middot; no download</p>
+  </header>
+
+  {
+    /*
+      What exists, first — before the page explains itself. Somebody who came
+      looking for letter tracing should be one link from letter tracing, and
+      the argument for how these sheets are ruled reads better after you have
+      seen one than before.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">On the shelf now</h2>
+    <p class="h2__sub">
+      Each of these is a page that is itself the worksheet &mdash; open it,
+      press print, and that is the whole of it. Every sheet comes on US Letter
+      and on A4, because a ⅝-inch rule shrunk to fit whatever is in the tray is
+      no longer a ⅝-inch rule.
+    </p>
+    {
+      groups.map((group) => (
+        <>
+          <h3 class="h2 h2--next">{group.label}</h3>
+          <p class="h2__sub">{group.blurb}</p>
+          <div class="prose">
+            <ul>
+              {group.sheets.map((sheet) => (
+                <li>
+                  <a href={hrefFor(sheet, letter)}>{sheet.name}</a> &mdash;{" "}
+                  {sheet.summary}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      ))
+    }
+  </section>
+
+  <div class="wrap"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Trace, copy, then write it alone</h2>
+    <div class="prose">
+      <p>
+        Every sheet here runs the same three steps, and they are meant to be
+        done in order. A solid model to look at. A dotted one to trace over. An
+        empty space where nobody is helping. Tracing on its own practises
+        following a line; the empty space is where a child practises writing,
+        and it is the reason these pages are worth more than a sheet of dotted
+        letters twice the length.
+      </p>
+      <p>
+        How far along that progression a page sits is a setting rather than a
+        different worksheet. The model can be dotted, dashed, hollow, grey or
+        left off altogether, and each thing can be written anywhere from once to
+        eight times. Turn the progression off and every repeat is drawn the same
+        way, which is the sheet for a child who is still tracing and not yet
+        ready to be left on their own.
+      </p>
+    </div>
+  </section>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">The ruling is the size it says it is</h2>
+      <p class="h2__sub">
+        Five handwriting sizes, three notebook rules, and squares, dots and
+        triangles &mdash; any of them, with any of the letterforms above.
+      </p>
+      <div class="prose">
+        <p>
+          A ⅝-inch rule is ⅝ of an inch under a ruler or it is teaching the
+          wrong size of letter, and a child who has been taught to write between
+          two lines notices before an adult does. So the lines are drawn as real
+          strokes at real distances rather than as a background tint &mdash;
+          which also means they survive a printer with &ldquo;background
+          graphics&rdquo; unticked, the setting most people never find and the
+          reason ruled paper from elsewhere so often comes out blank.
+        </p>
+        <p>
+          The letters are set to the ruling rather than to a type size: the
+          tallest letter stands on the baseline and reaches the top line, worked
+          out from the ruling and from the font&rsquo;s own measured
+          proportions. The dotted and hollow letterforms come from that same
+          ordinary font rather than from a licensed tracing font, which is why
+          there is nothing to buy and nothing to install here.
+        </p>
+        <p>
+          Blank paper in every one of those rulings is a page of its own, for
+          when what is wanted is the paper rather than the practice.
+        </p>
+      </div>
+      <div class="hero__actions">
+        <a class="cta cta--quiet" href="/printables/handwriting-paper">
+          Handwriting paper, ⅝ inch
+        </a>
+        <a class="cta cta--quiet" href="/printables/lined-paper">
+          Lined paper, wide ruled
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Your own words on the same sheet</h2>
+    <div class="prose">
+      <p>
+        This week&rsquo;s spellings off a school letter, a name to practise, a
+        verse to copy out &mdash; the builder takes a typed or pasted list and
+        prints it as any of the sheets above, on any ruling, at any size. The
+        settings travel in the link, so a sheet you make can be sent to another
+        family as it stands.
+      </p>
+      <p class="aside">
+        The <em>Name:</em> line is printed blank and filled in with a pencil. Nothing
+        is uploaded to make a sheet and there is nowhere in a shared link to put a
+        child&rsquo;s name &mdash; see <a href="/privacy"
+          >what we don&rsquo;t collect</a
+        >.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/make">Open the sheet builder</a>
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -1,6 +1,7 @@
 ---
 import Content from "@/layouts/Content.astro";
 import { STOCKS, pathFor, shelf } from "./_catalog";
+import { HANDWRITING_SHEETS, handwritingShelf, hrefFor } from "./_handwriting";
 import { MATHS_SHEETS, mathsShelf, pathFor as mathsPath } from "./_maths";
 
 /**
@@ -16,9 +17,10 @@ import { MATHS_SHEETS, mathsShelf, pathFor as mathsPath } from "./_maths";
  * It lists what exists and nothing else. A shelf of links to sheets that
  * haven't been built is the thin-content pattern Base.astro's `noindex` block
  * already argues against, and a catalog page here is meant to BE the worksheet
- * — real prerendered HTML a parent can print without touching anything. Two
- * families fill it: every ruling in §5 on both stocks, and the curated maths
- * topics of §8, each of which prints its own answer key.
+ * — real prerendered HTML a parent can print without touching anything. Three
+ * families fill it: every ruling in §5 on both stocks, the curated maths topics
+ * of §8, each of which prints its own answer key, and the handwriting sheets,
+ * which come on both stocks for the same reason the paper does.
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
@@ -28,6 +30,7 @@ const description =
 const letter = STOCKS[0];
 const groups = shelf();
 const strands = mathsShelf();
+const writing = handwritingShelf();
 ---
 
 <Content
@@ -70,11 +73,12 @@ const strands = mathsShelf();
   <section class="band band--tight wrap">
     <h2 class="h2">On the shelf now</h2>
     <p class="h2__sub">
-      Two families: maths worksheets, each with its answer key on the page
-      behind it, and paper in every ruling. Each of these is a page that is
-      itself the sheet &mdash; open it, press print, and that is the whole of
-      it. The paper comes on both stocks, because a ruling shrunk to fit
-      whatever is in the tray is no longer the ruling you chose.
+      Three families: maths worksheets, each with its answer key on the page
+      behind it, handwriting practice that traces before it copies, and paper in
+      every ruling. Each of these is a page that is itself the sheet &mdash;
+      open it, press print, and that is the whole of it. Handwriting and paper
+      come on both stocks, because a ruling shrunk to fit whatever is in the
+      tray is no longer the ruling you chose.
     </p>
 
     <h3 class="h2 h2--next">Maths worksheets</h3>
@@ -95,6 +99,28 @@ const strands = mathsShelf();
     }
     <div class="hero__actions">
       <a class="cta" href="/printables/math">All the maths sheets</a>
+    </div>
+
+    <h3 class="h2 h2--next">Handwriting</h3>
+    <p class="h2__sub">
+      {HANDWRITING_SHEETS.length} sheets, from the first capital letter to copying
+      out a poem. Each one traces, then copies, then leaves an empty line.
+    </p>
+    {
+      writing.map((group) => (
+        <nav class="stones" aria-label={group.label}>
+          {group.sheets.map((sheet) => (
+            <a class="stone" href={hrefFor(sheet, letter)}>
+              {sheet.short}
+            </a>
+          ))}
+        </nav>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta" href="/printables/handwriting">
+        All the handwriting sheets
+      </a>
     </div>
 
     {
@@ -153,15 +179,15 @@ const strands = mathsShelf();
       <h2 class="h2">What the press is being set for</h2>
       <p class="h2__sub">
         The Print Shop is opening a family at a time, and this page lists what
-        exists rather than what is planned. Paper and maths are open.
-        Handwriting is next.
+        exists rather than what is planned. Paper, maths and handwriting are
+        open. Cursive is next.
       </p>
       <div class="prose">
         <p>
-          The order it opens in: the paper and the maths sheets above, then
-          handwriting and copywork &mdash; passages from the public domain,
-          Scripture among them &mdash; then spelling, phonics, and the charts,
-          certificates and planners that are simply blank forms.
+          The order it opens in: the paper, the maths sheets and the handwriting
+          above, then cursive and the wider copywork &mdash; passages from the
+          public domain, Scripture among them &mdash; then spelling, phonics,
+          and the charts, certificates and planners that are simply blank forms.
         </p>
         <p>
           The one it is really being built for comes with the sheet builder:

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -226,7 +226,15 @@
    overhangs by four thousandths of an inch even on one that has (`faces.ts`).
    An SVG viewport clips by default, so the choice is between a model with its
    tail cut off at the baseline and one drawn through the line below. A child
-   writes the second of those, so the sheet prints it. */
+   writes the second of those, so the sheet prints it.
+
+   This gives up the clip in BOTH directions, which is not what was wanted:
+   the isometric ruling runs its diagonals off each side on the understanding
+   that something takes them off again, and a word wider than the declared mean
+   advance would print past the margin. So `TracedRow` nests a second `<svg>`
+   inside this one that is exactly as wide as the row and an em taller at each
+   end — a nested viewport clips to itself whatever its parent does, so the
+   overhang stays vertical. Don't add horizontal slack here; add it there. */
 .sheet__ink--trace {
   overflow: visible;
 }

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -220,6 +220,17 @@
   font-family: var(--sheet-face, var(--font-body, system-ui, sans-serif));
 }
 
+/* A traced row is exactly one repeat of its ruling tall, because that is what
+   keeps a ⅝ rule ⅝ of an inch down a page of them. The tail of a `g` does not
+   fit in that box on a ruling with no descender space — and on Playwrite it
+   overhangs by four thousandths of an inch even on one that has (`faces.ts`).
+   An SVG viewport clips by default, so the choice is between a model with its
+   tail cut off at the baseline and one drawn through the line below. A child
+   writes the second of those, so the sheet prints it. */
+.sheet__ink--trace {
+  overflow: visible;
+}
+
 /* ── The three faces (§17) ──────────────────────────────────────────────────
    Files now, self-hosted beside the site's own three — see `fonts.css` for
    which face does which job and why none of them is a request to a CDN. What


### PR DESCRIPTION
## What

A handwriting sheet family — `/printables/handwriting` plus seven per-topic
slugs — built on top of what PRINT04 and PRINT15 already landed: the twelve
rulings in `engine/sheets/paper.ts` and the letterforms in
`engine/sheets/faces.ts`. No second tracing font, nothing re-declared.

Closes #60.

## Why this shape

**One progression, two directions.** A row is `["solid", "dotted", "none"]` — a
model to look at, a trace to follow, and the place where the child is on their
own. That sequence *is* the family. Letters, numerals and words are short
enough to repeat several times across a row, so as many groups fit as the paper
is wide; a line of a passage fills the row, so the same sequence runs down the
page instead. Nothing else separates the four styles, which is why the
instruction line is read off the row that was actually produced rather than off
the config — a sheet with nothing dotted on it never says "trace".

**Every ruling × every letterform.** All twelve rulings work with all six
faces. Blank paper is the sole exception: a ruling with no pitch has no rows,
so it resolves to the ⅝ rule the shop already defaults to.

**Physical fidelity is checked, not assumed.** A row is exactly one repeat of
its ruling, so a ⅝ rule measures ⅝ of an inch down a page. The em is set from
the writing space and each face's own measured ascent, so the tallest letter
stands on the baseline and reaches the top line. `descent` was measured out of
the woff2 files with fontTools alongside the existing proportions, and the
suite checks each tail against the room its ruling gives it — Playwrite's
0.519 against 0.510 is why a traced row can no longer clip: an SVG viewport
cuts a tail at the baseline, and a `g` with no loop is a worse model than one
drawn through the line below.

**A face states three heights, not one.** Sizing every sheet off the tallest
ascender is right for a row containing an `l` and wrong for one without.
Andika's caps are 0.713 against a 0.791 ascender, so the capitals and numbers
pages — both of which invite a ruler — were printing a glyph a tenth of the
writing space below the line they claimed it started at. `Face.capHeight` and
`Face.figure` now sit beside `ascent`, and `glyphHeight` reads the text to pick
which of the three must reach the top line. A row mixing them falls back to the
ascender: a capital riding low is a smaller error than an ascender drawn
through the rule.

**Containment.** Un-clipping the trace row gave up horizontal containment along
with vertical, which both the isometric ruling and `Face.advance` relied on.
The overhang is now a nested viewport — exactly as wide as the row, an em taller
at each end — so a tail still crosses the line below and nothing crosses the
margin.

**`TraceRow` carries a text per cell.** Fifty-two rows of one letter each is
four sheets of ⅝ paper; a row that could only say one thing would have forced
the letters sheet to choose between a legible rule size and half an alphabet.

## Also in here

- "Copy each letter" needs a model as well as an empty place — a sheet with
  nothing drawn on it asks a child to copy thin air.
- The ruling controls are written once and shared by both panels, which gives
  handwriting sheets the square control they lacked and stops offering blank
  paper the family refuses.
- The trace renderer takes its writing space from `writingSpace`, as its doc
  block already claimed.
- One definition of the first twelve sight words.
- The engine's `MODELLED` and the renderer's `STROKED` no longer share a name
  for two different sets.
- Deleted the duplicated `writingSpace` helper from `faces.test.ts` — the
  engine exports the real one, so the suite now reads the same geometry the
  sheets are ruled with.

## Catalog

Seven curated slugs, each on both stocks for the same reason the paper pages
are: a scaled ⅝ rule is not a ⅝ rule. The catalog suite asserts that every
letter, numeral, word and line promised is actually on the page — the content
here is a set rather than a count, so "as many as fit" would give you a sheet
teaching twenty-four letters that looks exactly like one teaching twenty-six.

## Validation

`type-check`, `lint`, `test:unit` (809 passing), `build` (82 pages) and the
browser smoke test all green locally, with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
