### PR TITLE
PRINT20: this week's spelling list, and how words work

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -515,6 +515,27 @@ contractions · homophones · synonyms and antonyms.
 punctuation · capitalisation. Generatable from a tagged sentence bank, which is
 authored content but small and reusable.
 
+**What shipped (PRINT20).** The words shelf, and it is two families rather than
+one because the two halves are mirror images. `words/spelling.ts` is a list
+somebody else wrote in seven exercises — write it out, word shapes, missing
+letters, find it among its near misses, ABC order, use it in a sentence, and the
+blank test — where the list is the content and the exercise is a setting, so the
+same twelve words are a week's worth of paper from one box. `words/study.ts` is
+the other way round: the exercise is a parent's and the content is ours,
+authored in `words/bank.ts` because **English will not yield to a rule here** —
+a plural is `-s` until it is `-es`, `-ies`, `-ves` or `children`, and a generator
+reaching for the rule prints `mouses` in an answer key. Ten topics, each stating
+which of the three shapes of question it can honestly be asked in, because
+"write a word that rhymes with cat" has a hundred right answers and no key.
+
+Two things were reused rather than rebuilt, and both were nearly free. A "find
+the word" sheet's near misses are `wordDistractors` out of `decks/words.ts` —
+the same three the race's _spot it_ round deals — so a printed sheet and a played
+round ask one question of one list. And a sight word to _trace_ is the
+handwriting family with a word list on it, so the shelf's tracing page is a
+`HandwritingConfig` rather than an eighth spelling style: two families that draw
+letterforms would be one too many. Word search and crossword stay PRINT21.
+
 ### Templates — blank forms, high value, low effort
 
 Genuinely useful and completely honest: they're supposed to be empty.

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -25,6 +25,7 @@ import type {
   SheetFont,
   TimeConfig,
   TraceStyle,
+  WordsConfig,
 } from "@/engine/sheets/types";
 
 import { SheetView } from "./Sheet";
@@ -217,6 +218,16 @@ const EVERY_BLOCK: Block[] = [
     kind: "choice",
     questions: [
       { prompt: "How many legs?", options: ["two", "four"], answer: 1 },
+    ],
+  },
+  {
+    // The three bands a word is written in, in one word: a tall letter, a small
+    // one, and one with a tail.
+    kind: "wordshapes",
+    columns: 2,
+    words: [
+      { word: "big", letters: ["tall", "small", "tail"] },
+      { word: "cat", letters: ["small", "small", "tall"] },
     ],
   },
   {
@@ -1297,6 +1308,88 @@ describe("a rendered geometry sheet", () => {
         `>${problem.answer}<`,
       );
     }
+  });
+});
+
+/* ── The sheet whose answer is a box ───────────────────────────────────────
+   Word shapes. The engine's suite proves which band each letter belongs in;
+   this is the half that only exists once it is drawn, and it is the half the
+   exercise is: a tall box has to *look* taller than a small one and a tail box
+   has to hang below it, or the outline a child is being taught to recognise is
+   not on the paper.                                                          */
+
+const spelling = (over: Partial<WordsConfig> = {}): WordsConfig => ({
+  kind: "words",
+  paper: DEFAULT_PAPER,
+  fontPt: 12,
+  fields: ["name"],
+  style: "shapes",
+  words: ["big", "cat"],
+  times: 3,
+  gaps: 2,
+  count: 2,
+  columns: 1,
+  ...over,
+});
+
+/** Every box on the sheet, as the ink says it was drawn. */
+function boxes(html: string): Array<{ y: number; height: number }> {
+  return [
+    ...html.matchAll(
+      /<rect class="sheet__box" x="\d+" y="(\d+)" width="\d+" height="(\d+)"/g,
+    ),
+  ].map((box) => ({ y: Number(box[1]), height: Number(box[2]) }));
+}
+
+describe("a rendered word-shape sheet", () => {
+  it("draws a box per letter, in the band that letter is written in", () => {
+    // "big" is tall, small, tail — three boxes, three different geometries, and
+    // the whole point of the sheet is that they are visibly different.
+    const html = render(
+      buildSheet(spelling({ words: ["big"], count: 1 }), SEED),
+    );
+    const [tall, small, tail] = boxes(html);
+    expect(boxes(html)).toHaveLength(3);
+
+    expect(tall.y).toBeLessThan(small.y);
+    expect(tall.height).toBeGreaterThan(small.height);
+    // A tail starts where a small letter does and finishes below it.
+    expect(tail.y).toBe(small.y);
+    expect(tail.height).toBeGreaterThan(small.height);
+    expect(tail.y + tail.height).toBeGreaterThan(tall.y + tall.height);
+  });
+
+  it("draws the boxes in mil inside a box measured in inches", () => {
+    // The same correspondence every drawn thing on a sheet rests on: the <svg>
+    // is sized in inches while its viewBox counts mil, so one user unit is a
+    // thousandth of an inch. Get it wrong and the boxes are a thousand times the
+    // size they say — which a screen never shows.
+    expect(render(buildSheet(spelling({ words: ["big"], count: 1 }), SEED))) //
+      .toContain('width="0.685in" height="0.434in" viewBox="0 0 685 434"');
+  });
+
+  it("rules the boxes rather than tinting them, so they always print", () => {
+    // §5: a browser drops background paint unless the reader has found the
+    // "Background graphics" checkbox, and a word-shape sheet whose boxes were a
+    // tint comes out of the printer as an empty page.
+    const html = render(buildSheet(spelling(), SEED));
+    expect(html).not.toContain("background");
+    const css = read(join(ROOT, "src/styles/sheet.css"));
+    const box = css.slice(css.indexOf(".sheet__box {"));
+    const rule = box.slice(0, box.indexOf("}"));
+    expect(rule).toContain("fill: none");
+    expect(rule).toContain("stroke: currentcolor");
+  });
+
+  it("writes the letters into the boxes only on the key", () => {
+    const blank = render(buildSheet(spelling(), SEED));
+    const key = render(answerKey(spelling(), SEED));
+    // The word is printed either way — it is the question — so what is counted
+    // is the letters inside the boxes.
+    expect(blank).toContain(">big<");
+    expect(blank).not.toContain("sheet__cell--answered");
+    expect(count(key, "sheet__cell--answered")).toBe(6);
+    expect(key).toContain(">b</text>");
   });
 });
 

--- a/src/components/sheet/blocks/Matching.tsx
+++ b/src/components/sheet/blocks/Matching.tsx
@@ -1,10 +1,9 @@
+import { MATCH_ROW_EMS } from "@/engine/sheets/layout";
 import { points } from "@/engine/sheets/paper";
 
 import { HAIRLINE, inch } from "../units";
 import type { BlockProps } from "./block";
 
-/** A row is two lines of type tall: room to draw between, and to write in. */
-const ROW_TO_EM = 2.4;
 /** Big enough for a five-year-old with a pencil to aim a line at. */
 const DOT = points(1.6);
 /** How far in from each edge the dots sit, as a share of the block width. */
@@ -18,6 +17,10 @@ const RIGHT_DOT = 0.56;
  * a middle dot in a font sits at a height that depends on the face. On the key
  * the pairing is a stroke from dot to dot, which is what a marked matching
  * exercise looks like and what a parent checks against.
+ *
+ * A row is `MATCH_ROW_EMS` of the body type tall — two lines, room to draw
+ * between and room to read either side — and that number lives in `layout.ts`
+ * because the family that prints this block reserves the page against it.
  */
 export function Matching({ block, metrics }: BlockProps<"matching">) {
   const rows = Math.max(block.left.length, block.right.length);
@@ -25,7 +28,7 @@ export function Matching({ block, metrics }: BlockProps<"matching">) {
 
   const width = metrics.box.width;
   const size = points(metrics.fontPt);
-  const row = Math.round(size * ROW_TO_EM);
+  const row = Math.round(size * MATCH_ROW_EMS);
   const height = rows * row;
   const leftX = Math.round(width * LEFT_DOT);
   const rightX = Math.round(width * RIGHT_DOT);

--- a/src/components/sheet/blocks/WordShapes.tsx
+++ b/src/components/sheet/blocks/WordShapes.tsx
@@ -1,0 +1,118 @@
+import type { CSSProperties } from "react";
+
+import { points } from "@/engine/sheets/paper";
+import {
+  SHAPE_BOX_EMS,
+  SHAPE_BOX_GAP_EMS,
+  SHAPE_ROW_EMS,
+  shapeBand,
+} from "@/engine/sheets/words/shapes";
+import type { WordShape } from "@/engine/sheets/types";
+
+import { HAIRLINE, inch } from "../units";
+import type { BlockProps } from "./block";
+
+/**
+ * Words as the outline their letters make, one row of boxes each.
+ *
+ * The boxes are drawn rather than typed, and that is the whole reason this is a
+ * block: a tall box and a small box next to each other is a picture of a word,
+ * and there is no arrangement of text that produces it. They are `<rect>`
+ * strokes — foreground paint — so they survive a printer with "Background
+ * graphics" unticked (§5), which is the setting most people never find and the
+ * reason word boxes from elsewhere so often come out as one grey smudge.
+ *
+ * The word is printed beside its boxes because it is the question. A child
+ * copying it in has to decide, letter by letter, which of the three bands each
+ * one belongs in — which is the exercise — and the key writes the letters into
+ * the boxes so a parent can see where each one was meant to go.
+ *
+ * Every proportion here comes out of `words/shapes.ts` rather than being chosen
+ * again: the family reserved the row against those numbers, and a second set
+ * would be a row of boxes overhanging the one beneath it.
+ */
+export function WordShapes({ block, metrics }: BlockProps<"wordshapes">) {
+  const columns = Math.max(1, Math.floor(block.columns));
+
+  return (
+    <ol
+      className="sheet__wordshapes"
+      style={{ "--sheet-columns": columns } as CSSProperties}
+    >
+      {block.words.map((shape, index) => (
+        <li className="sheet__wordshape" key={`${index}-${shape.word}`}>
+          <span className="sheet__number">{index + 1}.</span>
+          <span className="sheet__prompt">{shape.word}</span>
+          <Boxes
+            shape={shape}
+            fontPt={metrics.fontPt}
+            answers={metrics.answers}
+          />
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/** One word's boxes: a rectangle per letter, in the band that letter sits in. */
+function Boxes({
+  shape,
+  fontPt,
+  answers,
+}: {
+  shape: WordShape;
+  fontPt: number;
+  answers: boolean;
+}) {
+  const em = points(fontPt);
+  const height = Math.round(em * SHAPE_ROW_EMS);
+  const box = Math.round(em * SHAPE_BOX_EMS);
+  const gap = Math.round(em * SHAPE_BOX_GAP_EMS);
+  const width = shape.letters.length * box + gap * (shape.letters.length - 1);
+  if (width <= 0) return null;
+
+  return (
+    <svg
+      className="sheet__ink sheet__boxes"
+      width={inch(width)}
+      height={inch(height)}
+      viewBox={`0 0 ${width} ${height}`}
+    >
+      {/* Named with a `<title>` rather than `role="img"`: on a key the letters
+          are `<text>` inside this `<svg>`, and `role="img"` would replace the
+          answer with this one sentence. */}
+      <title>{`Boxes for the letters of "${shape.word}"`}</title>
+
+      {shape.letters.map((letter, at) => {
+        const band = shapeBand(letter);
+        const top = Math.round(height * band.top);
+        const tall = Math.round(height * band.bottom) - top;
+        const left = at * (box + gap);
+        return (
+          <g key={at}>
+            <rect
+              className="sheet__box"
+              x={left}
+              y={top}
+              width={box}
+              height={tall}
+              strokeWidth={HAIRLINE}
+            />
+            {answers && (
+              <text
+                className="sheet__cell sheet__cell--answered"
+                x={left + box / 2}
+                y={top + tall / 2}
+                fontSize={em}
+                textAnchor="middle"
+                dominantBaseline="central"
+              >
+                {shape.word[at]}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/components/sheet/blocks/index.tsx
+++ b/src/components/sheet/blocks/index.tsx
@@ -27,6 +27,7 @@ import { Shapes } from "./Shapes";
 import { Spacer } from "./Spacer";
 import { Trace } from "./Trace";
 import { WordSearch } from "./WordSearch";
+import { WordShapes } from "./WordShapes";
 
 export function BlockView({
   block,
@@ -54,6 +55,8 @@ export function BlockView({
       return <Blanks block={block} metrics={metrics} />;
     case "choice":
       return <Choice block={block} metrics={metrics} />;
+    case "wordshapes":
+      return <WordShapes block={block} metrics={metrics} />;
     case "clock":
       return <Clock block={block} metrics={metrics} />;
     case "shapes":

--- a/src/engine/decks/words.ts
+++ b/src/engine/decks/words.ts
@@ -37,8 +37,17 @@ export const normaliseWord = (input: string) =>
  * Drawn from the same list and biased towards words that look like it —
  * "there" against "their", not against "squirrel". Four random words would
  * make recognition a spotting exercise rather than a reading one.
+ *
+ * Exported for the print shop's "find the word" sheet, which asks exactly this
+ * question on paper: the same list, the same three near misses, so a sheet and a
+ * "spot it" round are one exercise in two places rather than two rules about
+ * what counts as a plausible confusion.
  */
-function wordDistractors(answer: string, pool: string[], rand: () => number) {
+export function wordDistractors(
+  answer: string,
+  pool: string[],
+  rand: () => number,
+): string[] {
   const others = [...new Set(pool)].filter(
     (w) => normaliseWord(w) !== normaliseWord(answer),
   );

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -34,6 +34,7 @@ import { PAPER_SHEET } from "./templates/paper";
 import { HANDWRITING_SHEET } from "./writing/handwriting";
 import { MEMORY_SHEET } from "./writing/memory";
 import { WORDS_SHEET } from "./words/spelling";
+import { WORD_STUDY_SHEET } from "./words/study";
 
 const SHEETS: Record<string, SheetSpec> = {
   [BLANK_SHEET.id]: BLANK_SHEET,
@@ -52,6 +53,7 @@ const SHEETS: Record<string, SheetSpec> = {
   [STATISTICS_SHEET.id]: STATISTICS_SHEET,
   [WORD_PROBLEMS_SHEET.id]: WORD_PROBLEMS_SHEET,
   [WORDS_SHEET.id]: WORDS_SHEET,
+  [WORD_STUDY_SHEET.id]: WORD_STUDY_SHEET,
   [HANDWRITING_SHEET.id]: HANDWRITING_SHEET,
   [MEMORY_SHEET.id]: MEMORY_SHEET,
 };

--- a/src/engine/sheets/layout.ts
+++ b/src/engine/sheets/layout.ts
@@ -70,6 +70,29 @@ export const PROBLEM_GAP = { x: inches(0.3), y: inches(0.2) };
 export const WRAP_GAP: Mil = inches(0.06);
 
 /**
+ * The air between one item of a list and the next.
+ *
+ * `.sheet__blanks` and `.sheet__questions` are both flex columns with this as
+ * their `gap`, which is why it is one constant: a sentence with a gap in it and
+ * a multiple-choice question are the same shape of thing down the page, and two
+ * families now divide a page by it. The fourth of these to trail sheet.css, for
+ * the same reason as the three above — the failure is silent on screen and is
+ * the last question below the bottom margin on paper.
+ */
+export const LIST_GAP: Mil = inches(0.16);
+
+/**
+ * How tall one row of a matching block stands, in ems of the body size.
+ *
+ * `Matching.tsx` draws the block from this and a family reserves the page for
+ * it, so it is declared once here rather than in both: the renderer's own copy
+ * was the number, and a family that guessed a different one would print a
+ * column of pairs off the bottom of the page. Two lines of type — room to draw
+ * a line between two dots, and room to read the words either side of it.
+ */
+export const MATCH_ROW_EMS = 2.4;
+
+/**
  * The air between one block and the next.
  *
  * `.sheet__blocks` is a flex column and this is its `gap`, in the unit the

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -265,6 +265,30 @@ export type Problem = {
   workspace?: Mil;
 };
 
+/**
+ * How tall one letter of a word stands — the three bands a word is written in.
+ *
+ * `tall` reaches the top line (an ascender, a capital, a numeral), `small` stops
+ * at the midline, and `tail` drops below the baseline. It is the whole of what a
+ * word-shape box is: `bed` is tall-small-tall and `pig` is tail-small-tail, and
+ * the outline the two make is different enough to tell them apart without
+ * reading either — which is what the exercise is training.
+ *
+ * Punctuation counts as `small`. An apostrophe is not a letter with a body, and
+ * a box drawn for it at any other height would be a shape a child cannot match.
+ */
+export type LetterShape = "tall" | "small" | "tail";
+
+/**
+ * One word as a row of boxes, plus the word those boxes were drawn from.
+ *
+ * Both, because the word is the answer: the boxes are printed empty and the key
+ * writes the letters into them, exactly as a ruled slot works. The shapes are
+ * resolved by the engine rather than by the renderer, so the same word is the
+ * same outline in a unit test, on a catalog page and in the builder (§4).
+ */
+export type WordShape = { word: string; letters: LetterShape[] };
+
 /** One place on a tracing row: what is written there, and how it is drawn. */
 export type TraceCell = { text: string; style: TraceStyle };
 
@@ -418,6 +442,15 @@ export type Block =
     }
   | { kind: "blanks"; sentences: Blank[] }
   | { kind: "choice"; questions: Choice[] }
+  /**
+   * Words as the outline their letters make, one row of boxes each.
+   *
+   * A block of its own rather than a `problems` item with a drawing on it, for
+   * the reason a fraction diagram is not: the boxes *are* the answer place. A
+   * problem may have exactly one of those, and a row of eight boxes with a ruled
+   * slot on the end of it would be a sheet a child answers twice.
+   */
+  | { kind: "wordshapes"; columns: number; words: WordShape[] }
   | { kind: "clock"; faces: ClockFace[] }
   | { kind: "shapes"; figures: Figure[] }
   /** Where to cut, for cards and bookmarks. */
@@ -1226,13 +1259,21 @@ export type WordProblemConfig = SheetOptions & {
 /**
  * What the sheet asks a child to do with the list.
  *
+ * Seven exercises over one list, which is the whole reason this is a union
+ * rather than seven families: none of them changes what the sheet is *about*,
+ * so a parent who has typed in this week's words gets all seven from the one
+ * control beside them.
+ *
  * `copy` is "write it three times", the oldest spelling exercise there is;
  * `missing` takes letters out and leaves the gaps to fill; `test` prints
- * numbered lines and nothing else, for a list read aloud. The wider set —
- * ABC order, word shapes, use it in a sentence — is PRINT20's, and lands here
- * as more of this union rather than as another family.
+ * numbered lines and nothing else, for a list read aloud; `abc` prints the list
+ * as it was given and asks for it back in alphabetical order; `shapes` draws
+ * each word as the outline its letters make; `sentence` asks for the word used
+ * in one; `find` prints the word among the words it is most easily confused
+ * with, which is the same judgement the race's "spot it" round makes.
  */
-export type WordSheetStyle = "copy" | "missing" | "test";
+export type WordSheetStyle =
+  "copy" | "missing" | "test" | "abc" | "shapes" | "sentence" | "find";
 
 export type WordsConfig = SheetOptions & {
   kind: "words";
@@ -1247,13 +1288,89 @@ export type WordsConfig = SheetOptions & {
    * at the top of the page types them into `title` themselves.
    */
   words: string[];
-  /** `copy` only: how many times each word is written out. */
+  /**
+   * How many ruled lines each word gets: the times it is written out on a
+   * `copy` sheet, and the lines left to write a sentence on for `sentence`.
+   *
+   * One field because it is one measurement — the rules under a word — and the
+   * capacity arithmetic multiplies it by `answerLine` either way. Two names for
+   * the same number would be two things a saved config could disagree about.
+   */
   times: number;
   /** `missing` only: how many letters are taken out of each word. */
   gaps: number;
   /** How many words to ask for. Capped at what the page holds. */
   count: number;
-  /** `copy` and `test` only — a gapped word is a line of its own. */
+  /**
+   * How many words across the page.
+   *
+   * Ignored by the two styles that are a list down it: a gapped word and a word
+   * printed among its own near misses are each a line of their own, whatever a
+   * saved config says — see `wordsLayout`.
+   */
+  columns: number;
+};
+
+/* ── Word study ────────────────────────────────────────────────────────────
+   The other half of the words shelf, and the mirror image of the family above:
+   there the content is a parent's and the exercise is ours, here the exercise
+   is a parent's and the *content* is ours. Ten topics somebody teaches in a
+   week each — rhyming, syllables, word families, prefixes and suffixes,
+   plurals, contractions, homophones, synonyms and antonyms — and none of them
+   is generatable from a rule, because English is not. A plural is `-s` until it
+   is `-es`, `-ies`, `-ves` or `children`, and a generator that reached for the
+   rule would print `mouses` in an answer key.
+
+   So the words are authored, in `words/bank.ts`, and this config only says
+   which topic and which of the three shapes of question to ask it in. What that
+   buys is the thing §11 asks for: every answer here is one somebody wrote down
+   on purpose, and the key is right because a person checked it rather than
+   because arithmetic can't be wrong.                                        */
+
+/**
+ * Which lesson the sheet is about.
+ *
+ * One topic to a sheet, never a mix. A page of rhyming and contractions
+ * together is not a harder sheet, it is a sheet nobody set: these are separate
+ * weeks in every scheme there is, and the instruction line can only say one
+ * thing.
+ */
+export type WordStudyTopic =
+  | "rhyming"
+  | "syllables"
+  | "families"
+  | "prefixes"
+  | "suffixes"
+  | "plurals"
+  | "contractions"
+  | "homophones"
+  | "synonyms"
+  | "antonyms";
+
+/**
+ * How the question is put.
+ *
+ * `write` gives the prompt and a ruled slot; `choose` gives four options with
+ * the near misses drawn from the same topic; `match` is two columns to join with
+ * a pencil. Every topic states which of the three it can honestly be asked in
+ * (`STUDY_TOPICS`), because they are not interchangeable — "write a word that
+ * rhymes with cat" has a hundred right answers and no key, and matching a word
+ * to a syllable count is a column of four numbers repeated down the page.
+ */
+export type WordStudyStyle = "write" | "choose" | "match";
+
+export type WordStudyConfig = SheetOptions & {
+  kind: "word-study";
+  topic: WordStudyTopic;
+  /**
+   * Resolved against what the topic supports rather than trusted: a style
+   * saved in March must still print in June if the topic has since dropped it,
+   * for the same reason `sheetSpec` never throws.
+   */
+  style: WordStudyStyle;
+  /** How many questions to ask for. Capped at what the page holds. */
+  count: number;
+  /** `write` only — a choice and a matching column are the width of the page. */
   columns: number;
 };
 
@@ -1467,6 +1584,7 @@ export type SheetConfig =
   | StatisticsConfig
   | WordProblemConfig
   | WordsConfig
+  | WordStudyConfig
   | HandwritingConfig
   | MemoryConfig;
 

--- a/src/engine/sheets/words/bank.ts
+++ b/src/engine/sheets/words/bank.ts
@@ -22,15 +22,22 @@
  *   - **No second right answer among the near misses.** A distractor is drawn
  *     from another entry of the same topic (`study.ts`), so two entries that
  *     could answer each other are a question with two answers on it. `light` is
- *     the one to watch: its opposite is `dark` and also `heavy`.
+ *     the one to watch: its opposite is `dark` and also `heavy`. `soft` is the
+ *     other, and it is why `hard` is answered `easy` below rather than `soft`:
+ *     `soft` is the opposite of `hard` and equally of `loud`, so a bank holding
+ *     both pairs would eventually print `soft` as a near miss for `loud` and
+ *     mark a child wrong for a right answer. Neither word appears in `ANTONYMS`
+ *     at all, and no test can hold that line for you: a clash of meanings is
+ *     invisible to something comparing strings.
  *   - **British spelling**, as everywhere in this repo — and nothing whose
  *     spelling differs between the two, because a sheet is printed on both sides
  *     of the Atlantic and a child marked wrong for `colour` is a bad sheet.
  *   - **Words a child of the age can picture.** These are read without a
  *     teacher standing beside them.
- *   - `bank.test.ts` enforces the mechanical half: no duplicate prompts, no
- *     duplicate answers inside a topic, no empty strings, and — for the two
- *     topics built out of parts — that the parts really do make the word.
+ *   - `study.test.ts` enforces the mechanical half, under its "the word bank"
+ *     describe: no duplicate prompts, no duplicate answers inside a topic, no
+ *     empty strings, and — for the two topics built out of parts — that the
+ *     parts really do make the word.
  */
 
 /* ── Rimes, and what goes in front of them ─────────────────────────────────
@@ -372,7 +379,10 @@ export const ANTONYMS: Meaning[] = [
   { word: "old", match: "new" },
   { word: "open", match: "shut" },
   { word: "wet", match: "dry" },
-  { word: "hard", match: "soft" },
+  // Not "soft", which is also the opposite of "loud" further down: a distractor
+  // is another entry's answer, so the two pairs together put "soft" on the
+  // "loud" line as a wrong option that is right. See the house rules above.
+  { word: "hard", match: "easy" },
   { word: "full", match: "empty" },
   { word: "long", match: "short" },
   { word: "high", match: "low" },

--- a/src/engine/sheets/words/bank.ts
+++ b/src/engine/sheets/words/bank.ts
@@ -1,0 +1,388 @@
+/**
+ * The words a word-study sheet is made of.
+ *
+ * The one family in the shop whose content is neither generated nor handed over
+ * by a parent, and it has to be authored for a reason that is worth stating
+ * plainly: **English will not yield to a rule here.** A plural is `-s` until it
+ * is `-es`, `-ies`, `-ves`, `children` or `sheep`; `happy + ness` is
+ * `happiness`; `hop + ing` doubles the `p` and `hope + ing` drops the `e`. A
+ * generator reaching for the rule would print `mouses` in an answer key, and an
+ * answer key that is wrong is worse than no sheet at all (§11).
+ *
+ * So every answer below is one somebody wrote down on purpose. That is what
+ * makes this family's key trustworthy, and it is the same bargain
+ * `passages/*.ts` strikes for copywork: the engine owns the words, and the only
+ * thing it computes is which of them land on the page.
+ *
+ * ── House rules for adding one ──────────────────────────────────────────────
+ *   - **One right answer.** Every entry has to be an item a parent can mark
+ *     without judgement. "Write a word that rhymes with cat" is a fine thing to
+ *     ask a child and cannot be printed with a key, so it isn't here; "which of
+ *     these rhymes with cat" is.
+ *   - **No second right answer among the near misses.** A distractor is drawn
+ *     from another entry of the same topic (`study.ts`), so two entries that
+ *     could answer each other are a question with two answers on it. `light` is
+ *     the one to watch: its opposite is `dark` and also `heavy`.
+ *   - **British spelling**, as everywhere in this repo — and nothing whose
+ *     spelling differs between the two, because a sheet is printed on both sides
+ *     of the Atlantic and a child marked wrong for `colour` is a bad sheet.
+ *   - **Words a child of the age can picture.** These are read without a
+ *     teacher standing beside them.
+ *   - `bank.test.ts` enforces the mechanical half: no duplicate prompts, no
+ *     duplicate answers inside a topic, no empty strings, and — for the two
+ *     topics built out of parts — that the parts really do make the word.
+ */
+
+/* ── Rimes, and what goes in front of them ─────────────────────────────────
+   One list serving two topics, because they are two views of the same fact:
+   the words in a family rhyme, which is what makes a family worth teaching.
+   Every onset here has been checked to make a real word with its rime — a
+   word-family sheet whose answer key contains `jat` teaches a child that the
+   sheet is wrong.                                                           */
+
+export type Family = {
+  /** The ending the family is named after: `at`, `ing`. */
+  rime: string;
+  /** Every beginning that makes a word with it, easiest first. */
+  onsets: string[];
+};
+
+export const FAMILIES: Family[] = [
+  { rime: "at", onsets: ["c", "h", "m", "s", "b", "r", "fl", "ch"] },
+  { rime: "an", onsets: ["c", "f", "m", "p", "r", "v", "br", "pl"] },
+  { rime: "ap", onsets: ["c", "g", "l", "m", "n", "t", "cl", "sn"] },
+  { rime: "ed", onsets: ["b", "f", "l", "r", "w", "sh", "sl", "fl"] },
+  { rime: "en", onsets: ["d", "h", "m", "p", "t", "wh", "th"] },
+  { rime: "ig", onsets: ["b", "d", "f", "j", "p", "w", "tw"] },
+  { rime: "in", onsets: ["b", "f", "p", "t", "w", "ch", "sh", "sk"] },
+  { rime: "ip", onsets: ["d", "l", "r", "s", "t", "z", "dr", "sk"] },
+  { rime: "op", onsets: ["h", "m", "p", "t", "dr", "st", "sh", "fl"] },
+  { rime: "ot", onsets: ["d", "g", "h", "l", "n", "p", "sp", "sl"] },
+  { rime: "ug", onsets: ["b", "d", "h", "j", "m", "r", "t", "pl"] },
+  { rime: "un", onsets: ["b", "f", "r", "s", "st", "sp"] },
+  { rime: "ake", onsets: ["b", "c", "l", "m", "r", "t", "w", "sh"] },
+  { rime: "ing", onsets: ["k", "r", "s", "w", "br", "st", "th", "sw"] },
+];
+
+/** Every word in a family, in the order its onsets are listed. */
+export const familyWords = (family: Family): string[] =>
+  family.onsets.map((onset) => `${onset}${family.rime}`);
+
+/* ── Syllables ─────────────────────────────────────────────────────────────
+   Counted by hand, and only words whose count nobody argues about. `family`,
+   `chocolate`, `every` and `camera` are said with two syllables as often as
+   three, so they are not here: a sheet is marked by a parent who says the word
+   their own way, and an entry that depends on an accent is an entry that gets
+   a child marked wrong.                                                     */
+
+export type Syllable = { word: string; syllables: number };
+
+export const SYLLABLES: Syllable[] = [
+  { word: "dog", syllables: 1 },
+  { word: "hand", syllables: 1 },
+  { word: "bridge", syllables: 1 },
+  { word: "friend", syllables: 1 },
+  { word: "school", syllables: 1 },
+  { word: "tree", syllables: 1 },
+  { word: "rabbit", syllables: 2 },
+  { word: "pencil", syllables: 2 },
+  { word: "garden", syllables: 2 },
+  { word: "kitchen", syllables: 2 },
+  { word: "monkey", syllables: 2 },
+  { word: "table", syllables: 2 },
+  { word: "window", syllables: 2 },
+  { word: "morning", syllables: 2 },
+  { word: "birthday", syllables: 2 },
+  { word: "elephant", syllables: 3 },
+  { word: "butterfly", syllables: 3 },
+  { word: "computer", syllables: 3 },
+  { word: "banana", syllables: 3 },
+  { word: "dinosaur", syllables: 3 },
+  { word: "wonderful", syllables: 3 },
+  { word: "potato", syllables: 3 },
+  { word: "telephone", syllables: 3 },
+  { word: "remember", syllables: 3 },
+  { word: "caterpillar", syllables: 4 },
+  { word: "television", syllables: 4 },
+  { word: "watermelon", syllables: 4 },
+  { word: "invitation", syllables: 4 },
+  { word: "alligator", syllables: 4 },
+  { word: "celebration", syllables: 4 },
+];
+
+/** How many syllables a sheet may offer as an option. */
+export const MAX_SYLLABLES = 4;
+
+/* ── Two words that make one ───────────────────────────────────────────────
+   Prefixes and suffixes, written as the sum a child is shown: the part, the
+   word, and what the two make. The suffixes are chosen so that the spelling
+   changes are on the page rather than avoided — `happy + ness` is the entry
+   worth having, and `sad + ness` is the one it is learnt against.           */
+
+export type Sum = { part: string; base: string; word: string };
+
+export const PREFIXES: Sum[] = [
+  { part: "un", base: "happy", word: "unhappy" },
+  { part: "un", base: "kind", word: "unkind" },
+  { part: "un", base: "tidy", word: "untidy" },
+  { part: "un", base: "lock", word: "unlock" },
+  { part: "un", base: "fair", word: "unfair" },
+  { part: "re", base: "read", word: "reread" },
+  { part: "re", base: "build", word: "rebuild" },
+  { part: "re", base: "fill", word: "refill" },
+  { part: "re", base: "play", word: "replay" },
+  { part: "dis", base: "agree", word: "disagree" },
+  { part: "dis", base: "like", word: "dislike" },
+  { part: "dis", base: "appear", word: "disappear" },
+  { part: "pre", base: "view", word: "preview" },
+  { part: "pre", base: "school", word: "preschool" },
+  { part: "pre", base: "heat", word: "preheat" },
+  { part: "mis", base: "spell", word: "misspell" },
+  { part: "mis", base: "place", word: "misplace" },
+  { part: "mis", base: "behave", word: "misbehave" },
+  { part: "over", base: "take", word: "overtake" },
+  { part: "under", base: "water", word: "underwater" },
+  { part: "non", base: "stop", word: "nonstop" },
+  { part: "sub", base: "way", word: "subway" },
+];
+
+export const SUFFIXES: Sum[] = [
+  { part: "ful", base: "care", word: "careful" },
+  { part: "ful", base: "hope", word: "hopeful" },
+  { part: "ful", base: "use", word: "useful" },
+  { part: "less", base: "help", word: "helpless" },
+  { part: "less", base: "end", word: "endless" },
+  { part: "ness", base: "sad", word: "sadness" },
+  { part: "ness", base: "happy", word: "happiness" },
+  { part: "ness", base: "kind", word: "kindness" },
+  { part: "ly", base: "quick", word: "quickly" },
+  { part: "ly", base: "happy", word: "happily" },
+  { part: "ly", base: "slow", word: "slowly" },
+  { part: "ing", base: "make", word: "making" },
+  { part: "ing", base: "hop", word: "hopping" },
+  { part: "ing", base: "run", word: "running" },
+  { part: "ing", base: "read", word: "reading" },
+  { part: "ed", base: "bake", word: "baked" },
+  { part: "ed", base: "stop", word: "stopped" },
+  { part: "ed", base: "cry", word: "cried" },
+  { part: "ed", base: "play", word: "played" },
+  { part: "er", base: "teach", word: "teacher" },
+  { part: "er", base: "farm", word: "farmer" },
+  { part: "er", base: "big", word: "bigger" },
+  { part: "ship", base: "friend", word: "friendship" },
+  { part: "hood", base: "child", word: "childhood" },
+];
+
+/* ── One of it, and more than one ──────────────────────────────────────────
+   Every route English takes to a plural, in roughly the order a scheme teaches
+   them: the plain `-s`, the hissing endings that need `-es`, `-y` to `-ies`,
+   `-f` to `-ves`, the words that change shape, and the two that don't change at
+   all.                                                                      */
+
+export type Pair = { one: string; many: string };
+
+export const PLURALS: Pair[] = [
+  { one: "cat", many: "cats" },
+  { one: "book", many: "books" },
+  { one: "tree", many: "trees" },
+  { one: "box", many: "boxes" },
+  { one: "bus", many: "buses" },
+  { one: "brush", many: "brushes" },
+  { one: "watch", many: "watches" },
+  { one: "glass", many: "glasses" },
+  { one: "baby", many: "babies" },
+  { one: "city", many: "cities" },
+  { one: "story", many: "stories" },
+  { one: "party", many: "parties" },
+  { one: "day", many: "days" },
+  { one: "key", many: "keys" },
+  { one: "leaf", many: "leaves" },
+  { one: "knife", many: "knives" },
+  { one: "wolf", many: "wolves" },
+  { one: "shelf", many: "shelves" },
+  { one: "child", many: "children" },
+  { one: "man", many: "men" },
+  { one: "woman", many: "women" },
+  { one: "foot", many: "feet" },
+  { one: "tooth", many: "teeth" },
+  { one: "mouse", many: "mice" },
+  { one: "goose", many: "geese" },
+  { one: "person", many: "people" },
+  { one: "sheep", many: "sheep" },
+  { one: "fish", many: "fish" },
+  { one: "potato", many: "potatoes" },
+  { one: "tomato", many: "tomatoes" },
+];
+
+/* ── Two words squeezed into one ───────────────────────────────────────────
+   Where the apostrophe goes is the whole lesson, and `won't` is the entry that
+   makes the point that it is not always where the letters came out.          */
+
+export type Contraction = { words: string; short: string };
+
+export const CONTRACTIONS: Contraction[] = [
+  { words: "do not", short: "don't" },
+  { words: "did not", short: "didn't" },
+  { words: "does not", short: "doesn't" },
+  { words: "is not", short: "isn't" },
+  { words: "are not", short: "aren't" },
+  { words: "was not", short: "wasn't" },
+  { words: "have not", short: "haven't" },
+  { words: "cannot", short: "can't" },
+  { words: "will not", short: "won't" },
+  { words: "would not", short: "wouldn't" },
+  { words: "could not", short: "couldn't" },
+  { words: "should not", short: "shouldn't" },
+  { words: "I am", short: "I'm" },
+  { words: "I have", short: "I've" },
+  { words: "I will", short: "I'll" },
+  { words: "I would", short: "I'd" },
+  { words: "you are", short: "you're" },
+  { words: "we are", short: "we're" },
+  { words: "they are", short: "they're" },
+  { words: "he is", short: "he's" },
+  { words: "she will", short: "she'll" },
+  { words: "we have", short: "we've" },
+  { words: "they will", short: "they'll" },
+  { words: "let us", short: "let's" },
+  { words: "that is", short: "that's" },
+  { words: "there is", short: "there's" },
+];
+
+/* ── One sound, two spellings ──────────────────────────────────────────────
+   The sentence is not decoration here, it is the question: a child asked to
+   spell a sound they have been read cannot be wrong, because there is no
+   answer. Every sentence below settles which word is meant on its own, and the
+   rules `decks/wordlists.ts` states for a spoken clue hold for a printed one —
+   one gap, the word nowhere else in the sentence, and something a child of the
+   age can picture.                                                          */
+
+export type Homophone = {
+  /** The pair, printed beside the sentence so the choice is on the page. */
+  pair: [string, string];
+  /** `_` marks the gap, the same convention `Blank.text` uses. */
+  sentence: string;
+  /** Which of the pair belongs in it. */
+  answer: string;
+};
+
+export const HOMOPHONES: Homophone[] = [
+  {
+    pair: ["their", "there"],
+    sentence: "Put the box over _.",
+    answer: "there",
+  },
+  { pair: ["to", "two"], sentence: "I have _ hands.", answer: "two" },
+  { pair: ["hear", "here"], sentence: "Can you _ the bell?", answer: "hear" },
+  { pair: ["see", "sea"], sentence: "We swam in the _.", answer: "sea" },
+  {
+    pair: ["blue", "blew"],
+    sentence: "The wind _ my hat off.",
+    answer: "blew",
+  },
+  {
+    pair: ["knight", "night"],
+    sentence: "The _ rode a grey horse.",
+    answer: "knight",
+  },
+  {
+    pair: ["write", "right"],
+    sentence: "Please _ your name at the top.",
+    answer: "write",
+  },
+  { pair: ["one", "won"], sentence: "Our team _ the match.", answer: "won" },
+  { pair: ["ate", "eight"], sentence: "She _ all her dinner.", answer: "ate" },
+  {
+    pair: ["flour", "flower"],
+    sentence: "Bread is made from _.",
+    answer: "flour",
+  },
+  { pair: ["sun", "son"], sentence: "The _ came out at last.", answer: "sun" },
+  {
+    pair: ["bear", "bare"],
+    sentence: "A big brown _ ate the fish.",
+    answer: "bear",
+  },
+  { pair: ["for", "four"], sentence: "A dog has _ legs.", answer: "four" },
+  {
+    pair: ["new", "knew"],
+    sentence: "I _ the answer already.",
+    answer: "knew",
+  },
+  {
+    pair: ["would", "wood"],
+    sentence: "The chair is made of _.",
+    answer: "wood",
+  },
+  { pair: ["no", "know"], sentence: "I _ how to swim.", answer: "know" },
+  { pair: ["by", "buy"], sentence: "I want to _ a comic.", answer: "buy" },
+  {
+    pair: ["hour", "our"],
+    sentence: "We waited for an _ in the rain.",
+    answer: "hour",
+  },
+  {
+    pair: ["made", "maid"],
+    sentence: "She _ a birthday cake.",
+    answer: "made",
+  },
+  { pair: ["weigh", "way"], sentence: "Which _ is the park?", answer: "way" },
+];
+
+/* ── Words that mean the same, and words that mean the opposite ────────────
+   Pairs rather than sets, because a sheet needs one right answer (see the house
+   rules): `big` is asked with `large` beside three words that are not its
+   synonym, and a set of four synonyms would be a question with four answers.
+
+   `light` is deliberately absent from the opposites. Its opposite is `dark` and
+   equally `heavy`, and either would be marked wrong against the other.       */
+
+export type Meaning = { word: string; match: string };
+
+export const SYNONYMS: Meaning[] = [
+  { word: "big", match: "large" },
+  { word: "small", match: "little" },
+  { word: "quick", match: "fast" },
+  { word: "begin", match: "start" },
+  { word: "end", match: "finish" },
+  { word: "shout", match: "yell" },
+  { word: "jump", match: "leap" },
+  { word: "close", match: "shut" },
+  { word: "angry", match: "cross" },
+  { word: "tired", match: "sleepy" },
+  { word: "brave", match: "bold" },
+  { word: "clever", match: "smart" },
+  { word: "tidy", match: "neat" },
+  { word: "hard", match: "difficult" },
+  { word: "easy", match: "simple" },
+  { word: "pretty", match: "beautiful" },
+  { word: "quiet", match: "silent" },
+  { word: "strange", match: "odd" },
+  { word: "happy", match: "glad" },
+  { word: "sad", match: "gloomy" },
+];
+
+export const ANTONYMS: Meaning[] = [
+  { word: "hot", match: "cold" },
+  { word: "big", match: "small" },
+  { word: "up", match: "down" },
+  { word: "day", match: "night" },
+  { word: "fast", match: "slow" },
+  { word: "happy", match: "sad" },
+  { word: "old", match: "new" },
+  { word: "open", match: "shut" },
+  { word: "wet", match: "dry" },
+  { word: "hard", match: "soft" },
+  { word: "full", match: "empty" },
+  { word: "long", match: "short" },
+  { word: "high", match: "low" },
+  { word: "early", match: "late" },
+  { word: "rich", match: "poor" },
+  { word: "kind", match: "cruel" },
+  { word: "near", match: "far" },
+  { word: "loud", match: "quiet" },
+  { word: "first", match: "last" },
+  { word: "push", match: "pull" },
+  { word: "always", match: "never" },
+  { word: "true", match: "false" },
+];

--- a/src/engine/sheets/words/shapes.ts
+++ b/src/engine/sheets/words/shapes.ts
@@ -1,0 +1,100 @@
+/**
+ * A word as the outline its letters make.
+ *
+ * The one spelling exercise that is a drawing rather than a sentence, and the
+ * reason it earns a module: `bed` and `bad` are the same three sounds and a
+ * different picture, so a child who has learnt to read the *shape* of a word has
+ * a second way in when the letters have not stuck. Every reading scheme calls
+ * these word boxes, and the boxes are always the same three bands — a letter
+ * reaching the top line, one stopping at the midline, and one with a tail below
+ * the baseline.
+ *
+ * Which band a letter is in is a fact about the letterform, so it is written
+ * down here once. It is deliberately *not* read out of a face's own metrics
+ * (`faces.ts`): a word shape is the shape a child is taught, and `f` is drawn
+ * with a descender in some hands and none in others — a box that changed height
+ * when a parent switched to the cursive face would make the same word two
+ * different puzzles. So the classification is the printed convention, and the
+ * face only decides how the letter inside the box is drawn.
+ *
+ * The geometry is here too, in shares of one row, because both halves have to
+ * agree: the family reserves the row (§4) and `WordShapes.tsx` draws the boxes
+ * inside it, and a second copy of these numbers would be a row of boxes that
+ * overhangs the one beneath it.
+ */
+import type { LetterShape, WordShape } from "../types";
+
+/**
+ * The letters that reach the top line.
+ *
+ * `t` is in it, though it is drawn shorter than a `b` in most hands: the
+ * question a word shape asks is "is this letter taller than an `o`", and a `t`
+ * plainly is. Capitals and numerals are added by the test below rather than
+ * listed, because there are fifty-two of them and one rule.
+ */
+const TALL = new Set([..."bdfhklt"]);
+
+/** And the five that hang below it. `f` does not, by the convention above. */
+const TAIL = new Set([..."gjpqy"]);
+
+/** Which band one character is drawn in. */
+export function letterShape(letter: string): LetterShape {
+  if (TAIL.has(letter)) return "tail";
+  if (TALL.has(letter)) return "tall";
+  // A capital or a numeral is drawn from the top line to the baseline, which is
+  // the tall box — and `letter.toLowerCase() !== letter` is the whole test,
+  // rather than a range, so an accented capital is not read as a small letter.
+  if (/[0-9]/.test(letter) || letter.toLowerCase() !== letter) return "tall";
+  return "small";
+}
+
+/** One word, box by box. Punctuation and spaces count as small — see `LetterShape`. */
+export const wordShape = (word: string): WordShape => ({
+  word,
+  letters: [...word].map(letterShape),
+});
+
+/* ── How tall a row of boxes is ────────────────────────────────────────────
+   Three bands stacked, as shares of the whole row, and the row itself as a
+   multiple of the body type. The proportions are the ones a primary ruling
+   uses: rather more than a third above the midline, rather more than a third
+   between midline and baseline, and the rest for a tail — which is what makes a
+   `tall` box visibly twice a `small` one at a glance across a page.          */
+
+/**
+ * How tall one row of boxes stands, in ems of the body size.
+ *
+ * Rather taller than a line of type, because a box is not a letterform: what
+ * goes in it is a letter written by hand, and a child of five writes larger than
+ * the sheet is set in. At the 12pt default this is a shade over four tenths of
+ * an inch to the row, which puts a small letter's box at about an eighth of an
+ * inch high and a tall one at a third — the size a reading scheme prints them.
+ */
+export const SHAPE_ROW_EMS = 2.6;
+
+/** Where each band starts and stops, as a share of the row, top down. */
+export const BANDS = {
+  ascender: { top: 0, bottom: 0.38 },
+  body: { top: 0.38, bottom: 0.74 },
+  descender: { top: 0.74, bottom: 1 },
+} as const;
+
+/**
+ * How wide one box is, in ems — wider than the letter it holds, for the reason
+ * the row is taller: it is written in by hand rather than set in type. A box
+ * measured to the face's own mean advance would be a box a child cannot write a
+ * `w` in.
+ */
+export const SHAPE_BOX_EMS = 1.3;
+
+/** The air between one box and the next, in ems. */
+export const SHAPE_BOX_GAP_EMS = 0.1;
+
+/** The top and the bottom of one letter's box, as shares of the row. */
+export function shapeBand(shape: LetterShape): { top: number; bottom: number } {
+  if (shape === "tall")
+    return { top: BANDS.ascender.top, bottom: BANDS.body.bottom };
+  if (shape === "tail")
+    return { top: BANDS.body.top, bottom: BANDS.descender.bottom };
+  return { top: BANDS.body.top, bottom: BANDS.body.bottom };
+}

--- a/src/engine/sheets/words/spelling.test.ts
+++ b/src/engine/sheets/words/spelling.test.ts
@@ -2,9 +2,23 @@ import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
 import { answerLine } from "../layout";
-import type { Blank, Paper, Problem, WordsConfig } from "../types";
+import type {
+  Blank,
+  Choice,
+  Paper,
+  Problem,
+  WordShape,
+  WordsConfig,
+} from "../types";
 
-import { WORDS_SHEET, gapped, wordsLayout, wordsOf } from "./spelling";
+import { letterShape } from "./shapes";
+import {
+  WORDS_SHEET,
+  alphabetical,
+  gapped,
+  wordsLayout,
+  wordsOf,
+} from "./spelling";
 
 /**
  * Spelling, held to the bar the maths families set.
@@ -57,6 +71,21 @@ function blanksOf(over: Partial<WordsConfig>, seed = 1): Blank[] {
   if (block.kind !== "blanks")
     throw new Error(`expected blanks, got ${block.kind}`);
   return block.sentences;
+}
+
+function questionsOf(over: Partial<WordsConfig>, seed = 1): Choice[] {
+  const block = buildSheet(config({ style: "find", ...over }), seed).blocks[0];
+  if (block.kind !== "choice")
+    throw new Error(`expected choice, got ${block.kind}`);
+  return block.questions;
+}
+
+function shapesOf(over: Partial<WordsConfig>, seed = 1): WordShape[] {
+  const block = buildSheet(config({ style: "shapes", ...over }), seed)
+    .blocks[0];
+  if (block.kind !== "wordshapes")
+    throw new Error(`expected wordshapes, got ${block.kind}`);
+  return block.words;
 }
 
 /** The word a gapped sentence came from, rebuilt by putting the letters back. */
@@ -192,6 +221,119 @@ describe("the spelling test", () => {
   });
 });
 
+describe("ABC order", () => {
+  it("prints the whole list as a bank, and answers it in alphabetical order", () => {
+    // Two columns of one exercise: the bank on the left and the same words in
+    // order on the lines beside it. The answers are checked against a sort done
+    // here rather than against the family's own — a family that printed the bank
+    // twice would pass otherwise.
+    const items = problemsOf({ style: "abc" });
+    expect([...items.map((item) => item.prompt)].sort()).toEqual(
+      [...WORDS].sort(),
+    );
+    expect(items.map((item) => item.answer)).toEqual(
+      [...WORDS].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+    );
+  });
+
+  it("scrambles the bank, because every list it is set on arrives sorted", () => {
+    // The shipped lists are alphabetical and so is anything typed out of a
+    // dictionary, so printing the bank in the order it was given would put the
+    // answer column next to its own question column.
+    const sorted = ["ant", "bee", "cat", "dog", "eel", "fox", "gnu", "hen"];
+    const banks = [1, 2].map((seed) =>
+      problemsOf({ style: "abc", words: sorted, count: 8 }, seed) //
+        .map((item) => item.prompt),
+    );
+    for (const bank of banks) expect(bank).not.toEqual(sorted);
+    // And a different sheet is a different scramble (§7).
+    expect(banks[0]).not.toEqual(banks[1]);
+  });
+
+  it("files a word where a child would look for it, whatever its case", () => {
+    // "Because" belongs under B and not before every lower-case word there is,
+    // which is what a codepoint sort would do with it.
+    expect(alphabetical(["dog", "Cat", "ant"])).toEqual(["ant", "Cat", "dog"]);
+    // And the order is the same wherever it is built — no platform collation.
+    expect(alphabetical(["résumé", "red"])).toEqual(["red", "résumé"]);
+  });
+});
+
+describe("word shapes", () => {
+  it("draws a box per letter, in the band that letter is written in", () => {
+    const [shape] = shapesOf({ words: ["big"], count: 1 });
+    expect(shape).toEqual({ word: "big", letters: ["tall", "small", "tail"] });
+  });
+
+  it("knows a capital, a numeral and an apostrophe from a small letter", () => {
+    // The printed convention rather than a font's own metrics: a capital is
+    // drawn from the top line to the baseline whatever face the sheet is set in,
+    // and an apostrophe is not a letter with a body at all.
+    expect(letterShape("B")).toBe("tall");
+    expect(letterShape("7")).toBe("tall");
+    expect(letterShape("t")).toBe("tall");
+    expect(letterShape("f")).toBe("tall");
+    expect(letterShape("y")).toBe("tail");
+    expect(letterShape("'")).toBe("small");
+  });
+
+  it("gives two words the same letters the same outline", () => {
+    // The exercise only works because a word has a silhouette: "bed" and "bad"
+    // are the same picture, and "big" is not.
+    const [bed, bad, big] = shapesOf({
+      words: ["bed", "bad", "big"],
+      count: 3,
+    });
+    expect(bed.letters).toEqual(bad.letters);
+    expect(big.letters).not.toEqual(bed.letters);
+  });
+});
+
+describe("using it in a sentence", () => {
+  it("rules lines with nothing written on them, on either half of the build", () => {
+    // There is no right answer to a sentence a child wrote, so the lines are
+    // empty on the key as well — and the word still sits above them, because it
+    // is the question.
+    const items = problemsOf({ style: "sentence", times: 2 });
+    expect(items.map((item) => item.prompt)).toEqual(WORDS);
+    for (const item of items) {
+      expect(item.answers).toEqual(["", ""]);
+      expect(item.answer).toBe("");
+      expect(item.workspace).toBe(2 * answerLine(12));
+    }
+  });
+});
+
+describe("finding the word", () => {
+  it("prints the word among words from the same list, and marks which", () => {
+    for (const question of questionsOf({})) {
+      expect(WORDS).toContain(question.prompt);
+      expect(question.options).toContain(question.prompt);
+      expect(question.options[question.answer]).toBe(question.prompt);
+      // The near misses are the deck's own — drawn from the list rather than
+      // invented — so every option on the line is a word being taught.
+      for (const option of question.options) expect(WORDS).toContain(option);
+      expect(new Set(question.options).size).toBe(question.options.length);
+    }
+  });
+
+  it("offers what a short list can spare rather than repeating a word", () => {
+    // Two words cannot make four options, and a line with the same word twice
+    // on it is a question with two right answers.
+    const [question] = questionsOf({ words: ["cat", "cot"], count: 2 });
+    expect(question.options).toHaveLength(2);
+    expect(new Set(question.options).size).toBe(2);
+  });
+
+  it("puts the word in a different place on a different sheet", () => {
+    // "Another sheet like this one" is `seed + 1` (§7), and on this style it has
+    // to move the answer or a child learns the position rather than the word.
+    const places = (seed: number) =>
+      questionsOf({}, seed).map((question) => question.answer);
+    expect(places(1)).not.toEqual(places(2));
+  });
+});
+
 /* ── The key ───────────────────────────────────────────────────────────── */
 
 describe("the answer key", () => {
@@ -237,7 +379,15 @@ describe("the list itself", () => {
 
   it("never prints more words than the paper holds", () => {
     const many = Array.from({ length: 200 }, (_, i) => `word${i}`);
-    for (const style of ["copy", "missing", "test"] as const) {
+    for (const style of [
+      "copy",
+      "missing",
+      "test",
+      "abc",
+      "shapes",
+      "sentence",
+      "find",
+    ] as const) {
       const over = { style, words: many, count: many.length };
       const { perPage } = wordsLayout(config(over));
       const sheet = buildSheet(config(over), 1);
@@ -247,7 +397,11 @@ describe("the list itself", () => {
           ? block.sentences.length //
           : block.kind === "problems"
             ? block.items.length
-            : 0;
+            : block.kind === "choice"
+              ? block.questions.length
+              : block.kind === "wordshapes"
+                ? block.words.length
+                : 0;
       expect(printed, style).toBe(perPage);
       expect(sheet.header.score).toEqual({ outOf: perPage });
     }

--- a/src/engine/sheets/words/spelling.ts
+++ b/src/engine/sheets/words/spelling.ts
@@ -9,32 +9,37 @@
  * bootstraps in §14 land on: two of the three are "here is a list", and the
  * third is the same thing with the list chosen for you.
  *
- * Three styles, and each one is an exercise somebody actually sets: write it
- * three times, fill in the letters that are missing, or write it down as it is
- * read out. The wider spelling set — ABC order, word shapes, use it in a
- * sentence — is PRINT20's, and lands here as more of `WordSheetStyle` rather
- * than as a second family.
+ * Seven styles, and each one is an exercise somebody actually sets: write it
+ * three times, fill in the letters that are missing, write it down as it is read
+ * out, put the list in ABC order, write it into the shape its letters make, use
+ * it in a sentence, or pick it out from the words it is most easily confused
+ * with. All seven over one list, which is the whole reason they are a union
+ * rather than seven families — a parent who has typed in this week's words gets
+ * every one of them from the control beside the box.
  *
  * Everything the other families promise holds unchanged: the page comes out of
  * `(config, seed)` and nothing else, the answers are computed when the sheet is
  * built and the key only decides to print them, and no row is put on the page
  * that the capacity arithmetic did not reserve room for.
  */
-import { normaliseWord } from "@/engine/decks/words";
+import { normaliseWord, wordDistractors } from "@/engine/decks/words";
 import { mulberry32, shuffled } from "@/engine/random";
 
 import type {
   Blank,
   Block,
+  Choice,
   Mil,
   Problem,
   Sheet,
   SheetOptions,
+  WordShape,
   WordsConfig,
 } from "../types";
 
 import { sheetBlockBox } from "../chrome";
 import {
+  LIST_GAP,
   PROBLEM_GAP,
   WRAP_GAP,
   answerLine,
@@ -42,8 +47,9 @@ import {
   fitAcross,
   type Box,
 } from "../layout";
-import { inches, points } from "../paper";
+import { points } from "../paper";
 import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
+import { SHAPE_ROW_EMS, wordShape } from "./shapes";
 
 /* ── What a word takes on the page ────────────────────────────────────────
    Declared, not measured (§4). A word on a line is one line of the body type;
@@ -52,11 +58,19 @@ import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
 
 const ROW_EMS = 1.7;
 
-/** `.sheet__blanks` in sheet.css sets this between one sentence and the next. */
-const BLANK_GAP: Mil = inches(0.16);
-
 /** A gapped word is a line of body type, and a hair of air under it. */
 const BLANK_EMS = 1.35;
+
+/**
+ * A multiple choice is two rows: the word being looked for, and the row of
+ * candidates under it.
+ *
+ * Trailing `.sheet__questions` in sheet.css, which sets the options list 0.06in
+ * under the question it belongs to — 1.35 for each line of type and the gap
+ * between them, rounded up, because a row under-reserved is the last question
+ * of the page on a second sheet of paper.
+ */
+const CHOICE_EMS = 3.1;
 
 /** More than three columns of words is a page nobody can write on. */
 const MAX_COLUMNS = 3;
@@ -155,15 +169,38 @@ const gapsOf = (config: WordsConfig): string => {
   return `${gaps} ${gaps === 1 ? "letter" : "letters"}`;
 };
 
+/**
+ * The styles that are a list down the page rather than a grid across it.
+ *
+ * One column whatever the config says, and the list gap rather than the problem
+ * one: the `blanks` and `choice` blocks are both flex columns of full-width
+ * items, and a family that asked either of them for two columns would be
+ * declaring a layout the renderer does not have.
+ */
+const DOWN_THE_PAGE = new Set<WordsConfig["style"]>(["missing", "find"]);
+
 /** How tall one word stands, the lines it is written on included. */
 function rowHeight(config: WordsConfig): Mil {
-  if (config.style === "missing") return points(config.fontPt * BLANK_EMS);
-  const body = points(config.fontPt * ROW_EMS);
-  if (config.style === "test") return body;
-  // The rules a word is copied onto wrap under it, inside the same cell, so
-  // the gap the browser puts between the two lines is reserved for here — see
-  // `WRAP_GAP`, which is that gap in the unit the arithmetic works in.
-  return body + WRAP_GAP + timesOf(config) * answerLine(config.fontPt);
+  const em = (rows: number): Mil => points(config.fontPt * rows);
+  switch (config.style) {
+    case "missing":
+      return em(BLANK_EMS);
+    case "find":
+      return em(CHOICE_EMS);
+    case "shapes":
+      return em(SHAPE_ROW_EMS);
+    case "test":
+    case "abc":
+      return em(ROW_EMS);
+    default:
+      // The rules a word is copied onto — or writes a sentence on — wrap under
+      // it inside the same cell, so the gap the browser puts between the two
+      // lines is reserved for here. See `WRAP_GAP`, which is that gap in the
+      // unit the arithmetic works in.
+      return (
+        em(ROW_EMS) + WRAP_GAP + timesOf(config) * answerLine(config.fontPt)
+      );
+  }
 }
 
 /**
@@ -171,10 +208,6 @@ function rowHeight(config: WordsConfig): Mil {
  *
  * Arithmetic rather than measurement, so the answer is the same in a unit test,
  * in the build of a catalog page and in the builder's live preview (§4).
- *
- * A gapped word is always one column: the `blanks` block is a list of
- * sentences down the page, and a family that asked it for two would be
- * declaring a layout the renderer does not have.
  */
 export function wordsLayout(config: WordsConfig): {
   box: Box;
@@ -188,10 +221,10 @@ export function wordsLayout(config: WordsConfig): {
   // its words. Reserving for the wrong header is a last row below the bottom
   // margin — invisible on screen, and a second sheet out of the printer.
   const box = sheetBlockBox(headerOf(config), true);
-  const columns =
-    config.style === "missing" ? 1 : clamp(config.columns, 1, MAX_COLUMNS);
+  const down = DOWN_THE_PAGE.has(config.style);
+  const columns = down ? 1 : clamp(config.columns, 1, MAX_COLUMNS);
   const row = rowHeight(config);
-  const gap = config.style === "missing" ? BLANK_GAP : PROBLEM_GAP.y;
+  const gap = down ? LIST_GAP : PROBLEM_GAP.y;
   return {
     box,
     columns,
@@ -205,9 +238,13 @@ export function wordsLayout(config: WordsConfig): {
  * The words this sheet actually prints, in the order they were given.
  *
  * A spelling list is often taught in order and a list of missed words arrives
- * ranked worst-first, so neither is shuffled. The count is a request rather
- * than a promise, the same as everywhere else: what does not fit is not
- * printed, because print is the whole of the output path (§10).
+ * ranked worst-first, so *which* words are printed is the first `count` of them
+ * rather than a draw. The count is a request rather than a promise, the same as
+ * everywhere else: what does not fit is not printed, because print is the whole
+ * of the output path (§10).
+ *
+ * How they are then laid out is the style's business, and one of the seven does
+ * shuffle — see `abcItems`, where the order is the exercise.
  */
 export function sheetWords(config: WordsConfig): string[] {
   const { perPage } = wordsLayout(config);
@@ -224,6 +261,19 @@ function problemOf(word: string, config: WordsConfig): Problem {
     return { prompt: "", answer: word };
   }
   const times = timesOf(config);
+  if (config.style === "sentence") {
+    // The same rules as a copying sheet and nothing written on them, on either
+    // half of the build: what a child puts there is their own sentence, so
+    // there is no answer for a key to print. The word still sits above them —
+    // it is the question — and the lines are the answer place, which is why it
+    // gets no ruled slot as well (see `Problem.answers`).
+    return {
+      prompt: word,
+      answer: "",
+      answers: Array.from({ length: times }, () => ""),
+      workspace: times * answerLine(config.fontPt),
+    };
+  }
   return {
     prompt: word,
     answer: word,
@@ -234,28 +284,98 @@ function problemOf(word: string, config: WordsConfig): Problem {
   };
 }
 
+/**
+ * The list in alphabetical order.
+ *
+ * Compared on the normalised word so that "Because" files where a child would
+ * look for it, and compared with `<` rather than with `localeCompare`, which
+ * consults whatever collation the platform happens to ship: a sheet built in CI
+ * and the same sheet built in a browser have to be the same sheet (§7), and this
+ * is a list of English words rather than a general-purpose sort.
+ */
+export const alphabetical = (words: string[]): string[] =>
+  [...words].sort((a, b) => {
+    const [left, right] = [normaliseWord(a), normaliseWord(b)];
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
+
+/**
+ * The list scrambled, each word paired with the one that belongs on that line.
+ *
+ * Two columns of one exercise: the words down the left are the bank and the
+ * ruled slots beside them are where the same words go in alphabetical order.
+ * Line four's answer is the fourth word alphabetically and has nothing to do
+ * with the word printed next to it, which is what the instruction says and what
+ * makes the key read as a list.
+ *
+ * The bank is shuffled, and it is the one style where that is right. Everywhere
+ * else the list is printed in the order it was given, because a spelling list is
+ * taught in order — but here the order *is* the exercise, and every list this
+ * sheet is likely to be set on arrives alphabetical already: the shipped Dolch
+ * lists are, and so is anything typed out of a dictionary. A sheet whose answer
+ * column is its own question column is not a sheet. Which scramble is the
+ * seed's, so "another one like this" is another order (§7).
+ */
+const abcItems = (words: string[], rand: () => number): Problem[] => {
+  const ordered = alphabetical(words);
+  return shuffled(words, rand).map((word, at) => ({
+    prompt: word,
+    answer: ordered[at],
+  }));
+};
+
+/**
+ * One word among the words it is most easily mistaken for.
+ *
+ * The near misses are the deck's own — `wordDistractors` is what the race's
+ * "spot it" round has always used — so a printed sheet and a played round ask
+ * the same question of the same list. "there" against "their", never against
+ * "squirrel": four unrelated words would make this a spotting exercise rather
+ * than a reading one.
+ */
+const findQuestion = (
+  word: string,
+  pool: string[],
+  rand: () => number,
+): Choice => {
+  const options = shuffled([word, ...wordDistractors(word, pool, rand)], rand);
+  return { prompt: word, options, answer: options.indexOf(word) };
+};
+
 function bodyOf(
   config: WordsConfig,
   seed: number,
 ): { blocks: Block[]; outOf: number } {
   const words = sheetWords(config);
+  const { columns } = wordsLayout(config);
+  const outOf = words.length;
+
   if (config.style === "missing") {
     const rand = mulberry32(seed);
     const sentences = words.map((word) => gapped(word, config.gaps, rand));
     return { blocks: [{ kind: "blanks", sentences }], outOf: sentences.length };
   }
 
-  const { columns } = wordsLayout(config);
-  return {
-    blocks: [
-      {
-        kind: "problems",
-        columns,
-        items: words.map((w) => problemOf(w, config)),
-      },
-    ],
-    outOf: words.length,
-  };
+  if (config.style === "find") {
+    // The pool is the words on the page rather than the whole list, so every
+    // near miss printed is a word the child is being taught this week — and a
+    // list too short to have three of them says so by offering fewer options
+    // rather than by borrowing from somewhere else.
+    const rand = mulberry32(seed);
+    const questions = words.map((word) => findQuestion(word, words, rand));
+    return { blocks: [{ kind: "choice", questions }], outOf };
+  }
+
+  if (config.style === "shapes") {
+    const shapes: WordShape[] = words.map(wordShape);
+    return { blocks: [{ kind: "wordshapes", columns, words: shapes }], outOf };
+  }
+
+  const items =
+    config.style === "abc"
+      ? abcItems(words, mulberry32(seed))
+      : words.map((word) => problemOf(word, config));
+  return { blocks: [{ kind: "problems", columns, items }], outOf };
 }
 
 /* ── What it is called ─────────────────────────────────────────────────── */
@@ -264,6 +384,10 @@ const TITLE: Record<WordsConfig["style"], string> = {
   copy: "Spelling practice",
   missing: "Missing letters",
   test: "Spelling test",
+  abc: "ABC order",
+  shapes: "Word shapes",
+  sentence: "Words in sentences",
+  find: "Find the word",
 };
 
 function instructionOf(config: WordsConfig): string {
@@ -272,6 +396,14 @@ function instructionOf(config: WordsConfig): string {
       return "Fill in the missing letters.";
     case "test":
       return "Write each word as it is read out.";
+    case "abc":
+      return "Write the words in ABC order on the lines.";
+    case "shapes":
+      return "Write each word in the boxes. Tall letters fill the top of the box, and letters with a tail hang below the line.";
+    case "sentence":
+      return "Use each word in a sentence of your own.";
+    case "find":
+      return "Circle the word that matches the one at the start of the line.";
     default:
       return `Write each word ${timesOf(config)} times.`;
   }
@@ -302,6 +434,7 @@ export function describeWords(config: WordsConfig): string {
     `${words.length} ${words.length === 1 ? "word" : "words"}`,
     config.style === "copy" ? `written ${timesOf(config)} times` : null,
     config.style === "missing" ? `${gapsOf(config)} out` : null,
+    config.style === "sentence" ? "a sentence each" : null,
   ]
     .filter((part): part is string => part !== null)
     .join(" — ");

--- a/src/engine/sheets/words/study.test.ts
+++ b/src/engine/sheets/words/study.test.ts
@@ -198,7 +198,7 @@ describe("the word-study family", () => {
     for (const size of ["letter", "a4"] as const) {
       for (const fontPt of [10, 12, 18]) {
         for (const one of EVERY_SHEET) {
-          const big = { ...one, paper: { ...paper, size }, count: 200 };
+          const big = { ...one, paper: { ...paper, size }, fontPt, count: 200 };
           const { perPage } = studyLayout(big);
           const printed = countOf(blockOf(big));
           expect(printed, `${where(one)} ${size}@${fontPt}`) //

--- a/src/engine/sheets/words/study.test.ts
+++ b/src/engine/sheets/words/study.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import type { Block, Paper, WordStudyConfig, WordStudyStyle } from "../types";
+
+import {
+  CONTRACTIONS,
+  FAMILIES,
+  HOMOPHONES,
+  MAX_SYLLABLES,
+  PREFIXES,
+  SUFFIXES,
+  SYLLABLES,
+  familyWords,
+} from "./bank";
+import {
+  STUDY_TOPICS,
+  WORD_STUDY_SHEET,
+  studyLayout,
+  studyStyles,
+  topicOf,
+} from "./study";
+
+/**
+ * Word study, held to the bar the maths families set — and to one more.
+ *
+ * "Verified by an independent path" means something different again here. There
+ * is no arithmetic to check an answer against: the answers are authored, so what
+ * a test can prove is that the *bank* is sound and that the sheet does not spoil
+ * it. Both halves matter, and the second is the one that bites.
+ *
+ * **The bank.** No question asked twice, no answer used twice inside a topic —
+ * which is what stops a near miss also being right — every sum really making the
+ * word it claims, and every homophone sentence settling which of its pair is
+ * meant.
+ *
+ * **The sheet.** A question and its answer stay together through a shuffle, a
+ * matching column points at the row it belongs to, and a choice prints the
+ * answer exactly once. Those are the three ways a page of correct answers can
+ * still be a wrong worksheet.
+ */
+
+const paper: Paper = {
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+};
+
+const config = (over: Partial<WordStudyConfig> = {}): WordStudyConfig => ({
+  kind: "word-study",
+  paper,
+  fontPt: 12,
+  fields: ["name", "date"],
+  topic: "rhyming",
+  style: "choose",
+  count: 10,
+  columns: 2,
+  ...over,
+});
+
+/** Every topic in every style it offers — the whole surface, as configs. */
+const EVERY_SHEET: WordStudyConfig[] = STUDY_TOPICS.flatMap((topic) =>
+  studyStyles(topic).map((style) => config({ topic, style, count: 12 })),
+);
+
+const where = (one: WordStudyConfig) => `${one.topic}/${one.style}`;
+
+const blockOf = (one: WordStudyConfig, seed = 1): Block =>
+  buildSheet(one, seed).blocks[0];
+
+/* ── The bank ──────────────────────────────────────────────────────────── */
+
+describe("the word bank", () => {
+  it("asks nothing twice and answers nothing twice inside a topic", () => {
+    // The property the near misses rest on: a distractor is another entry's
+    // answer, so two entries sharing one would put two right answers on a line.
+    for (const topic of STUDY_TOPICS) {
+      const { questions } = topicOf(topic);
+      expect(questions.length, topic).toBeGreaterThan(9);
+      for (const question of questions) {
+        expect(question.ask.trim(), topic).not.toBe("");
+        expect(question.cue.trim(), topic).not.toBe("");
+        expect(question.answer.trim(), topic).not.toBe("");
+      }
+      const asks = questions.map((question) => question.ask);
+      const answers = questions.map((question) => question.answer);
+      expect(new Set(asks).size, `${topic} asks`).toBe(asks.length);
+      // Except where the answers are a scale rather than words: half the words
+      // on a syllable sheet have three of them, and nothing is ambiguous about
+      // that because the options are the numbers one to four either way.
+      if (topicOf(topic).options) continue;
+      expect(new Set(answers).size, `${topic} answers`).toBe(answers.length);
+    }
+  });
+
+  it("makes a real word out of every word-family sum", () => {
+    // The independent path for this topic: the answer is checked against its own
+    // parts rather than against the generator that joined them.
+    for (const family of FAMILIES) {
+      for (const word of familyWords(family)) {
+        expect(word.endsWith(family.rime), word).toBe(true);
+        expect(word.length, word).toBeGreaterThan(family.rime.length);
+      }
+    }
+  });
+
+  it("puts a prefix on the front and a suffix on the back", () => {
+    for (const { part, base, word } of PREFIXES) {
+      expect(word.startsWith(part), word).toBe(true);
+      expect(word.endsWith(base), word).toBe(true);
+    }
+    for (const { part, base, word } of SUFFIXES) {
+      expect(word.endsWith(part), word).toBe(true);
+      // Not the whole base — "happy + ness" is "happiness" and "make + ing" is
+      // "making", which is the lesson — but a word that had lost its beginning
+      // would be a typo rather than a spelling change.
+      expect(word.startsWith(base.slice(0, 2)), word).toBe(true);
+    }
+  });
+
+  it("counts every syllable between one and four", () => {
+    for (const { word, syllables } of SYLLABLES) {
+      expect(syllables, word).toBeGreaterThanOrEqual(1);
+      expect(syllables, word).toBeLessThanOrEqual(MAX_SYLLABLES);
+    }
+  });
+
+  it("marks where the letters went in every contraction", () => {
+    for (const { words, short } of CONTRACTIONS) {
+      expect(short, words).toContain("'");
+      expect(short.length, words).toBeLessThan(words.length);
+    }
+  });
+
+  it("gives every homophone a sentence that settles which one is meant", () => {
+    // The house rule from `wordlists.ts`, held to on paper: one gap, the answer
+    // one of the pair, and *neither* spelling anywhere else in the sentence — a
+    // sentence containing the word answers itself.
+    for (const { pair, sentence, answer } of HOMOPHONES) {
+      expect(sentence.match(/_/g) ?? [], sentence).toHaveLength(1);
+      expect(pair, sentence).toContain(answer);
+      expect(pair[0], sentence).not.toBe(pair[1]);
+      for (const word of pair) {
+        expect(sentence.toLowerCase(), sentence) //
+          .not.toMatch(new RegExp(`\\b${word}\\b`));
+      }
+    }
+    const sentences = HOMOPHONES.map((one) => one.sentence);
+    expect(new Set(sentences).size).toBe(sentences.length);
+  });
+});
+
+/* ── The family ────────────────────────────────────────────────────────── */
+
+describe("the word-study family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("word-study")).toBe(WORD_STUDY_SHEET);
+    expect(sheetSpec("word-study").label).toBe("Word study");
+  });
+
+  it("prints a titled, marked page for every topic and style", () => {
+    for (const one of EVERY_SHEET) {
+      const sheet = buildSheet(one, 1);
+      expect(sheet.header.title, where(one)).not.toBe("");
+      expect(sheet.header.instructions, where(one)).toBeTruthy();
+      expect(sheet.header.score?.outOf, where(one)).toBe(12);
+      expect(sheet.blocks, where(one)).toHaveLength(1);
+    }
+  });
+
+  it("names what it prints, in the terms it was chosen by", () => {
+    expect(describeSheet(config({ topic: "plurals", style: "write" }))) //
+      .toBe("Plurals — 10 questions — written in");
+    expect(describeSheet(config({ topic: "synonyms", style: "match" }))) //
+      .toBe("Synonyms — 10 questions — joined up");
+  });
+
+  it("falls back to a style the topic has rather than throwing", () => {
+    // A saved sheet outlives the table it was made from (§7): rhyming has never
+    // been writable, and a config that says so still has to print something.
+    const rhyming = config({ topic: "rhyming", style: "write" });
+    expect(blockOf(rhyming).kind).toBe("choice");
+    // As does a topic this build has never heard of.
+    const unknown = config({ topic: "kennings" as never });
+    expect(() => buildSheet(unknown, 1)).not.toThrow();
+  });
+
+  it("builds the same sheet twice, and a different one next seed", () => {
+    for (const one of EVERY_SHEET) {
+      expect(JSON.stringify(buildSheet(one, 5)), where(one)) //
+        .toBe(JSON.stringify(buildSheet(one, 5)));
+      expect(JSON.stringify(buildSheet(one, 6)), where(one)) //
+        .not.toBe(JSON.stringify(buildSheet(one, 5)));
+    }
+  });
+
+  it("never prints more questions than the paper holds", () => {
+    for (const size of ["letter", "a4"] as const) {
+      for (const fontPt of [10, 12, 18]) {
+        for (const one of EVERY_SHEET) {
+          const big = { ...one, paper: { ...paper, size }, count: 200 };
+          const { perPage } = studyLayout(big);
+          const printed = countOf(blockOf(big));
+          expect(printed, `${where(one)} ${size}@${fontPt}`) //
+            .toBeLessThanOrEqual(perPage);
+          // And never more than the bank has, which is the other cap: a page
+          // with room for forty rhymes still only has fourteen families.
+          expect(printed, where(one)) //
+            .toBeLessThanOrEqual(topicOf(one.topic).questions.length);
+        }
+      }
+    }
+  });
+});
+
+/** How many questions a block put on the paper. */
+function countOf(block: Block): number {
+  if (block.kind === "problems") return block.items.length;
+  if (block.kind === "choice") return block.questions.length;
+  if (block.kind === "matching") return block.left.length;
+  throw new Error(`unexpected block ${block.kind}`);
+}
+
+/* ── The three shapes of question ──────────────────────────────────────── */
+
+describe("writing the answer", () => {
+  it("keeps every question with its own answer through the draw", () => {
+    // The failure a shuffle makes possible and nothing else catches: a page of
+    // correct answers attached to the wrong prompts.
+    for (const topic of STUDY_TOPICS) {
+      if (!studyStyles(topic).includes("write")) continue;
+      const block = blockOf(config({ topic, style: "write", count: 12 }));
+      if (block.kind !== "problems") throw new Error("expected problems");
+      const bank = new Map(
+        topicOf(topic).questions.map((one) => [one.ask, one.answer]),
+      );
+      for (const item of block.items) {
+        expect(bank.get(item.prompt), item.prompt).toBe(item.answer);
+      }
+    }
+  });
+});
+
+describe("circling one of four", () => {
+  it("prints the answer once, marks it, and draws the rest from the topic", () => {
+    for (const topic of STUDY_TOPICS) {
+      if (!studyStyles(topic).includes("choose")) continue;
+      const { questions, options: scale } = topicOf(topic);
+      const block = blockOf(config({ topic, style: "choose", count: 12 }));
+      if (block.kind !== "choice") throw new Error("expected choice");
+
+      const bank = new Map(questions.map((one) => [one.cue, one.answer]));
+      const answers = new Set(questions.map((one) => one.answer));
+      for (const question of block.questions) {
+        const right = bank.get(question.prompt);
+        expect(right, question.prompt).toBeDefined();
+        expect(question.options[question.answer], question.prompt).toBe(right);
+        // Exactly once: an option list with the answer twice on it has two
+        // right answers and no way to mark either.
+        expect(
+          question.options.filter((option) => option === right),
+          question.prompt,
+        ).toHaveLength(1);
+        expect(new Set(question.options).size).toBe(question.options.length);
+        expect(question.options.length).toBe(scale ? scale.length : 4);
+        // The near misses are other answers from the same topic, which is what
+        // makes them near — never a word from somewhere else.
+        for (const option of question.options) {
+          expect(answers.has(option), `${topic}: ${option}`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("offers a syllable count as a scale rather than as a shuffle", () => {
+    const block = blockOf(config({ topic: "syllables", style: "choose" }));
+    if (block.kind !== "choice") throw new Error("expected choice");
+    for (const question of block.questions) {
+      expect(question.options).toEqual(["1", "2", "3", "4"]);
+    }
+  });
+});
+
+describe("joining two columns", () => {
+  it("points every left-hand word at the row its answer landed in", () => {
+    for (const topic of STUDY_TOPICS) {
+      if (!studyStyles(topic).includes("match")) continue;
+      const block = blockOf(config({ topic, style: "match", count: 12 }));
+      if (block.kind !== "matching") throw new Error("expected matching");
+
+      const bank = new Map(
+        topicOf(topic).questions.map((one) => [one.cue, one.answer]),
+      );
+      expect(block.left.length).toBe(block.right.length);
+      expect([...block.right].sort()).toEqual(
+        block.left.map((cue) => bank.get(cue) ?? "").sort(),
+      );
+      block.left.forEach((cue, at) => {
+        expect(block.right[block.answer[at]], cue).toBe(bank.get(cue));
+      });
+    }
+  });
+});
+
+/* ── The key ───────────────────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("is the same sheet keyed, never a second generation", () => {
+    for (const one of EVERY_SHEET) {
+      const sheet = buildSheet(one, 7);
+      const key = answerKey(one, 7);
+      expect(key.answers, where(one)).toBe(true);
+      expect(key.footer.note, where(one)).toBe("Answer key");
+      expect({ ...key, answers: false, footer: sheet.footer }, where(one)) //
+        .toEqual(sheet);
+    }
+  });
+});
+
+/* ── What a panel is allowed to offer ──────────────────────────────────── */
+
+describe("the styles a topic offers", () => {
+  it("gives every topic at least one, and its first as the default", () => {
+    const known: WordStudyStyle[] = ["write", "choose", "match"];
+    for (const topic of STUDY_TOPICS) {
+      const styles = studyStyles(topic);
+      expect(styles.length, topic).toBeGreaterThan(0);
+      for (const style of styles) expect(known, topic).toContain(style);
+      expect(new Set(styles).size, topic).toBe(styles.length);
+    }
+  });
+});

--- a/src/engine/sheets/words/study.ts
+++ b/src/engine/sheets/words/study.ts
@@ -1,0 +1,600 @@
+/**
+ * Word study: the ten lessons about words that are not spelling a list.
+ *
+ * The mirror image of `spelling.ts`. There the content is a parent's and the
+ * exercise is ours; here the exercise is a parent's and the content is ours —
+ * rhyming, syllables, word families, prefixes and suffixes, plurals,
+ * contractions, homophones, synonyms and antonyms, out of the authored bank
+ * beside this file (`bank.ts`, which is where the reason for authoring rather
+ * than generating is written down).
+ *
+ * One family rather than ten, because the ten differ only in what is on the
+ * paper. Every topic reduces to the same three-field question — what is given,
+ * what is wanted, and the short form of the same thing for a column — and from
+ * that the three shapes of sheet fall out: a prompt with a ruled slot, four
+ * options to circle, or two columns to join with a pencil. What a topic *cannot*
+ * honestly be asked in it does not offer (`Topic.styles`): "write a word that
+ * rhymes with cat" has a hundred right answers and no answer key.
+ *
+ * Everything the other families promise holds: the page comes out of
+ * `(config, seed)` and nothing else, the answers are decided when the sheet is
+ * built and the key only prints them, and no row goes on the page that the
+ * capacity arithmetic did not reserve.
+ */
+import { mulberry32, shuffled } from "@/engine/random";
+
+import type {
+  Block,
+  Choice,
+  Mil,
+  Problem,
+  Sheet,
+  SheetOptions,
+  WordStudyConfig,
+  WordStudyStyle,
+  WordStudyTopic,
+} from "../types";
+
+import { sheetBlockBox } from "../chrome";
+import { faceOf, fittedCharacters } from "../faces";
+import {
+  LIST_GAP,
+  MATCH_ROW_EMS,
+  PROBLEM_GAP,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches, own, points } from "../paper";
+import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
+
+import {
+  ANTONYMS,
+  CONTRACTIONS,
+  FAMILIES,
+  HOMOPHONES,
+  MAX_SYLLABLES,
+  PLURALS,
+  PREFIXES,
+  SUFFIXES,
+  SYLLABLES,
+  SYNONYMS,
+  familyWords,
+  type Meaning,
+  type Sum,
+} from "./bank";
+
+/* ── What a row takes on the page ─────────────────────────────────────────
+   Declared, not measured (§4), and the three numbers are the three blocks this
+   family prints through — the same ones `spelling.ts` reserves for, because the
+   blocks are the same blocks.                                                */
+
+/** A prompt and its ruled slot, on one line of body type. */
+const ROW_EMS = 1.7;
+
+/** A question and the row of options under it — see `spelling.ts`. */
+const CHOICE_EMS = 3.1;
+
+/** `.sheet__slot` in sheet.css is this wide before anything is written in it. */
+const SLOT_WIDTH: Mil = inches(0.8);
+
+/** Room for the "12." a numbered list prints in front of every prompt. */
+const NUMBER_CHARACTERS = 3;
+
+/** The answer and three near misses — the same four the race deals. */
+const CHOICES = 4;
+
+/** More than three columns of words is a page nobody can write on. */
+const MAX_COLUMNS = 3;
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/* ── A question, whatever topic it came from ──────────────────────────────── */
+
+/**
+ * One thing to ask, in the three forms a sheet needs it in.
+ *
+ * `ask` is the sentence a `write` sheet prints — "un + happy =", "one box,
+ * two _" — and carries a `_` where the answer belongs inside it rather than
+ * after it, the convention `Problem.prompt` already uses. `cue` is the same
+ * question with the scaffolding off, for the left of a matching column and the
+ * line above a row of options, where the verb has already been said once in the
+ * instruction. `answer` is the one right answer somebody wrote down.
+ */
+type Question = { ask: string; cue: string; answer: string };
+
+type Topic = {
+  /** How the topic is named in a picker and in `describe`. */
+  label: string;
+  /** The sheet's own title. */
+  title: string;
+  /**
+   * The styles this topic can honestly be asked in, its default first.
+   *
+   * A style a topic does not offer is not an error — a saved sheet outlives the
+   * table below, exactly as it outlives the registry (§7) — so `styleOf`
+   * resolves it to the first of these rather than refusing to print.
+   */
+  styles: WordStudyStyle[];
+  /** The line at the top of the page. Per style, because the verb changes. */
+  instruction: Partial<Record<WordStudyStyle, string>>;
+  questions: Question[];
+  /**
+   * Where the options are a fixed scale rather than other answers.
+   *
+   * A syllable sheet offers one, two, three or four in that order: drawing three
+   * "near misses" from the other questions would offer a child the numbers 1, 4
+   * and 2 and call it a choice, and shuffling them would make the row read
+   * differently on every line for no reason.
+   */
+  options?: string[];
+};
+
+/* ── The ten topics ──────────────────────────────────────────────────────── */
+
+/**
+ * Rhyming, one question to a family.
+ *
+ * One per family and never two, because a matching column of "cat" and "hat"
+ * against "mat" and "bat" is a question with two right answers — and the whole
+ * point of a rime is that every word in the family answers it. Which family
+ * lands on a sheet is the seed's business, which is what makes "another sheet
+ * like this one" mean something here.
+ */
+const rhymes = (): Question[] =>
+  FAMILIES.map((family) => {
+    const [first, second] = familyWords(family);
+    return { ask: first, cue: first, answer: second };
+  });
+
+/** Word families, as the sum a child is shown: an onset, a rime, a word. */
+const blends = (): Question[] =>
+  FAMILIES.flatMap((family) =>
+    family.onsets.map((onset) => ({
+      ask: `${onset} + ${family.rime} =`,
+      cue: `${onset} + ${family.rime}`,
+      answer: `${onset}${family.rime}`,
+    })),
+  );
+
+const syllables = (): Question[] =>
+  SYLLABLES.map(({ word, syllables: count }) => ({
+    ask: word,
+    cue: word,
+    answer: String(count),
+  }));
+
+/**
+ * A prefix or a suffix, added on the side it goes on.
+ *
+ * `un + happy` and `care + ful` rather than one order for both: which end the
+ * part joins is the difference between the two topics, and a suffix sheet that
+ * printed "ful + care" would be teaching the wrong thing in the first line.
+ */
+const sums = (list: Sum[], before: boolean): Question[] =>
+  list.map(({ part, base, word }) => {
+    const cue = before ? `${part} + ${base}` : `${base} + ${part}`;
+    return { ask: `${cue} =`, cue, answer: word };
+  });
+
+const plurals = (): Question[] =>
+  PLURALS.map(({ one, many }) => ({
+    ask: `one ${one}, two _`,
+    cue: one,
+    answer: many,
+  }));
+
+const contractions = (): Question[] =>
+  CONTRACTIONS.map(({ words, short }) => ({
+    ask: `${words} =`,
+    cue: words,
+    answer: short,
+  }));
+
+/**
+ * A homophone, as a sentence with the pair printed beside it.
+ *
+ * The pair is on the paper because without it the question has no answer: both
+ * spellings are the same sound, so a child who has only heard the sentence
+ * cannot be wrong. It rides on `ask` rather than on the instruction line for the
+ * same reason a clue does in `wordlists.ts` — the choice belongs to the
+ * sentence, and every sentence has a different pair.
+ */
+const homophones = (): Question[] =>
+  HOMOPHONES.map(({ pair, sentence, answer }) => ({
+    ask: `${sentence} (${pair[0]} / ${pair[1]})`,
+    cue: sentence,
+    answer,
+  }));
+
+const meanings = (list: Meaning[]): Question[] =>
+  list.map(({ word, match }) => ({ ask: word, cue: word, answer: match }));
+
+const TOPICS: Record<WordStudyTopic, Topic> = {
+  rhyming: {
+    label: "Rhyming words",
+    title: "Rhyming words",
+    styles: ["choose", "match"],
+    instruction: {
+      choose: "Circle the word that rhymes with the word on the left.",
+      match: "Join each word to the word that rhymes with it.",
+    },
+    questions: rhymes(),
+  },
+  syllables: {
+    label: "Syllables",
+    title: "Syllables",
+    styles: ["write", "choose"],
+    instruction: {
+      write: "Write how many syllables you can hear in each word.",
+      choose: "Circle how many syllables you can hear in each word.",
+    },
+    questions: syllables(),
+    options: Array.from({ length: MAX_SYLLABLES }, (_, at) => String(at + 1)),
+  },
+  families: {
+    label: "Word families",
+    title: "Word families",
+    styles: ["write"],
+    instruction: {
+      write: "Add the letters together and write the word they make.",
+    },
+    questions: blends(),
+  },
+  prefixes: {
+    label: "Prefixes",
+    title: "Prefixes",
+    styles: ["write"],
+    instruction: {
+      write: "Add the beginning to each word and write the new word.",
+    },
+    questions: sums(PREFIXES, true),
+  },
+  suffixes: {
+    label: "Suffixes",
+    title: "Suffixes",
+    styles: ["write"],
+    instruction: {
+      write:
+        "Add the ending to each word and write the new word. Some of the words change before the ending goes on.",
+    },
+    questions: sums(SUFFIXES, false),
+  },
+  plurals: {
+    label: "Plurals",
+    title: "One and more than one",
+    styles: ["write", "match"],
+    instruction: {
+      write: "Write each word as more than one.",
+      match:
+        "Join each word to the way it is written when there is more than one.",
+    },
+    questions: plurals(),
+  },
+  contractions: {
+    label: "Contractions",
+    title: "Contractions",
+    styles: ["write", "match"],
+    instruction: {
+      write:
+        "Write the two words as one, with an apostrophe where the missing letters were.",
+      match: "Join each pair of words to the short form it makes.",
+    },
+    questions: contractions(),
+  },
+  homophones: {
+    label: "Homophones",
+    title: "Homophones",
+    styles: ["write"],
+    instruction: {
+      write: "Write the word from the pair that belongs in the sentence.",
+    },
+    questions: homophones(),
+  },
+  synonyms: {
+    label: "Synonyms",
+    title: "Words that mean the same",
+    styles: ["choose", "match"],
+    instruction: {
+      choose: "Circle the word that means the same as the word on the left.",
+      match: "Join each word to a word that means the same.",
+    },
+    questions: meanings(SYNONYMS),
+  },
+  antonyms: {
+    label: "Antonyms",
+    title: "Words that mean the opposite",
+    styles: ["choose", "match"],
+    instruction: {
+      choose: "Circle the word that means the opposite.",
+      match: "Join each word to the word that means the opposite.",
+    },
+    questions: meanings(ANTONYMS),
+  },
+};
+
+/** Every topic, for a picker and for the catalog. */
+export const STUDY_TOPICS: WordStudyTopic[] = Object.keys(
+  TOPICS,
+) as WordStudyTopic[];
+
+/**
+ * The topic a config names, or rhyming if this build has never heard of it.
+ *
+ * Never throws, for the reason `sheetSpec` doesn't: the id arrives from a saved
+ * sheet or from a link somebody was sent, and a page that prints something is
+ * worth more than an exception inside a build.
+ */
+export const topicOf = (topic: string): Topic =>
+  own(TOPICS, topic, TOPICS.rhyming);
+
+/** What a topic is called, and which styles it can be asked in. */
+export const studyTopicLabel = (topic: string): string => topicOf(topic).label;
+export const studyStyles = (topic: string): WordStudyStyle[] =>
+  topicOf(topic).styles;
+
+/** The style this config will actually print in — see `Topic.styles`. */
+export const styleOf = (config: WordStudyConfig): WordStudyStyle => {
+  const { styles } = topicOf(config.topic);
+  return styles.includes(config.style) ? config.style : styles[0];
+};
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+/**
+ * How many lines the longest prompt in a topic wraps onto.
+ *
+ * Taken over the whole bank rather than over the questions that were drawn,
+ * because the reservation is made before the draw: a row height that depended on
+ * the seed would be a layout that disagreed with `sheetWords`' own arithmetic
+ * from one sheet to the next. It over-reserves by a line on a page whose longest
+ * homophone sentence stayed in the bank, which is the cheap side to be wrong on
+ * (`chrome.ts`).
+ */
+function promptRows(topic: Topic, config: WordStudyConfig, cell: Mil): number {
+  const across = fittedCharacters(
+    Math.max(1, cell - SLOT_WIDTH),
+    points(config.fontPt),
+    faceOf(config.font),
+  );
+  const longest = topic.questions.reduce(
+    (most, question) => Math.max(most, question.ask.length),
+    0,
+  );
+  return Math.max(1, Math.ceil((longest + NUMBER_CHARACTERS) / across));
+}
+
+/**
+ * How many questions the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic rather than measurement, so a unit test, a catalog page built at
+ * build time and the builder's live preview all get the same answer (§4). The
+ * three styles are three different shapes of page: a grid of prompts across it,
+ * a list of choices down it, or two columns of pairs the width of the paper.
+ */
+export function studyLayout(config: WordStudyConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print rather than the one the config
+  // holds, and with the score box, because a word-study sheet is marked out of
+  // its questions. Reserving for the wrong header is a last row below the
+  // bottom margin — invisible on screen, and a second sheet out of the printer.
+  const box = sheetBlockBox(headerOf(config), true);
+  const topic = topicOf(config.topic);
+  const style = styleOf(config);
+  const write = style === "write";
+  const columns = write ? clamp(config.columns, 1, MAX_COLUMNS) : 1;
+  const cell = columnWidth(box, columns, PROBLEM_GAP.x);
+
+  const row = points(
+    config.fontPt *
+      (style === "match"
+        ? MATCH_ROW_EMS
+        : style === "choose"
+          ? CHOICE_EMS
+          : ROW_EMS * promptRows(topic, config, cell)),
+  );
+  // A matching block draws its own rows one under another with nothing between
+  // them, so there is no gap to pay for; the other two are lists with one.
+  const gap = style === "match" ? 0 : write ? PROBLEM_GAP.y : LIST_GAP;
+
+  return {
+    box,
+    columns,
+    cell,
+    row,
+    perPage: columns * fitAcross(box.height, row, gap),
+  };
+}
+
+/**
+ * The questions this sheet prints, drawn from the topic's bank by the seed.
+ *
+ * Shuffled rather than taken in order, because the bank is written in teaching
+ * order — every plain `-s` plural first — and a sheet of the first twelve would
+ * be a sheet of the easy half. Never more than the bank holds and never more
+ * than the page holds, so the count is a request exactly as it is everywhere
+ * else in the shop.
+ */
+export function studyQuestions(
+  config: WordStudyConfig,
+  seed: number,
+): Question[] {
+  const { questions } = topicOf(config.topic);
+  const { perPage } = studyLayout(config);
+  const room = Math.min(perPage, questions.length);
+  const wanted = clamp(config.count ?? room, 0, room);
+  return shuffled(questions, mulberry32(seed)).slice(0, wanted);
+}
+
+/** A prompt and a ruled slot — the shape of every `write` sheet. */
+const written = (question: Question): Problem => ({
+  prompt: question.ask,
+  answer: question.answer,
+});
+
+/**
+ * A question with four things it could be.
+ *
+ * The near misses are the other answers in the same topic, which is what makes
+ * them near: the opposite of "hot" is asked against "small", "night" and "slow"
+ * rather than against three words picked out of the dictionary. That the three
+ * are never *also* right is a fact about the bank rather than about this
+ * function — see the house rules in `bank.ts`.
+ */
+function chosen(question: Question, topic: Topic, rand: () => number): Choice {
+  if (topic.options) {
+    return {
+      prompt: question.cue,
+      options: topic.options,
+      answer: topic.options.indexOf(question.answer),
+    };
+  }
+  const others = topic.questions
+    .map((other) => other.answer)
+    .filter((answer) => answer !== question.answer);
+  const options = shuffled(
+    [question.answer, ...shuffled(others, rand).slice(0, CHOICES - 1)],
+    rand,
+  );
+  return {
+    prompt: question.cue,
+    options,
+    answer: options.indexOf(question.answer),
+  };
+}
+
+function bodyOf(
+  config: WordStudyConfig,
+  seed: number,
+): { blocks: Block[]; outOf: number } {
+  const topic = topicOf(config.topic);
+  const drawn = studyQuestions(config, seed);
+  const outOf = drawn.length;
+  const style = styleOf(config);
+  // One generator for the whole page, so the draw and the options are one
+  // sequence and the sheet is reproducible from its seed alone (§7).
+  const rand = mulberry32(seed);
+
+  if (style === "choose") {
+    const questions = drawn.map((question) => chosen(question, topic, rand));
+    return { blocks: [{ kind: "choice", questions }], outOf };
+  }
+
+  if (style === "match") {
+    // The right column is shuffled and the left is not: the left is the order
+    // the questions were drawn in, and a matching sheet whose columns lined up
+    // would be a sheet a child could answer with a ruler.
+    const right = shuffled(
+      drawn.map((question) => question.answer),
+      rand,
+    );
+    return {
+      blocks: [
+        {
+          kind: "matching",
+          left: drawn.map((question) => question.cue),
+          right,
+          answer: drawn.map((question) => right.indexOf(question.answer)),
+        },
+      ],
+      outOf,
+    };
+  }
+
+  const { columns } = studyLayout(config);
+  return {
+    blocks: [{ kind: "problems", columns, items: drawn.map(written) }],
+    outOf,
+  };
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+/** How the style reads in a description, in the terms a parent chose it by. */
+const STYLE_WORDS: Record<WordStudyStyle, string> = {
+  write: "written in",
+  choose: "circled",
+  match: "joined up",
+};
+
+/**
+ * The header this sheet will actually print.
+ *
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page. `config.title` is an override
+ * and is usually absent — a family names its own sheet.
+ */
+function headerOf(config: WordStudyConfig): SheetOptions {
+  const topic = topicOf(config.topic);
+  const style = styleOf(config);
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? topic.title,
+    instructions: config.instructions ?? topic.instruction[style],
+  };
+}
+
+/** One line naming what the sheet holds, in the terms it was chosen by. */
+export function describeStudy(config: WordStudyConfig): string {
+  const topic = topicOf(config.topic);
+  // What the sheet will print rather than what was asked for, and by the same
+  // arithmetic the build uses — a line that promised twenty over a page of
+  // fourteen would be wrong in the record book and in the picker at once.
+  const room = Math.min(studyLayout(config).perPage, topic.questions.length);
+  const asked = clamp(config.count ?? room, 0, room);
+  return [
+    topic.label,
+    `${asked} ${asked === 1 ? "question" : "questions"}`,
+    STYLE_WORDS[styleOf(config)],
+  ].join(" — ");
+}
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+export function buildStudySheet(config: WordStudyConfig, seed: number): Sheet {
+  const head = headerOf(config);
+  const { blocks, outOf } = bodyOf(config, seed);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is on the page rather than what was asked for: a sheet
+      // that says "/ 20" over eighteen questions is wrong twice.
+      score: { outOf },
+    },
+    blocks,
+    // The jungle, as a spelling sheet does: it is the word world, and a child
+    // who has just sorted twenty plurals on paper is the one likeliest to run
+    // the race that reads words aloud (§16).
+    footer: { credit: SHEET_CREDIT, url: gameUrl("jungle"), seed },
+    answers: false,
+  };
+}
+
+export const WORD_STUDY_SHEET: SheetSpec<WordStudyConfig> = {
+  id: "word-study",
+  label: "Word study",
+  world: SHEET_WORLD,
+  build: buildStudySheet,
+  // Every answer was decided when the sheet was built — which questions were
+  // drawn, which options they were printed against, which column the pair
+  // landed in — so a key cannot disagree with the sheet it belongs to.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeStudy,
+};

--- a/src/engine/sheets/words/study.ts
+++ b/src/engine/sheets/words/study.ts
@@ -477,8 +477,14 @@ function bodyOf(
   const drawn = studyQuestions(config, seed);
   const outOf = drawn.length;
   const style = styleOf(config);
-  // One generator for the whole page, so the draw and the options are one
-  // sequence and the sheet is reproducible from its seed alone (§7).
+  // A second generator off the same seed — `studyQuestions` made its own for
+  // the draw and this one shuffles the options. Two streams rather than one, as
+  // in `spelling.ts`, and reproducibility comes from the seed being fixed
+  // rather than from there being a single sequence: same seed, same draw, same
+  // options, every build (§7). What it costs is that the options replay values
+  // the draw already spent, which is harmless — they are consumed against
+  // different lengths — but it does mean anything reaching for statistical
+  // independence between the two has to thread one generator through instead.
   const rand = mulberry32(seed);
 
   if (style === "choose") {

--- a/src/games/printshop/Bootstrap.tsx
+++ b/src/games/printshop/Bootstrap.tsx
@@ -2,12 +2,13 @@
  * The three ways into a sheet that is already about something (§14).
  *
  * Three buttons and not a wizard, because each one is a source a parent
- * already has: the record book knows what their child keeps missing, the word
- * lists they typed into Word Jungle are sitting in IndexedDB, and this week's
- * spellings are on a letter they can paste. None of the three is a new kind of
- * sheet — they all end at `bench.open(config, seed)` with a config the picker
- * and the panels below can then tune, which is why a bootstrap is a way to
- * start rather than a mode to be in.
+ * already has: the record book knows what their child keeps missing, the sight
+ * words this build ships and the lists they typed into Word Jungle are both a
+ * list already, and this week's spellings are on a letter they can paste. None
+ * of the three is a new kind of sheet — they all end at
+ * `bench.open(config, seed)` with a config the picker and the panels below can
+ * then tune, which is why a bootstrap is a way to start rather than a mode to be
+ * in.
  *
  * Everything here goes through a service. The missed facts come from
  * `services/practice.ts` and the saved lists from `services/decks.ts`; nothing
@@ -17,6 +18,7 @@
 import { useEffect, useState } from "react";
 
 import { Button, Field, Select } from "@/components/ui/kit";
+import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
 import { PRACTICE_SEED, wordsSheet } from "@/engine/sheets/practice";
 import type { SheetConfig } from "@/engine/sheets/types";
 import type { CustomDeck } from "@/engine/types";
@@ -36,21 +38,31 @@ export function Bootstrap({ onOpen }: { onOpen: Open }) {
         bench, so the style, the paper and the rest are still yours to change.
       </p>
       <Missed onOpen={onOpen} />
-      <FromSavedList onOpen={onOpen} />
+      <FromWordList onOpen={onOpen} />
       <FromPaste onOpen={onOpen} />
     </section>
   );
 }
 
+/** A list to print, whoever wrote it: the id, how it reads, and the words. */
+type Listed = { id: string; label: string; words: string[] };
+
 /**
- * A word list a parent already typed in, as paper.
+ * A word list, as paper — the shipped sight-word lists and every list a parent
+ * has typed in, in one control.
  *
- * Nearly free, and the reason it is here rather than in a later story: the
- * data is in IndexedDB already, parsed already, and a spelling deck is exactly
- * a spelling sheet's content. One press turns this week's list into a
- * worksheet; the style control beside it turns that into three of them.
+ * Nearly free, and the reason it is here rather than in a later story: both
+ * sources are already parsed, and a spelling deck is exactly a spelling sheet's
+ * content. One press turns this week's list into a worksheet; the style control
+ * beside it turns that into seven of them.
+ *
+ * The two are one picker rather than two steps because a parent choosing a list
+ * is not thinking about where it came from. The shipped ones are listed first
+ * and are always there, which is the reason this step no longer disappears: the
+ * Dolch lists exist whether or not a browser has storage, so the only thing
+ * IndexedDB decides is whether a parent's own lists join them.
  */
-function FromSavedList({ onOpen }: { onOpen: Open }) {
+function FromWordList({ onOpen }: { onOpen: Open }) {
   const [decks, setDecks] = useState<CustomDeck[]>([]);
   const [chosen, setChosen] = useState("");
 
@@ -58,9 +70,8 @@ function FromSavedList({ onOpen }: { onOpen: Open }) {
     let live = true;
     deckService
       .all()
-      // Silent on failure, unlike the missed-facts panel above: this is the
-      // one of the three that a parent has no reason to expect, so a browser
-      // with no storage simply doesn't offer it rather than explaining itself
+      // Silent on failure, unlike the missed-facts panel above: a browser with
+      // no storage simply offers the shipped lists rather than explaining itself
       // twice on one screen.
       .then((loaded) => live && setDecks(loaded))
       .catch(() => {});
@@ -69,26 +80,35 @@ function FromSavedList({ onOpen }: { onOpen: Open }) {
     };
   }, []);
 
-  if (decks.length === 0) return null;
-  const deck = decks.find((d) => d.id === chosen) ?? decks[0];
+  const lists: Listed[] = [
+    ...WORD_LISTS.map((list) => ({
+      id: list.id,
+      label: `${list.emoji} ${list.name} — ${list.group}`,
+      words: listWords(list),
+    })),
+    ...decks.map((deck) => ({
+      id: deck.id,
+      label: `${deck.emoji} ${deck.name} — ${deck.words.length} words`,
+      words: deck.words,
+    })),
+  ];
+  const list = lists.find((one) => one.id === chosen) ?? lists[0];
+  if (!list) return null;
 
   return (
     <div className="bootstrap__step">
-      <h3 className="bootstrap__name">A list you saved</h3>
+      <h3 className="bootstrap__name">A word list</h3>
       <Field label="Which list">
         <Select
-          value={deck.id}
+          value={list.id}
           onChange={setChosen}
-          options={decks.map((d) => ({
-            value: d.id,
-            label: `${d.emoji} ${d.name} — ${d.words.length} words`,
-          }))}
+          options={lists.map(({ id, label }) => ({ value: id, label }))}
         />
       </Field>
       <Button
         variant="accent"
         size="sm"
-        onClick={() => onOpen(wordsSheet(deck.words), PRACTICE_SEED)}
+        onClick={() => onOpen(wordsSheet(list.words), PRACTICE_SEED)}
       >
         Make a sheet
       </Button>

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -248,6 +248,21 @@ const DEFAULTS: Record<string, SheetConfig> = {
     count: STARTER_WORDS.length,
     columns: 2,
   },
+  "word-study": {
+    ...BASE,
+    kind: "word-study",
+    // Rhyming, circled: the youngest sheet on this shelf and the one that looks
+    // most like a worksheet at a glance, which is what the bench opening on it
+    // has to do. Every other topic is one control away, and the control lists
+    // them in the order they are taught.
+    topic: "rhyming",
+    style: "choose",
+    count: 12,
+    // Only the written topics lay their questions out across the page, and this
+    // is what they get when a parent switches to one — a circle-one sheet is a
+    // list down the page whatever this says (`studyLayout`).
+    columns: 2,
+  },
   handwriting: {
     ...BASE,
     kind: "handwriting",

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -36,6 +36,7 @@ import { StatisticsPanel } from "./statistics";
 import { TimePanel } from "./time";
 import { WordProblemsPanel } from "./wordproblems";
 import { WordsPanel } from "./words";
+import { WordStudyPanel } from "./wordstudy";
 import type { PanelProps } from "./parts";
 
 type FamilyPanel = (props: PanelProps) => ReactNode;
@@ -88,6 +89,7 @@ const PANELS: Record<string, FamilyPanel> = {
   statistics: panel(StatisticsPanel),
   "word-problems": panel(WordProblemsPanel),
   words: panel(WordsPanel),
+  "word-study": panel(WordStudyPanel),
   handwriting: panel(HandwritingPanel),
   memory: panel(MemoryPanel),
 };

--- a/src/games/printshop/options/words.tsx
+++ b/src/games/printshop/options/words.tsx
@@ -7,10 +7,13 @@
  * comes first, and it is the same box the bootstrap pastes into — see
  * `WordList` in parts.tsx for why there is only one of them.
  *
- * Two of the four steppers are conditional, and neither is a nicety. Nothing
- * is written three times on a sheet that is only numbered lines, and nothing
- * has letters taken out of it unless the gaps are the exercise. An option that
- * does nothing teaches a parent that the panel doesn't do what it says.
+ * Two of the steppers are conditional, and neither is a nicety. Nothing is
+ * written three times on a sheet that is only numbered lines, and nothing has
+ * letters taken out of it unless the gaps are the exercise. An option that does
+ * nothing teaches a parent that the panel doesn't do what it says — which is
+ * also why the columns stepper disappears on the two styles that are a list down
+ * the page rather than a grid across it (`wordsLayout` is the half of this that
+ * decides).
  */
 import { FieldSet, NumberStepper } from "@/components/ui/kit";
 import type { WordSheetStyle, WordsConfig } from "@/engine/sheets/types";
@@ -19,13 +22,34 @@ import { parseWords } from "@/services/decks";
 
 import { Choice, Sizing, WordList, opt, type PanelProps } from "./parts";
 
+/**
+ * The seven exercises, in the order a week uses them: look at the word, take it
+ * apart, then be tested on it.
+ */
 const STYLES = [
   opt<WordSheetStyle>("copy", "Write it out"),
+  opt<WordSheetStyle>("shapes", "Word shapes"),
   opt<WordSheetStyle>("missing", "Missing letters"),
+  opt<WordSheetStyle>("find", "Find the word"),
+  opt<WordSheetStyle>("abc", "ABC order"),
+  opt<WordSheetStyle>("sentence", "In a sentence"),
   opt<WordSheetStyle>("test", "Spelling test"),
 ];
 
+/** The styles that put a ruled line under every word, and what to call them. */
+const LINES: Partial<
+  Record<WordSheetStyle, { legend: string; label: string }>
+> = {
+  copy: { legend: "Times each", label: "Times each word is written" },
+  sentence: { legend: "Lines each", label: "Lines to write a sentence on" },
+};
+
+/** The two styles that are one word to a line whatever the config says. */
+const DOWN_THE_PAGE: WordSheetStyle[] = ["missing", "find"];
+
 export function WordsPanel({ config, set }: PanelProps<WordsConfig>) {
+  const lines = LINES[config.style];
+
   return (
     <>
       <WordList
@@ -50,10 +74,10 @@ export function WordsPanel({ config, set }: PanelProps<WordsConfig>) {
         options={STYLES}
       />
 
-      {config.style === "copy" && (
-        <FieldSet legend="Times each">
+      {lines && (
+        <FieldSet legend={lines.legend}>
           <NumberStepper
-            label="Times each word is written"
+            label={lines.label}
             value={config.times}
             min={1}
             max={MAX_TIMES}
@@ -77,12 +101,12 @@ export function WordsPanel({ config, set }: PanelProps<WordsConfig>) {
         </FieldSet>
       )}
 
-      {/* A gapped word is a line of its own, so that sheet has no columns to
-          choose — see `wordsLayout`, which is the half of this that decides. */}
       <Sizing
         label="Words"
         count={config.count}
-        columns={config.style === "missing" ? undefined : config.columns}
+        columns={
+          DOWN_THE_PAGE.includes(config.style) ? undefined : config.columns
+        }
         onCount={(count) => set({ count })}
         onColumns={(columns) => set({ columns })}
         maxColumns={3}

--- a/src/games/printshop/options/wordstudy.tsx
+++ b/src/games/printshop/options/wordstudy.tsx
@@ -1,0 +1,75 @@
+/**
+ * Which lesson about words, and how the question is put.
+ *
+ * Two controls, and the second one depends on the first: a topic states the
+ * styles it can honestly be asked in (`studyStyles`), so the row of shapes below
+ * is built from the topic rather than being a fixed three with one of them
+ * greyed out. "Write a word that rhymes with cat" is a fine thing to ask a child
+ * and cannot be printed with an answer key, so rhyming does not offer it — and a
+ * control that offered it anyway would be a control that lies.
+ *
+ * Switching to a topic that cannot do the style already chosen sets the style as
+ * well, in the same patch. The engine resolves it either way (`styleOf` never
+ * throws), but a panel showing "Join them up" over a sheet that plainly writes
+ * them out is the panel disagreeing with the paper.
+ */
+import type { WordStudyConfig, WordStudyStyle } from "@/engine/sheets/types";
+import {
+  STUDY_TOPICS,
+  studyStyles,
+  studyTopicLabel,
+} from "@/engine/sheets/words/study";
+
+import { Choice, Sizing, opt, type PanelProps } from "./parts";
+
+/** The ten topics, in the order the engine lists them — roughly by age. */
+const TOPICS = STUDY_TOPICS.map((topic) => opt(topic, studyTopicLabel(topic)));
+
+const STYLE_LABELS: Record<WordStudyStyle, string> = {
+  write: "Write it",
+  choose: "Circle one",
+  match: "Join them up",
+};
+
+export function WordStudyPanel({ config, set }: PanelProps<WordStudyConfig>) {
+  const styles = studyStyles(config.topic);
+  const style = styles.includes(config.style) ? config.style : styles[0];
+
+  return (
+    <>
+      <Choice
+        label="Topic"
+        value={config.topic}
+        onChange={(topic) =>
+          set(
+            studyStyles(topic).includes(style)
+              ? { topic }
+              : { topic, style: studyStyles(topic)[0] },
+          )
+        }
+        options={TOPICS}
+        hint="One topic to a sheet. These are separate weeks in every scheme there is, and the instruction line can only say one thing."
+      />
+
+      {styles.length > 1 && (
+        <Choice
+          label="How it is asked"
+          value={style}
+          onChange={(next) => set({ style: next })}
+          options={styles.map((one) => opt(one, STYLE_LABELS[one]))}
+        />
+      )}
+
+      {/* Only the written topics lay their questions out across the page: a row
+          of options and a matching column are both the width of the paper. */}
+      <Sizing
+        label="Questions"
+        count={config.count}
+        columns={style === "write" ? config.columns : undefined}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={3}
+      />
+    </>
+  );
+}

--- a/src/pages/printables/_spelling.test.ts
+++ b/src/pages/printables/_spelling.test.ts
@@ -196,6 +196,10 @@ describe("the sheet on a catalog page", () => {
       // a handwriting sheet and has nothing anybody can award a mark for.
       if (sheet.config.kind === "handwriting") {
         expect(header.score, sheet.slug).toBeUndefined();
+        // And titled after the page it came off rather than after the family
+        // that built it: paper headed "Handwriting practice" on a sight-word
+        // page is paper that disagrees with the page it was printed from.
+        expect(header.title, sheet.slug).toBe(sheet.name);
       } else {
         expect(header.score?.outOf, sheet.slug).toBe(promised(sheet.config));
       }

--- a/src/pages/printables/_spelling.test.ts
+++ b/src/pages/printables/_spelling.test.ts
@@ -1,0 +1,276 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet } from "@/engine/sheets";
+import type { Block, SheetConfig } from "@/engine/sheets/types";
+import { STUDY_TOPICS } from "@/engine/sheets/words/study";
+
+import { BIBLE_SHEETS, hrefFor as bibleHref } from "./_bible";
+import { PAPER_SHEETS, STOCKS, pathFor as paperPath } from "./_catalog";
+import { CURSIVE_SHEETS, hrefFor as cursiveHref } from "./_cursive";
+import { HANDWRITING_SHEETS, hrefFor as handwritingHref } from "./_handwriting";
+import { MATHS_SHEETS, pathFor as mathsPath } from "./_maths";
+import {
+  SPELLING_GROUPS,
+  SPELLING_SEED,
+  SPELLING_SHEETS,
+  builderHref,
+  keyed,
+  pathFor,
+  spellingShelf,
+  type SpellingSheet,
+} from "./_spelling";
+
+/**
+ * The spelling catalog, held to the four things a catalog page has to be.
+ *
+ * **It has to be a worksheet.** Every entry is prerendered as the page a parent
+ * lands on (§8), so an entry whose config produces an empty page is a URL in the
+ * sitemap with nothing on it.
+ *
+ * **It has to print everything it promised.** A count is a request everywhere
+ * else in the shop, capped at what the page holds — but a catalog page's prose
+ * says "eighteen words" in as many words, and a sheet that quietly dropped two
+ * off the bottom would look exactly like a sheet that didn't. So every entry is
+ * checked against its own config rather than against the family's cap.
+ *
+ * **It has to be curated.** No two entries print the same sheet, no two answer
+ * the same query, and every one carries prose somebody wrote.
+ *
+ * **It has to be reachable.** Every slug in the sitemap, and every slug distinct
+ * from the five catalogs that share the prefix.
+ */
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/** How many things a block puts on the paper, whichever kind it is. */
+function items(block: Block): number {
+  switch (block.kind) {
+    case "problems":
+      return block.items.length;
+    case "blanks":
+      return block.sentences.length;
+    case "choice":
+      return block.questions.length;
+    case "wordshapes":
+      return block.words.length;
+    case "matching":
+      return block.left.length;
+    case "trace":
+      return block.rows.length;
+    default:
+      return 0;
+  }
+}
+
+/** What the config asked for, read off the config rather than off the family. */
+function promised(config: SheetConfig): number {
+  if (config.kind === "words") return config.words.length;
+  if (config.kind === "word-study") return config.count;
+  // The tracing sheet: one row per word, which the handwriting family decides.
+  if (config.kind === "handwriting") return config.words?.length ?? 0;
+  return 0;
+}
+
+const built = (sheet: SpellingSheet) => buildSheet(sheet.config, SPELLING_SEED);
+
+describe("the spelling catalog", () => {
+  it("is bounded, and every slug is a route somebody could type", () => {
+    for (const sheet of SPELLING_SHEETS) {
+      expect(sheet.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+    expect(new Set(SPELLING_SHEETS.map((sheet) => sheet.slug)).size).toBe(
+      SPELLING_SHEETS.length,
+    );
+  });
+
+  it("never claims a path another shelf already prints on", () => {
+    // Six route patterns over one prefix. They only coexist because the paths
+    // they emit are disjoint; the day they are not, Astro has two routes for one
+    // URL and picks one of them.
+    const taken = new Set([
+      ...PAPER_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => `/printables/${paperPath(sheet, stock)}`),
+      ),
+      ...MATHS_SHEETS.map((sheet) => mathsPath(sheet)),
+      ...HANDWRITING_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => handwritingHref(sheet, stock)),
+      ),
+      ...CURSIVE_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => cursiveHref(sheet, stock)),
+      ),
+      ...BIBLE_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => bibleHref(sheet, stock)),
+      ),
+    ]);
+    for (const sheet of SPELLING_SHEETS) {
+      expect(taken.has(pathFor(sheet)), sheet.slug).toBe(false);
+    }
+  });
+
+  it("answers a different query on every page", () => {
+    const fields = ["keyword", "heading", "name", "short"] as const;
+    for (const field of fields) {
+      const values = SPELLING_SHEETS.map((sheet) => sheet[field]);
+      expect(new Set(values).size, `duplicate ${field}`).toBe(values.length);
+    }
+  });
+
+  it("prints a different sheet on every page", () => {
+    const configs = SPELLING_SHEETS.map((sheet) =>
+      JSON.stringify(sheet.config),
+    );
+    expect(new Set(configs).size).toBe(configs.length);
+  });
+
+  it("carries prose on every page rather than a filled-in template", () => {
+    for (const sheet of SPELLING_SHEETS) {
+      expect(sheet.notes.length, sheet.slug).toBeGreaterThanOrEqual(2);
+      for (const note of sheet.notes) {
+        expect(note.length, sheet.slug).toBeGreaterThan(200);
+      }
+      expect(sheet.lead.length, sheet.slug).toBeGreaterThan(80);
+      expect(sheet.summary.length, sheet.slug).toBeGreaterThan(40);
+      expect(sheet.teaches, sheet.slug).not.toBe("");
+      expect(sheet.ages, sheet.slug).toMatch(/^Ages /);
+    }
+  });
+
+  it("shelves every sheet exactly once", () => {
+    const shelved = spellingShelf().flatMap((group) => group.sheets);
+    expect(shelved).toHaveLength(SPELLING_SHEETS.length);
+    expect(spellingShelf().every((group) => group.sheets.length > 0)) //
+      .toBe(true);
+    expect(SPELLING_GROUPS).toHaveLength(spellingShelf().length);
+  });
+
+  it("covers the whole of what the story asked for", () => {
+    // The five spelling styles the story names, the sight-word trio, and a page
+    // for every word-study topic — so each of them is a thing a parent can print
+    // rather than a thing the engine can do.
+    const styles = SPELLING_SHEETS.flatMap((sheet) =>
+      sheet.config.kind === "words" ? [sheet.config.style] : [],
+    );
+    for (const style of [
+      "copy",
+      "missing",
+      "abc",
+      "shapes",
+      "sentence",
+      "find",
+    ])
+      expect(styles, style).toContain(style);
+
+    const topics = SPELLING_SHEETS.flatMap((sheet) =>
+      sheet.config.kind === "word-study" ? [sheet.config.topic] : [],
+    );
+    expect(new Set(topics)).toEqual(new Set(STUDY_TOPICS));
+
+    // Trace, write, find — the three sight-word sheets, one of them ruled.
+    const sight = SPELLING_SHEETS.filter((sheet) => sheet.group === "sight");
+    expect(sight.map((sheet) => sheet.config.kind)).toEqual(
+      expect.arrayContaining(["handwriting", "words"]),
+    );
+    expect(sight).toHaveLength(3);
+  });
+});
+
+describe("the sheet on a catalog page", () => {
+  it("prints every word and every question it promised", () => {
+    for (const sheet of SPELLING_SHEETS) {
+      const blocks = built(sheet).blocks;
+      const printed = blocks.reduce((total, block) => total + items(block), 0);
+      expect(printed, sheet.slug).toBe(promised(sheet.config));
+      expect(printed, sheet.slug).toBeGreaterThan(7);
+    }
+  });
+
+  it("has a title, an instruction and a score box on it", () => {
+    for (const sheet of SPELLING_SHEETS) {
+      const header = built(sheet).header;
+      expect(header.title, sheet.slug).not.toBe("");
+      expect(header.instructions, sheet.slug).toBeTruthy();
+      // Marked out of what is on the page — except the tracing sheet, which is
+      // a handwriting sheet and has nothing anybody can award a mark for.
+      if (sheet.config.kind === "handwriting") {
+        expect(header.score, sheet.slug).toBeUndefined();
+      } else {
+        expect(header.score?.outOf, sheet.slug).toBe(promised(sheet.config));
+      }
+    }
+  });
+
+  it("points back at the game that reads these words aloud", () => {
+    for (const sheet of SPELLING_SHEETS) {
+      if (sheet.config.kind === "handwriting") continue;
+      expect(built(sheet).footer.url, sheet.slug) //
+        .toBe("schoolskills.app/spelling/play");
+    }
+  });
+
+  it("is the same sheet on every build", () => {
+    for (const sheet of SPELLING_SHEETS) {
+      expect(JSON.stringify(built(sheet)), sheet.slug) //
+        .toBe(JSON.stringify(buildSheet(sheet.config, SPELLING_SEED)));
+    }
+  });
+
+  it("has an answer key exactly where there is an answer to print", () => {
+    for (const sheet of SPELLING_SHEETS) {
+      const key = answerKey(sheet.config, SPELLING_SEED);
+      const blank = built(sheet);
+      // The key is the same build with `answers` flipped, never a second
+      // generation of the answers — so the two can never disagree (§7).
+      expect({ ...key, answers: false, footer: blank.footer }, sheet.slug) //
+        .toEqual(blank);
+
+      if (!keyed(sheet)) continue;
+      // And where a key is printed, it has something on it the sheet withheld.
+      expect(key.answers, sheet.slug).toBe(true);
+      expect(key.footer.note, sheet.slug).toBe("Answer key");
+    }
+  });
+});
+
+describe("the link into the builder", () => {
+  it("opens the bench on the sheet that was printed", () => {
+    for (const sheet of SPELLING_SHEETS) {
+      const href = builderHref(sheet);
+      expect(href.startsWith("/printables/make#s=")).toBe(true);
+
+      const payload = href.slice("/printables/make#s=".length);
+      const base64 = payload.replaceAll("-", "+").replaceAll("_", "/");
+      const shared = JSON.parse(
+        atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")),
+      );
+      expect(shared).toEqual({ config: sheet.config, seed: SPELLING_SEED });
+    }
+  });
+});
+
+describe("the sitemap", () => {
+  /*
+   * A URL missing from the sitemap is the failure nobody notices — nothing
+   * breaks, the page is simply never submitted. Skipped when there is no
+   * `dist/`, exactly as the other catalogs' are; CI builds before it runs the
+   * suite.
+   */
+  it("carries every spelling slug and the hub", () => {
+    const file = `${ROOT}/dist/sitemap-0.xml`;
+    if (!existsSync(file)) return; // `npm run build` hasn't run yet.
+
+    const xml = readFileSync(file, "utf8");
+    const found = new Set(
+      [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) =>
+        new URL(match[1]).pathname.replace(/\/$/, ""),
+      ),
+    );
+
+    expect(found.has("/printables/spelling")).toBe(true);
+    for (const sheet of SPELLING_SHEETS) {
+      expect(found.has(pathFor(sheet)), sheet.slug).toBe(true);
+    }
+  });
+});

--- a/src/pages/printables/_spelling.ts
+++ b/src/pages/printables/_spelling.ts
@@ -1,0 +1,544 @@
+/**
+ * The spelling and word-study sheets the Print Shop has set, and the words that
+ * go round them.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data two pages
+ * share — `spelling/[slug].astro`, which prerenders one sheet per entry, and
+ * `spelling/index.astro`, which is the subject hub — rather than a route of its
+ * own. `_catalog.ts` does that job for paper, `_maths.ts` for maths and
+ * `_handwriting.ts`, `_cursive.ts` and `_bible.ts` for the writing shelves.
+ *
+ * **The slugs are curated; the sheets are generated.** §8 is explicit about why.
+ * Seven styles over any list a parent can type, times ten word-study topics in
+ * three shapes of question, is a set with no bottom to it — so eighteen slugs,
+ * each one a phrase somebody types into a search box, each with prose that is
+ * true of that sheet and of no other, and everything else reached through the
+ * builder, which is where *choosing* belongs.
+ *
+ * **Where the words come from.** Every spelling sheet here is set on one of the
+ * six shipped Dolch lists, which is the point rather than a convenience: the
+ * words a child races in the jungle are the words they write on paper, and the
+ * age band on the list is what decides which page a parent lands on. A list of
+ * their own is the same sheet with the box refilled — the builder's second
+ * bootstrap, one press from every page on this shelf.
+ *
+ * **One stock, as with maths and unlike paper.** Nothing on a spelling sheet is
+ * a measurement: there is no ⅝ rule to be scaled into a ⅗ rule by a printer
+ * loaded with A4, so the sheet is correct on either stock and the A4 switch lives
+ * in the builder with the other options. The one page here that *is* ruled — the
+ * tracing sheet — says so and links to the handwriting shelf, which comes on
+ * both.
+ */
+import { WORD_LISTS, listWords, type WordList } from "@/engine/decks/wordlists";
+import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
+import type {
+  SheetConfig,
+  WordSheetStyle,
+  WordStudyConfig,
+  WordStudyStyle,
+  WordStudyTopic,
+  WordsConfig,
+} from "@/engine/sheets/types";
+
+import { SHEET_FIELDS as FIELDS, benchHref, paperOf, shelve } from "./_catalog";
+
+/** How the hub groups the shelf: what the sheet is really about. */
+export type SpellingGroup = "spelling" | "sight" | "study";
+
+export type SpellingSheet = {
+  /** The route under /printables/spelling, and the head term it answers. */
+  slug: string;
+  /** How it is listed on a hub. */
+  name: string;
+  /** How it is labelled in the row of neighbouring sheets. A few words. */
+  short: string;
+  /** The page's `<h1>`. */
+  heading: string;
+  /** The query this page exists to answer, in the words a parent types. */
+  keyword: string;
+  /** One sentence of what is on the sheet. Used in the description and hubs. */
+  summary: string;
+  /** The lead paragraph: what the sheet asks for, stated plainly. */
+  lead: string;
+  /** Two things that are true of this sheet and not of the one beside it. */
+  notes: string[];
+  /** For the `LearningResource` block. */
+  teaches: string;
+  ages: string;
+  group: SpellingGroup;
+  /** The sheet itself. Prerendered at build time — this IS the page (§8). */
+  config: SheetConfig;
+};
+
+/**
+ * The seed every sheet on this shelf is built from, and it never moves.
+ *
+ * On half of these it decides nothing — a list written out three times is the
+ * list — and on the other half it decides which letters come out, which near
+ * misses a word is printed against, and which twelve of the bank's questions
+ * land. Which is exactly what §7 promises stays put: the sheet a parent printed
+ * in March is the sheet they print in June, down to the gaps.
+ */
+export const SPELLING_SEED = 1;
+
+/**
+ * A shipped list, by id.
+ *
+ * Throws rather than falling back, and this is the one place in the shop where
+ * that is right: it runs at build time over data in this repository, so a slug
+ * naming a list that has been renamed is a broken page — and the honest moment
+ * to find that out is the build rather than the morning a parent prints it.
+ */
+function listOf(id: string): WordList {
+  const found = WORD_LISTS.find((list) => list.id === id);
+  if (!found) throw new Error(`No shipped word list "${id}"`);
+  return found;
+}
+
+/** The first `count` words of a shipped list, in the order it teaches them. */
+const dolch = (id: string, count: number): string[] =>
+  listWords(listOf(id)).slice(0, count);
+
+/**
+ * A spelling sheet on Letter, with the name and date line printed blank.
+ *
+ * The count follows the list rather than being set beside it: a catalog page
+ * prints every word it names, and `_spelling.test.ts` is what holds it to that —
+ * a list one word longer than the page holds is a sheet that silently teaches
+ * nineteen of twenty words.
+ */
+const spelling = (
+  style: WordSheetStyle,
+  words: string[],
+  over: Partial<WordsConfig> = {},
+): WordsConfig => ({
+  kind: "words",
+  paper: paperOf("letter"),
+  fontPt: DEFAULT_FONT_PT,
+  fields: FIELDS,
+  style,
+  words,
+  times: 3,
+  gaps: 2,
+  columns: 2,
+  count: words.length,
+  ...over,
+});
+
+/** A word-study sheet: a topic, a shape of question, and how many. */
+const study = (
+  topic: WordStudyTopic,
+  style: WordStudyStyle,
+  count: number,
+  columns = 1,
+): WordStudyConfig => ({
+  kind: "word-study",
+  paper: paperOf("letter"),
+  fontPt: DEFAULT_FONT_PT,
+  fields: FIELDS,
+  topic,
+  style,
+  count,
+  columns,
+});
+
+export const SPELLING_SHEETS: SpellingSheet[] = [
+  /* ── Spelling a list ────────────────────────────────────────────────── */
+  {
+    slug: "spelling-practice-worksheets",
+    name: "Spelling practice — write it three times",
+    short: "Write it out",
+    heading: "Spelling practice worksheets",
+    keyword: "Free printable spelling practice worksheets",
+    summary:
+      "Twelve words to write out three times each on ruled lines — the oldest spelling exercise there is, on the words phonics stops helping with.",
+    lead: "One word to a line, printed once to read and then three ruled lines to write it on. The words are the ones that stop yielding to sounding out at about six or seven — “could”, “know”, “once” — which is the point at which writing a word out starts being worth the time.",
+    notes: [
+      "Writing a word three times is not busywork if the word was chosen properly, and that is the whole difference between this page and a page of lines. A word that can be sounded out does not need to be written out; a word like “because” or “friend” has to be held in the hand until it comes back without thinking, and three goes is roughly where that starts. If a child is copying the model letter by letter rather than looking, cover it after the first line.",
+      "The model at the start of the line is printed once and never repeated, which is deliberate. A sheet that prints the word at the head of every line is a tracing exercise wearing a spelling exercise's clothes — the eye never has to hold the word for more than a second. One model, three empty lines, and the last of the three is the one worth marking.",
+    ],
+    teaches: "Spelling high-frequency words",
+    ages: "Ages 6–9",
+    group: "spelling",
+    config: spelling("copy", dolch("dolch-3", 12)),
+  },
+  {
+    slug: "missing-letters-worksheets",
+    name: "Missing letters",
+    short: "Missing letters",
+    heading: "Missing letters worksheets",
+    keyword: "Free printable missing letters worksheets",
+    summary:
+      "Eighteen words with two letters taken out of each — never the first, and never two in a row — with the answer key on the page behind.",
+    lead: "Each word is printed with two of its letters missing and a ruled gap where each one goes. The letters taken out are always inside the word rather than at the start of it, so there is a word to work from rather than a guessing game.",
+    notes: [
+      "Never the first letter, and never two in a row: those two rules are what make this an exercise rather than a puzzle. A child reading “_at” has a word to work from; a child reading “_ _ t” has a lottery. What is being practised is the middle of a word, which is where nearly every spelling mistake in English actually happens — the vowels a speaker cannot hear the difference between and the doubled consonants nobody sounds out.",
+      "The words are the longer sight words, which is where the gaps do the most work. “Because”, “before”, “their” and “would” are all mis-spelt in the middle by the same children who can spell them aloud, and a gap in that exact position is a question they cannot answer by sounding it out. The answer key on the page behind prints the letters back in, so this can be marked by somebody who was not sitting next to them.",
+    ],
+    teaches: "Spelling patterns inside a word",
+    ages: "Ages 6–9",
+    group: "spelling",
+    config: spelling("missing", dolch("dolch-4", 18), { gaps: 2 }),
+  },
+  {
+    slug: "abc-order-worksheets",
+    name: "ABC order",
+    short: "ABC order",
+    heading: "ABC order worksheets",
+    keyword: "Free printable ABC order worksheets",
+    summary:
+      "Fifteen everyday words to put in alphabetical order, printed as a word bank with a numbered ruled line for each, and the ordered list as the key.",
+    lead: "The words down the left are the bank, in no particular order; the ruled lines beside them are where the same words go in alphabetical order. Line one takes the word that comes first in the alphabet, whatever happens to be printed next to it.",
+    notes: [
+      "Alphabetical order is the first thing a child does with the alphabet that is not reciting it, and it is the skill behind every index, dictionary, register and contact list they will ever use. The words here are concrete nouns on purpose — a child sorting “apple”, “ball” and “bed” is thinking about letters rather than about what the words mean, and the two that share a first letter are where the real work is.",
+      "Words sharing an initial are what make a sheet worth doing, so the list is chosen to have several of them. Getting from “ball” to “bed” means going to the second letter, which is the step most children have to be shown once and then never again. The answer key is the same fifteen words in order, so a parent can mark it by reading down one column.",
+    ],
+    teaches: "Alphabetical order",
+    ages: "Ages 5–8",
+    group: "spelling",
+    config: spelling("abc", dolch("dolch-nouns", 15), { columns: 1 }),
+  },
+  {
+    slug: "word-shapes-worksheets",
+    name: "Word shapes",
+    short: "Word shapes",
+    heading: "Word shapes worksheets",
+    keyword: "Free printable word shapes worksheets",
+    summary:
+      "Sixteen words to write into the outline their letters make — a tall box for a letter that reaches the top line, a small one for a letter that does not, and a dropped box for a tail.",
+    lead: "Every word is drawn as a row of boxes, one per letter, and the height of each box is the height of the letter that goes in it. Writing the word into its own shape means deciding, letter by letter, whether it is tall, small, or hangs below the line.",
+    notes: [
+      "Word shapes are the reading scheme's answer to a child who knows all their sounds and still cannot spell, and they work because a word has a silhouette. “Bed” and “bad” are the same three sounds and a different picture; “light” has two tall letters at the front and a tail nowhere. A child who has drawn the shape a few times has a second way of checking a word that has nothing to do with sounding it out.",
+      "The boxes are drawn as hairlines rather than as shaded blocks, which matters more here than it looks: browsers throw away background paint when printing unless somebody has found the “Background graphics” checkbox, and a word-shape sheet whose boxes were a tint comes out of the printer as an empty page. Everything on this sheet is a stroke, so it prints as it looks. The answer key writes each letter into its own box.",
+    ],
+    teaches: "Recognising the shape of a word",
+    ages: "Ages 5–8",
+    group: "spelling",
+    config: spelling("shapes", dolch("dolch-3", 16)),
+  },
+  {
+    slug: "spelling-sentence-worksheets",
+    name: "Use it in a sentence",
+    short: "In a sentence",
+    heading: "Spelling sentence worksheets",
+    keyword: "Free printable spelling sentence worksheets",
+    summary:
+      "Eight of the hardest sight words, each with two ruled lines to use it in a sentence of the child's own.",
+    lead: "One word at the top of each group and two ruled lines under it. Nothing to copy: what goes on the lines is a sentence the child writes, using the word properly, with a capital at the front and a full stop at the end.",
+    notes: [
+      "A word is not learnt until it has been used, and this is the sheet that asks for that. A child can spell “together” in a test on Friday and still not put it in a sentence, and the gap between those two things is most of what a spelling list is for. It is also the page where handwriting, punctuation and spelling are being practised at once, which is why the lines are ruled rather than blank.",
+      "There is no answer key on this one, and there should not be: a sentence a child wrote is not a thing that has a right answer printed somewhere. What a parent marks is whether the word is spelt correctly and used as the word actually means — which is worth a conversation rather than a tick, and is the reason this sheet is eight words long rather than twenty.",
+    ],
+    teaches: "Using spelling words in writing",
+    ages: "Ages 7–10",
+    group: "spelling",
+    config: spelling("sentence", dolch("dolch-5", 8), { times: 2, columns: 1 }),
+  },
+
+  /* ── Sight words ────────────────────────────────────────────────────── */
+  {
+    slug: "sight-word-worksheets",
+    name: "Sight words to write out",
+    short: "Sight words",
+    heading: "Sight word worksheets",
+    keyword: "Free printable sight word worksheets",
+    summary:
+      "The first twelve sight words, each written out three times on ruled lines — the words that turn up most often and are least worth sounding out.",
+    lead: "The first twelve words of the Dolch list, one to a line, each printed once and then written three times. These are the words a beginning reader meets most often and can least afford to stop at.",
+    notes: [
+      "A sight word is one worth knowing by sight rather than by sounding out, and the reason is arithmetic: a hundred or so words make up about half of everything a child reads, and a good many of them — “said”, “one”, “come”, “because” — do not say what their letters suggest. Time spent on these is worth several times the same time spent on a word a child could have worked out.",
+      "Writing them is a different exercise from reading them, and this is the sheet that closes that gap. A child who recognises “away” instantly on a page can still stall when asked to write it, because recognising a word and producing it are two different pieces of memory. Three goes at each, with the model printed once, is what turns the first into the second.",
+    ],
+    teaches: "Writing first sight words",
+    ages: "Ages 4–6",
+    group: "sight",
+    config: spelling("copy", dolch("dolch-1", 12)),
+  },
+  {
+    slug: "sight-word-tracing-worksheets",
+    name: "Sight words to trace",
+    short: "Trace them",
+    heading: "Sight word tracing worksheets",
+    keyword: "Free printable sight word tracing worksheets",
+    summary:
+      "Twelve sight words on ⅝-inch handwriting paper, each traced once in dots and then written on an empty stretch of line.",
+    lead: "One word to a line on ruled handwriting paper: a solid model to read, a dotted word to trace over, and then empty line to write it on. Spelling and handwriting in the same three minutes.",
+    notes: [
+      "Tracing before writing is the right order at this age and the wrong place to stop. A dotted word practises following a line; the empty stretch after it is where a child practises writing the word, and it is the part that teaches. This sheet is one line of each because that is what fits on ⅝-inch paper with room to write — the ruling is a real ⅝ of an inch, which is what a school means by handwriting paper.",
+      "It is a handwriting sheet whose words happen to be a spelling list, which is why it is ruled and the rest of this shelf is not. That also means it comes on A4 as well as on US Letter, over on the handwriting shelf: a ruling shrunk to fit whatever is in the printer is no longer the size it was chosen for, and every ruled sheet here has a twin measured for the other stock.",
+    ],
+    teaches: "Tracing and writing sight words",
+    ages: "Ages 4–6",
+    group: "sight",
+    config: {
+      kind: "handwriting",
+      paper: paperOf("letter"),
+      fontPt: DEFAULT_FONT_PT,
+      fields: FIELDS,
+      style: "words",
+      words: dolch("dolch-2", 12),
+      rule: { style: "hand-5-8", midline: "dashed", descender: true },
+      trace: "dotted",
+      repeats: 3,
+    },
+  },
+  {
+    slug: "sight-word-find-worksheets",
+    name: "Find the sight word",
+    short: "Find it",
+    heading: "Sight word find worksheets",
+    keyword: "Free printable sight word find worksheets",
+    summary:
+      "Twelve sight words, each printed beside three words it is easily mistaken for, with the matching one to circle and the key behind.",
+    lead: "The word is at the start of the line and four words follow it. One of them is the same word; the other three are the words this one gets confused with. Circle the one that matches.",
+    notes: [
+      "The three wrong answers are chosen rather than random, and that is the whole of the exercise. A word printed against three unrelated words is found by glancing at the first letter; a word printed against the words that start the same way or run to the same length has to actually be read. “There” against “their” and “these” is a question; “there” against “squirrel” is not.",
+      "Picking a word out of a row of near misses is what reading a sentence actually asks of a child, which is why this is worth a page of its own. It is also the one sheet on this shelf that needs no writing at all, so it is a fair thing to hand to a child whose hand is tired — or to one who can read a word and is not yet ready to write it.",
+    ],
+    teaches: "Telling sight words apart",
+    ages: "Ages 5–7",
+    group: "sight",
+    config: spelling("find", dolch("dolch-2", 12)),
+  },
+
+  /* ── Word study ─────────────────────────────────────────────────────── */
+  {
+    slug: "rhyming-words-worksheets",
+    name: "Rhyming words",
+    short: "Rhyming",
+    heading: "Rhyming words worksheets",
+    keyword: "Free printable rhyming words worksheets",
+    summary:
+      "Twelve words, each with four to choose from, and one of the four rhymes with it. The answer key is on the page behind.",
+    lead: "A word at the start of each line and four words to choose between. One of them rhymes with it and the other three do not. Circle the one that does.",
+    notes: [
+      "Hearing that two words rhyme is the first piece of phonological awareness a child gets, and it comes before letters do: it is the skill that lets them notice that “cat” and “hat” differ at the front and are otherwise the same word, which is the whole idea a word family is built on. A child who cannot hear a rhyme yet is not ready for a spelling list, and this page is a fair way to find out.",
+      "Every line comes from a different family of words, which is why the sheet is twelve lines rather than twenty. If two lines came from the same family, both of their answers would rhyme with both of their words — and a question with two right answers on it is worse than no question. Say the options aloud with a child who is guessing; a rhyme is a thing you hear rather than a thing you spot.",
+    ],
+    teaches: "Hearing rhyme",
+    ages: "Ages 4–6",
+    group: "study",
+    config: study("rhyming", "choose", 12),
+  },
+  {
+    slug: "syllable-worksheets",
+    name: "Syllables",
+    short: "Syllables",
+    heading: "Syllable worksheets",
+    keyword: "Free printable syllable worksheets",
+    summary:
+      "Twenty words to break into syllables, from one-beat words up to four, with the count written on a ruled line and the key behind.",
+    lead: "Each word has a ruled slot beside it for how many syllables you can hear in it. Say the word, clap the beats, and write the number down — one for “bridge”, four for “caterpillar”.",
+    notes: [
+      "Counting syllables is what makes a long word writable. A child who tries to spell “caterpillar” in one go gets three letters in and stops; a child who has broken it into four beats has four short words to spell instead, and that is the actual technique behind spelling anything longer than about six letters. It is also how a dictionary breaks a word at the end of a line.",
+      "Every word here is one whose count nobody argues about, which took some choosing. “Family”, “chocolate” and “every” are said with two syllables as often as three depending on who is speaking, so they are not on this sheet: a word whose answer depends on an accent is a word a child gets marked wrong for saying properly. Clap them out loud rather than counting the vowels — the ear is right more often than the spelling is.",
+    ],
+    teaches: "Breaking words into syllables",
+    ages: "Ages 6–9",
+    group: "study",
+    config: study("syllables", "write", 20, 2),
+  },
+  {
+    slug: "word-family-worksheets",
+    name: "Word families",
+    short: "Word families",
+    heading: "Word family worksheets",
+    keyword: "Free printable word family worksheets",
+    summary:
+      "Twenty-four sums to blend into words — a beginning, an ending, and the word the two make — across fourteen of the commonest word families.",
+    lead: "Each line is an addition: a beginning sound, an ending, and a ruled slot for the word they make. “c + at” makes “cat”, and once that is seen, so do “h + at”, “m + at” and “fl + at”.",
+    notes: [
+      "A word family is the most economical thing in early reading: learn one ending and you can read every word that uses it. The child who works out “-op” has hop, mop, pop, top, drop, stop, shop and flop, which is eight words for the price of one — and blending a beginning onto an ending, rather than sounding out a word letter by letter, is the step that makes reading start to move.",
+      "The beginnings include blends as well as single letters, and that is where this sheet earns its second half. Going from “c + at” to “fl + at” means holding two sounds together before the ending, which is the thing a child stalls on for months after single letters are easy. Every answer on this page is a real word — checked, because a sheet whose key contains “jat” teaches a child not to trust the sheet.",
+    ],
+    teaches: "Blending onsets and rimes",
+    ages: "Ages 4–7",
+    group: "study",
+    config: study("families", "write", 24, 3),
+  },
+  {
+    slug: "prefix-worksheets",
+    name: "Prefixes",
+    short: "Prefixes",
+    heading: "Prefix worksheets",
+    keyword: "Free printable prefix worksheets",
+    summary:
+      "Eighteen prefixes to add to the front of a word — un-, re-, dis-, pre-, mis- and more — with the new word written on a ruled line.",
+    lead: "A beginning, a word, and a slot for what the two make. “un + happy” is “unhappy”, and once the pattern is visible a child can read and spell a hundred words they have never met.",
+    notes: [
+      "A prefix is the cheapest vocabulary a child will ever learn. Knowing that “un-” means not, “re-” means again and “dis-” means the opposite turns every root word they already have into two or three more, and it works in reverse too: a reader who meets “unfamiliar” for the first time can take the front off it and be nearly right. Four prefixes cover most of what turns up in primary reading.",
+      "Nothing changes at the join, which is the whole reason prefixes come before suffixes. “un” plus “happy” is “unhappy” with both parts intact — no letter dropped, no letter doubled — so a child can trust the addition. That stops being true the moment an ending is added instead, which is what the suffix sheet is for. “mis + spell” is the one to look at twice: both s's stay, which is why “misspell” is the word people most often mis-spell.",
+    ],
+    teaches: "Prefixes and word building",
+    ages: "Ages 7–10",
+    group: "study",
+    config: study("prefixes", "write", 18, 2),
+  },
+  {
+    slug: "suffix-worksheets",
+    name: "Suffixes",
+    short: "Suffixes",
+    heading: "Suffix worksheets",
+    keyword: "Free printable suffix worksheets",
+    summary:
+      "Eighteen suffixes to add to the end of a word — -ful, -less, -ness, -ly, -ing, -ed and -er — including the words that change before the ending goes on.",
+    lead: "A word, an ending, and a slot for what the two make. Some of them simply join — “care + ful” is “careful” — and some change first: “happy + ness” is “happiness”, and “hop + ing” doubles the p.",
+    notes: [
+      "The words that change are the reason this sheet exists. Adding an ending to a word is straightforward until the word ends in y, in e, or in a single consonant after a short vowel — and those three cases cover most of the spelling mistakes made by children who can already spell every word on their list. Meeting “happiness”, “making” and “hopping” on the same page is what makes the three rules visible as a set rather than as three surprises.",
+      "Every answer here was written out by a person rather than worked out by a rule, and that is deliberate. English has too many exceptions for a generator to be trusted with them: a program that added “-ing” by rule would print “hopeing” or “makeing” somewhere on the page, and an answer key that is wrong is worse than no sheet at all. The words on this page are checked, which is what makes the key behind it worth marking against.",
+    ],
+    teaches: "Suffixes and the spelling changes they cause",
+    ages: "Ages 7–10",
+    group: "study",
+    config: study("suffixes", "write", 18, 2),
+  },
+  {
+    slug: "plural-nouns-worksheets",
+    name: "Plurals — one and more than one",
+    short: "Plurals",
+    heading: "Plural nouns worksheets",
+    keyword: "Free printable plural nouns worksheets",
+    summary:
+      "Twenty words to write as more than one, covering every route English takes to a plural: -s, -es, -ies, -ves, and the ones that change shape entirely.",
+    lead: "“One box, two ____.” Each line gives a word as one of something and asks for it as more than one. Most take an s; a good many do not, and those are the ones worth the page.",
+    notes: [
+      "Plurals look like a single rule and are about six. A word takes -s until it hisses, and then it takes -es; a y after a consonant becomes -ies but a y after a vowel does not; several f words take -ves; and then there are the ones that change in the middle — children, men, feet, teeth, mice, geese — and the two that do not change at all. A child who has met all of those on one page has seen that there is a pattern rather than a rule.",
+      "The irregular ones are the sheet's real content, and they are irregular because they are old: the words English has used most often for longest are the ones that never got tidied up. “Sheep” and “fish” are on here for the same reason — they are the answer a child least expects to be allowed to write, and getting to write “two sheep” once is worth more than another twenty -s words.",
+    ],
+    teaches: "Singular and plural nouns",
+    ages: "Ages 6–9",
+    group: "study",
+    config: study("plurals", "write", 20, 2),
+  },
+  {
+    slug: "contraction-worksheets",
+    name: "Contractions",
+    short: "Contractions",
+    heading: "Contraction worksheets",
+    keyword: "Free printable contraction worksheets",
+    summary:
+      "Twelve pairs of words to join to the short form they make, with the apostrophe where the missing letters were — matched up rather than written out.",
+    lead: "Two columns: the long way on the left, the short way on the right, and a pencil line between them. “Do not” joins to “don’t”, and the apostrophe stands exactly where the missing o used to be.",
+    notes: [
+      "The apostrophe is the whole lesson, and it has one job: it marks where letters were taken out. A child who knows that never has to remember whether it is “dont”, “do’nt” or “don’t” — the o is the letter that went, so the mark goes where the o was. That one idea covers nearly every contraction in English and is worth ten minutes more than it usually gets.",
+      "“Won’t” is the one that breaks it, and it is on this sheet on purpose. It comes from “woll not” rather than “will not”, which no child needs to be told — but it is worth knowing that the mark is not always where the letters came out, so that one odd spelling is met as an exception rather than as evidence that the rule was never real. Matching rather than writing keeps the focus on the pairing; the builder prints the same twelve as a write-it-out sheet.",
+    ],
+    teaches: "Contractions and apostrophes",
+    ages: "Ages 6–9",
+    group: "study",
+    config: study("contractions", "match", 12),
+  },
+  {
+    slug: "homophone-worksheets",
+    name: "Homophones",
+    short: "Homophones",
+    heading: "Homophone worksheets",
+    keyword: "Free printable homophone worksheets",
+    summary:
+      "Twelve sentences with a pair of homophones beside each — their and there, to and two, blue and blew — and a ruled gap for the one that belongs.",
+    lead: "Each sentence has a word missing and the two spellings it could be printed beside it. Only one of them fits the sentence, and the sentence is the only thing that can decide it.",
+    notes: [
+      "A homophone cannot be spelt from its sound, which is what makes this the one word exercise that has to be a sentence. “Their” and “there” are one noise, so a child asked to spell that noise cannot be wrong — there is no answer to the question. Put the noise in “put the box over ___” and there is exactly one right answer, and it is decided by meaning rather than by phonics.",
+      "These are the mistakes that survive into adult writing, which is a fair argument for meeting them early and often. Their/there, to/too/two, your/you’re and its/it’s are mis-spelt by people who spell everything else correctly, because the ear cannot help and the eye was never trained. Both spellings are printed beside every sentence so that the choice is on the page — the exercise is choosing, not remembering that a choice exists.",
+    ],
+    teaches: "Choosing between homophones",
+    ages: "Ages 7–11",
+    group: "study",
+    config: study("homophones", "write", 12),
+  },
+  {
+    slug: "synonym-worksheets",
+    name: "Synonyms",
+    short: "Synonyms",
+    heading: "Synonym worksheets",
+    keyword: "Free printable synonym worksheets",
+    summary:
+      "Twelve words to join to a word that means the same — big and large, begin and start, quiet and silent — in two columns with a pencil line between.",
+    lead: "Two columns of words, and each word on the left means the same as one on the right. Draw a line between them. Every pair is a word a child already has beside a word that will make their writing better.",
+    notes: [
+      "Synonyms are how a piece of writing stops saying “big” four times in a paragraph, and that is worth doing before anybody hands a child a thesaurus. A thesaurus offers twenty words for “big” of which three are usable by a nine-year-old; a page of pairs offers one, and it is one they can actually reach for. Every word on the right of this sheet is one a primary child can use without sounding like a dictionary.",
+      "Matching rather than writing is the right shape for this one, because the pairing is the whole content. There is nothing to spell here and no rule to apply — the question is whether two words mean the same, which is a judgement about meaning and the first properly semantic exercise on this shelf. Say the pairs in a sentence if one looks doubtful: two words mean the same when swapping them leaves the sentence true.",
+    ],
+    teaches: "Words that mean the same",
+    ages: "Ages 7–11",
+    group: "study",
+    config: study("synonyms", "match", 12),
+  },
+  {
+    slug: "antonym-worksheets",
+    name: "Antonyms",
+    short: "Antonyms",
+    heading: "Antonym worksheets",
+    keyword: "Free printable antonym worksheets",
+    summary:
+      "Twelve words, each with four to choose from, and one of the four means the opposite. The answer key prints on the page behind.",
+    lead: "A word at the start of each line and four words after it. One of them means the opposite; circle it. Hot and cold, always and never, push and pull.",
+    notes: [
+      "Opposites are the easiest way into what a word means, which is why they are taught before synonyms and to much younger children. A four-year-old who cannot define “empty” can point at the opposite of “full” without hesitating, and that is the same piece of knowledge arriving by the door it fits through. It is also the pairing that makes early reading comprehension questions answerable.",
+      "The three wrong answers come from the same set of opposites rather than from anywhere, which keeps the exercise honest: every option on the line is a word that is somebody's opposite, so the answer cannot be found by looking for the odd one out. One word is missing from this sheet on purpose — “light”, whose opposite is “dark” and equally “heavy”, so either answer would be marked wrong against the other.",
+    ],
+    teaches: "Words that mean the opposite",
+    ages: "Ages 5–9",
+    group: "study",
+    config: study("antonyms", "choose", 12),
+  },
+];
+
+/** What each group is called on a hub, in the order they are listed. */
+export const SPELLING_GROUPS: Array<{
+  id: SpellingGroup;
+  label: string;
+  blurb: string;
+}> = [
+  {
+    id: "spelling",
+    label: "This week's spelling list",
+    blurb: "Five things to do with a list of words, on paper.",
+  },
+  {
+    id: "sight",
+    label: "Sight words",
+    blurb:
+      "The words that turn up most often and are least worth sounding out — traced, written, and picked out.",
+  },
+  {
+    id: "study",
+    label: "How words work",
+    blurb:
+      "Rhyme, syllables, families, prefixes and suffixes, plurals, contractions, homophones, synonyms and antonyms.",
+  },
+];
+
+/**
+ * Whether this sheet's answer key says anything its sheet doesn't.
+ *
+ * A copying sheet prints the word at the head of every line, so its key is the
+ * same page twice; a sentence sheet has no right answer to print at all. Every
+ * other style here has an answer the sheet is withholding — a missing letter, an
+ * ordered list, which box a letter goes in, which of four words it was — and on
+ * those the key is the most useful thing on the shelf.
+ */
+export function keyed(sheet: SpellingSheet): boolean {
+  const { config } = sheet;
+  if (config.kind === "words")
+    return config.style !== "copy" && config.style !== "sentence";
+  return config.kind === "word-study";
+}
+
+/** The route a sheet prints at. One stock, so one route — see the note above. */
+export const pathFor = (sheet: SpellingSheet): string =>
+  `/printables/spelling/${sheet.slug}`;
+
+/** The builder, opened on this sheet. */
+export const builderHref = (sheet: SpellingSheet): string =>
+  benchHref(sheet.config, SPELLING_SEED);
+
+/** The shelf, grouped — the shape every page lists it in. */
+export function spellingShelf(): Array<{
+  id: SpellingGroup;
+  label: string;
+  blurb: string;
+  sheets: SpellingSheet[];
+}> {
+  return shelve(SPELLING_GROUPS, SPELLING_SHEETS);
+}

--- a/src/pages/printables/_spelling.ts
+++ b/src/pages/printables/_spelling.ts
@@ -152,7 +152,7 @@ export const SPELLING_SHEETS: SpellingSheet[] = [
     keyword: "Free printable spelling practice worksheets",
     summary:
       "Twelve words to write out three times each on ruled lines — the oldest spelling exercise there is, on the words phonics stops helping with.",
-    lead: "One word to a line, printed once to read and then three ruled lines to write it on. The words are the ones that stop yielding to sounding out at about six or seven — “could”, “know”, “once” — which is the point at which writing a word out starts being worth the time.",
+    lead: "One word to a line, printed once to read and then three ruled lines to write it on. The words are the ones that stop yielding to sounding out at about six or seven — “again”, “could”, “every” — which is the point at which writing a word out starts being worth the time.",
     notes: [
       "Writing a word three times is not busywork if the word was chosen properly, and that is the whole difference between this page and a page of lines. A word that can be sounded out does not need to be written out; a word like “because” or “friend” has to be held in the hand until it comes back without thinking, and three goes is roughly where that starts. If a child is copying the model letter by letter rather than looking, cover it after the first line.",
       "The model at the start of the line is printed once and never repeated, which is deliberate. A sheet that prints the word at the head of every line is a tracing exercise wearing a spelling exercise's clothes — the eye never has to hold the word for more than a second. One model, three empty lines, and the last of the three is the one worth marking.",
@@ -173,7 +173,7 @@ export const SPELLING_SHEETS: SpellingSheet[] = [
     lead: "Each word is printed with two of its letters missing and a ruled gap where each one goes. The letters taken out are always inside the word rather than at the start of it, so there is a word to work from rather than a guessing game.",
     notes: [
       "Never the first letter, and never two in a row: those two rules are what make this an exercise rather than a puzzle. A child reading “_at” has a word to work from; a child reading “_ _ t” has a lottery. What is being practised is the middle of a word, which is where nearly every spelling mistake in English actually happens — the vowels a speaker cannot hear the difference between and the doubled consonants nobody sounds out.",
-      "The words are the longer sight words, which is where the gaps do the most work. “Because”, “before”, “their” and “would” are all mis-spelt in the middle by the same children who can spell them aloud, and a gap in that exact position is a question they cannot answer by sounding it out. The answer key on the page behind prints the letters back in, so this can be marked by somebody who was not sitting next to them.",
+      "The words are the longer sight words, which is where the gaps do the most work. “Because”, “before”, “around” and “always” are all mis-spelt in the middle by the same children who can spell them aloud, and a gap in that exact position is a question they cannot answer by sounding it out. The answer key on the page behind prints the letters back in, so this can be marked by somebody who was not sitting next to them.",
     ],
     teaches: "Spelling patterns inside a word",
     ages: "Ages 6–9",
@@ -275,6 +275,11 @@ export const SPELLING_SHEETS: SpellingSheet[] = [
       paper: paperOf("letter"),
       fontPt: DEFAULT_FONT_PT,
       fields: FIELDS,
+      // The one sheet on this shelf built by another family, so the one whose
+      // paper would otherwise come out headed "Handwriting practice" while the
+      // page it printed from is headed for sight words. `title` is the override
+      // for exactly that, and `_spelling.test.ts` holds the two together.
+      title: "Sight words to trace",
       style: "words",
       words: dolch("dolch-2", 12),
       rule: { style: "hand-5-8", midline: "dashed", descender: true },

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -13,6 +13,11 @@ import {
   hrefFor as handwritingHref,
 } from "./_handwriting";
 import { MATHS_SHEETS, mathsShelf, pathFor as mathsPath } from "./_maths";
+import {
+  SPELLING_SHEETS,
+  pathFor as spellingPath,
+  spellingShelf,
+} from "./_spelling";
 
 /**
  * The Print Shop's front door.
@@ -27,11 +32,13 @@ import { MATHS_SHEETS, mathsShelf, pathFor as mathsPath } from "./_maths";
  * It lists what exists and nothing else. A shelf of links to sheets that
  * haven't been built is the thin-content pattern Base.astro's `noindex` block
  * already argues against, and a catalog page here is meant to BE the worksheet
- * — real prerendered HTML a parent can print without touching anything. Five
+ * — real prerendered HTML a parent can print without touching anything. Six
  * families fill it: every ruling in §5 on both stocks, the curated maths topics
  * of §8, each of which prints its own answer key, the handwriting and cursive
- * sheets, which come on both stocks for the same reason the paper does, and the
- * Scripture shelf, which is those same families with a passage on them.
+ * sheets, which come on both stocks for the same reason the paper does, the
+ * Scripture shelf, which is those same families with a passage on them, and the
+ * spelling shelf, which is the one whose content a parent can replace with their
+ * own list.
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
@@ -44,6 +51,7 @@ const strands = mathsShelf();
 const writing = handwritingShelf();
 const joined = cursiveShelf();
 const scripture = bibleShelf();
+const words = spellingShelf();
 ---
 
 <Content
@@ -86,13 +94,14 @@ const scripture = bibleShelf();
   <section class="band band--tight wrap">
     <h2 class="h2">On the shelf now</h2>
     <p class="h2__sub">
-      Five families: maths worksheets, each with its answer key on the page
+      Six families: maths worksheets, each with its answer key on the page
       behind it, handwriting practice that traces before it copies, the same
-      progression again in cursive, Scripture copywork and memory work, and
-      paper in every ruling. Each of these is a page that is itself the sheet
-      &mdash; open it, press print, and that is the whole of it. Everything
-      ruled comes on both stocks, because a ruling shrunk to fit whatever is in
-      the tray is no longer the ruling you chose.
+      progression again in cursive, Scripture copywork and memory work, spelling
+      and word study on this week&rsquo;s list or your own, and paper in every
+      ruling. Each of these is a page that is itself the sheet &mdash; open it,
+      press print, and that is the whole of it. Everything ruled comes on both
+      stocks, because a ruling shrunk to fit whatever is in the tray is no
+      longer the ruling you chose.
     </p>
 
     <h3 class="h2 h2--next">Maths worksheets</h3>
@@ -177,6 +186,27 @@ const scripture = bibleShelf();
       <a class="cta" href="/printables/bible">All the Scripture sheets</a>
     </div>
 
+    <h3 class="h2 h2--next">Spelling and words</h3>
+    <p class="h2__sub">
+      {SPELLING_SHEETS.length} sheets: a week&rsquo;s list in five shapes, sight words
+      to trace, write and find, and ten pages on how words work. Answer keys where
+      there is an answer.
+    </p>
+    {
+      words.map((group) => (
+        <nav class="stones" aria-label={`Spelling — ${group.label}`}>
+          {group.sheets.map((sheet) => (
+            <a class="stone" href={spellingPath(sheet)}>
+              {sheet.short}
+            </a>
+          ))}
+        </nav>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta" href="/printables/spelling">All the spelling sheets</a>
+    </div>
+
     {
       /*
         Paper keeps its groups and its one-line summaries; maths gets a row of
@@ -233,16 +263,16 @@ const scripture = bibleShelf();
       <h2 class="h2">What the press is being set for</h2>
       <p class="h2__sub">
         The Print Shop is opening a family at a time, and this page lists what
-        exists rather than what is planned. Paper, maths, handwriting, cursive
-        and copywork are open. Spelling is next.
+        exists rather than what is planned. Paper, maths, handwriting, cursive,
+        copywork and spelling are open. Phonics is next.
       </p>
       <div class="prose">
         <p>
           The order it opens in: the paper, the maths sheets, the handwriting
           and the cursive above, then the copywork &mdash; a few hundred
-          passages from the public domain, Scripture among them &mdash; then
-          spelling, phonics, and the charts, certificates and planners that are
-          simply blank forms.
+          passages from the public domain, Scripture among them &mdash; then the
+          spelling and word-study shelf, and after that phonics and the charts,
+          certificates and planners that are simply blank forms.
         </p>
         <p>
           The one it is really being built for comes with the sheet builder:

--- a/src/pages/printables/spelling/[slug].astro
+++ b/src/pages/printables/spelling/[slug].astro
@@ -1,0 +1,255 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { answerKey, buildSheet } from "@/engine/sheets";
+import {
+  SPELLING_SEED,
+  SPELLING_SHEETS,
+  builderHref,
+  keyed,
+  pathFor,
+  spellingShelf,
+  type SpellingSheet,
+} from "../_spelling";
+
+/**
+ * One prerendered spelling sheet per topic — and the page is the sheet.
+ *
+ * The shape §8 describes, applied to the shelf where the *content* is the thing
+ * somebody searched for: "free printable rhyming words worksheets" and "plural
+ * nouns worksheets" are queries a parent types, and a page that answers one of
+ * them has prose above the sheet, the sheet itself as HTML under it, and nothing
+ * to click before pressing ⌘P.
+ *
+ * **One stock, as with maths and unlike the ruled shelves.** Nothing on a
+ * spelling sheet is a measurement, so there is no A4 twin to keep in step — the
+ * one ruled page here says so in its own prose and sends a parent to the
+ * handwriting shelf, which has both. That is also why this is a single-segment
+ * `[slug]` under `spelling/` rather than a rest pattern: there is no second
+ * segment to carry.
+ *
+ * **The answer key prints only where there is one.** A copying sheet has the
+ * word at the head of every line already and a sentence sheet has no right
+ * answer at all, so `keyed` decides and those two pages print one article
+ * instead of two identical ones. Where a key does print it is `answerKey` —
+ * `answers` flipped on the same build, so it cannot disagree with the sheet it
+ * belongs to (§7).
+ *
+ * **No client directive on `SheetView`, ever.** `@astrojs/react` renders a
+ * component with no `client:*` to HTML at build time, so these pages ship zero
+ * JavaScript — the whole SEO argument of §2. `Sheet.test.tsx` holds every page in
+ * this directory to it, against the source and against `dist/`.
+ *
+ * **Everything that is not the sheet carries `.no-print`.** `@page` cannot be
+ * scoped to a class, so the zeroed page margin a sheet needs applies to the
+ * prose as well and it would print off the edge.
+ */
+
+type Props = { sheet: SpellingSheet };
+
+export function getStaticPaths() {
+  return SPELLING_SHEETS.map((sheet) => ({
+    params: { slug: sheet.slug },
+    props: { sheet },
+  }));
+}
+
+const { sheet } = Astro.props;
+
+const printed = buildSheet(sheet.config, SPELLING_SEED);
+const key = keyed(sheet) ? answerKey(sheet.config, SPELLING_SEED) : null;
+
+const title = `${sheet.keyword} | School Skills`;
+const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const url = `https://schoolskills.app${pathFor(sheet)}`;
+
+const groups = spellingShelf();
+const group = groups.find((entry) => entry.id === sheet.group)!;
+
+/**
+ * Whether the page's words are the engine's rather than a parent's.
+ *
+ * The one thing the prose below cannot say the same way for every page on this
+ * shelf: a spelling sheet is a list somebody can replace with their own, and a
+ * word-study sheet is a bank of authored questions where what a parent changes is
+ * the topic. Offering to refill the box on a homophones page would be offering
+ * something the family does not do.
+ */
+const study = sheet.config.kind === "word-study";
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    name: sheet.heading,
+    description,
+    url,
+    learningResourceType: "Worksheet",
+    educationalUse: "Practice",
+    teaches: sheet.teaches,
+    typicalAgeRange: sheet.ages,
+    isAccessibleForFree: true,
+    inLanguage: "en",
+  }}
+>
+  <header class="hero wrap no-print">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Spelling &middot; {group.label}
+    </p>
+    <h1 class="hero__title">{sheet.heading}</h1>
+    <p class="hero__lead">{sheet.lead}</p>
+    <p class="aside">
+      The sheet below <strong>is</strong> the printout{
+        key ? ", and the page behind it is the answer key" : ""
+      }. Press <strong>&#8984;P</strong> &mdash; <strong>Ctrl+P</strong> on Windows
+      &mdash; and everything but the paper disappears. To keep a copy instead, pick
+      <em>Save as PDF</em> in the print dialog and your browser writes one.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  {
+    /*
+      The sheets, outside `.wrap` deliberately. A wrap adds an inline padding
+      that print.css cannot take back off, and a sheet printed a centimetre in
+      from where it says it is has the wrong geometry everywhere at once. The
+      key is a sibling of the sheet with nothing between them, because
+      print.css breaks pages on `.sheet + .sheet` as well.
+    */
+  }
+  <div class="sheet-frame">
+    <SheetView sheet={printed} />
+    {key && <SheetView sheet={key} />}
+  </div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">What is on this sheet</h2>
+    <div class="prose">
+      {sheet.notes.map((note) => <p>{note}</p>)}
+      {
+        key ? (
+          <p>
+            The answers were decided when the sheet was built, so the key is the
+            same page with them drawn in rather than a second attempt at the
+            same questions &mdash; there is no way for the two to disagree. The
+            number in the footer is the seed the sheet was built from: it is
+            printed so that the identical sheet can be had again next week,
+            rather than one that merely looks like it.
+          </p>
+        ) : (
+          <p>
+            There is no answer key behind this one, and that is the honest
+            answer rather than an omission &mdash; what goes on these lines is
+            the child&rsquo;s own. The number in the footer is the seed the
+            sheet was built from, so the identical sheet can be had again next
+            week.
+          </p>
+        )
+      }
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">
+      {study ? "Change what is on it" : "Your own words on the same sheet"}
+    </h2>
+    <div class="prose">
+      {
+        study ? (
+          <p>
+            This page is one sheet out of a family that can print thousands. The
+            topic is a setting rather than a different worksheet: ten of them
+            &mdash; rhyme, syllables, word families, prefixes and suffixes,
+            plurals, contractions, homophones, synonyms and antonyms &mdash; and
+            each is asked in whichever of the three shapes suits it, written on
+            a ruled line, circled from four, or joined up in two columns. How
+            many questions and how many columns are switches beside them.
+          </p>
+        ) : (
+          <p>
+            This page is one sheet out of a family that can print thousands. The
+            words on it are one of the shipped sight-word lists, and the box
+            that holds them takes a typed or pasted list instead &mdash; this
+            week&rsquo;s spellings off a school letter, or a list you already
+            keep in the game. The same words then print as any of the seven
+            styles: written out, in word shapes, with letters missing, in ABC
+            order, in a sentence, found among near misses, or as a blank test.
+          </p>
+        )
+      }
+      <p class="aside">
+        The settings travel in the link rather than on a server, so a sheet you
+        make can be bookmarked or sent to another family as it stands &mdash;
+        and the <em>Name:</em> line is printed blank, because there is nowhere in
+        a shared link to put a child&rsquo;s name. See{" "}
+        <a href="/privacy">what we don&rsquo;t collect</a>.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href={builderHref(sheet)}>
+        Open this sheet in the builder
+      </a>
+      <a class="cta cta--quiet" href="/printables/spelling">
+        All the spelling sheets
+      </a>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">The same words, on screen</h2>
+    <div class="prose">
+      <p>
+        Word Jungle deals the sight-word lists as flash cards: the word is read
+        aloud, in a sentence, and typed back &mdash; which is the half of
+        spelling a worksheet cannot do, because paper cannot say a word out
+        loud. A child who has just worked through a page is the one likeliest to
+        race it, and the record book then knows which words they keep missing,
+        so the next sheet can be exactly those.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/spelling">Spelling and sight words</a>
+      <a class="cta cta--quiet" href="/spelling/play">Start a spelling race</a>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Every spelling sheet</h2>
+    <p class="h2__sub">
+      {SPELLING_SHEETS.length} pages, each one a sheet like this one. Nothing is locked
+      and nothing needs an account.
+    </p>
+    {
+      groups.map((entry) => (
+        <>
+          <h3 class="h2 h2--next">{entry.label}</h3>
+          <p class="h2__sub">{entry.blurb}</p>
+          <nav class="stones" aria-label={entry.label}>
+            {entry.sheets.map((candidate) => (
+              <a
+                class="stone"
+                href={pathFor(candidate)}
+                aria-current={
+                  candidate.slug === sheet.slug ? "page" : undefined
+                }
+              >
+                {candidate.short}
+              </a>
+            ))}
+          </nav>
+        </>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/spelling/index.astro
+++ b/src/pages/printables/spelling/index.astro
@@ -1,0 +1,196 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SPELLING_SHEETS, pathFor, spellingShelf } from "../_spelling";
+
+/**
+ * The spelling subject hub — a peer of `/printables/math`,
+ * `/printables/handwriting`, `/printables/cursive` and `/printables/bible`.
+ *
+ * A listing rather than a sheet, like the other hubs, and that is the right
+ * split: nobody searches for "printable list of spelling worksheets". What it is
+ * for is the two jobs a hub does — giving a parent who arrived on
+ * `/printables/spelling/homophone-worksheets` somewhere to go next, and giving
+ * the topic pages a crawlable parent that says what they have in common.
+ *
+ * It is also the one hub with a game on the other side of it. `/spelling` is the
+ * page about Word Jungle and this is the page about its paper, and the two link
+ * both ways on purpose: the same word list is a race and a worksheet, and a
+ * parent who has typed one in should not have to discover that twice.
+ */
+const title =
+  "Free printable spelling worksheets — lists, sight words and word study | School Skills";
+const description =
+  "Printable spelling practice: write it three times, missing letters, ABC order, word shapes, sight words to trace and find, and word study — rhyming, syllables, prefixes, suffixes, plurals, contractions, homophones, synonyms and antonyms. Answer keys included, free, no account.";
+
+const groups = spellingShelf();
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Printable spelling worksheets",
+    description,
+    url: "https://schoolskills.app/printables/spelling",
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    hasPart: SPELLING_SHEETS.map((sheet) => ({
+      "@type": "LearningResource",
+      name: sheet.heading,
+      url: `https://schoolskills.app${pathFor(sheet)}`,
+      learningResourceType: "Worksheet",
+      teaches: sheet.teaches,
+      typicalAgeRange: sheet.ages,
+      isAccessibleForFree: true,
+    })),
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Spelling and words
+    </p>
+    <h1 class="hero__title">Printable spelling worksheets</h1>
+    <p class="hero__lead">
+      {SPELLING_SHEETS.length} sheets: a week&rsquo;s spelling list in five shapes,
+      the first sight words to trace, write and find, and ten pages on how words actually
+      work. Every one of them prints its answer key where there is an answer to print.
+    </p>
+    <p class="hero__note">Free &middot; answer keys &middot; no download</p>
+  </header>
+
+  {
+    /*
+      What exists, first — before the page explains itself. Somebody who came
+      looking for homophones should be one link from homophones, and the
+      argument for how these sheets are put together reads better after you
+      have seen one than before.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">On the shelf now</h2>
+    <p class="h2__sub">
+      Each of these is a page that is itself the worksheet &mdash; open it,
+      press print, and that is the whole of it. The answer key is the page
+      behind the sheet, on every page where the sheet is withholding something.
+    </p>
+    {
+      groups.map((group) => (
+        <>
+          <h3 class="h2 h2--next">{group.label}</h3>
+          <p class="h2__sub">{group.blurb}</p>
+          <div class="prose">
+            <ul>
+              {group.sheets.map((sheet) => (
+                <li>
+                  <a href={pathFor(sheet)}>{sheet.name}</a> &mdash;{" "}
+                  {sheet.summary}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      ))
+    }
+  </section>
+
+  <div class="wrap"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">One list, seven sheets</h2>
+    <div class="prose">
+      <p>
+        A spelling list is not a worksheet, and that is the whole design here:
+        the list is the content and the exercise is a setting. The same twelve
+        words print as a page to write out three times, a page with two letters
+        missing from each word, a page of word shapes to write into, a page to
+        put in ABC order, a page to use each word in a sentence, a page to pick
+        each word out from the words it gets confused with, or a blank test with
+        nothing on it but numbered lines.
+      </p>
+      <p>
+        Which means Monday and Friday are the same list. The words go in through
+        one box &mdash; typed, or pasted off whatever the school sent home,
+        newlines and commas both understood &mdash; and every sheet for the week
+        comes off the same list without retyping it once.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/make">Open the sheet builder</a>
+    </div>
+  </section>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">
+        The words on the word-study sheets are written, not generated
+      </h2>
+      <p class="h2__sub">
+        Rhyme, syllables, word families, prefixes and suffixes, plurals,
+        contractions, homophones, synonyms and antonyms &mdash; ten topics, and
+        every answer on them checked by a person.
+      </p>
+      <div class="prose">
+        <p>
+          English will not yield to a rule here, which is the reason to say so
+          out loud. A plural takes an s until it takes -es, -ies or -ves, and
+          then there are children, feet, mice and sheep. &ldquo;Happy&rdquo;
+          plus &ldquo;ness&rdquo; is happiness; &ldquo;hop&rdquo; plus
+          &ldquo;ing&rdquo; doubles the p and &ldquo;hope&rdquo; plus
+          &ldquo;ing&rdquo; drops the e. A generator reaching for the rule
+          prints &ldquo;mouses&rdquo; in an answer key, and an answer key that
+          is wrong is worse than no sheet at all.
+        </p>
+        <p>
+          So the words on those ten pages are authored rather than assembled,
+          and the questions on a sheet are drawn from them. That also decides
+          which shape a topic is asked in: &ldquo;write a word that rhymes with
+          cat&rdquo; is a fine thing to ask a child and cannot be printed with
+          an answer key, so rhyming is asked as a choice instead. Where a topic
+          can honestly be written, circled or joined up, all three are offered.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">And the same words, read aloud</h2>
+    <div class="prose">
+      <p>
+        Paper cannot say a word out loud, which is the one half of spelling a
+        worksheet has never been able to do. Word Jungle deals the same
+        sight-word lists as flash cards: the word is spoken, then spoken in a
+        sentence, and typed back &mdash; which is what makes a homophone
+        answerable at all. A list a parent types in there is a list this shelf
+        can print, and the record book keeps track of which words a child keeps
+        missing, so the next sheet can be exactly those.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/spelling">Spelling and sight words</a>
+      <a class="cta cta--quiet" href="/printables/handwriting">
+        Handwriting worksheets
+      </a>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Your child&rsquo;s name is not in the file</h2>
+    <div class="prose">
+      <p>
+        The <em>Name:</em> line is printed blank and filled in with a pencil. Nothing
+        is uploaded to make a sheet, no account is needed to print one, and a sheet
+        you send to another family carries the words and the settings you chose and
+        nothing else &mdash; see{" "}
+        <a href="/privacy">what we don&rsquo;t collect</a>.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/spelling/index.astro
+++ b/src/pages/spelling/index.astro
@@ -164,6 +164,39 @@ const description =
     </div>
   </section>
 
+  {
+    /*
+      The paper half of the same list, linked both ways: /printables/spelling
+      links back here. A list typed in once should not have to be discovered
+      twice, and the two surfaces read the same words out of the same place.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">The same list, on paper</h2>
+    <div class="prose">
+      <p>
+        Every list here prints as a worksheet, and the list is the content
+        rather than the sheet: the same words come out as a page to write three
+        times, a page with letters missing, word shapes, ABC order, a sentence
+        each, or a page of near misses to pick the right word out of. There are
+        ten more on how words work &mdash; rhyme, syllables, prefixes and
+        suffixes, plurals, contractions, homophones, synonyms and antonyms
+        &mdash; and every sheet that has an answer prints the key on the page
+        behind it.
+      </p>
+      <p>
+        Which is the half of practice a screen is bad at. A word typed on a
+        keyboard is not a word written by hand, and a child who has done both
+        remembers it better than one who has done either.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables/spelling">
+        Printable spelling worksheets
+      </a>
+    </div>
+  </section>
+
   <section class="band wrap">
     <h2 class="h2">Practising it properly</h2>
     <div class="prose">

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -203,6 +203,7 @@
 .sheet__blanks,
 .sheet__questions,
 .sheet__options,
+.sheet__wordshapes,
 .sheet__words {
   list-style: none;
   padding-left: 0;
@@ -627,6 +628,42 @@
   gap: 0.06in 0.28in;
   margin-top: 0.12in;
   font-size: 0.9em;
+}
+
+/* ── Word shapes ────────────────────────────────────────────────────────────
+   The same grid a page of problems is laid out on, and for the same reason: the
+   family decided how many columns fit and reserved the page against it, so the
+   gaps here are the ones `PROBLEM_GAP` names in mil. The boxes themselves are
+   drawn in the block — strokes rather than borders on a `<span>`, because their
+   heights are three bands of one row rather than three sizes of text.        */
+
+.sheet__wordshapes {
+  display: grid;
+  grid-template-columns: repeat(var(--sheet-columns, 2), minmax(0, 1fr));
+  gap: 0.2in 0.3in;
+}
+
+/* The one row on a sheet that may not wrap. Every other flex row here wraps
+   onto a second line and the family reserves for it (`WRAP_GAP`); a row of
+   boxes cannot, because how tall it is was declared before the words were known
+   and a very long word in a narrow column would take a line nobody reserved —
+   which is the last row of the page on a second sheet of paper. `.sheet__ink`
+   is already `max-width: 100%`, so what a word too wide for its column does
+   instead is shrink its own boxes, which is the cheap side to be wrong on. */
+.sheet__wordshape {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 0.06in;
+  break-inside: avoid;
+}
+
+/* A hairline box, never a filled one: a child writes in these, and the ink note
+   above is the other half of it — a tinted box is the one mark a browser drops
+   when printing, which would print a word-shape sheet as a blank page. */
+.sheet__box {
+  fill: none;
+  stroke: currentcolor;
 }
 
 .sheet__faces,


### PR DESCRIPTION
Closes #64. Epic #76, PRINT20.

## What this is

The words shelf of the print shop. A parent already types this week's spelling
list into Word Jungle; now that same list prints, and the shipped Dolch lists
print too.

It landed as **two sheet families**, because the two halves of "words" are
mirror images of each other:

- **`src/engine/sheets/words/spelling.ts`** — the list is the content, the
  exercise is a setting. Seven styles: write it out, word shapes, missing
  letters, find it among its near misses, ABC order, use it in a sentence, and
  the blank test. One box of words a parent typed is a week of paper rather
  than one sheet. ABC order is the only style that shuffles what it prints, and
  it must: every list it will be set on arrives alphabetical, and a sheet whose
  answer column is its own question column is not a sheet.
- **`src/engine/sheets/words/study.ts`** — the other way round. The exercise is
  the parent's; the content is ours, authored in `words/bank.ts`. Ten topics:
  rhyme, syllables, word families, prefixes, suffixes, plurals, contractions,
  homophones, synonyms, antonyms. Each declares which of the three question
  shapes it can honestly be asked in, because "write a word that rhymes with
  cat" has a hundred right answers and no key.

**Why a bank and not a rule.** English will not yield here. A plural is `-s`
until it is `-es`, `-ies`, `-ves` or `children`; happy + ness is happiness and
hop + ing doubles the p. A generator reaching for the rule prints `mouses` in an
answer key, which is worse than printing nothing.

## Reused rather than rebuilt

- A "find the word" sheet's near misses are `wordDistractors` from
  `src/engine/decks/words.ts` — the same three the race's *spot it* round deals
  — so a printed sheet and a played round ask one question of one list.
- A sight word to **trace** is the handwriting family with a word list on it,
  not an eighth spelling style. Two families that draw letterforms would be one
  too many.

## Sources

The shipped Dolch lists and any `CustomDeck` a parent saved. The bench's list
bootstrap offers both in one picker, through `src/services/decks.ts` as before —
nothing added here has learnt that IndexedDB exists.

## New block

`wordshapes`: a row of hairline boxes per word, in the three bands a word is
written in. A block rather than a drawing beside a problem, because the boxes
*are* the answer place — and strokes rather than tint, because browsers drop
background paint when printing.

## Pages

`/printables/spelling` plus eighteen curated slugs beneath it, cross-linked both
ways with `/spelling`. The same list is a race and a worksheet; a parent who
typed one in should not have to discover that twice. Answer keys wherever an
answer exists.

## Out of scope

Word search and crossword are PRINT21.

## Validation

`type-check`, `lint`, `test:unit` (967 passing), `build` (static, 135 pages,
sitemap guard clean), and the browser smoke test — all green. The smoke test
matters here because the custom-deck path reads storage; its bench and reload
checks pass.
