### PR TITLE
PRINT19: copywork and memory work, with Scripture in the same picker

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -625,6 +625,28 @@ For anything else, **paste your own verse** covers it — the same move
 small, per-book JSON as static files fetched on demand
 (`/data/bible/webu/john.json`) keeps it static and keeps it out of the bundle.
 
+**What shipped (PRINT18/PRINT19).** 274 entries in the WEBu with the KJV beside
+them, checked character for character against eBible's own release
+(`passages/release/*.vpl.txt`), and thirty public-domain passages around them.
+"Woven through" turned out to be two fields rather than a feature:
+`HandwritingConfig.passage` and `MemoryConfig.passage` are a library id, read in
+one place (`writing/copywork.ts`) which either resolves it or falls back to
+whatever was pasted — so by the time a row is built the sheet cannot tell which
+door the words came in, and an id nine characters long is what makes a copywork
+sheet fit in a `#s=` link where the psalm would not. The picker is one control
+with every collection in it, Scripture first and "your own words" last, and the
+credit travels on the passage rather than beside it: `SheetFooter.source` is a
+field of its own precisely because an answer key has to say _both_ "Answer key"
+and where the passage came from.
+
+Memory work is the second family, and it is the one §12's licence condition
+actually bites on: rounds of the same passage with a growing share of the words
+gone, chosen by the seed, nesting so nothing comes back. The instruction line
+says the words are left out for the exercise and the key prints the passage
+whole — both halves, in the engine, so neither is a page's decision to forget.
+The shelf is `/printables/bible`, a peer of `/printables/math` and
+`/printables/handwriting`; the maths sheets stay clear of it, as above.
+
 ### Scripture on the front door: content, never a credential
 
 The site is Christian-owned and Christian-run. It is not _marketed_ as such,

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -9,6 +9,7 @@ import { answerKey, buildSheet } from "@/engine/sheets";
 import { figureBounds, labelPad } from "@/engine/sheets/figure";
 import { ticks } from "@/engine/sheets/numberline";
 import { DEFAULT_PAPER } from "@/engine/sheets/paper";
+import { SCRIPTURE_CREDIT } from "@/engine/sheets/passages";
 import type {
   ArithmeticConfig,
   Block,
@@ -354,6 +355,38 @@ describe("rendering a sheet", () => {
     const html = render();
     expect(html).toContain("Name");
     expect(html).toContain("sheet__field-rule");
+  });
+
+  it("prints the credit its words came with, beside the note and not instead of it", () => {
+    // §12, in the one place it has to be: the credit line is a condition of the
+    // World English Bible's name rather than a courtesy, and `.sheet__source`
+    // has no CSS rule of its own — so a renamed or dropped span would pass every
+    // other gate in this file and every gate in the engine's, which only assert
+    // the `Sheet` object's field. This is the assertion that it reaches paper.
+    const credited = (over: Partial<Sheet["footer"]> = {}) =>
+      render(
+        sheet({
+          footer: {
+            credit: "Free printables and learning games",
+            source: SCRIPTURE_CREDIT,
+            url: "schoolskills.app",
+            seed: 4242,
+            ...over,
+          },
+        }),
+      );
+
+    // Nothing where the words are the sheet's own: an 1885 poem needs no credit
+    // line, and one printed anyway would be noise on a child's page.
+    expect(render()).not.toContain("sheet__source");
+
+    expect(credited()).toContain(SCRIPTURE_CREDIT);
+    // And on an answer key, both — the page that carries the whole passage is
+    // the one that most needs to say where the passage came from.
+    const key = credited({ note: "Answer key" });
+    expect(key).toContain(SCRIPTURE_CREDIT);
+    expect(key).toContain("Answer key");
+    expect(key).toContain("Free printables and learning games");
   });
 
   it("prints the answers only when the sheet says so", () => {

--- a/src/components/sheet/SheetFoot.tsx
+++ b/src/components/sheet/SheetFoot.tsx
@@ -9,11 +9,17 @@ import type { SheetFooter } from "@/engine/sheets/types";
  * whole of what generated it (§7). The URL is plain text rather than a link:
  * it exists to be read off paper and typed, and a link on a catalog page that
  * points at the site the page is on earns nothing.
+ *
+ * `source` is where the words on the sheet came from, where they are somebody
+ * else's — for Scripture a condition of the name rather than a courtesy (§12).
+ * It prints beside the note rather than instead of it, because an answer key of
+ * a Scripture sheet has to say both things.
  */
 export function SheetFoot({ footer }: { footer: SheetFooter }) {
   return (
     <footer className="sheet__foot">
       <span className="sheet__credit">{footer.credit}</span>
+      {footer.source && <span className="sheet__source">{footer.source}</span>}
       {footer.note && <span className="sheet__note">{footer.note}</span>}
       {footer.url && <span className="sheet__link">{footer.url}</span>}
       <span className="sheet__seed">#{footer.seed}</span>

--- a/src/engine/sheets/chrome.ts
+++ b/src/engine/sheets/chrome.ts
@@ -17,14 +17,25 @@
  * So: a title is 1.7em over a 1.05 line-height, a field line 0.82em over 1.35,
  * an instruction 0.9em, and the footer 0.62em above a rule with 0.18in of air
  * over it.
+ *
+ * **Three of the rows are not always one row.** The name line wraps because it
+ * is a flex row; the instruction line wraps because it is a paragraph; the
+ * footer wraps because it is a flex row that a Scripture credit joins (§12).
+ * Each is counted below rather than assumed, and each was assumed once.
  */
 import type { Mil, SheetOptions } from "./types";
 
+import { faceOf } from "./faces";
 import { blockBox, contentBox, type Box } from "./layout";
 import { inches, points } from "./paper";
+import { LONGEST_SHEET_URL, SHEET_CREDIT } from "./spec";
 
 const HEAD_ROWS = { title: 1.9, fields: 1.2, instructions: 1.3 } as const;
 const FOOT_ROW = 0.9;
+
+/** The share of the body size sheet.css sets each of the wrapping rows at. */
+const INSTRUCTION_EM = 0.9;
+const FOOT_EM = 0.62;
 
 /** The gap sheet.css puts between the header's rows. */
 const HEAD_GAP = inches(0.09);
@@ -47,32 +58,57 @@ const SCORE_WIDTH = inches(1.4);
 const FIELD_GAP = inches(0.28);
 const FIELD_ROW_GAP = inches(0.06);
 
+/** `.sheet__foot` sets 0.04in between rows and 0.16in between its spans. */
+const FOOT_GAP = inches(0.16);
+const FOOT_ROW_GAP = inches(0.04);
+
+/**
+ * The seed's own place, at the widest a printed one can be.
+ *
+ * `decodeSharedSheet` takes any safe integer, so the allowance is sixteen
+ * digits and a hash rather than the `#1` the catalog happens to print. It is
+ * declared rather than passed in because the reservation is made before the
+ * sheet exists — and it costs under an inch of a row that has several to spare
+ * once the content credit is off it.
+ */
+const FOOT_SEED = `#${"0".repeat(16)}`;
+
 /** A height quoted in ems of the body size, in the unit the page is in. */
 const em = (fontPt: number, rows: number): Mil => points(fontPt * rows);
 
 /**
- * How many rows the name line wraps onto, packed the way a flex row packs.
+ * How wide a run of text is set, declared rather than measured.
  *
- * Greedy, item by item, because that is what `flex-wrap` does — and because
- * the items are not all the same width once a score box joins them. Counting
- * the score as another 2.5in field instead would push a name-date-score header
- * onto a second row it does not use, and on ⅝ paper a row is a line to write
- * on.
+ * The same bargain `layout.ts` strikes over a problem cell (§4) and the same
+ * mean advance `handwriting.ts` packs a row of letters by: characters times the
+ * face's own declared mean, at whatever share of the body size sheet.css sets
+ * this part of the chrome in. There is no DOM at build time to ask instead.
  */
-function fieldRows(options: SheetOptions, score: boolean): number {
-  const widths = [
-    ...options.fields.map(() => FIELD_WIDTH),
-    ...(score ? [SCORE_WIDTH] : []),
-  ];
-  if (widths.length === 0) return 0;
+const declaredWidth = (
+  text: string,
+  options: SheetOptions,
+  share: number,
+): Mil =>
+  Math.round(
+    text.length * points(options.fontPt * share) * faceOf(options.font).advance,
+  );
 
-  const limit = contentBox(options.paper).width;
+/**
+ * How many rows a wrapping flex row packs its items onto.
+ *
+ * Greedy, item by item, because that is what `flex-wrap` does, and because the
+ * items are not all the same width — a score box is a third of a field, and a
+ * Scripture credit is twice the site's own. Neither of the two rows this counts
+ * breaks *inside* an item: a field rule and a credit line are atomic, so a page
+ * too narrow for one whole item still prints one per row rather than looping
+ * forever, which is what `used > 0` is for.
+ */
+function packRows(widths: Mil[], limit: Mil, gap: Mil): number {
+  if (widths.length === 0) return 0;
   let rows = 1;
   let used = 0;
   for (const width of widths) {
-    const next = used === 0 ? width : used + FIELD_GAP + width;
-    // A page too narrow for one whole field still prints one per row rather
-    // than looping forever — `used > 0` is what makes the wrap terminate.
+    const next = used === 0 ? width : used + gap + width;
     if (next > limit && used > 0) {
       rows += 1;
       used = width;
@@ -81,6 +117,106 @@ function fieldRows(options: SheetOptions, score: boolean): number {
     }
   }
   return rows;
+}
+
+/**
+ * How many rows the name line wraps onto.
+ *
+ * Counting the score as another 2.5in field instead of at its own width would
+ * push a name-date-score header onto a second row it does not use, and on ⅝
+ * paper a row is a line to write on.
+ */
+const fieldRows = (options: SheetOptions, score: boolean): number =>
+  packRows(
+    [...options.fields.map(() => FIELD_WIDTH), ...(score ? [SCORE_WIDTH] : [])],
+    contentBox(options.paper).width,
+    FIELD_GAP,
+  );
+
+/**
+ * How many rows the instruction line wraps onto.
+ *
+ * A paragraph rather than a flex row, so it breaks *inside* itself and the
+ * answer is its length against the content width rather than a packing. One row
+ * was assumed flat until the memory family arrived: the notice §12 asks that
+ * sheet to print runs to a hundred and fifty-seven characters, which is two
+ * rows at 12pt on both stocks and five at the largest type a config may ask for.
+ */
+function instructionRows(options: SheetOptions): number {
+  if (!options.instructions) return 0;
+  const limit = contentBox(options.paper).width;
+  if (limit <= 0) return 1;
+  return Math.max(
+    1,
+    Math.ceil(
+      declaredWidth(options.instructions, options, INSTRUCTION_EM) / limit,
+    ),
+  );
+}
+
+/**
+ * What the footer will hold beyond the three every sheet's carries.
+ *
+ * The credit, the link and the seed are the spine's (`spec.ts`) and are counted
+ * for every sheet; these two belong to a family, and a family that prints either
+ * has to say so here — the reservation is made before the footer is built, so
+ * nothing down there can be discovered from it.
+ */
+export type FootLine = {
+  /**
+   * The content credit, where the words on the page are somebody else's — for
+   * Scripture a condition of the name rather than a courtesy (§12), and 75
+   * characters of it, which is more than twice the site's own credit.
+   */
+  source?: string;
+  /**
+   * The note a key prints — "Answer key".
+   *
+   * Declared on the *sheet* rather than only on the key, because the two are
+   * laid out against one box: `SheetSpec.key` replaces the footer and keeps the
+   * blocks, so a key whose footer is a row taller than its sheet's prints that
+   * row below the bottom margin. Reserving it either way costs a footer row a
+   * family with no key does not use, which is the cheap side to be wrong on.
+   */
+  note?: string;
+};
+
+/**
+ * How many rows the footer wraps onto.
+ *
+ * One row was assumed flat until a sheet arrived carrying credit, source, link,
+ * seed *and* a note — the answer key of a Scripture memory sheet, which is two
+ * rows at 12pt on both stocks and was reserved as one.
+ *
+ * The content credit is given **its own row** rather than packed with the rest,
+ * and that is a deliberate over-reservation. Whether 75 characters of Scripture
+ * credit share a row with the credit, the link and the seed comes down to a few
+ * thousandths of an inch under a declared mean advance — the strings a shipped
+ * page carries measure 7,097 against a 7,268 A4 content width, on a mean taken
+ * over `a`–`z` — and that is not a distinction this arithmetic can honestly
+ * claim to make. So a sheet that credits its source reserves a row for the
+ * credit and a row for everything else, and pays for it at the bottom of the
+ * page: a footer row over-reserved costs one rule line, and one under-reserved
+ * costs a second sheet of paper.
+ *
+ * The credit still gets *more* than one row where it needs it — at 36pt it is
+ * wider than either stock on its own — which is why it is a count and not a
+ * flag.
+ */
+function footRows(options: SheetOptions, foot: FootLine): number {
+  const limit = contentBox(options.paper).width;
+  const spine = packRows(
+    [SHEET_CREDIT, foot.note, LONGEST_SHEET_URL, FOOT_SEED]
+      .filter((text): text is string => Boolean(text))
+      .map((text) => declaredWidth(text, options, FOOT_EM)),
+    limit,
+    FOOT_GAP,
+  );
+  if (!foot.source || limit <= 0) return spine;
+  return (
+    spine +
+    Math.max(1, Math.ceil(declaredWidth(foot.source, options, FOOT_EM) / limit))
+  );
 }
 
 /**
@@ -99,13 +235,17 @@ export function chromeHeight(
    * of problems it ended up with, which is known after the build.
    */
   score = false,
+  /** What this family will put at the foot beyond the spine's own three. */
+  foot: FootLine = {},
 ): { header: Mil; footer: Mil } {
   const fields = fieldRows(options, score);
+  const instructions = instructionRows(options);
   const rows = [
     options.title ? HEAD_ROWS.title : 0,
     HEAD_ROWS.fields * fields,
-    options.instructions ? HEAD_ROWS.instructions : 0,
+    HEAD_ROWS.instructions * instructions,
   ].filter((row) => row > 0);
+  const feet = footRows(options, foot);
 
   return {
     // The margin is there even when the header is empty — SheetHead renders
@@ -115,7 +255,10 @@ export function chromeHeight(
       rows.reduce((total, row) => total + em(options.fontPt, row), 0) +
       HEAD_GAP * Math.max(0, rows.length - 1) +
       FIELD_ROW_GAP * Math.max(0, fields - 1),
-    footer: FOOT_MARGIN + em(options.fontPt, FOOT_ROW),
+    footer:
+      FOOT_MARGIN +
+      em(options.fontPt, FOOT_ROW * feet) +
+      FOOT_ROW_GAP * Math.max(0, feet - 1),
   };
 }
 
@@ -128,6 +271,10 @@ export function chromeHeight(
  * this box, which is the content box minus a non-negative number, so any
  * chrome at all satisfies it, including none.
  */
-export function sheetBlockBox(options: SheetOptions, score = false): Box {
-  return blockBox(options.paper, chromeHeight(options, score));
+export function sheetBlockBox(
+  options: SheetOptions,
+  score = false,
+  foot: FootLine = {},
+): Box {
+  return blockBox(options.paper, chromeHeight(options, score, foot));
 }

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -32,6 +32,7 @@ import { WORD_PROBLEMS_SHEET } from "./maths/wordproblems";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
 import { PAPER_SHEET } from "./templates/paper";
 import { HANDWRITING_SHEET } from "./writing/handwriting";
+import { MEMORY_SHEET } from "./writing/memory";
 import { WORDS_SHEET } from "./words/spelling";
 
 const SHEETS: Record<string, SheetSpec> = {
@@ -52,6 +53,7 @@ const SHEETS: Record<string, SheetSpec> = {
   [WORD_PROBLEMS_SHEET.id]: WORD_PROBLEMS_SHEET,
   [WORDS_SHEET.id]: WORDS_SHEET,
   [HANDWRITING_SHEET.id]: HANDWRITING_SHEET,
+  [MEMORY_SHEET.id]: MEMORY_SHEET,
 };
 
 /**

--- a/src/engine/sheets/passages/index.ts
+++ b/src/engine/sheets/passages/index.ts
@@ -34,10 +34,17 @@ import type {
   PassageCollection,
   PassageSource,
   PassageSummary,
+  TranslationId,
 } from "./types";
 
 export { SCRIPTURE_CREDIT };
-export type { Passage, PassageCollection, PassageSource, PassageSummary };
+export type {
+  Passage,
+  PassageCollection,
+  PassageSource,
+  PassageSummary,
+  TranslationId,
+};
 
 /** The words as one block, for the places that want a paragraph. */
 export const passageText = (passage: Passage): string =>
@@ -54,8 +61,6 @@ const summarise = ({ lines, ...rest }: Passage): PassageSummary => ({
    "Yahweh"; the KJV because a good many families want it and it is equally
    free. Never ESV, NIV, NASB or CSB — those are licensed, and bundling one
    would be a genuine problem rather than an oversight.                      */
-
-export type TranslationId = "webu" | "kjv";
 
 export type Translation = {
   id: TranslationId;
@@ -180,14 +185,25 @@ export const listPassageSummaries = (
   translation: TranslationId = DEFAULT_TRANSLATION,
 ): PassageSummary[] => listPassages(translation).map(summarise);
 
+/*
+   Indexed by id, once. `passage()` is called several times per sheet built —
+   the layout, the header, the body and the one-line description each ask —
+   and a linear scan of three hundred entries for each of them is a scan the
+   catalog build repeats a few thousand times. A `Map` also takes an untrusted
+   id safely, which is the same trap `hasOwn` guards above: `OTHERS["toString"]`
+   is a function off the prototype, and `.get("toString")` is nothing.        */
+
+const SCRIPTURE_BY_ID = new Map(SCRIPTURE.map((entry) => [entry.id, entry]));
+const OTHERS_BY_ID = new Map(OTHERS.map((entry) => [entry.id, entry]));
+
 /** One passage, or nothing. See the note at the top on why it never throws. */
 export function passage(
   id: string,
   translation: TranslationId = DEFAULT_TRANSLATION,
 ): Passage | undefined {
-  const entry = SCRIPTURE.find((candidate) => candidate.id === id);
+  const entry = SCRIPTURE_BY_ID.get(id);
   if (entry) return fromScripture(entry, translation);
-  return OTHERS.find((candidate) => candidate.id === id);
+  return OTHERS_BY_ID.get(id);
 }
 
 /** Everything in one collection, for a picker grouped the way §12 groups it. */

--- a/src/engine/sheets/passages/types.ts
+++ b/src/engine/sheets/passages/types.ts
@@ -29,6 +29,18 @@
 export type PassageKind = "scripture" | "prose" | "poetry" | "document";
 
 /**
+ * Which translation a Scripture passage is read in — the two of §12, and the
+ * reasoning for both is beside the table in index.ts.
+ *
+ * The id lives here rather than there for one practical reason: a sheet config
+ * carries a translation, so `engine/sheets/types.ts` has to be able to name the
+ * type — and a type-only import of this module costs nothing, where an import
+ * of the library's front door would put a hundred kilobytes of verses in front
+ * of every module that so much as mentions a `Sheet`.
+ */
+export type TranslationId = "webu" | "kjv";
+
+/**
  * Where the text came from, and why we may print it.
  *
  * `edition` is the load-bearing one and the one it is tempting to leave vague.

--- a/src/engine/sheets/spec.ts
+++ b/src/engine/sheets/spec.ts
@@ -48,6 +48,22 @@ export function gameUrl(world: World): string {
 }
 
 /**
+ * The longest link the foot of a sheet can carry.
+ *
+ * Derived from the registry rather than written out, because it is `chrome.ts`
+ * that reads it: the footer's height is reserved before the sheet is built, so
+ * the reservation has to be made against the widest link a family might choose
+ * rather than against the one it did. A second copy of "schoolskills.app/
+ * spelling/play" would be a second thing to keep in step with `worlds.ts`.
+ */
+export const LONGEST_SHEET_URL: string = WORLDS.map((world) =>
+  gameUrl(world.id),
+).reduce(
+  (longest, url) => (url.length > longest.length ? url : longest),
+  SHEET_URL,
+);
+
+/**
  * `C` is the family's own config, and the registry in index.ts is what ties it
  * back to the union: a spec is only ever handed the config whose `kind` looked
  * it up. Declaring `build` and `describe` as methods rather than as arrow

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -12,6 +12,7 @@
  * answers the build already computed — `answers: true` and nothing else — so
  * however a key is obtained it can't disagree with the sheet it belongs to.
  */
+import type { TranslationId } from "./passages/types";
 
 /* ── Units ────────────────────────────────────────────────────────────────
    Every length on a sheet is a whole number of thousandths of an inch.
@@ -478,11 +479,27 @@ export type SheetHeader = {
 
 export type SheetFooter = {
   credit: string;
+  /**
+   * The credit the *content* requires, where the words on the page are
+   * somebody else's: "Scripture: World English Bible Updated (public domain) ·
+   * worldenglish.bible" (§12).
+   *
+   * A field of its own rather than a second use of `note` below, because a
+   * sheet often has to say both things at once and they are different claims.
+   * `note` is what this printout *is* — an answer key — and it is set by
+   * `SheetSpec.key` on a sheet that already carries a source; joining the two
+   * into one string would make the key overwrite the credit, which is the one
+   * of the pair we promised to print.
+   *
+   * Absent where the source asks for nothing. An 1885 poem needs no credit
+   * line, and a sheet that printed one anyway would be noise on a child's page.
+   */
+  source?: string;
   /** Short, and pointing back at the game the sheet came from (§16). */
   url?: string;
   /** Printed small, so the same sheet can be had again next week (§7). */
   seed: number;
-  /** "Answer key", or a source credit the sheet's content requires. */
+  /** What this printout is, where it is not simply the sheet: "Answer key". */
   note?: string;
 };
 
@@ -1364,8 +1381,69 @@ export type HandwritingConfig = SheetOptions & {
    * Wrapped to the ruling by the family rather than by the renderer, because
    * there is no DOM to measure in (§4) — a newline here is a line break the
    * author asked for, and everything else breaks where the paper runs out.
+   *
+   * What a parent typed or pasted. `passage` below is the other door, and it
+   * wins where both are set — see `copyworkSource`.
    */
   text?: string;
+  /**
+   * `passage` only: one of the library's passages, by id — Psalm 23, the
+   * Gettysburg Address, a fable (`engine/sheets/passages`).
+   *
+   * An id rather than the words, which is what makes a copywork sheet fit in a
+   * link (§14): "psalm-23" is nine characters where the psalm is seven hundred,
+   * and the sheet built from it carries the provenance the library holds rather
+   * than a quotation with no source attached. A passage this build has never
+   * heard of falls back to `text`, for the same reason `sheetSpec` never throws
+   * — a bookmark outlives the library it was made on.
+   */
+  passage?: string;
+  /**
+   * Which translation a Scripture passage is read in. Ignored by everything
+   * else in the library, which has only the one text.
+   */
+  translation?: TranslationId;
+};
+
+/* ── Memory work ───────────────────────────────────────────────────────────
+   The one family whose exercise is what is *missing* from the page. Every
+   other sheet in the shop either generates its content or prints somebody's
+   words as they stand; this one prints them and then takes them away a few at
+   a time, which is how a verse is learnt by heart and is also the one thing
+   §12's licence condition has something to say about — so the sheet says
+   plainly that words are left out on purpose, and the answer key is the whole
+   passage.                                                                  */
+
+/**
+ * A passage written out several times, with more of it missing each time.
+ *
+ * The oldest memory-work exercise there is, and it is one dial: how many times
+ * the passage is written. The first round is the whole thing to read, the last
+ * has every word gone, and the ones between take out a share of the words that
+ * grows evenly — so a sheet is a progression rather than a difficulty setting,
+ * exactly as a handwriting sheet is.
+ *
+ * Which words go is decided by the seed and nothing else, and the sets nest:
+ * a word missing in round two is missing in round three. A round that gave a
+ * word back would read as a mistake in the printing.
+ *
+ * The text comes from the library or from a paste, the same two doors a
+ * copywork sheet has, and by exactly the same fields — see `copyworkSource`,
+ * which is the one place either is read.
+ */
+export type MemoryConfig = SheetOptions & {
+  kind: "memory";
+  /** A passage from the library, by id. */
+  passage?: string;
+  /** Which translation a Scripture passage is read in. */
+  translation?: TranslationId;
+  /** What a parent typed or pasted. `passage` wins where both are set. */
+  text?: string;
+  /**
+   * How many times the passage is written out, the whole one at the top and
+   * the empty one at the bottom included. Capped at what the page holds.
+   */
+  rounds: number;
 };
 
 /**
@@ -1389,7 +1467,8 @@ export type SheetConfig =
   | StatisticsConfig
   | WordProblemConfig
   | WordsConfig
-  | HandwritingConfig;
+  | HandwritingConfig
+  | MemoryConfig;
 
 /* ── A sheet somebody kept ─────────────────────────────────────────────── */
 

--- a/src/engine/sheets/writing/copywork.ts
+++ b/src/engine/sheets/writing/copywork.ts
@@ -25,17 +25,39 @@ import { DEFAULT_TRANSLATION, passage, passageText } from "../passages";
 import type { TranslationId } from "../passages/types";
 
 /**
- * The longest passage worth setting.
+ * The longest **paste** worth setting.
  *
  * The smallest ruling holds about twenty-two lines to a page and about
  * forty-six characters to a line, so a thousand characters is already more than
- * any sheet can print — this is twice that, and still short enough that a
- * config fits in a URL (§14), which is not the place for an essay. Applied to
- * the library's own passages as well as to a paste: the Christmas story is
- * longer than this, and a sheet that printed the first page of it and stopped
- * is the honest thing rather than one that refuses to build.
+ * any sheet can print — this is twice that, and still short enough that a config
+ * fits in a URL (§14), which is not the place for an essay.
+ *
+ * A paste only. A library passage is nine characters of id in the `#s=` link and
+ * its words never travel, so the cap's own reason does not reach it — and
+ * applying it there once cost the Christmas story (2,048 characters) its last
+ * eight words *and* half of the word before them, on a sheet whose instruction
+ * line promises the whole passage on the answer key. Nothing refuses to build
+ * without the cap either: how much of a passage reaches the paper is already
+ * decided by the capacity arithmetic, a page at a time.
  */
 export const MAX_TEXT = 2000;
+
+/**
+ * A paste cut down to length on a boundary its author put there.
+ *
+ * Back to the last space rather than to a character index, because the cut shows
+ * on the paper: half a word reads as a misprint, and on a memory sheet it is
+ * printed under a promise that the answer key holds the passage whole. A run
+ * with no whitespace in it at all keeps the plain cut — there is no boundary to
+ * find, and one very long word is still better than a blank page.
+ */
+export function trimText(text: string, limit: number = MAX_TEXT): string {
+  if (text.length <= limit) return text;
+  const cut = text.slice(0, limit);
+  if (/\s/.test(text.charAt(limit))) return cut.trimEnd();
+  const whole = cut.replace(/\S+$/, "").trimEnd();
+  return whole === "" ? cut : whole;
+}
 
 /** What either family is actually handed, whichever door the words came in. */
 export type CopyworkSource = {
@@ -72,14 +94,17 @@ export function copyworkSource(config: CopyworkConfig): CopyworkSource {
       : undefined;
 
   if (chosen) {
+    // Verbatim, and uncapped: the library's own text is the one thing on a sheet
+    // that is quoted rather than generated (§12), so it is handed on whole and
+    // the page decides how much of it fits.
     return {
-      text: passageText(chosen).slice(0, MAX_TEXT),
+      text: passageText(chosen),
       title: chosen.title,
       attribution: chosen.attribution,
       credit: chosen.credit,
     };
   }
   return {
-    text: typeof config.text === "string" ? config.text.slice(0, MAX_TEXT) : "",
+    text: typeof config.text === "string" ? trimText(config.text) : "",
   };
 }

--- a/src/engine/sheets/writing/copywork.ts
+++ b/src/engine/sheets/writing/copywork.ts
@@ -1,0 +1,85 @@
+/**
+ * Where the words on a copywork sheet come from.
+ *
+ * Two doors, and this is the only place either is opened. A parent either picks
+ * something out of the library — Psalm 23, the Gettysburg Address, a fable —
+ * or pastes what they have in front of them, and the sheet that comes out is
+ * the same sheet either way. That is §12's "woven through" reduced to a
+ * function: choosing Scripture and choosing Lincoln are the same interaction,
+ * and neither the handwriting family nor the memory one learns which it got.
+ *
+ * Two things it owns that neither family should have to:
+ *
+ *   - **The provenance travels with the words.** A passage out of the library
+ *     carries the credit its source asks for (`Passage.credit`), and the sheet
+ *     puts that on the paper. A pasted verse carries none, because we have no
+ *     idea where it came from and printing a credit we made up would be worse
+ *     than printing nothing.
+ *   - **It never fails.** An id this build has never heard of falls back to
+ *     whatever `text` says and then to an empty page, the way `sheetSpec`
+ *     answers with `UNKNOWN_SHEET`: a link bookmarked in March must still open
+ *     in June after a passage was retired, and a build of the catalog must not
+ *     stop because of it.
+ */
+import { DEFAULT_TRANSLATION, passage, passageText } from "../passages";
+import type { TranslationId } from "../passages/types";
+
+/**
+ * The longest passage worth setting.
+ *
+ * The smallest ruling holds about twenty-two lines to a page and about
+ * forty-six characters to a line, so a thousand characters is already more than
+ * any sheet can print — this is twice that, and still short enough that a
+ * config fits in a URL (§14), which is not the place for an essay. Applied to
+ * the library's own passages as well as to a paste: the Christmas story is
+ * longer than this, and a sheet that printed the first page of it and stopped
+ * is the honest thing rather than one that refuses to build.
+ */
+export const MAX_TEXT = 2000;
+
+/** What either family is actually handed, whichever door the words came in. */
+export type CopyworkSource = {
+  /** The words, as they should be set. A newline is a break the author made. */
+  text: string;
+  /** How the passage is named — "Psalm 23". Absent for a paste. */
+  title?: string;
+  /** Who wrote it, or which translation it is. Absent for a paste. */
+  attribution?: string;
+  /** Printed small at the foot of any sheet that quotes it (§12). */
+  credit?: string;
+};
+
+/** The two fields both families carry, and nothing else about either of them. */
+export type CopyworkConfig = {
+  passage?: string;
+  translation?: TranslationId;
+  text?: string;
+};
+
+/**
+ * The words a config asks for.
+ *
+ * The library wins where both are set, which is the way round that keeps a
+ * shared link honest: `passage` is the choice a parent made in the picker and
+ * `text` is what the box happened to be holding underneath it, so a sheet built
+ * from an id prints the passage rather than whatever was typed before it was
+ * chosen. Clearing the id is how you go back to your own words.
+ */
+export function copyworkSource(config: CopyworkConfig): CopyworkSource {
+  const chosen =
+    typeof config.passage === "string" && config.passage !== ""
+      ? passage(config.passage, config.translation ?? DEFAULT_TRANSLATION)
+      : undefined;
+
+  if (chosen) {
+    return {
+      text: passageText(chosen).slice(0, MAX_TEXT),
+      title: chosen.title,
+      attribution: chosen.attribution,
+      credit: chosen.credit,
+    };
+  }
+  return {
+    text: typeof config.text === "string" ? config.text.slice(0, MAX_TEXT) : "",
+  };
+}

--- a/src/engine/sheets/writing/handwriting.test.ts
+++ b/src/engine/sheets/writing/handwriting.test.ts
@@ -9,7 +9,12 @@ import {
 } from "../faces";
 import { ruleCapacity, ruledLines } from "../layout";
 import { RULINGS, inches, rulePitch, toInches, writingSpace } from "../paper";
-import { SCRIPTURE_CREDIT, passage, passageText } from "../passages";
+import {
+  SCRIPTURE_CREDIT,
+  listPassages,
+  passage,
+  passageText,
+} from "../passages";
 import type {
   HandwritingConfig,
   Rule,
@@ -18,6 +23,7 @@ import type {
   TraceStyle,
 } from "../types";
 
+import { MAX_TEXT, copyworkSource } from "./copywork";
 import {
   DEFAULT_HAND_RULE,
   HANDWRITING_SHEET,
@@ -640,6 +646,37 @@ describe("copywork out of the passage library", () => {
     // attached to the name (§12).
     const words = passageText(passage(VERSE)!).replace(/\s+/g, " ");
     expect(copied({ passage: VERSE, rule: { style: "hand-3-8" } })).toBe(words);
+  });
+
+  it("hands on the longest passage in the library whole, and cuts a paste on a word", () => {
+    /*
+     * The cap on a paste is not a cap on the library, and the difference is a
+     * licence condition rather than a tidiness one (§12). A library passage
+     * travels as its id — nine characters in a `#s=` link — so §14's reason for
+     * capping a config never reaches it; applying the cap there anyway cost the
+     * longest entry its last eight words *and* half of the word before them, and
+     * on a memory sheet that truncated text is what the answer key prints, under
+     * an instruction line promising the passage whole.
+     *
+     * Over the longest entry rather than a named one, so the case cannot quietly
+     * stop being the interesting one when a longer passage is added.
+     */
+    const longest = listPassages().reduce((most, entry) =>
+      passageText(entry).length > passageText(most).length ? entry : most,
+    );
+    expect(passageText(longest).length).toBeGreaterThan(MAX_TEXT);
+    expect(copyworkSource({ passage: longest.id }).text, longest.id) //
+      .toBe(passageText(longest));
+
+    // A paste is still capped, because a config does have to fit in a URL — but
+    // on a boundary its author put there, so nothing reaches the paper as half a
+    // word. Every word of the cut is a whole word of the paste, in order.
+    const paste = `${"seven-letter ".repeat(200)}last`;
+    const cut = copyworkSource({ text: paste }).text;
+    expect(cut.length).toBeLessThanOrEqual(MAX_TEXT);
+    const words = cut.split(/\s+/);
+    expect(words.length).toBeGreaterThan(1);
+    expect(paste.split(/\s+/).slice(0, words.length)).toEqual(words);
   });
 
   it("puts the credit its source asks for at the foot of the page", () => {

--- a/src/engine/sheets/writing/handwriting.test.ts
+++ b/src/engine/sheets/writing/handwriting.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../faces";
 import { ruleCapacity, ruledLines } from "../layout";
 import { RULINGS, inches, rulePitch, toInches, writingSpace } from "../paper";
+import { SCRIPTURE_CREDIT, passage, passageText } from "../passages";
 import type {
   HandwritingConfig,
   Rule,
@@ -594,6 +595,122 @@ describe("joined writing", () => {
     expect(
       describeHandwriting(config({ style: "joins", joins: "round" })),
     ).toContain("joins into a round letter");
+  });
+});
+
+/* ── Copywork, from the library or from a paste ────────────────────────────
+   The passage style's other door (§12). Two things have to hold, and the
+   second is a licence condition rather than a nicety: the words that reach the
+   paper are the library's exactly, and the credit its source asks for is on the
+   sheet that quotes it.                                                      */
+
+describe("copywork out of the passage library", () => {
+  const VERSE = "trust-in-the-lord";
+
+  /** Everything a copywork sheet printed, as one string. */
+  const copied = (over: Partial<HandwritingConfig>): string =>
+    written(rowsOf({ style: "passage", trace: "dim", repeats: 2, ...over }))
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+  it("sets a library passage at every ruling and every trace style", () => {
+    // The story's first line, as an assertion. A passage is not a special kind
+    // of sheet: it is the same rows on the same twelve rulings, so all sixty
+    // combinations have to print something rather than the handful the catalog
+    // happens to use.
+    for (const style of STYLES) {
+      for (const trace of TRACES) {
+        const rows = rowsOf({
+          style: "passage",
+          passage: VERSE,
+          rule: { style },
+          trace,
+          repeats: 2,
+        });
+        expect(rows.length, `${style} / ${trace}`).toBeGreaterThan(0);
+        expect(rows[0].cells.length, `${style} / ${trace}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("prints the passage's own words, not a paraphrase of them", () => {
+    // The line breaks are the family's — a row is one repeat of the ruling —
+    // but nothing between them may change, which for Scripture is the condition
+    // attached to the name (§12).
+    const words = passageText(passage(VERSE)!).replace(/\s+/g, " ");
+    expect(copied({ passage: VERSE, rule: { style: "hand-3-8" } })).toBe(words);
+  });
+
+  it("puts the credit its source asks for at the foot of the page", () => {
+    const verse = HANDWRITING_SHEET.build(
+      config({ style: "passage", passage: VERSE }),
+      1,
+    );
+    expect(verse.footer.source).toBe(SCRIPTURE_CREDIT);
+    // And nothing where nothing is asked for. An 1885 poem needs no credit
+    // line, and one printed anyway is noise on a child's page.
+    const poem = HANDWRITING_SHEET.build(
+      config({ style: "passage", passage: "bed-in-summer" }),
+      1,
+    );
+    expect(poem.footer.source).toBeUndefined();
+  });
+
+  it("reads a verse in the translation that was asked for", () => {
+    const webu = copied({ passage: VERSE, rule: { style: "hand-3-8" } });
+    const kjv = copied({
+      passage: VERSE,
+      translation: "kjv",
+      rule: { style: "hand-3-8" },
+    });
+    expect(kjv).not.toBe(webu);
+    expect(kjv).toContain("Trust in the LORD with all thine heart");
+    // Whole, not half: the text and the credit under it come from the same
+    // translation or the page is quoting one edition under another's name.
+    expect(
+      HANDWRITING_SHEET.build(
+        config({ style: "passage", passage: VERSE, translation: "kjv" }),
+        1,
+      ).footer.source,
+    ).toContain("King James");
+  });
+
+  it("names the passage on the paper, so the sheet says what is on it", () => {
+    const sheet = HANDWRITING_SHEET.build(
+      config({ style: "passage", passage: VERSE }),
+      1,
+    );
+    expect(sheet.header.title).toBe("Copywork — Proverbs 3:5-6");
+    expect(
+      describeHandwriting(config({ style: "passage", passage: VERSE })),
+    ).toContain("Proverbs 3:5-6");
+  });
+
+  it("prefers the library to whatever the paste box was holding", () => {
+    // Which way round matters for a shared link: the id is the choice somebody
+    // made in the picker, and the text is what was underneath it beforehand.
+    const both = { passage: VERSE, text: "Something else entirely." };
+    expect(copied({ ...both, rule: { style: "hand-3-8" } })).toBe(
+      passageText(passage(VERSE)!).replace(/\s+/g, " "),
+    );
+    // And clearing the id is how a parent gets their own words back.
+    expect(copied({ text: "Something else entirely." })).toBe(
+      "Something else entirely.",
+    );
+  });
+
+  it("falls back to the paste when the passage has been retired", () => {
+    // A bookmark outlives the library it was made on, the same way a saved
+    // sheet outlives its family — so an id this build never heard of prints
+    // whatever else the config had rather than throwing mid-build.
+    const stale = { passage: "no-such-passage", text: "Still prints." };
+    expect(() => rowsOf({ style: "passage", ...stale })).not.toThrow();
+    expect(copied(stale)).toBe("Still prints.");
+    expect(
+      HANDWRITING_SHEET.build(config({ style: "passage", ...stale }), 1).footer
+        .source,
+    ).toBeUndefined();
   });
 });
 

--- a/src/engine/sheets/writing/handwriting.ts
+++ b/src/engine/sheets/writing/handwriting.ts
@@ -286,10 +286,16 @@ export function handwritingLayout(
   longest: number,
 ): HandwritingLayout {
   const rule = ruleOf(config);
-  // Against the header the sheet will print rather than the one the config
-  // holds, and with no score box: there is nothing on a handwriting sheet to
-  // mark out of anything.
-  const box = sheetBlockBox(headerOf(config));
+  // Against the header and the footer the sheet will print rather than the ones
+  // the config holds, and with no score box: there is nothing on a handwriting
+  // sheet to mark out of anything. No `note` either — this family's key is the
+  // sheet itself, so nothing is ever added to the foot after the layout.
+  const credit = sourceOf(config)?.credit;
+  const box = sheetBlockBox(
+    headerOf(config),
+    false,
+    credit ? { source: credit } : {},
+  );
   const face = faceOf(fontOf(config));
   const em = glyphEm(writingSpace(rule), face, writtenOf(config));
   const rows = ruleCapacity(box.height, rule);

--- a/src/engine/sheets/writing/handwriting.ts
+++ b/src/engine/sheets/writing/handwriting.ts
@@ -21,6 +21,13 @@
  * same sequence runs *down* the page instead. Nothing else differs between the
  * five styles.
  *
+ * **Copywork is the passage style, and its words come from one of two doors.**
+ * Either the library (`passages/`) by id, or a paste — `copyworkSource` is the
+ * only place either is read, and by the time a row is built the sheet cannot
+ * tell which it got. That is what makes choosing Psalm 23 and choosing the
+ * Gettysburg Address the same interaction (§12); what a library passage adds is
+ * a credit line at the foot of the page, where its source asks for one.
+ *
  * **Cursive is not a sixth style.** A cursive sheet is these same sheets set in
  * a joining face (`SheetOptions.font`), because a letter, a word and a passage
  * are the same exercises whether or not the letters touch — and a cell is one
@@ -65,6 +72,7 @@ import { sheetBlockBox } from "../chrome";
 import { ruleCapacity, type Box } from "../layout";
 import { own, rulePitch, rulingOf, writingSpace } from "../paper";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import { copyworkSource, type CopyworkSource } from "./copywork";
 import { joinFamily, joinPairs } from "./joins";
 
 /* ── What the family will and won't do ─────────────────────────────────── */
@@ -83,16 +91,6 @@ const MAX_WORDS = 200;
 
 /** Long enough for "onomatopoeia" twice over; short enough not to wrap. */
 const MAX_LETTERS = 24;
-
-/**
- * The longest passage worth setting.
- *
- * The smallest ruling here holds about twenty-two lines to a page and about
- * forty-six characters to a line, so a thousand characters is already more than
- * any sheet can print — this is twice that, and still short enough that a config
- * fits in a URL (§14), which is not the place for an essay.
- */
-const MAX_TEXT = 2000;
 
 const clamp = (value: number, low: number, high: number): number =>
   Math.max(low, Math.min(high, Math.floor(value)));
@@ -359,7 +357,9 @@ export const fontOf = (config: HandwritingConfig): SheetFont | undefined =>
  * order it is joined in and the spaces between are beside the point.
  */
 const writtenOf = (config: HandwritingConfig): string =>
-  config.style === "passage" ? (config.text ?? "") : contentOf(config).join("");
+  config.style === "passage"
+    ? copyworkSource(config).text
+    : contentOf(config).join("");
 
 /** The longest thing on the page, in characters. Never less than one. */
 const longestOf = (things: string[]): number =>
@@ -415,7 +415,7 @@ function bodyOf(config: HandwritingConfig): Block[] {
 
   if (config.style === "passage") {
     const { box, em, face, perPage, rule } = handwritingLayout(config, 1);
-    const text = (config.text ?? "").slice(0, MAX_TEXT);
+    const { text } = copyworkSource(config);
     const lines = wrapPassage(text, fittedCharacters(box.width, em, face));
     return [
       { kind: "trace", rule, rows: rowsDown(lines.slice(0, perPage), styles) },
@@ -500,17 +500,37 @@ export function instructionOf(config: HandwritingConfig): string {
 }
 
 /**
- * What the sheet is called, which depends on the hand it is written in.
+ * The words a copywork sheet is set on, and nothing for the sheets that are
+ * set on an alphabet.
+ *
+ * One function so that the four places that ask — the layout, the header, the
+ * page and the one-line description — cannot disagree about which passage is
+ * on the paper.
+ */
+const sourceOf = (config: HandwritingConfig): CopyworkSource | undefined =>
+  config.style === "passage" ? copyworkSource(config) : undefined;
+
+/**
+ * What the sheet is called, which depends on the hand it is written in and on
+ * what is being copied.
  *
  * Read off the face the sheet will actually be set in rather than off the one
  * the config asked for, so the title and the letterforms can't disagree — a
  * joins sheet whose config says `print` still prints joined, and still says so.
+ *
+ * A passage out of the library names itself in the title: "Copywork" over a
+ * page of Psalm 23 is a sheet that does not say what is on it, and the title is
+ * what somebody reads off the paper on the fridge a week later. A pasted
+ * passage keeps the plain title, because the only name we would have for it is
+ * one we invented.
  */
 function titleOf(config: HandwritingConfig): string {
-  const title = own(TITLE, config.style, TITLE.letters);
-  return isCursive(fontOf(config))
-    ? own(CURSIVE_TITLE, config.style, title)
-    : title;
+  const plain = own(TITLE, config.style, TITLE.letters);
+  const title = isCursive(fontOf(config))
+    ? own(CURSIVE_TITLE, config.style, plain)
+    : plain;
+  const named = sourceOf(config)?.title;
+  return named ? `${title} — ${named}` : title;
 }
 
 /** How the content is described in one phrase, in the terms it was chosen by. */
@@ -527,7 +547,9 @@ function contentLabel(config: HandwritingConfig): string {
       return `${words} ${words === 1 ? "word" : "words"}`;
     }
     case "passage":
-      return "a passage";
+      // The title already names a passage out of the library, so what is left
+      // worth saying is who wrote it — and, for a paste, that nobody knows.
+      return sourceOf(config)?.attribution ?? "a passage";
     default:
       switch (config.letters ?? "both") {
         case "upper":
@@ -576,6 +598,7 @@ export function buildHandwritingSheet(
   seed: number,
 ): Sheet {
   const head = headerOf(config);
+  const credit = sourceOf(config)?.credit;
 
   return {
     paper: config.paper,
@@ -594,7 +617,16 @@ export function buildHandwritingSheet(
     // No game to point at. A handwriting sheet has no race behind it — the
     // words on one may come from the jungle, but what is being practised is the
     // shape of the letters and not the spelling (§16).
-    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    //
+    // `source` is where the words came from, on the sheets that quote somebody:
+    // printed on every page that carries a passage the library asks credit for,
+    // which for Scripture is a condition rather than a courtesy (§12).
+    footer: {
+      credit: SHEET_CREDIT,
+      url: SHEET_URL,
+      seed,
+      ...(credit ? { source: credit } : {}),
+    },
     answers: false,
   };
 }

--- a/src/engine/sheets/writing/memory.test.ts
+++ b/src/engine/sheets/writing/memory.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { sheetBlockBox } from "../chrome";
-import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "../paper";
+import { chromeHeight, sheetBlockBox, type FootLine } from "../chrome";
+import { faceOf } from "../faces";
+import { contentBox } from "../layout";
+import { DEFAULT_FONT_PT, DEFAULT_PAPER, points } from "../paper";
 import { SCRIPTURE_CREDIT, passage, passageText } from "../passages";
-import type { Blank, MemoryConfig } from "../types";
+import type { Blank, MemoryConfig, SheetOptions } from "../types";
 
 import {
   MAX_ROUNDS,
   MEMORY_SHEET,
   describeMemory,
+  instructionOf,
   memoryLayout,
   memoryWords,
   removalCounts,
@@ -238,6 +241,69 @@ describe("what fits on the paper", () => {
           );
         }
       }
+    }
+  });
+
+  it("reserves the rows the notice and the credit line actually wrap onto", () => {
+    /*
+     * The check the test above cannot make. "Never prints more than the page
+     * holds" measures the rounds against `sheetBlockBox` — the same number the
+     * layout used — so a chrome that under-reserved by a row satisfies it while
+     * the last round prints below the bottom margin.
+     *
+     * This family is the one that made two rows of the chrome wrap: the §12
+     * notice is 157 characters, and the answer key's foot carries a 75-character
+     * Scripture credit beside "Answer key". Both are measured here against what
+     * `chromeHeight` reserved, and both are measured off *sheet.css's* own
+     * line-height rather than off `chrome.ts`'s rounded-up row — so the test
+     * cannot pass by restating the constant it is checking.
+     */
+    const LINE = 1.35; // `.sheet`
+    const INSTRUCTION_EM = 0.9; // `.sheet__instructions`
+    const FOOT_EM = 0.62; // `.sheet__foot`
+    const notice = instructionOf(4);
+
+    for (const size of ["letter", "a4"] as const) {
+      const paper = {
+        size,
+        orientation: "portrait",
+        margin: "normal",
+      } as const;
+      const head: SheetOptions = {
+        paper,
+        fontPt: DEFAULT_FONT_PT,
+        fields: ["name", "date"],
+        title: "Memory work — Psalm 23",
+        instructions: notice,
+      };
+      const width = contentBox(paper).width;
+
+      /** How many rows a run of text takes, and how tall those rows are. */
+      const wrapped = (text: string, share: number): number => {
+        const advance =
+          points(DEFAULT_FONT_PT * share) * faceOf(head.font).advance;
+        const rows = Math.ceil((text.length * advance) / width);
+        expect(rows, `${text.slice(0, 12)} on ${size}`).toBeGreaterThan(0);
+        return rows * points(DEFAULT_FONT_PT * share * LINE);
+      };
+
+      // The header, less the header without the notice in it: whatever that
+      // difference is, the wrapped sentence has to fit inside it.
+      const bare: SheetOptions = { ...head, instructions: undefined };
+      expect(
+        chromeHeight(head).header - chromeHeight(bare).header,
+        `notice on ${size}`,
+      ).toBeGreaterThanOrEqual(wrapped(notice, INSTRUCTION_EM));
+
+      // And the same for the credit line, against the foot without it. The note
+      // is on both sides, because a key's footer carries it either way.
+      const foot = (over: FootLine): number =>
+        chromeHeight(head, false, over).footer;
+      expect(
+        foot({ source: SCRIPTURE_CREDIT, note: "Answer key" }) -
+          foot({ note: "Answer key" }),
+        `credit on ${size}`,
+      ).toBeGreaterThanOrEqual(wrapped(SCRIPTURE_CREDIT, FOOT_EM));
     }
   });
 

--- a/src/engine/sheets/writing/memory.test.ts
+++ b/src/engine/sheets/writing/memory.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+
+import { sheetBlockBox } from "../chrome";
+import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "../paper";
+import { SCRIPTURE_CREDIT, passage, passageText } from "../passages";
+import type { Blank, MemoryConfig } from "../types";
+
+import {
+  MAX_ROUNDS,
+  MEMORY_SHEET,
+  describeMemory,
+  memoryLayout,
+  memoryWords,
+  removalCounts,
+  roundHeight,
+} from "./memory";
+
+/**
+ * The family whose exercise is what is missing from the page.
+ *
+ * Four properties, and two of them are promises to somebody outside this
+ * repository:
+ *
+ * **The progression only ever takes.** A word missing in one round is missing
+ * in every round after it. A round that handed one back would read as a
+ * misprint, and a child correcting themselves against it would be learning the
+ * wrong thing.
+ *
+ * **The answer key is the passage, whole.** Which is the second half of what
+ * §12 asks of a sheet that deliberately removes words from a text it names —
+ * the first half being the instruction line that says so. Both are checked
+ * here, because both are the licence rather than the layout.
+ *
+ * **The last round is the empty one.** A count is a request capped at what the
+ * page holds everywhere in the shop, but this family caps the number of rounds
+ * and re-spreads them rather than dropping the end off the progression.
+ *
+ * **It fits.** Print is the whole of the output path (§10), and a gap is wider
+ * than the word it replaces, so the rounds get taller as the sheet goes on.
+ */
+
+const VERSE = "for-god-so-loved-the-world";
+
+const BASE: MemoryConfig = {
+  kind: "memory",
+  paper: DEFAULT_PAPER,
+  fontPt: DEFAULT_FONT_PT,
+  fields: ["name", "date"],
+  rounds: 4,
+  passage: VERSE,
+};
+
+const config = (over: Partial<MemoryConfig> = {}): MemoryConfig => ({
+  ...BASE,
+  ...over,
+});
+
+/** The rounds a config actually printed. */
+function roundsOf(over: Partial<MemoryConfig> = {}, seed = 1): Blank[] {
+  const [block] = MEMORY_SHEET.build(config(over), seed).blocks;
+  return block?.kind === "blanks" ? block.sentences : [];
+}
+
+/** Which words are missing from a round, as their places in the passage. */
+const goneIn = (round: Blank): number =>
+  round.text.split(" ").filter((word) => word === "_").length;
+
+/** A round with its gaps filled from the answers, which is what a key prints. */
+function filled(round: Blank): string {
+  let at = 0;
+  return round.text
+    .split(" ")
+    .map((word) => (word === "_" ? round.answers[at++] : word))
+    .join(" ");
+}
+
+describe("what goes on a memory sheet", () => {
+  it("writes the passage out whole first, and empty last", () => {
+    const rounds = roundsOf();
+    expect(rounds.length).toBe(4);
+    expect(rounds[0].answers).toEqual([]);
+    expect(rounds[0].text).toBe(passageText(passage(VERSE)!));
+    // Every word gone in the last one: saying it from memory, with somewhere
+    // to write it down.
+    const words = memoryWords(passageText(passage(VERSE)!));
+    expect(rounds[3].answers).toEqual(words);
+    expect(rounds[3].text.replace(/[_ ]/g, "")).toBe("");
+  });
+
+  it("only ever takes words away, never gives one back", () => {
+    // The property that makes it a progression rather than four sheets. A word
+    // missing in round two is missing in round three.
+    for (const rounds of [2, 3, 4, 5]) {
+      const printed = roundsOf({ rounds });
+      let previous = new Set<string>();
+      for (const round of printed) {
+        const missing = new Set(round.answers);
+        for (const word of previous) {
+          expect(missing.has(word), `${rounds} rounds`).toBe(true);
+        }
+        expect(missing.size).toBeGreaterThanOrEqual(previous.size);
+        previous = missing;
+      }
+    }
+  });
+
+  it("spreads the removals evenly, nought to all", () => {
+    expect(removalCounts(1, 12)).toEqual([0]);
+    expect(removalCounts(2, 12)).toEqual([0, 12]);
+    expect(removalCounts(3, 12)).toEqual([0, 6, 12]);
+    expect(removalCounts(5, 10)).toEqual([0, 3, 5, 8, 10]);
+    // Clamped, the way every count in the shop is: a saved config can say
+    // anything, and a hundred rounds of a verse is not a sheet.
+    expect(removalCounts(99, 8).length).toBe(MAX_ROUNDS);
+    expect(removalCounts(0, 8)).toEqual([0]);
+  });
+
+  it("keeps the punctuation with the word it belongs to", () => {
+    // What makes the finished key the passage rather than a paraphrase of it
+    // with the commas guessed at.
+    const rounds = roundsOf({ passage: "trust-in-the-lord", rounds: 3 });
+    for (const round of rounds) {
+      expect(filled(round)).toBe(
+        passageText(passage("trust-in-the-lord")!).replace(/\s+/g, " "),
+      );
+    }
+  });
+
+  it("leaves a space between two gaps in a row", () => {
+    // `Blanks` reads a run of underscores as ONE gap, so two missing words
+    // written "__" would be one rule with two words expected in it and a key
+    // that printed only the first. A space between them is the whole fix.
+    for (const round of roundsOf({ rounds: 5 })) {
+      expect(round.text).not.toMatch(/_{2,}/);
+      expect(goneIn(round)).toBe(round.answers.length);
+    }
+  });
+});
+
+describe("the sheet it prints", () => {
+  it("says the words are left out on purpose, and keys the whole passage", () => {
+    // §12, in the two places it has to be: a sheet that quietly dropped a third
+    // of a named translation would be publishing a modified text under its
+    // name, and the answer key is what makes the claim recoverable.
+    const sheet = MEMORY_SHEET.build(config(), 1);
+    expect(sheet.header.instructions).toContain("left out");
+    expect(sheet.header.instructions).toContain("answer key");
+    expect(sheet.answers).toBe(false);
+
+    const key = MEMORY_SHEET.key(sheet);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+    // And the credit survives the key, which is why it is a field of its own:
+    // the page that carries the whole passage is the one that most needs to say
+    // where the passage came from.
+    expect(key.footer.source).toBe(SCRIPTURE_CREDIT);
+  });
+
+  it("carries the credit its source asks for, and none where none is", () => {
+    expect(MEMORY_SHEET.build(config(), 1).footer.source).toBe(
+      SCRIPTURE_CREDIT,
+    );
+    expect(
+      MEMORY_SHEET.build(config({ passage: "bed-in-summer" }), 1).footer.source,
+    ).toBeUndefined();
+    expect(
+      MEMORY_SHEET.build(config({ passage: undefined, text: "Mine." }), 1)
+        .footer.source,
+    ).toBeUndefined();
+  });
+
+  it("says nothing about missing words on a sheet that has none", () => {
+    const one = MEMORY_SHEET.build(config({ rounds: 1 }), 1);
+    expect(one.header.instructions).not.toContain("left out");
+    expect(roundsOf({ rounds: 1 })[0].answers).toEqual([]);
+  });
+
+  it("names the passage, and has nothing to mark", () => {
+    const sheet = MEMORY_SHEET.build(config(), 1);
+    expect(sheet.header.title).toBe("Memory work — John 3:16");
+    expect(sheet.header.score).toBeUndefined();
+    expect(describeMemory(config())).toBe(
+      "Memory work — John 3:16 — 4 times over",
+    );
+  });
+
+  it("is the same page on every build, and a different one on another seed", () => {
+    for (const seed of [0, 1, 4242]) {
+      expect(JSON.stringify(MEMORY_SHEET.build(config(), seed))).toBe(
+        JSON.stringify(MEMORY_SHEET.build(config(), seed)),
+      );
+    }
+    // §7's "another sheet like this one": the same verse with other words out.
+    expect(JSON.stringify(roundsOf({}, 1))).not.toBe(
+      JSON.stringify(roundsOf({}, 2)),
+    );
+  });
+
+  it("survives a config that says something this build has never heard of", () => {
+    const stale = {
+      ...config(),
+      passage: "toString",
+      translation: "constructor",
+      rounds: "several",
+    } as unknown as MemoryConfig;
+    expect(() => MEMORY_SHEET.build(stale, 1)).not.toThrow();
+    // Nothing to print, and a page that says so rather than a build that fails.
+    expect(MEMORY_SHEET.build(stale, 1).blocks).toEqual([]);
+  });
+});
+
+describe("what fits on the paper", () => {
+  it("never prints more than the page holds, on either stock", () => {
+    for (const size of ["letter", "a4", "legal"] as const) {
+      for (const rounds of [1, 3, MAX_ROUNDS]) {
+        for (const fontPt of [10, 12, 18]) {
+          const asked = config({
+            rounds,
+            fontPt,
+            paper: { size, orientation: "portrait", margin: "wide" },
+            passage: "psalm-23",
+          });
+          const { box, rounds: printed } = memoryLayout(asked, 1);
+          const height = printed.reduce(
+            (total, round) => total + roundHeight(round, asked, box),
+            0,
+          );
+          expect(height, `${size} × ${rounds} × ${fontPt}pt`) //
+            .toBeLessThanOrEqual(box.height);
+          // Against the header the sheet actually prints, which is the
+          // reservation `chromeHeight` made rather than the content box.
+          expect(box.height).toBeLessThanOrEqual(
+            sheetBlockBox({
+              paper: asked.paper,
+              fontPt: asked.fontPt,
+              fields: asked.fields,
+            }).height,
+          );
+        }
+      }
+    }
+  });
+
+  it("drops a round rather than the end of the progression", () => {
+    // A long psalm cannot have five rounds on one page. What it must not do is
+    // print the first four and stop: the last round is the one the whole sheet
+    // aims at, so the count comes down and the removals spread again.
+    const long = roundsOf({ passage: "psalm-23", rounds: 5 });
+    expect(long.length).toBeLessThan(5);
+    expect(long.length).toBeGreaterThan(1);
+    expect(long[0].answers).toEqual([]);
+    expect(long[long.length - 1].text.replace(/[_ ]/g, "")).toBe("");
+  });
+
+  it("comes down to one round rather than printing a round off the bottom", () => {
+    // A paste at the cap is more than a progression can be made of, so what is
+    // left is the passage itself — which is still a page worth having, and is
+    // what the arithmetic arrives at on its own rather than by a special case.
+    const long = roundsOf({ passage: undefined, text: "word ".repeat(600) });
+    expect(long.length).toBe(1);
+    expect(long[0].answers).toEqual([]);
+    // And a config with nothing to say prints a header over an empty page,
+    // rather than a build that fails on the way to a catalog.
+    expect(roundsOf({ passage: undefined, text: "" })).toEqual([]);
+  });
+});

--- a/src/engine/sheets/writing/memory.ts
+++ b/src/engine/sheets/writing/memory.ts
@@ -41,7 +41,7 @@ import type {
   SheetOptions,
 } from "../types";
 
-import { sheetBlockBox } from "../chrome";
+import { sheetBlockBox, type FootLine } from "../chrome";
 import { faceOf } from "../faces";
 import { type Box } from "../layout";
 import { inches, points } from "../paper";
@@ -173,7 +173,7 @@ export type MemoryLayout = {
  * many rounds it has.
  */
 export function memoryLayout(config: MemoryConfig, seed: number): MemoryLayout {
-  const box = sheetBlockBox(headerOf(config));
+  const box = sheetBlockBox(headerOf(config), false, footOf(config));
   const words = memoryWords(copyworkSource(config).text);
   if (words.length === 0) return { box, rounds: [] };
 
@@ -216,6 +216,33 @@ export function instructionOf(rounds: number): string {
   if (rounds <= 1) return "Read it, and say it from memory.";
   return "Read it, then fill in the missing words from memory — more of them go each time. Words are left out for the exercise; the whole passage is on the answer key.";
 }
+
+/**
+ * What this printout is, where it is the key rather than the sheet.
+ *
+ * One constant because two places read it: `SheetSpec.key`, which prints it,
+ * and `footOf` below, which reserves room for it on the *sheet* — the key keeps
+ * the sheet's blocks, so both are laid out against one box and the taller of
+ * the two footers is the one that has to fit.
+ */
+const KEY_NOTE = "Answer key";
+
+/**
+ * What the foot of this sheet will carry beyond the spine's own three.
+ *
+ * The credit its source asks for, and the note the key prints. Both are
+ * declared to `chrome.ts` rather than discovered from the footer, because the
+ * footer is built after the rounds have been fitted against the room the footer
+ * left — and this family is the one that made both of them more than one row:
+ * 75 characters of Scripture credit beside "Answer key" is two rows at 12pt on
+ * A4, and a round reserved into that second row prints below the bottom margin.
+ */
+const footOf = (config: MemoryConfig): FootLine => ({
+  note: KEY_NOTE,
+  ...(copyworkSource(config).credit
+    ? { source: copyworkSource(config).credit }
+    : {}),
+});
 
 /**
  * The header this sheet will actually print.
@@ -298,7 +325,7 @@ export const MEMORY_SHEET: SheetSpec<MemoryConfig> = {
   key: (sheet) => ({
     ...sheet,
     answers: true,
-    footer: { ...sheet.footer, note: "Answer key" },
+    footer: { ...sheet.footer, note: KEY_NOTE },
   }),
   describe: describeMemory,
 };

--- a/src/engine/sheets/writing/memory.ts
+++ b/src/engine/sheets/writing/memory.ts
@@ -1,0 +1,304 @@
+/**
+ * Memory work: the same passage, with more of it missing each time.
+ *
+ * The exercise every family that learns verses by heart already does on a
+ * whiteboard — write it out, rub a few words off, say it again, rub off a few
+ * more — and the one sheet in the shop whose content is what is *not* printed.
+ *
+ * **The progression is the whole family.** Round one is the passage entire,
+ * which is what a child reads; the last round has every word gone, which is
+ * saying it from memory with somewhere to write it down; the rounds between
+ * take out a share that grows evenly. Which words go is decided by the seed and
+ * nothing else, and the sets nest — a word missing in round two is missing in
+ * round three — because a word handed back would read as a misprint rather than
+ * as a lesson.
+ *
+ * **It says that it is an exercise, and that is not decoration.** eBible.org
+ * attaches one condition to the World English Bible: a modified text must not
+ * carry the name (§12). A sheet that quietly dropped a third of a verse and
+ * printed the translation's name underneath would be exactly that, so the
+ * instruction line says the words are left out on purpose and the answer key
+ * prints the passage whole. Both halves are the promise; neither is optional,
+ * which is why the instruction is written here rather than left to a parent.
+ *
+ * **A verse, not a poem.** A round is one paragraph, so the passage's own line
+ * breaks are set as spaces — fine for prose and for Scripture, and an edit to a
+ * poem, whose lines are the poet's. A poem belongs on the copywork sheet, which
+ * keeps them.
+ *
+ * Everything the other families promise holds unchanged: the page comes out of
+ * `(config, seed)` and nothing else, and no round is put on the page that the
+ * capacity arithmetic did not reserve room for.
+ */
+import { mulberry32, shuffled } from "@/engine/random";
+
+import type {
+  Blank,
+  Block,
+  MemoryConfig,
+  Mil,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import { faceOf } from "../faces";
+import { type Box } from "../layout";
+import { inches, points } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import { copyworkSource } from "./copywork";
+
+/* ── What a round takes on the page ───────────────────────────────────────
+   Declared, not measured (§4), and trailing sheet.css exactly as `chrome.ts`
+   does: a round is a paragraph of body type with ruled gaps in it, and how
+   many lines it wraps onto has to be answerable in plain Node.            */
+
+/** One line of the paragraph: the body type, and a hair of air under it. */
+const LINE_EMS = 1.35;
+
+/** `.sheet__blanks` sets this between one round and the next. */
+const ROUND_GAP: Mil = inches(0.16);
+
+/** `.sheet__slot` is at least this wide, whatever word is written in it. */
+const SLOT: Mil = inches(0.8);
+
+/** `.sheet__number` and its margin — the "1." at the head of a round. */
+const NUMBER: Mil = inches(0.3);
+
+/**
+ * How many times a passage may be written out.
+ *
+ * Six rounds of a memory verse is already a full page and the last two are
+ * mostly blank; past that the sheet is asking for the same recitation more
+ * times than anyone does it in one sitting.
+ */
+export const MAX_ROUNDS = 6;
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/* ── Taking the words out ──────────────────────────────────────────────── */
+
+/**
+ * The passage as the words it is made of, line breaks set as spaces.
+ *
+ * Split on whitespace and nothing cleverer: punctuation stays attached to the
+ * word it belongs to, so the answer key puts back "shepherd:" rather than
+ * "shepherd" — which is what keeps the finished key the passage verbatim
+ * rather than a paraphrase of it with the commas guessed at.
+ */
+export const memoryWords = (text: string): string[] =>
+  text.split(/\s+/).filter((word) => word !== "");
+
+/**
+ * How many words are gone in each round, first to last.
+ *
+ * None in the first and all of them in the last, with the rounds between
+ * spread evenly — so three rounds of a twelve-word verse lose nought, six and
+ * twelve. Rounded rather than floored, because the middle of the progression
+ * should sit in the middle rather than lag behind it.
+ */
+export function removalCounts(rounds: number, words: number): number[] {
+  const times = clamp(rounds, 1, MAX_ROUNDS);
+  if (times === 1) return [0];
+  return Array.from({ length: times }, (_, round) =>
+    Math.round((round * words) / (times - 1)),
+  );
+}
+
+/**
+ * One round: the passage with `gone` of its words replaced by a gap.
+ *
+ * The order words are taken in comes from the seed, and it is one order for the
+ * whole sheet — every round takes the first `gone` of it — which is what makes
+ * the rounds nest. `Blanks` reads a run of underscores as one gap, and the
+ * words are joined with spaces, so two missing words in a row are two gaps
+ * rather than one blank a child cannot tell the length of.
+ */
+export function roundOf(words: string[], order: number[], gone: number): Blank {
+  const missing = new Set(order.slice(0, gone));
+  return {
+    text: words.map((word, at) => (missing.has(at) ? "_" : word)).join(" "),
+    answers: words.filter((_, at) => missing.has(at)),
+  };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+/**
+ * How tall a round stands, once the paragraph has wrapped.
+ *
+ * A gap is wider than the word it replaces — `.sheet__slot` has a minimum, so
+ * that a child has room to write in it — which means a round gets *taller* as
+ * the exercise goes on. A family that sized every round like the first would
+ * put the last one off the bottom of the page, and print is the whole of the
+ * output path (§10).
+ */
+export function roundHeight(round: Blank, config: MemoryConfig, box: Box): Mil {
+  const em = points(config.fontPt);
+  const advance = em * faceOf(config.font).advance;
+  const written = round.text.replaceAll("_", "").length;
+  const width = NUMBER + written * advance + round.answers.length * SLOT;
+  // Against the width less one slot, not the whole width. A browser wraps
+  // greedily and cannot break a gap in half, so a line can end up to a slot
+  // short of the margin — and the two errors are not symmetrical (`chrome.ts`):
+  // reserving a line too many costs a line at the bottom of the page, and
+  // reserving one too few costs a second sheet of paper.
+  const usable = Math.max(1, box.width - SLOT);
+  const lines = Math.max(1, Math.ceil(width / usable));
+  return lines * points(config.fontPt * LINE_EMS);
+}
+
+export type MemoryLayout = {
+  box: Box;
+  /** The rounds that fit, in order, gaps and all. */
+  rounds: Blank[];
+};
+
+/**
+ * The rounds this sheet actually prints.
+ *
+ * A count asked for is a request capped at what the page holds, as everywhere
+ * else in the shop — but a memory sheet cannot be capped by dropping the last
+ * round off the bottom, because the last round is the one with everything
+ * missing and the whole progression aims at it. A sheet that stopped two thirds
+ * of the way along would ask a child to fill in six words and then stop, which
+ * is a different exercise from the one the instruction line promised.
+ *
+ * So the *number of rounds* is what gets capped, and the progression is worked
+ * out again for the number that fit: four rounds that don't fit become three
+ * that do, spread nought, half, all. Trying the longest first and stepping down
+ * is the only honest way round — the rounds are not the same height, since a
+ * gap is wider than the word it replaces, so how tall a sheet is depends on how
+ * many rounds it has.
+ */
+export function memoryLayout(config: MemoryConfig, seed: number): MemoryLayout {
+  const box = sheetBlockBox(headerOf(config));
+  const words = memoryWords(copyworkSource(config).text);
+  if (words.length === 0) return { box, rounds: [] };
+
+  // One order for the whole sheet, so round three takes the words round two
+  // took and two more of them — and the same order however many rounds fit.
+  const order = shuffled(
+    words.map((_, at) => at),
+    mulberry32(seed),
+  );
+
+  for (let times = clamp(config.rounds, 1, MAX_ROUNDS); times >= 1; times--) {
+    const rounds = removalCounts(times, words.length).map((gone) =>
+      roundOf(words, order, gone),
+    );
+    const height = rounds.reduce(
+      (total, round) => total + roundHeight(round, config, box),
+      ROUND_GAP * (rounds.length - 1),
+    );
+    if (height <= box.height) return { box, rounds };
+  }
+  // Not even the passage on its own fits, which takes an over-long paste in
+  // the largest type. A header over nothing is the honest page for it, and the
+  // same answer `UNKNOWN_SHEET` gives: print, and print nothing that isn't so.
+  return { box, rounds: [] };
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const TITLE = "Memory work";
+
+/**
+ * What the child is being asked to do — and the notice §12 requires, in the
+ * one place on the sheet nobody skips.
+ *
+ * A sheet with a single round has nothing missing from it and says nothing
+ * about anything being left out, which is the honest version of the same
+ * sentence: it is the passage, printed.
+ */
+export function instructionOf(rounds: number): string {
+  if (rounds <= 1) return "Read it, and say it from memory.";
+  return "Read it, then fill in the missing words from memory — more of them go each time. Words are left out for the exercise; the whole passage is on the answer key.";
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page — a header the layout
+ * under-reserved for is a round below the bottom margin.
+ *
+ * The instruction is worked out against the rounds the config *asked* for
+ * rather than the rounds that fit, which is the only way round that terminates:
+ * how many fit is decided against this header, so reading it back would be a
+ * circle. The two only differ on a sheet asking for more rounds than the paper
+ * holds, and the sentence is the same length either way.
+ */
+function headerOf(config: MemoryConfig): SheetOptions {
+  const source = copyworkSource(config);
+  const named = source.title ? `${TITLE} — ${source.title}` : TITLE;
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? named,
+    instructions:
+      config.instructions ?? instructionOf(clamp(config.rounds, 1, MAX_ROUNDS)),
+  };
+}
+
+/** One line naming what the sheet holds, for the catalog and the record. */
+export function describeMemory(config: MemoryConfig): string {
+  const source = copyworkSource(config);
+  const words = memoryWords(source.text).length;
+  const rounds = clamp(config.rounds, 1, MAX_ROUNDS);
+  return [
+    TITLE,
+    source.title ?? `${words} ${words === 1 ? "word" : "words"}`,
+    `${rounds} ${rounds === 1 ? "time" : "times"} over`,
+  ].join(" — ");
+}
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+export function buildMemorySheet(config: MemoryConfig, seed: number): Sheet {
+  const head = headerOf(config);
+  const { credit } = copyworkSource(config);
+  const { rounds } = memoryLayout(config, seed);
+  const blocks: Block[] = rounds.length
+    ? [{ kind: "blanks", sentences: rounds }]
+    : [];
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // No score box. A verse said from memory is marked by the person
+      // listening, and a number out of the rounds would be marking the paper.
+    },
+    blocks,
+    footer: {
+      credit: SHEET_CREDIT,
+      url: SHEET_URL,
+      seed,
+      ...(credit ? { source: credit } : {}),
+    },
+    answers: false,
+  };
+}
+
+export const MEMORY_SHEET: SheetSpec<MemoryConfig> = {
+  id: "memory",
+  label: "Memory verse",
+  world: SHEET_WORLD,
+  build: buildMemorySheet,
+  // The answer key is the passage whole — every gap filled from the words that
+  // were taken out when the sheet was built, so the key cannot disagree with
+  // the sheet and cannot disagree with the source either. That is the second
+  // half of what §12 asks a progressive-blank sheet to do.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeMemory,
+};

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -92,6 +92,23 @@ const PASSAGE =
 const COPYWORK_PASSAGE = "psalm-23";
 const MEMORY_PASSAGE = "for-god-so-loved-the-world";
 
+/**
+ * A passage to open memory work's own paste box on.
+ *
+ * Not `PASSAGE` above, for two reasons. A memory sheet is something somebody
+ * means to know by heart, where a handwriting sentence is chosen for the letters
+ * it happens to use; and a round is a paragraph — `memory.ts` sets a passage's
+ * own line breaks as spaces — so the second line of a pangram would arrive
+ * looking like a break the sheet then ignored.
+ *
+ * Here for the reason `PASSAGE` is: the family opens on the library, and this is
+ * what choosing "Your own words" leaves behind. Without it that choice lands a
+ * parent in an empty box, `memoryLayout` finds no words to take out, and the
+ * preview goes to a header over a blank page — the one thing the bench must
+ * never show.
+ */
+const MEMORY_TEXT = "A verse is learnt by saying it, not by reading it again.";
+
 const DEFAULTS: Record<string, SheetConfig> = {
   blank: { ...BASE, kind: "blank", title: "Blank sheet" },
   paper: { ...BASE, kind: "paper", rule: { style: "wide" } },
@@ -251,6 +268,7 @@ const DEFAULTS: Record<string, SheetConfig> = {
     ...BASE,
     kind: "memory",
     passage: MEMORY_PASSAGE,
+    text: MEMORY_TEXT,
     // The whole verse, two rounds with more of it gone, and one with none of
     // it left — the shortest progression that is still a progression.
     rounds: 4,

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -66,9 +66,31 @@ export const STARTER_WORDS = listWords(WORD_LISTS[0]).slice(0, 12);
  * The second line is there so the box arrives holding two lines: a passage is
  * broken where the paper runs out, and a parent who has never seen that happen
  * would not know a newline of their own is honoured.
+ *
+ * It is what the *paste* box holds rather than what the sheet prints: copywork
+ * opens on a passage out of the library (see below), and `copyworkSource`
+ * prefers the library wherever both are set. Clearing the passage is what
+ * brings this back, which is the point of it being here at all — the box a
+ * parent lands in is never empty.
  */
 const PASSAGE =
   "The quick brown fox jumps over the lazy dog.\nGood handwriting is slow before it is neat.";
+
+/**
+ * The passage the two library families open on.
+ *
+ * Psalm 23 for copywork, because it is the piece of English most likely to be
+ * the reason somebody came looking for a copywork sheet at all, and it is long
+ * enough that the sheet arrives looking like a page of work rather than a
+ * demonstration. John 3:16 for memory work, because a memory sheet wants a
+ * verse somebody would actually set to be learnt by heart, and twenty-five
+ * words is what four rounds of it fit into.
+ *
+ * Both are one entry in the same picker as the Gettysburg Address and "The
+ * Owl and the Pussy-Cat" (§12), and either is replaced in two clicks.
+ */
+const COPYWORK_PASSAGE = "psalm-23";
+const MEMORY_PASSAGE = "for-god-so-loved-the-world";
 
 const DEFAULTS: Record<string, SheetConfig> = {
   blank: { ...BASE, kind: "blank", title: "Blank sheet" },
@@ -222,7 +244,16 @@ const DEFAULTS: Record<string, SheetConfig> = {
     // what puts the whole alphabet on one page at this rule size.
     repeats: 3,
     words: STARTER_WORDS,
+    passage: COPYWORK_PASSAGE,
     text: PASSAGE,
+  },
+  memory: {
+    ...BASE,
+    kind: "memory",
+    passage: MEMORY_PASSAGE,
+    // The whole verse, two rounds with more of it gone, and one with none of
+    // it left — the shortest progression that is still a progression.
+    rounds: 4,
   },
   "word-problems": {
     ...BASE,

--- a/src/games/printshop/options/handwriting.tsx
+++ b/src/games/printshop/options/handwriting.tsx
@@ -17,7 +17,9 @@
  * What is written changes with the style and nothing else does, which is why
  * only one content control is on screen at a time: a word list on a sheet of
  * the alphabet is a box that does nothing, and a box that does nothing is worse
- * than a missing one.
+ * than a missing one. Copywork is the one whose content is a picker rather than
+ * a box — every passage in the library, Scripture first, and "your own words"
+ * as the last entry in the same list (`passages.tsx`).
  *
  * The one thing not on this panel is the hand. Cursive is a *face* rather than a
  * style of handwriting sheet — the letters, words and passages above are the
@@ -35,15 +37,10 @@ import type {
   TraceStyle,
 } from "@/engine/sheets/types";
 
-import {
-  Checkbox,
-  Field,
-  FieldSet,
-  NumberStepper,
-  TextArea,
-} from "@/components/ui/kit";
+import { Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
 import { parseWords } from "@/services/decks";
 
+import { PassageControls } from "./passages";
 import {
   Choice,
   RULED_STYLES,
@@ -136,16 +133,12 @@ export function HandwritingPanel({
       )}
 
       {config.style === "passage" && (
-        <Field
-          label="Passage"
-          hint="Broken where the line runs out. A line break of your own is kept."
-        >
-          <TextArea
-            value={config.text ?? ""}
-            rows={4}
-            onChange={(text) => set({ text })}
-          />
-        </Field>
+        <PassageControls
+          passage={config.passage}
+          translation={config.translation}
+          text={config.text}
+          onChange={set}
+        />
       )}
 
       <RulingControls

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -26,6 +26,7 @@ import { GeometryPanel } from "./geometry";
 import { HandwritingPanel } from "./handwriting";
 import { IntegersPanel } from "./integers";
 import { MeasurePanel } from "./measure";
+import { MemoryPanel } from "./memory";
 import { MoneyPanel } from "./money";
 import { MultiplicationPanel } from "./multiplication";
 import { PaperPanel } from "./paper";
@@ -88,6 +89,7 @@ const PANELS: Record<string, FamilyPanel> = {
   "word-problems": panel(WordProblemsPanel),
   words: panel(WordsPanel),
   handwriting: panel(HandwritingPanel),
+  memory: panel(MemoryPanel),
 };
 
 /**

--- a/src/games/printshop/options/memory.tsx
+++ b/src/games/printshop/options/memory.tsx
@@ -1,0 +1,46 @@
+/**
+ * Memory work: which passage, and how many times over.
+ *
+ * Two questions, and the first of them is the same picker copywork uses — the
+ * whole point of §12 being that choosing a verse is not a different kind of
+ * interaction from choosing a poem. What this family adds is one dial: how many
+ * times the passage is written out, which is the progression from the whole
+ * thing to none of it.
+ *
+ * There is no control for *which* words go, and there should not be. That is
+ * the seed's job — "another sheet like this one" is `seed + 1` (§7) — and a
+ * parent choosing them by hand would be choosing the exercise away.
+ */
+import { MAX_ROUNDS } from "@/engine/sheets/writing/memory";
+import type { MemoryConfig } from "@/engine/sheets/types";
+
+import { FieldSet, NumberStepper } from "@/components/ui/kit";
+
+import { PassageControls } from "./passages";
+import type { PanelProps } from "./parts";
+
+export function MemoryPanel({ config, set }: PanelProps<MemoryConfig>) {
+  return (
+    <>
+      <PassageControls
+        passage={config.passage}
+        translation={config.translation}
+        text={config.text}
+        onChange={set}
+      />
+
+      <FieldSet
+        legend="Times written out"
+        hint="The whole passage first, none of it last, and more gone each time. Capped at what the page holds."
+      >
+        <NumberStepper
+          label="Times written out"
+          value={config.rounds}
+          min={1}
+          max={MAX_ROUNDS}
+          onChange={(rounds) => set({ rounds })}
+        />
+      </FieldSet>
+    </>
+  );
+}

--- a/src/games/printshop/options/passages.tsx
+++ b/src/games/printshop/options/passages.tsx
@@ -1,0 +1,145 @@
+/**
+ * Which words are on the sheet — one picker, every source, Scripture first.
+ *
+ * §12 in a control. The collections come out of the library in the library's
+ * own order, which puts Psalm 23 and the Gettysburg Address in the same
+ * dropdown with the same two clicks between them; there is no Scripture mode to
+ * switch into and no separate section to find, because a mode is the thing this
+ * story exists to not build. What Scripture adds is one more question — which
+ * translation — and it is asked where it applies and nowhere else.
+ *
+ * "Your own words" is the last entry rather than a fourth control. Pasting a
+ * verse is choosing a source, the same as picking one off the shelf, and a
+ * paste box sitting under a chosen passage doing nothing would be a box that
+ * lies about what is on the page (`copyworkSource` prefers the library).
+ *
+ * Two families share it — copywork and memory work — which is why it is here
+ * beside `parts.tsx` rather than inside either panel. They ask for exactly the
+ * same three fields, so a second copy would be a second answer to "what does
+ * clearing the passage mean".
+ */
+import { Field, TextArea } from "@/components/ui/kit";
+import {
+  PASSAGE_COLLECTIONS,
+  TRANSLATION_LIST,
+  listPassages,
+  passage as passageById,
+  type TranslationId,
+} from "@/engine/sheets/passages";
+
+import { Choice, opt } from "./parts";
+
+/** The three fields a passage travels in, on either family's config. */
+export type PassageFields = {
+  passage?: string;
+  translation?: TranslationId;
+  text?: string;
+};
+
+/**
+ * "Your own words", as a collection id that is not one.
+ *
+ * The empty string rather than a sentinel word, because absent is already what
+ * the config means by "no passage chosen" — inventing an `"own"` to store would
+ * be a second way of saying the same thing in every saved sheet.
+ */
+const OWN = "";
+
+const SOURCES = [
+  ...PASSAGE_COLLECTIONS.map((collection) =>
+    opt(collection.id, collection.name, collection.blurb),
+  ),
+  opt(OWN, "Your own words", "a verse or a passage you paste"),
+];
+
+const TRANSLATIONS = TRANSLATION_LIST.map((translation) =>
+  opt(translation.id, translation.name),
+);
+
+/**
+ * Every passage, resolved once at module load.
+ *
+ * The library is static data and the picker lists all of it, so the alternative
+ * to doing this here is doing it on every keystroke in the builder — a
+ * debounced rebuild already runs on each of those, and this is the one list on
+ * the screen that cannot have changed since the last one.
+ */
+const CHOICES = listPassages();
+
+const inCollection = (collection: string) =>
+  CHOICES.filter((entry) => entry.collection === collection);
+
+/**
+ * Which source is showing, read back off the passage rather than stored beside
+ * it — the same bargain `RulingControls` makes with the grid pitch. A second
+ * field naming the collection would be a second thing that can disagree with
+ * the passage it claims to hold.
+ */
+const sourceOf = (chosen?: string): string =>
+  (chosen ? passageById(chosen)?.collection : undefined) ?? OWN;
+
+export function PassageControls({
+  passage,
+  translation,
+  text,
+  onChange,
+}: PassageFields & { onChange: (patch: PassageFields) => void }) {
+  const source = sourceOf(passage);
+  const chosen = passage ? passageById(passage) : undefined;
+  const scripture = chosen?.kind === "scripture";
+
+  return (
+    <>
+      <Choice
+        label="Where the words come from"
+        value={source}
+        // Moving to another shelf takes the first thing on it, so the sheet is
+        // never showing a passage that belongs to a collection it isn't in.
+        onChange={(next) =>
+          onChange({ passage: next ? inCollection(next)[0]?.id : undefined })
+        }
+        options={SOURCES}
+      />
+
+      {source !== OWN && (
+        <Choice
+          label="Passage"
+          value={passage ?? ""}
+          onChange={(next) => onChange({ passage: next })}
+          options={inCollection(source).map((entry) =>
+            opt(entry.id, entry.title),
+          )}
+          // The provenance, on the screen where the passage is chosen: who
+          // wrote it, and the credit the sheet will print under it (§12).
+          hint={
+            [chosen?.attribution, chosen?.credit].filter(Boolean).join(" · ") ||
+            undefined
+          }
+        />
+      )}
+
+      {scripture && (
+        <Choice
+          label="Translation"
+          value={translation ?? TRANSLATION_LIST[0].id}
+          onChange={(next) => onChange({ translation: next })}
+          options={TRANSLATIONS}
+          hint="Both are public domain. Never a licensed translation — see the note in the engine."
+        />
+      )}
+
+      {source === OWN && (
+        <Field
+          label="Your own passage"
+          hint="Broken where the line runs out. A line break of your own is kept."
+        >
+          <TextArea
+            value={text ?? ""}
+            rows={4}
+            onChange={(next) => onChange({ text: next })}
+          />
+        </Field>
+      )}
+    </>
+  );
+}

--- a/src/pages/printables/_bible.test.ts
+++ b/src/pages/printables/_bible.test.ts
@@ -1,0 +1,275 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet } from "@/engine/sheets";
+import { passage, passageText } from "@/engine/sheets/passages";
+import type { Blank, PaperSize, TraceRow } from "@/engine/sheets/types";
+
+import {
+  BIBLE_GROUPS,
+  BIBLE_SEED,
+  BIBLE_SHEETS,
+  STOCKS,
+  bibleShelf,
+  builderHref,
+  configFor,
+  creditFor,
+  hrefFor,
+  keyed,
+  type BibleSheet,
+} from "./_bible";
+import { PAPER_SHEETS, pathFor as paperPath } from "./_catalog";
+import { CURSIVE_SHEETS, hrefFor as cursiveHref } from "./_cursive";
+import { HANDWRITING_SHEETS, hrefFor as handwritingHref } from "./_handwriting";
+import { MATHS_SHEETS, pathFor as mathsPath } from "./_maths";
+
+/**
+ * The Scripture catalog, held to what every catalog page has to be — and to the
+ * two things only this one has to be.
+ *
+ * **It has to be a worksheet**, prerendered as the page a parent lands on (§8),
+ * **curated**, and **reachable**: no two entries print the same sheet, no two
+ * answer the same query, and no slug collides with the four catalogs that share
+ * the prefix.
+ *
+ * **It has to print the whole passage.** A count is a request capped at what
+ * fits everywhere else in the shop. A verse is not a count: a copywork sheet
+ * that quietly dropped the last clause off the bottom of the page would be
+ * quoting a translation wrongly while looking exactly like one that didn't.
+ *
+ * **It has to say where the words came from.** The credit line is a condition
+ * of the WEB's name rather than a courtesy (§12), so it is on the sheet, and it
+ * is read off the passage rather than typed onto the page.
+ */
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/**
+ * The passage as a sheet prints it, whichever family printed it.
+ *
+ * Distinct lines in the order they first appear, because a copywork sheet
+ * writes each line two or three times over — a model, a trace and an empty
+ * place — and a straight read of the rows would interleave the repeats. What is
+ * being checked is that the passage is on the page and in one piece; how many
+ * times each line of it is written is the handwriting family's own suite.
+ */
+function printed(sheet: BibleSheet, size: PaperSize): string {
+  const built = buildSheet(configFor(sheet, size), BIBLE_SEED);
+  const rows = built.blocks.flatMap((block): TraceRow[] =>
+    block.kind === "trace" ? block.rows : [],
+  );
+  const sentences = built.blocks.flatMap((block): Blank[] =>
+    block.kind === "blanks" ? block.sentences : [],
+  );
+  const lines = [
+    ...rows.flatMap((row) => row.cells.map((cell) => cell.text)),
+    ...sentences.map((sentence) => sentence.text),
+  ].filter((line) => line !== "");
+  return [...new Set(lines)].join(" ").replace(/\s+/g, " ");
+}
+
+describe("the Scripture catalog", () => {
+  it("is bounded, and every slug is a route somebody could type", () => {
+    for (const sheet of BIBLE_SHEETS) {
+      expect(sheet.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+    expect(new Set(BIBLE_SHEETS.map((sheet) => sheet.slug)).size) //
+      .toBe(BIBLE_SHEETS.length);
+  });
+
+  it("never claims a path one of the other four shelves already prints on", () => {
+    // Five route patterns over one prefix. They only coexist because the paths
+    // they emit are disjoint; the day they are not, Astro has two routes for
+    // one URL and picks one of them.
+    const taken = new Set([
+      ...PAPER_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => `/printables/${paperPath(sheet, stock)}`),
+      ),
+      ...MATHS_SHEETS.map((sheet) => mathsPath(sheet)),
+      ...HANDWRITING_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => handwritingHref(sheet, stock)),
+      ),
+      ...CURSIVE_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => cursiveHref(sheet, stock)),
+      ),
+    ]);
+    for (const sheet of BIBLE_SHEETS) {
+      for (const stock of STOCKS) {
+        expect(taken.has(hrefFor(sheet, stock)), sheet.slug).toBe(false);
+      }
+    }
+  });
+
+  it("answers a different query on every page", () => {
+    const fields = ["keyword", "heading", "name", "short"] as const;
+    for (const field of fields) {
+      const values = BIBLE_SHEETS.map((sheet) => sheet[field]);
+      expect(new Set(values).size, `duplicate ${field}`).toBe(values.length);
+    }
+  });
+
+  it("prints a different sheet on every page", () => {
+    const configs = BIBLE_SHEETS.map((sheet) =>
+      JSON.stringify(configFor(sheet, "letter")),
+    );
+    expect(new Set(configs).size).toBe(configs.length);
+  });
+
+  it("carries prose on every page rather than a filled-in template", () => {
+    for (const sheet of BIBLE_SHEETS) {
+      expect(sheet.notes.length, sheet.slug).toBeGreaterThanOrEqual(2);
+      for (const note of sheet.notes) {
+        expect(note.length, sheet.slug).toBeGreaterThan(200);
+      }
+      expect(sheet.lead.length, sheet.slug).toBeGreaterThan(80);
+      expect(sheet.summary.length, sheet.slug).toBeGreaterThan(40);
+      expect(sheet.teaches, sheet.slug).not.toBe("");
+      expect(sheet.ages, sheet.slug).toMatch(/^Ages /);
+    }
+  });
+
+  it("shelves every sheet exactly once", () => {
+    const shelved = bibleShelf().flatMap((group) => group.sheets);
+    expect(shelved).toHaveLength(BIBLE_SHEETS.length);
+    expect(bibleShelf().every((group) => group.sheets.length > 0)).toBe(true);
+    expect(BIBLE_GROUPS).toHaveLength(bibleShelf().length);
+  });
+
+  it("covers the whole of what the story asked for", () => {
+    // Copywork at more than one ruling and more than one trace style, and the
+    // memory sheet — the three things §12 says Scripture goes into.
+    const rules = new Set(
+      BIBLE_SHEETS.map((sheet) => sheet.config).flatMap((config) =>
+        config.kind === "handwriting" ? [JSON.stringify(config.rule)] : [],
+      ),
+    );
+    expect(rules.size).toBeGreaterThanOrEqual(4);
+    const kinds = new Set(BIBLE_SHEETS.map((sheet) => sheet.config.kind));
+    expect(kinds).toEqual(new Set(["handwriting", "memory"]));
+  });
+});
+
+describe("the sheet on a catalog page", () => {
+  it("quotes the library, and quotes all of it", () => {
+    // The whole passage, on both stocks, in order and word for word. A verse
+    // with its last clause below the bottom margin is a misquotation that looks
+    // exactly like a sheet — which is the failure this shelf cannot have.
+    for (const sheet of BIBLE_SHEETS) {
+      const words = passageText(passage(sheet.passage)!).replace(/\s+/g, " ");
+      for (const stock of STOCKS) {
+        expect(printed(sheet, stock.id), `${sheet.slug} on ${stock.id}`) //
+          .toContain(words);
+      }
+    }
+  });
+
+  it("names the passage on the paper and credits it at the foot", () => {
+    for (const sheet of BIBLE_SHEETS) {
+      const built = buildSheet(configFor(sheet, "letter"), BIBLE_SEED);
+      const quoted = passage(sheet.passage)!;
+      expect(built.header.title, sheet.slug).toContain(quoted.title);
+      expect(built.header.instructions, sheet.slug).toBeTruthy();
+      // §12: the credit is the engine's constant, on the sheet and on the page.
+      expect(built.footer.source, sheet.slug).toBe(quoted.credit);
+      expect(creditFor(sheet), sheet.slug).toBe(quoted.credit);
+      expect(creditFor(sheet), sheet.slug).toContain("public domain");
+    }
+  });
+
+  it("keys a memory sheet with the whole passage, and nothing else at all", () => {
+    for (const sheet of BIBLE_SHEETS) {
+      const config = configFor(sheet, "letter");
+      const key = answerKey(config, BIBLE_SEED);
+      if (!keyed(sheet)) {
+        // Copywork's model is already printed, so its key is its own sheet —
+        // and the page behind it would be a second copy of the same paper.
+        expect(JSON.stringify(key), sheet.slug) //
+          .toBe(JSON.stringify(buildSheet(config, BIBLE_SEED)));
+        continue;
+      }
+      expect(key.answers, sheet.slug).toBe(true);
+      expect(key.footer.source, sheet.slug).toBe(creditFor(sheet));
+      // Every gap on the key is filled from the words that came out, so the
+      // marked-up page reads as the passage itself.
+      const [block] = key.blocks;
+      expect(block.kind).toBe("blanks");
+      if (block.kind !== "blanks") continue;
+      const whole = passageText(passage(sheet.passage)!).replace(/\s+/g, " ");
+      for (const sentence of block.sentences) {
+        let at = 0;
+        const filled = sentence.text
+          .split(" ")
+          .map((word) => (word === "_" ? sentence.answers[at++] : word))
+          .join(" ");
+        expect(filled, sheet.slug).toBe(whole);
+      }
+      // And the blank sheet says the words are missing on purpose.
+      expect(
+        buildSheet(config, BIBLE_SEED).header.instructions,
+        sheet.slug,
+      ).toContain("left out");
+    }
+  });
+
+  it("is the same sheet on every build", () => {
+    for (const sheet of BIBLE_SHEETS) {
+      const config = configFor(sheet, "letter");
+      expect(JSON.stringify(buildSheet(config, BIBLE_SEED))).toBe(
+        JSON.stringify(buildSheet(config, BIBLE_SEED)),
+      );
+    }
+  });
+});
+
+describe("the link into the builder", () => {
+  it("opens the bench on the sheet that was printed, on the right stock", () => {
+    for (const sheet of BIBLE_SHEETS) {
+      for (const stock of STOCKS) {
+        const href = builderHref(sheet, stock);
+        expect(href.startsWith("/printables/make#s=")).toBe(true);
+
+        const payload = href.slice("/printables/make#s=".length);
+        const base64 = payload.replaceAll("-", "+").replaceAll("_", "/");
+        const shared = JSON.parse(
+          atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")),
+        );
+        expect(shared).toEqual({
+          config: configFor(sheet, stock.id),
+          seed: BIBLE_SEED,
+        });
+        // The passage travels as an id, which is the whole reason a copywork
+        // sheet fits in a link at all (§14).
+        expect(shared.config.passage).toBe(sheet.passage);
+        expect(href.length).toBeLessThan(600);
+      }
+    }
+  });
+});
+
+describe("the sitemap", () => {
+  /*
+   * A URL missing from the sitemap is the failure nobody notices — nothing
+   * breaks, the page is simply never submitted. Skipped when there is no
+   * `dist/`, exactly as the other shelves' are; CI builds before it runs.
+   */
+  it("carries every Scripture slug, on both stocks, and the hub", () => {
+    const file = `${ROOT}/dist/sitemap-0.xml`;
+    if (!existsSync(file)) return; // `npm run build` hasn't run yet.
+
+    const xml = readFileSync(file, "utf8");
+    const found = new Set(
+      [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) =>
+        new URL(match[1]).pathname.replace(/\/$/, ""),
+      ),
+    );
+
+    expect(found.has("/printables/bible")).toBe(true);
+    for (const sheet of BIBLE_SHEETS) {
+      for (const stock of STOCKS) {
+        expect(found.has(hrefFor(sheet, stock)), sheet.slug).toBe(true);
+      }
+    }
+  });
+});

--- a/src/pages/printables/_bible.ts
+++ b/src/pages/printables/_bible.ts
@@ -1,0 +1,441 @@
+/**
+ * The Scripture sheets the Print Shop has set, and the words that go round
+ * them.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data two pages
+ * share — `bible/[...slug].astro`, which prerenders one sheet per entry, and
+ * `bible/index.astro`, which is the subject hub — rather than a route of its
+ * own. `_catalog.ts` does the same job for paper, `_maths.ts` for maths, and
+ * `_handwriting.ts` and `_cursive.ts` for the two hands.
+ *
+ * **A shelf of its own, and a peer of the others** (§12). Not because Scripture
+ * is set apart — the whole design decision is that it isn't; a verse sits in the
+ * same passage picker as the Gettysburg Address, and the sheets below are the
+ * ordinary copywork and memory families with a passage id on them. It is a
+ * shelf because a shelf is how somebody arrives: "bible verse copywork
+ * printable" and "scripture handwriting practice" are queries a parent types,
+ * and a page that answers one of them has to exist to be found. The engine has
+ * no Scripture family and does not need one.
+ *
+ * **Where it doesn't go is in `_maths.ts`.** A verse reference bolted to a long
+ * division serves neither, and that is a craft judgement rather than a
+ * positioning one (§12).
+ *
+ * **The credit prints on every page here.** A public-domain text needs none,
+ * and eBible.org attaches one condition to the World English Bible's name that
+ * a credit line is the easiest way to keep honestly. The line is the engine's
+ * own constant, read off the passage rather than typed here, so the sheet
+ * footer and the page around it cannot drift apart.
+ *
+ * **Two stocks, as with paper and handwriting.** Most of this shelf is ruled,
+ * and a ⅝ rule sent to a printer loaded with A4 is scaled to fit — which is no
+ * longer a ⅝ rule. The memory sheets have no ruling to distort and could have
+ * lived on one stock, as the maths sheets do; they come on both anyway, because
+ * a shelf where some pages have an A4 twin and some don't is a shelf a parent
+ * has to check.
+ */
+import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
+import { passage as passageById } from "@/engine/sheets/passages";
+import type {
+  HandwritingConfig,
+  MemoryConfig,
+  PaperSize,
+  SheetConfig,
+} from "@/engine/sheets/types";
+
+import {
+  SHEET_FIELDS as FIELDS,
+  STOCKS,
+  benchHref,
+  paperOf,
+  shelve,
+  stockHref,
+  stockPath,
+  type Stock,
+} from "./_catalog";
+
+/** How the hub groups the shelf: what is being done with the words. */
+export type BibleGroup = "tracing" | "copywork" | "memory";
+
+/** Either of the two families that take a passage. Nothing else is on here. */
+export type BibleConfig = HandwritingConfig | MemoryConfig;
+
+export type BibleSheet = {
+  /** The route under /printables/bible, and the head term it answers. */
+  slug: string;
+  /** How it is listed on a hub. */
+  name: string;
+  /** How it is labelled in the row of neighbouring sheets. A few words. */
+  short: string;
+  /** The page's `<h1>`. */
+  heading: string;
+  /** The query this page exists to answer, in the words a parent types. */
+  keyword: string;
+  /** One sentence of what is on the sheet. Used in the description and hubs. */
+  summary: string;
+  /** The lead paragraph: what the sheet asks for, stated plainly. */
+  lead: string;
+  /** Two things that are true of this sheet and not of the one beside it. */
+  notes: string[];
+  /** For the `LearningResource` block. */
+  teaches: string;
+  ages: string;
+  group: BibleGroup;
+  /**
+   * Which passage, by its id in the library.
+   *
+   * Here rather than inside `config` so that the page and the sheet cannot
+   * quote two different verses: `configFor` is what puts it on the config, and
+   * it is also what the page reads to print the passage's own credit line.
+   */
+  passage: string;
+  /** The sheet itself, less the passage. Prerendered — this IS the page (§8). */
+  config: BibleConfig;
+};
+
+/**
+ * The seed every sheet on this shelf is built from, and it never moves.
+ *
+ * It decides nothing on a copywork sheet — a passage is a passage — and on a
+ * memory sheet it decides *which* words come out in each round, which is
+ * exactly the kind of thing §7 promises stays put: the sheet a parent printed
+ * in March is the sheet they print in June, down to the gaps.
+ */
+export const BIBLE_SEED = 1;
+
+export const BIBLE_SHEETS: BibleSheet[] = [
+  /* ── Tracing ────────────────────────────────────────────────────────── */
+  {
+    slug: "bible-verse-tracing-worksheets",
+    name: "Bible verse tracing — Genesis 1:1",
+    short: "Genesis 1:1",
+    heading: "Bible verse tracing worksheets",
+    keyword: "Free printable Bible verse tracing worksheets",
+    summary:
+      "The first verse of Genesis on ⅝-inch handwriting paper: printed to read, dotted to trace, and an empty line to write it alone.",
+    lead: "Ten words a five-year-old can hear the whole of, on the ⅝-inch ruling a school means by “handwriting paper”. Each line is printed once to read, once in dots to trace over, and then left empty.",
+    notes: [
+      "This is a handwriting sheet that happens to be a verse, which is the right way round at this age. A child who is still forming letters cannot also be thinking about what a sentence means, so the sentence had better be one they already half know — and “In the beginning, God created the heavens and the earth” is ten words, one clause, and no word longer than nine letters. By the fourth line it is being written from memory without anybody having called it memory work.",
+      "The ⅝ ruling has a dashed midline and room below the baseline for a tail, which this verse needs twice over: the g of “beginning” and the g of “God” both drop below the line, and on paper without descender space they get written small and flat to avoid the rule underneath. Print the ¾ or the inch version from the builder if letters are still growing into the line — the sheet is identical apart from the size.",
+    ],
+    teaches: "Letter formation and Scripture copywork",
+    ages: "Ages 5–7",
+    group: "tracing",
+    passage: "in-the-beginning",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "passage",
+      rule: { style: "hand-5-8", midline: "dashed", descender: true },
+      trace: "dotted",
+      repeats: 3,
+    },
+  },
+  {
+    slug: "bible-verse-handwriting-worksheets",
+    name: "Bible verse handwriting — John 3:16",
+    short: "John 3:16",
+    heading: "Bible verse handwriting worksheets",
+    keyword: "Free printable Bible verse handwriting worksheets",
+    summary:
+      "John 3:16 on half-inch handwriting paper, each line traced twice and then written on a line of its own.",
+    lead: "The verse most families teach first, on the half-inch ruling that fits a whole clause on a line. Every line appears three times down the page: printed to read, dotted to trace, and empty to write.",
+    notes: [
+      "Half an inch is where handwriting stops being about forming letters and starts being about getting to the end of a line without the words drifting. That makes it the right size for a verse rather than a word: the clauses are short enough to sit one to a line, so a child copying this is copying whole phrases — which is also how a verse is actually learnt, in pieces that mean something rather than word by word.",
+      "The dotted model runs down the page rather than across it, which is the difference between a word sheet and a copywork sheet. A word can be written six times on one line; a line of a verse fills the line, so the repeats have to go underneath — and the empty rule at the bottom of each group is the one that counts, because it is the only place nobody is helping.",
+    ],
+    teaches: "Handwriting and Scripture copywork",
+    ages: "Ages 6–9",
+    group: "tracing",
+    passage: "for-god-so-loved-the-world",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "passage",
+      rule: { style: "hand-1-2", midline: "dashed", descender: true },
+      trace: "dotted",
+      repeats: 3,
+    },
+  },
+
+  /* ── Copywork ───────────────────────────────────────────────────────── */
+  {
+    slug: "bible-copywork-worksheets",
+    name: "Bible copywork — Proverbs 3:5-6",
+    short: "Proverbs 3:5-6",
+    heading: "Bible copywork worksheets",
+    keyword: "Free printable Bible copywork worksheets",
+    summary:
+      "Proverbs 3:5-6 on ⅜-inch transitional paper: the line printed, a grey copy to write over, and an empty line to write it from nothing.",
+    lead: "Two verses on the transitional ⅜-inch ruling — a top line, a baseline and nothing between them. Each line is printed to read, printed faintly once to write over, and then left as an empty rule.",
+    notes: [
+      "The faint grey line is what marks this sheet as the one after tracing. A dotted letter is a path to follow and a grey one is a shape to write over, so the pencil has to do the deciding about where a stroke starts and how far it goes. It is a small change and it is the whole step between copying a letter and writing one, which is why the middle line here is grey rather than dotted.",
+      "Copywork is the oldest handwriting exercise there is and it is still the best one once letters are formed, because it is three lessons at once: the hand practises, the eye holds the spelling and the punctuation long enough for them to go in, and the words themselves get read four or five times without anybody being asked to memorise anything. Two verses is about right for one sitting at this age — long enough to be work, short enough to finish.",
+    ],
+    teaches: "Copywork and sustained handwriting",
+    ages: "Ages 7–10",
+    group: "copywork",
+    passage: "trust-in-the-lord",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "passage",
+      rule: { style: "hand-3-8", midline: "none", descender: true },
+      trace: "dim",
+      repeats: 3,
+    },
+  },
+  {
+    slug: "psalm-23-copywork",
+    name: "Psalm 23 copywork",
+    short: "Psalm 23",
+    heading: "Psalm 23 copywork worksheet",
+    keyword: "Free printable Psalm 23 copywork",
+    summary:
+      "The whole of Psalm 23 on narrow ruled paper, every line printed once to read and left once to copy.",
+    lead: "All six verses of the psalm, on the quarter-inch ruling that gets the whole of it onto one page. Each line is printed and then left blank underneath, which is copywork with nothing else in the way.",
+    notes: [
+      "The whole psalm rather than a verse of it, and that is what decides the ruling: at six hundred characters this needs about thirty lines, so quarter-inch rules are the only ones that fit the lot on a single sheet. It is a page for a child who is writing fluently and wants a real piece of work — twenty minutes rather than five — and it is worth saying that out loud before handing it over.",
+      "There is nothing dotted and nothing grey on this sheet. A reader at this stage does not need a model to write over; what they need is the line above to look at and an empty rule to fill, which is exactly what a page of copywork is. If a lighter version is wanted, the builder will set the same psalm with a grey model and fewer lines to a page, on any of the twelve rulings.",
+    ],
+    teaches: "Copywork and Scripture memory",
+    ages: "Ages 9–13",
+    group: "copywork",
+    passage: "psalm-23",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "passage",
+      rule: { style: "narrow" },
+      trace: "dim",
+      repeats: 2,
+    },
+  },
+  {
+    slug: "lords-prayer-copywork",
+    name: "The Lord’s Prayer copywork",
+    short: "Lord’s Prayer",
+    heading: "The Lord’s Prayer copywork worksheet",
+    keyword: "Free printable Lord’s Prayer copywork",
+    summary:
+      "The Lord’s Prayer from Matthew 6 on ⅜-inch paper, each line printed once and left once to copy.",
+    lead: "The prayer as Matthew has it, a line at a time on the transitional ⅜-inch ruling. Each line is printed to read and followed by an empty rule to write it on.",
+    notes: [
+      "The Lord’s Prayer is the passage most often learnt by heart before it is understood, which makes it unusually good copywork: a child who has said it a hundred times meets the words on paper and notices where the clauses actually break. Writing “as we also have forgiven our debtors” out slowly is the first time most people see that half of it is a comparison.",
+      "One copy under each line rather than two, because the lines here are long and the prayer is not short. That is the trade a copywork sheet always makes — how many times each line is written against how much of the passage fits on the page — and the builder is where to change it: the same prayer at three copies a line runs to two sheets, which is a perfectly good week’s work if that is what is wanted.",
+    ],
+    teaches: "Copywork and Scripture memory",
+    ages: "Ages 7–11",
+    group: "copywork",
+    passage: "the-lords-prayer",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "passage",
+      rule: { style: "hand-3-8", midline: "none", descender: true },
+      trace: "dim",
+      repeats: 2,
+    },
+  },
+  {
+    slug: "1-corinthians-13-copywork",
+    name: "1 Corinthians 13 copywork — love is patient",
+    short: "1 Cor 13",
+    heading: "1 Corinthians 13 copywork worksheet",
+    keyword: "Free printable 1 Corinthians 13 copywork",
+    summary:
+      "“Love is patient and is kind…” — five verses on college ruled paper, printed to read and left to copy.",
+    lead: "The passage from verse four to verse eight, on college ruled paper. Each line is printed once and followed by an empty rule, so the whole of it fits on a single page.",
+    notes: [
+      "This is the longest passage on the shelf and the one that reads least like a list when it is copied out — which is the point of copying it. Fifteen separate statements about one word go past far too quickly when they are read; written out at the speed of a hand, the shape of the argument shows up, and so does the fact that most of the statements are about what love does not do.",
+      "College ruled rather than handwriting paper, because by the age this passage is worth setting a child is writing on ordinary lined paper at school and should be practising on the same thing. There is no midline and no descender space here; what there is instead is about six more lines to the page than wide ruled gives you, which is what makes a passage this long fit on one.",
+    ],
+    teaches: "Copywork and sustained handwriting",
+    ages: "Ages 10–14",
+    group: "copywork",
+    passage: "love-is-patient",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "passage",
+      rule: { style: "college" },
+      trace: "dim",
+      repeats: 2,
+    },
+  },
+
+  /* ── Memory work ────────────────────────────────────────────────────── */
+  {
+    slug: "bible-memory-verse-worksheets",
+    name: "Memory verse — John 3:16",
+    short: "John 3:16 by heart",
+    heading: "Bible memory verse worksheets",
+    keyword: "Free printable Bible memory verse worksheets",
+    summary:
+      "John 3:16 written out four times with more words missing each time — and the whole verse on the answer key.",
+    lead: "The verse in full at the top, then three times over with more of it gone: a few words, then most of them, then a line of blanks. It is the whiteboard exercise every family already does, on paper.",
+    notes: [
+      "Rubbing a few words off the board and saying it again is how a verse is learnt, and the reason it works is that each round is only slightly harder than the one before. That is the whole of what this sheet does: the words are taken away in the same order every round, so nothing that has gone ever comes back, and by the last line there is nothing left to read from. A child who gets to the bottom has said the verse from memory four times without being asked to recite it once.",
+      "Words are left out here on purpose, and the sheet says so on it — printing part of a translation without saying that is what it is would be publishing a modified text under somebody else’s name. The answer key behind this page is the verse whole, exactly as the translation has it, punctuation and all. That is also the page to hand the person doing the listening.",
+    ],
+    teaches: "Scripture memory",
+    ages: "Ages 6–12",
+    group: "memory",
+    passage: "for-god-so-loved-the-world",
+    config: {
+      kind: "memory",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      rounds: 4,
+    },
+  },
+  {
+    slug: "psalm-23-memory-verse",
+    name: "Memory work — Psalm 23",
+    short: "Psalm 23 by heart",
+    heading: "Psalm 23 memory worksheet",
+    keyword: "Free printable Psalm 23 memory worksheet",
+    summary:
+      "The whole of Psalm 23 three times over, with half the words gone in the second and all of them in the third.",
+    lead: "A psalm rather than a verse, which changes the exercise: six hundred characters will not go four times onto one page, so this is the whole psalm, then half of it, then none of it.",
+    notes: [
+      "Three rounds rather than four is the page deciding, not a judgement about difficulty — the sheet asks for as many as fit and comes down to the number that do, keeping the empty round at the end because that is the one the whole progression aims at. It also makes the middle round harder than it looks: half of six hundred characters is three hundred, and the gaps are spread through the psalm rather than clustered.",
+      "This is a sheet to spend a fortnight on rather than an afternoon. The usual way through it is to do the first round as copywork on one day, the middle round a few days later, and the last one when somebody thinks they have it — and the answer key behind this page is the psalm entire, which is what the person listening should be holding.",
+    ],
+    teaches: "Scripture memory",
+    ages: "Ages 9–14",
+    group: "memory",
+    passage: "psalm-23",
+    config: {
+      kind: "memory",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      rounds: 3,
+    },
+  },
+  {
+    slug: "fruit-of-the-spirit-memory-verse",
+    name: "Memory verse — the fruit of the Spirit",
+    short: "Fruit of the Spirit",
+    heading: "Fruit of the Spirit memory worksheet",
+    keyword: "Free printable fruit of the Spirit worksheet",
+    summary:
+      "Galatians 5:22-23 four times over with more of the list missing each time, and the full verse on the key.",
+    lead: "The nine-word list every Sunday school teaches, in the sentence it comes in. Written out in full, then three times with more of it gone, ending with a line of blanks.",
+    notes: [
+      "A list is the hardest kind of thing to learn by heart and the easiest to think you have learnt: most children can say seven of the nine and stall in the same place every time. Taking the words out in a fixed order is what finds the gap — whichever two are missing on the third round are the two that were never really there, and they are worth five minutes on their own before the last round is attempted.",
+      "The verse rather than the list on its own, deliberately. “Love, joy, peace…” recited as nine nouns is a spelling test; the sentence around them says what they are and what they are not, and the last clause — “against such things there is no law” — is the part almost nobody remembers, which is a fair sign it is usually taught as a list rather than as a verse.",
+    ],
+    teaches: "Scripture memory",
+    ages: "Ages 7–12",
+    group: "memory",
+    passage: "the-fruit-of-the-spirit",
+    config: {
+      kind: "memory",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      rounds: 4,
+    },
+  },
+];
+
+/** What each group is called on a hub, in the order they are listed. */
+export const BIBLE_GROUPS: Array<{
+  id: BibleGroup;
+  label: string;
+  blurb: string;
+}> = [
+  {
+    id: "tracing",
+    label: "Verses to trace",
+    blurb:
+      "A verse on primary ruled paper, traced first and then written alone.",
+  },
+  {
+    id: "copywork",
+    label: "Copywork",
+    blurb:
+      "A passage a line at a time, once the letters are no longer the work.",
+  },
+  {
+    id: "memory",
+    label: "Memory work",
+    blurb:
+      "The same passage with more of it missing each time, and the whole of it on the key.",
+  },
+];
+
+/**
+ * The sheet, measured for a stock and pointed at its passage.
+ *
+ * The passage is put on here rather than written into each config for the
+ * reason `BibleSheet.passage` gives: one field, so the verse the page names and
+ * the verse the sheet prints cannot come apart.
+ */
+export function configFor(sheet: BibleSheet, size: PaperSize): SheetConfig {
+  return { ...sheet.config, passage: sheet.passage, paper: paperOf(size) };
+}
+
+/**
+ * The credit the sheet will print, read off the passage itself.
+ *
+ * Never typed on a page. §12 puts the line in one constant in the engine
+ * precisely so that the footer of the sheet and the prose around it cannot
+ * disagree, and a catalog page that quoted it by hand would be the second copy
+ * that goes stale.
+ */
+export const creditFor = (sheet: BibleSheet): string | undefined =>
+  passageById(sheet.passage)?.credit;
+
+/** How the passage is named — "Psalm 23" — and who it is by. */
+export const passageFor = (sheet: BibleSheet) => passageById(sheet.passage);
+
+/**
+ * Whether this sheet has an answer key worth printing.
+ *
+ * Copywork has none and needs none: the model is already on the page, which is
+ * the exercise. A memory sheet's key is the passage whole, and it is the single
+ * most useful page on this shelf — it is what the person listening holds.
+ */
+export const keyed = (sheet: BibleSheet): boolean =>
+  sheet.config.kind === "memory";
+
+/** The route a sheet prints at, on a given stock — see `_catalog.ts`. */
+export const pathFor = (sheet: BibleSheet, stock: Stock): string =>
+  stockPath(sheet.slug, stock);
+
+/** The whole URL, which is what a hub links to and the canonical says. */
+export const hrefFor = (sheet: BibleSheet, stock: Stock): string =>
+  stockHref("/printables/bible", sheet.slug, stock);
+
+/** The builder, opened on this sheet. */
+export const builderHref = (sheet: BibleSheet, stock: Stock): string =>
+  benchHref(configFor(sheet, stock.id), BIBLE_SEED);
+
+/** The shelf, grouped — the shape every page lists it in. */
+export function bibleShelf(): Array<{
+  id: BibleGroup;
+  label: string;
+  blurb: string;
+  sheets: BibleSheet[];
+}> {
+  return shelve(BIBLE_GROUPS, BIBLE_SHEETS);
+}
+
+/** Letter first, then A4 — the order `_catalog.ts` sets and the reason for it. */
+export { STOCKS };

--- a/src/pages/printables/_bible.ts
+++ b/src/pages/printables/_bible.ts
@@ -116,7 +116,7 @@ export const BIBLE_SHEETS: BibleSheet[] = [
     lead: "Ten words a five-year-old can hear the whole of, on the ⅝-inch ruling a school means by “handwriting paper”. Each line is printed once to read, once in dots to trace over, and then left empty.",
     notes: [
       "This is a handwriting sheet that happens to be a verse, which is the right way round at this age. A child who is still forming letters cannot also be thinking about what a sentence means, so the sentence had better be one they already half know — and “In the beginning, God created the heavens and the earth” is ten words, one clause, and no word longer than nine letters. By the fourth line it is being written from memory without anybody having called it memory work.",
-      "The ⅝ ruling has a dashed midline and room below the baseline for a tail, which this verse needs twice over: the g of “beginning” and the g of “God” both drop below the line, and on paper without descender space they get written small and flat to avoid the rule underneath. Print the ¾ or the inch version from the builder if letters are still growing into the line — the sheet is identical apart from the size.",
+      "The ⅝ ruling has a dashed midline and room below the baseline for a tail, which this verse needs twice over: the two g’s of “beginning” are the only letters on it that drop below the line, and on paper without descender space they get written small and flat to avoid the rule underneath. Print the ¾ or the inch version from the builder if letters are still growing into the line — the sheet is identical apart from the size.",
     ],
     teaches: "Letter formation and Scripture copywork",
     ages: "Ages 5–7",
@@ -229,7 +229,7 @@ export const BIBLE_SHEETS: BibleSheet[] = [
       "The Lord’s Prayer from Matthew 6 on ⅜-inch paper, each line printed once and left once to copy.",
     lead: "The prayer as Matthew has it, a line at a time on the transitional ⅜-inch ruling. Each line is printed to read and followed by an empty rule to write it on.",
     notes: [
-      "The Lord’s Prayer is the passage most often learnt by heart before it is understood, which makes it unusually good copywork: a child who has said it a hundred times meets the words on paper and notices where the clauses actually break. Writing “as we also have forgiven our debtors” out slowly is the first time most people see that half of it is a comparison.",
+      "The Lord’s Prayer is the passage most often learnt by heart before it is understood, which makes it unusually good copywork: a child who has said it a hundred times meets the words on paper and notices where the clauses actually break. Writing “Forgive us our debts, as we also forgive our debtors” out slowly is the first time most people see that half of it is a comparison.",
       "One copy under each line rather than two, because the lines here are long and the prayer is not short. That is the trade a copywork sheet always makes — how many times each line is written against how much of the passage fits on the page — and the builder is where to change it: the same prayer at three copies a line runs to two sheets, which is a perfectly good week’s work if that is what is wanted.",
     ],
     teaches: "Copywork and Scripture memory",
@@ -257,7 +257,7 @@ export const BIBLE_SHEETS: BibleSheet[] = [
       "“Love is patient and is kind…” — five verses on college ruled paper, printed to read and left to copy.",
     lead: "The passage from verse four to verse eight, on college ruled paper. Each line is printed once and followed by an empty rule, so the whole of it fits on a single page.",
     notes: [
-      "This is the longest passage on the shelf and the one that reads least like a list when it is copied out — which is the point of copying it. Fifteen separate statements about one word go past far too quickly when they are read; written out at the speed of a hand, the shape of the argument shows up, and so does the fact that most of the statements are about what love does not do.",
+      "Psalm 23 aside, this is the longest passage on the shelf, and the one that reads least like a list when it is copied out — which is the point of copying it. Fifteen separate statements about one word go past far too quickly when they are read; written out at the speed of a hand, the shape of the argument shows up, and so does the fact that most of the statements are about what love does not do.",
       "College ruled rather than handwriting paper, because by the age this passage is worth setting a child is writing on ordinary lined paper at school and should be practising on the same thing. There is no midline and no descender space here; what there is instead is about six more lines to the page than wide ruled gives you, which is what makes a passage this long fit on one.",
     ],
     teaches: "Copywork and sustained handwriting",
@@ -287,7 +287,7 @@ export const BIBLE_SHEETS: BibleSheet[] = [
       "John 3:16 written out four times with more words missing each time — and the whole verse on the answer key.",
     lead: "The verse in full at the top, then three times over with more of it gone: a few words, then most of them, then a line of blanks. It is the whiteboard exercise every family already does, on paper.",
     notes: [
-      "Rubbing a few words off the board and saying it again is how a verse is learnt, and the reason it works is that each round is only slightly harder than the one before. That is the whole of what this sheet does: the words are taken away in the same order every round, so nothing that has gone ever comes back, and by the last line there is nothing left to read from. A child who gets to the bottom has said the verse from memory four times without being asked to recite it once.",
+      "Rubbing a few words off the board and saying it again is how a verse is learnt, and the reason it works is that each round is only slightly harder than the one before. That is the whole of what this sheet does: the words are taken away in the same order every round, so nothing that has gone ever comes back, and by the last line there is nothing left to read from. A child who gets to the bottom has said the verse from memory three times without being asked to recite it once.",
       "Words are left out here on purpose, and the sheet says so on it — printing part of a translation without saying that is what it is would be publishing a modified text under somebody else’s name. The answer key behind this page is the verse whole, exactly as the translation has it, punctuation and all. That is also the page to hand the person doing the listening.",
     ],
     teaches: "Scripture memory",
@@ -309,11 +309,11 @@ export const BIBLE_SHEETS: BibleSheet[] = [
     heading: "Psalm 23 memory worksheet",
     keyword: "Free printable Psalm 23 memory worksheet",
     summary:
-      "The whole of Psalm 23 three times over, with half the words gone in the second and all of them in the third.",
-    lead: "A psalm rather than a verse, which changes the exercise: six hundred characters will not go four times onto one page, so this is the whole psalm, then half of it, then none of it.",
+      "The whole of Psalm 23 printed to read, and then asked for again with every word of it gone — with the psalm entire on the answer key.",
+    lead: "A psalm rather than a verse, which changes the exercise: a hundred and eighteen words will not go three times onto one page once every one of them needs a gap wide enough to write in, so this is the psalm printed whole and then asked for with nothing left to read from.",
     notes: [
-      "Three rounds rather than four is the page deciding, not a judgement about difficulty — the sheet asks for as many as fit and comes down to the number that do, keeping the empty round at the end because that is the one the whole progression aims at. It also makes the middle round harder than it looks: half of six hundred characters is three hundred, and the gaps are spread through the psalm rather than clustered.",
-      "This is a sheet to spend a fortnight on rather than an afternoon. The usual way through it is to do the first round as copywork on one day, the middle round a few days later, and the last one when somebody thinks they have it — and the answer key behind this page is the psalm entire, which is what the person listening should be holding.",
+      "Two rounds rather than four is the page deciding, not a judgement about difficulty — the sheet asks for four and comes down to the number that fit, keeping the empty round at the end because that is the one the whole progression aims at. A gap has to be wide enough to write a word in, so it takes more room on the paper than the word it replaced: the psalm printed runs to eight lines and the psalm with every word gone to about twice that, which is why a whole psalm gets two rounds where a single verse gets four.",
+      "This is a sheet to spend a fortnight on rather than an afternoon. The usual way through it is to do the first round as copywork on one day and the second one when somebody thinks they have it, a week or two later — and the answer key behind this page is the psalm entire, which is what the person listening should be holding.",
     ],
     teaches: "Scripture memory",
     ages: "Ages 9–14",
@@ -324,7 +324,11 @@ export const BIBLE_SHEETS: BibleSheet[] = [
       paper: paperOf("letter"),
       fontPt: DEFAULT_FONT_PT,
       fields: FIELDS,
-      rounds: 3,
+      // Four asked for and two printed. Nothing here decides that the psalm
+      // gets fewer rounds than the verses do — `memoryLayout` does, against the
+      // room a hundred and eighteen gaps take, and the note above says so
+      // because the page says so.
+      rounds: 4,
     },
   },
   {
@@ -337,7 +341,7 @@ export const BIBLE_SHEETS: BibleSheet[] = [
       "Galatians 5:22-23 four times over with more of the list missing each time, and the full verse on the key.",
     lead: "The nine-word list every Sunday school teaches, in the sentence it comes in. Written out in full, then three times with more of it gone, ending with a line of blanks.",
     notes: [
-      "A list is the hardest kind of thing to learn by heart and the easiest to think you have learnt: most children can say seven of the nine and stall in the same place every time. Taking the words out in a fixed order is what finds the gap — whichever two are missing on the third round are the two that were never really there, and they are worth five minutes on their own before the last round is attempted.",
+      "A list is the hardest kind of thing to learn by heart and the easiest to think you have learnt: most children can say seven of the nine and stall in the same place every time. Taking the words out in a fixed order is what finds the gap — a third of the verse is gone in the second round and two thirds of it in the third, so whichever of the nine is missed at that point is missed in the same place every time, and it is worth five minutes on its own before the last round is attempted.",
       "The verse rather than the list on its own, deliberately. “Love, joy, peace…” recited as nine nouns is a spelling test; the sentence around them says what they are and what they are not, and the last clause — “against such things there is no law” — is the part almost nobody remembers, which is a fair sign it is usually taught as a list rather than as a verse.",
     ],
     teaches: "Scripture memory",

--- a/src/pages/printables/bible/[...slug].astro
+++ b/src/pages/printables/bible/[...slug].astro
@@ -1,0 +1,229 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { answerKey, buildSheet } from "@/engine/sheets";
+import {
+  BIBLE_SEED,
+  BIBLE_SHEETS,
+  STOCKS,
+  bibleShelf,
+  builderHref,
+  configFor,
+  creditFor,
+  hrefFor,
+  keyed,
+  passageFor,
+  type BibleSheet,
+} from "../_bible";
+import type { Stock } from "../_catalog";
+
+/**
+ * One prerendered Scripture sheet per topic — and the page is the sheet.
+ *
+ * The shape §8 describes and the shape the other three shelves already build,
+ * applied to the passages of §12: "bible verse copywork printable" is a query
+ * with real homeschool volume, and a parent who lands here gets prose that
+ * answers it, the sheet itself directly under it as HTML, and nothing to click.
+ *
+ * **The credit line prints twice, and both are required.** Once at the foot of
+ * the sheet, where the engine puts it, and once in the prose here — this is the
+ * "every catalog page previewing one" half of §12. It is read off the passage
+ * through `creditFor` rather than typed, so the two cannot drift apart and a
+ * page that switched translations cannot keep the old line.
+ *
+ * **Two stocks, two routes — as with paper and handwriting.** Most of this
+ * shelf is ruled and a ⅝ rule scaled to fit A4 is no longer a ⅝ rule, and
+ * `@page` is a document rule, so the two cannot share a page.
+ *
+ * **The answer key prints only where there is one.** A memory sheet's key is
+ * the passage whole and is the most useful page on this shelf; copywork already
+ * has its model on the paper, so its key is its own sheet and printing it twice
+ * would be two identical pages out of the printer.
+ *
+ * **No client directive on `SheetView`, ever**, and **everything that is not
+ * the sheet carries `.no-print`** — the two contracts `Sheet.test.tsx` holds
+ * every page in this directory to.
+ */
+
+type Props = { sheet: BibleSheet; stock: Stock };
+
+export function getStaticPaths() {
+  return BIBLE_SHEETS.flatMap((sheet) =>
+    STOCKS.map((stock) => ({
+      params: { slug: stock.path ? `${sheet.slug}/${stock.path}` : sheet.slug },
+      props: { sheet, stock },
+    })),
+  );
+}
+
+const { sheet, stock } = Astro.props;
+
+const a4 = stock.id === "a4";
+const config = configFor(sheet, stock.id);
+const printed = buildSheet(config, BIBLE_SEED);
+const key = keyed(sheet) ? answerKey(config, BIBLE_SEED) : null;
+const other = STOCKS.find((candidate) => candidate.id !== stock.id)!;
+
+const quoted = passageFor(sheet)!;
+const credit = creditFor(sheet);
+
+const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
+const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
+const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const url = `https://schoolskills.app${hrefFor(sheet, stock)}`;
+
+const groups = bibleShelf();
+const group = groups.find((entry) => entry.id === sheet.group)!;
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    name: heading,
+    description,
+    url,
+    learningResourceType: "Worksheet",
+    educationalUse: "Practice",
+    teaches: sheet.teaches,
+    typicalAgeRange: sheet.ages,
+    isAccessibleForFree: true,
+    inLanguage: "en",
+  }}
+>
+  <header class="hero wrap no-print">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Bible &middot; {group.label}
+    </p>
+    <h1 class="hero__title">{heading}</h1>
+    <p class="hero__lead">{sheet.lead}</p>
+    <p class="aside">
+      The sheet below <strong>is</strong> the printout{
+        key ? ", and the page behind it is the answer key" : ""
+      }. Press <strong>&#8984;P</strong> &mdash; <strong>Ctrl+P</strong> on Windows
+      &mdash; and everything but the paper disappears. Nothing here needs choosing
+      first. To keep a copy instead, pick <em>Save as PDF</em> in the print dialog
+      and your browser writes one.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  {
+    /*
+      The sheet, outside `.wrap` deliberately. A wrap adds an inline padding
+      that print.css cannot take back off, and a sheet printed a centimetre in
+      from where it says it is has the wrong geometry everywhere at once. The
+      key is a sibling with nothing between them: `print.css` breaks on
+      `.sheet + .sheet`, and an element in between would take that away.
+    */
+  }
+  <div class="sheet-frame">
+    <SheetView sheet={printed} />
+    {key && <SheetView sheet={key} />}
+  </div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">What is on this sheet</h2>
+    <div class="prose">
+      {sheet.notes.map((note) => <p>{note}</p>)}
+      <p>
+        The passage is <strong>{quoted.title}</strong>, printed exactly as the
+        translation has it &mdash; the punctuation, the spelling and the
+        capitals are the source&rsquo;s rather than ours, which is a condition
+        of using the name and is also what a child copying it should be copying.
+        {
+          key &&
+            " Where words are left out for the exercise, the sheet says so and the answer key prints the passage whole."
+        }
+      </p>
+      {credit && <p class="aside">{credit}</p>}
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Any passage, any ruling</h2>
+    <div class="prose">
+      <p>
+        This page is one sheet out of a family that can print thousands.
+        {quoted.title} sits in the same passage picker as the Gettysburg Address and
+        &ldquo;The Owl and the Pussy-Cat&rdquo; &mdash; a few hundred entries, Scripture
+        listed first &mdash; and any of them can be set at any of the twelve rulings,
+        in any of the five trace styles, in print or in cursive. Or paste your own
+        verse and get the same sheet.
+      </p>
+      <p class="aside">
+        The settings travel in the address bar rather than on a server, so the
+        link below opens the bench on exactly the sheet above, and a sheet you
+        make can be sent to another family as it stands. There is nowhere in it
+        to put a child&rsquo;s name &mdash; see{" "}
+        <a href="/privacy">what we don&rsquo;t collect</a>.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href={builderHref(sheet, stock)}>
+        Open this sheet in the builder
+      </a>
+      <a class="cta cta--quiet" href="/printables/handwriting">
+        Handwriting worksheets
+      </a>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Printing it on {other.label}</h2>
+    <div class="prose">
+      <p>
+        This sheet is set for {stock.label} &mdash; {stock.size}. Paper size is
+        not a preference on a ruled sheet: sent to a printer loaded with
+        something else, the browser shrinks the page to fit, and a ruling that
+        has been shrunk is no longer the size it was chosen for. So there is a
+        second copy of this sheet, measured for {other.label}.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href={hrefFor(sheet, other)}>The {other.label} version</a>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Every Scripture sheet</h2>
+    <p class="h2__sub">
+      {BIBLE_SHEETS.length} sheets, each one a page like this one. Nothing is locked
+      and nothing needs an account.
+    </p>
+    {
+      groups.map((entry) => (
+        <>
+          <h3 class="h2 h2--next">{entry.label}</h3>
+          <p class="h2__sub">{entry.blurb}</p>
+          <nav class="stones" aria-label={entry.label}>
+            {entry.sheets.map((candidate) => (
+              <a
+                class="stone"
+                href={hrefFor(candidate, stock)}
+                aria-current={
+                  candidate.slug === sheet.slug ? "page" : undefined
+                }
+              >
+                {candidate.short}
+              </a>
+            ))}
+          </nav>
+        </>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables/bible">
+        All the Scripture sheets
+      </a>
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/bible/index.astro
+++ b/src/pages/printables/bible/index.astro
@@ -1,0 +1,190 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SCRIPTURE_CREDIT } from "@/engine/sheets/passages";
+import { BIBLE_SHEETS, STOCKS, bibleShelf, hrefFor } from "../_bible";
+
+/**
+ * The Scripture subject hub — the third of the §8 subject names to exist, and
+ * a peer of `/printables/math` and `/printables/handwriting` rather than a
+ * footnote under one of them.
+ *
+ * A listing rather than a sheet, as the other hubs are: nobody searches for
+ * "printable list of Bible copywork worksheets". What it is for is the two jobs
+ * a hub does — giving a parent who arrived on one sheet somewhere to go next,
+ * and giving the topic pages a crawlable parent that says what they have in
+ * common.
+ *
+ * **It says what translation, and it says it plainly.** The one thing a parent
+ * wants to know before printing a verse is which text it is, and the credit
+ * line is the engine's own constant rather than a sentence typed here (§12).
+ */
+const title =
+  "Free printable Bible copywork, handwriting and memory verse worksheets | School Skills";
+const description =
+  "Printable Scripture practice: verses to trace, copywork at every ruling, and memory sheets with progressive blanks and the full verse on the answer key. Public-domain text, free, no account, and nothing to download.";
+
+const groups = bibleShelf();
+const letter = STOCKS[0];
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Printable Bible worksheets",
+    description,
+    url: "https://schoolskills.app/printables/bible",
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    hasPart: BIBLE_SHEETS.map((sheet) => ({
+      "@type": "LearningResource",
+      name: sheet.heading,
+      url: `https://schoolskills.app${hrefFor(sheet, letter)}`,
+      learningResourceType: "Worksheet",
+      teaches: sheet.teaches,
+      typicalAgeRange: sheet.ages,
+      isAccessibleForFree: true,
+    })),
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Bible
+    </p>
+    <h1 class="hero__title">Printable Bible copywork and memory verses</h1>
+    <p class="hero__lead">
+      {BIBLE_SHEETS.length} sheets, from a first verse traced on ⅝-inch paper to the
+      whole of Psalm 23 copied out. Every one of them is an ordinary handwriting or
+      memory sheet with a passage on it &mdash; the same sheets, the same rulings,
+      the same builder.
+    </p>
+    <p class="hero__note">Free &middot; two paper sizes &middot; no download</p>
+  </header>
+
+  {
+    /*
+      What exists, first — before the page explains itself. Somebody who came
+      looking for Psalm 23 copywork should be one link from it, and the
+      argument about which translation reads better after you have seen a
+      sheet than before.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">On the shelf now</h2>
+    <p class="h2__sub">
+      Each of these is a page that is itself the worksheet &mdash; open it,
+      press print, and that is the whole of it. Every sheet comes on US Letter
+      and on A4, because a ⅝-inch rule shrunk to fit whatever is in the tray is
+      no longer a ⅝-inch rule.
+    </p>
+    {
+      groups.map((group) => (
+        <>
+          <h3 class="h2 h2--next">{group.label}</h3>
+          <p class="h2__sub">{group.blurb}</p>
+          <div class="prose">
+            <ul>
+              {group.sheets.map((sheet) => (
+                <li>
+                  <a href={hrefFor(sheet, letter)}>{sheet.name}</a> &mdash;{" "}
+                  {sheet.summary}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      ))
+    }
+  </section>
+
+  <div class="wrap"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">A verse is one passage among several</h2>
+    <div class="prose">
+      <p>
+        Scripture is not a mode here and there is no separate section for it.
+        The sheets above are the ordinary copywork and handwriting families with
+        a passage chosen, and the picker they were chosen from holds a few
+        hundred entries &mdash; the Psalms, the Gospels and the Proverbs listed
+        first, then the founding documents, the fables, the openings of a dozen
+        novels and the poems. Choosing Psalm 23 and choosing the Gettysburg
+        Address are the same two clicks.
+      </p>
+      <p>
+        So every one of these sheets is also a setting rather than a fixed page.
+        Any passage can be set at any of the twelve rulings, from inch-high
+        kindergarten paper to college ruled; the model can be dotted, dashed,
+        hollow, grey or left off; and the whole thing can be printed in a joined
+        hand instead. Or paste a verse of your own and get the identical sheet.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/make">Open the sheet builder</a>
+      <a class="cta cta--quiet" href="/printables/handwriting">
+        Handwriting worksheets
+      </a>
+      <a class="cta cta--quiet" href="/printables/cursive">
+        Cursive worksheets
+      </a>
+    </div>
+  </section>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">Which translation, and why that one</h2>
+      <p class="h2__sub">
+        The World English Bible Updated, with the King James beside it. Both are
+        public domain; neither costs anybody a licence.
+      </p>
+      <div class="prose">
+        <p>
+          The default is the <strong>World English Bible Updated</strong>: a
+          modern English translation in the public domain, which renders the
+          divine name as <em>LORD</em> rather than transliterating it, and uses American
+          spelling. The <strong>King James Version</strong> is the other option in
+          the builder, switchable on any sheet. There is nothing else on offer, and
+          that is deliberate &mdash; the ESV, NIV, NASB and CSB are licensed texts,
+          and bundling one into a free worksheet site would be a real problem rather
+          than an oversight.
+        </p>
+        <p>
+          The text is printed exactly as the translation has it: the
+          punctuation, the capitals and the spelling are the source&rsquo;s, and
+          nothing is re-wrapped or tidied. That is a condition of using the
+          name, and it is checked against the publisher&rsquo;s own release
+          every time this site is built rather than promised in a comment. Verse
+          numbers are left off, because they are typography rather than text and
+          a child copying &ldquo;1&rdquo; before every clause is copying a
+          printer.
+        </p>
+        <p>
+          Where a sheet deliberately leaves words out &mdash; the memory sheets,
+          which is the whole exercise &mdash; the page says so, and the answer
+          key behind it prints the passage whole.
+        </p>
+        <p class="aside">{SCRIPTURE_CREDIT}</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Your child&rsquo;s name is not in the file</h2>
+    <div class="prose">
+      <p>
+        The <em>Name:</em> line is printed blank and filled in with a pencil. Nothing
+        is uploaded to make a sheet, no account is needed to print one, and a sheet
+        you share with another family carries the settings you chose and nothing else
+        &mdash; see <a href="/privacy">what we don&rsquo;t collect</a>.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/handwriting/index.astro
+++ b/src/pages/printables/handwriting/index.astro
@@ -21,8 +21,9 @@ import {
  * It lists what exists and nothing else. Cursive prints now and has a hub of
  * its own, linked both ways: it is a second progression rather than a group
  * under this one, and a parent whose child is ready to join needs the whole
- * shelf rather than one sheet from it. Scripture copywork is still a story of
- * its own and is not linked from here until it prints.
+ * shelf rather than one sheet from it. The Scripture shelf is linked the same
+ * way and for the same reason — those are these sheets with a passage on them,
+ * so a parent who wants one wants the shelf and not a sheet.
  */
 const title =
   "Free printable handwriting worksheets — trace, copy, write | School Skills";
@@ -191,6 +192,24 @@ const letter = STOCKS[0];
     </div>
     <div class="hero__actions">
       <a class="cta" href="/printables/cursive">Cursive worksheets</a>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">And a passage somebody wrote</h2>
+    <div class="prose">
+      <p>
+        The copywork sheet above is a poem, and the passage on it is a setting
+        rather than the sheet. A few hundred are shipped &mdash; the Psalms, the
+        Gospels and the Proverbs listed first, then the founding documents, the
+        fables, the openings of a dozen novels and the poems &mdash; and any of
+        them prints at any of these rulings, in any of the trace styles.
+        Scripture has a shelf of its own because it is what people search for,
+        not because it is a different kind of sheet.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/bible">Bible copywork worksheets</a>
     </div>
   </section>
 

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { BIBLE_SHEETS, bibleShelf, hrefFor as bibleHref } from "./_bible";
 import { STOCKS, pathFor, shelf } from "./_catalog";
 import {
   CURSIVE_SHEETS,
@@ -26,10 +27,11 @@ import { MATHS_SHEETS, mathsShelf, pathFor as mathsPath } from "./_maths";
  * It lists what exists and nothing else. A shelf of links to sheets that
  * haven't been built is the thin-content pattern Base.astro's `noindex` block
  * already argues against, and a catalog page here is meant to BE the worksheet
- * — real prerendered HTML a parent can print without touching anything. Four
+ * — real prerendered HTML a parent can print without touching anything. Five
  * families fill it: every ruling in §5 on both stocks, the curated maths topics
- * of §8, each of which prints its own answer key, and the handwriting and
- * cursive sheets, which come on both stocks for the same reason the paper does.
+ * of §8, each of which prints its own answer key, the handwriting and cursive
+ * sheets, which come on both stocks for the same reason the paper does, and the
+ * Scripture shelf, which is those same families with a passage on them.
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
@@ -41,6 +43,7 @@ const groups = shelf();
 const strands = mathsShelf();
 const writing = handwritingShelf();
 const joined = cursiveShelf();
+const scripture = bibleShelf();
 ---
 
 <Content
@@ -83,12 +86,13 @@ const joined = cursiveShelf();
   <section class="band band--tight wrap">
     <h2 class="h2">On the shelf now</h2>
     <p class="h2__sub">
-      Four families: maths worksheets, each with its answer key on the page
+      Five families: maths worksheets, each with its answer key on the page
       behind it, handwriting practice that traces before it copies, the same
-      progression again in cursive, and paper in every ruling. Each of these is
-      a page that is itself the sheet &mdash; open it, press print, and that is
-      the whole of it. Everything ruled comes on both stocks, because a ruling
-      shrunk to fit whatever is in the tray is no longer the ruling you chose.
+      progression again in cursive, Scripture copywork and memory work, and
+      paper in every ruling. Each of these is a page that is itself the sheet
+      &mdash; open it, press print, and that is the whole of it. Everything
+      ruled comes on both stocks, because a ruling shrunk to fit whatever is in
+      the tray is no longer the ruling you chose.
     </p>
 
     <h3 class="h2 h2--next">Maths worksheets</h3>
@@ -153,6 +157,26 @@ const joined = cursiveShelf();
       <a class="cta" href="/printables/cursive">All the cursive sheets</a>
     </div>
 
+    <h3 class="h2 h2--next">Bible</h3>
+    <p class="h2__sub">
+      {BIBLE_SHEETS.length} sheets of Scripture copywork, handwriting and memory work
+      &mdash; the same families above with a passage on them, in a public-domain translation.
+    </p>
+    {
+      scripture.map((group) => (
+        <nav class="stones" aria-label={`Bible — ${group.label}`}>
+          {group.sheets.map((sheet) => (
+            <a class="stone" href={bibleHref(sheet, letter)}>
+              {sheet.short}
+            </a>
+          ))}
+        </nav>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta" href="/printables/bible">All the Scripture sheets</a>
+    </div>
+
     {
       /*
         Paper keeps its groups and its one-line summaries; maths gets a row of
@@ -209,16 +233,16 @@ const joined = cursiveShelf();
       <h2 class="h2">What the press is being set for</h2>
       <p class="h2__sub">
         The Print Shop is opening a family at a time, and this page lists what
-        exists rather than what is planned. Paper, maths, handwriting and
-        cursive are open. The wider copywork is next.
+        exists rather than what is planned. Paper, maths, handwriting, cursive
+        and copywork are open. Spelling is next.
       </p>
       <div class="prose">
         <p>
           The order it opens in: the paper, the maths sheets, the handwriting
-          and the cursive above, then the wider copywork &mdash; passages from
-          the public domain, Scripture among them &mdash; then spelling,
-          phonics, and the charts, certificates and planners that are simply
-          blank forms.
+          and the cursive above, then the copywork &mdash; a few hundred
+          passages from the public domain, Scripture among them &mdash; then
+          spelling, phonics, and the charts, certificates and planners that are
+          simply blank forms.
         </p>
         <p>
           The one it is really being built for comes with the sheet builder:


### PR DESCRIPTION
## What this does

Closes #63 (PRINT19). The passage library from PRINT18 landed with nothing
reading it. This is the story that reads it — copywork and memory work at every
ruling and trace style, with Scripture in the same picker as everything else.

## Scripture is not a mode

The whole of "woven through" turned out to be two fields:
`HandwritingConfig.passage` and `MemoryConfig.passage` hold a library id, and
`src/engine/sheets/writing/copywork.ts` is the only place either is resolved. By
the time a row is built the sheet cannot tell whether it is holding a psalm or
the Gettysburg Address — which is the acceptance criterion, expressed as an
absence of branching rather than as a feature.

The picker (`options/passages.tsx`) is **one** control with every collection in
it, Scripture first and "your own words" last in the same list. Not a separate
mode, not a walled-off section — a mode is the thing this story exists to not
build.

An id is also what makes a copywork sheet fit in a link: nine characters where
Psalm 23 is six hundred, so a shared `#s=` carries the verse rather than a
quotation with no source attached.

## Memory work

Rounds of the same passage with a growing share of the words removed, chosen by
the seed and nesting so nothing ever comes back. The count is capped by
re-spreading the removals rather than by dropping the end off the progression,
because the empty round is what the whole sheet aims at. The instruction line
says the words are left out for the exercise and the answer key prints the
passage whole — both halves live in the engine, so neither is a page's decision
to forget. `memory.test.ts` fills every gap back in and compares against the
library character for character.

## The credit line

`SheetFooter.source` is a field of its own rather than a second use of `note`:
an answer key has to say both "Answer key" and where the passage came from, and
joining them would make the key overwrite the credit — which is the one of the
pair we promised to print (§12). It is read off the passage, never typed on a
page, so the sheet footer and the prose around it cannot drift.

## `/printables/bible`

Nine sheets on both stocks, from a first verse traced on ⅝ paper through to the
whole of Psalm 23 on narrow rules — a peer of `/printables/math` and
`/printables/handwriting` in the shelf and in the cross-links, not a footnote.
`_bible.test.ts` checks that every one prints its whole passage on both stocks
rather than hoping: a verse with its last clause below the bottom margin is a
misquotation that looks exactly like a sheet. The maths sheets stay clear of all
of it, as §12 asks.

## Two fixes that reach paper

`chrome.ts` reserved one row for the instruction line and one for the footer.
The §12 notice a memory sheet must print is 157 characters — two rows at 12pt on
both stocks, five at the largest type a config may ask for — and the answer key's
foot carries a 75-character Scripture credit beside "Answer key". Both are
counted now, the way the name line always has been: `packRows` is the one greedy
flex packer, and `instructionRows` wraps a paragraph inside itself.

The measured consequence is exactly one sheet: Psalm 23's memory page prints two
rounds where it printed three, because three never fitted the room the corrected
reservation leaves. Every other page in the shop comes out byte for byte as
before. The copy on that page was rewritten to the two rounds it now prints.

`MAX_TEXT` also capped library passages as well as pastes, and the Christmas
story is 2,048 characters, so the answer key of a sheet promising the whole
passage ended "…all the things that th". A library passage travels as its id, so
§14's reason for a cap never reached it: the cap is a paste's now, and a paste is
cut back to the last space.

## Validation

`type-check`, `lint`, `test:unit` (921 tests, 46 files), `build` (116 pages,
static, sitemap guard clean) and the browser smoke test all pass locally. The
tallest Scripture sheet, 1 Corinthians 13 on A4, was measured in a browser at
29px inside the block box.

Design: `docs/printables.md`, updated with what actually shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
