### PR TITLE
PRINT21: word search, crossword and scramble sheets from any list

### DIFF
--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -206,6 +206,10 @@ const EVERY_BLOCK: Block[] = [
     // A word the grid had no room for, printed rather than dropped — the one
     // line on a sheet whose job is to admit a failure.
     omitted: ["ELEPHANT"],
+    // And the ones the page had no room to *name*. The line is reserved for at
+    // a capped number of rows, so past that the count carries what the names
+    // cannot — see `Block.omittedMore`.
+    omittedMore: 3,
   },
   {
     // Two entries crossing at their shared T, one of them numbered in both
@@ -371,6 +375,17 @@ describe("rendering a sheet", () => {
     expect(html).toContain("Times tables");
     expect(html).toContain("schoolskills.app");
     expect(html).toContain("#4242");
+  });
+
+  it("admits what a puzzle could not hold, and counts what it could not name", () => {
+    // The one line on a sheet whose job is to admit a failure. Both halves of
+    // it, because a page that named three of twenty-three and said nothing
+    // about the rest would be the silent drop again in a smaller font.
+    const search = EVERY_BLOCK.filter((block) => block.kind === "wordsearch");
+    const html = renderToStaticMarkup(
+      <SheetView sheet={sheet({ blocks: search })} />,
+    );
+    expect(html).toContain("Not in the grid: ELEPHANT … and 3 more");
   });
 
   it("keeps the problems as real text, not as a picture of text", () => {

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -197,12 +197,31 @@ const EVERY_BLOCK: Block[] = [
   {
     kind: "wordsearch",
     letters: [
-      ["c", "a", "t"],
-      ["x", "y", "z"],
-      ["d", "o", "g"],
+      ["C", "A", "T"],
+      ["X", "Y", "Z"],
+      ["D", "O", "G"],
     ],
-    find: ["cat", "dog"],
-    solution: [{ word: "cat", column: 0, row: 0, dx: 1, dy: 0 }],
+    find: ["CAT", "DOG"],
+    solution: [{ word: "CAT", column: 0, row: 0, dx: 1, dy: 0 }],
+    // A word the grid had no room for, printed rather than dropped — the one
+    // line on a sheet whose job is to admit a failure.
+    omitted: ["ELEPHANT"],
+  },
+  {
+    // Two entries crossing at their shared T, one of them numbered in both
+    // directions — the smallest thing that draws every part of the block.
+    kind: "crossword",
+    cells: [
+      [{ letter: "C", number: 1 }, { letter: "A" }, { letter: "T", number: 2 }],
+      [null, null, { letter: "O" }],
+      [null, null, { letter: "P" }],
+    ],
+    across: [
+      { number: 1, clue: "It purrs.", answer: "CAT", column: 0, row: 0 },
+    ],
+    down: [
+      { number: 2, clue: "Jumbled: O P T", answer: "TOP", column: 2, row: 0 },
+    ],
   },
   {
     kind: "matching",

--- a/src/components/sheet/blocks/Crossword.tsx
+++ b/src/components/sheet/blocks/Crossword.tsx
@@ -1,0 +1,138 @@
+/**
+ * A crossword: the squares, the numbers in their corners, and the two clue
+ * lists under them.
+ *
+ * An `<svg>` rather than a table for the reason the word search is one — the
+ * letters of the key have to land in the same coordinate system as the boxes
+ * they belong in — and squares drawn as strokes rather than as filled cells for
+ * the reason everything on a sheet is: background paint is what a browser drops
+ * when printing (§5), and a crossword whose grid came out as blank paper is not
+ * a puzzle at all.
+ *
+ * The clues are real HTML under it, so they are selectable, they wrap, and a
+ * crawler reads them as the text they are.
+ */
+import { searchCell } from "@/engine/sheets/words/search";
+import type { CrosswordEntry } from "@/engine/sheets/types";
+
+import { HAIRLINE, inch } from "../units";
+import type { BlockProps } from "./block";
+import { Omitted } from "./Omitted";
+
+/** A letter that fills its square without touching the sides of it. */
+const LETTER_TO_EM = 0.58;
+/** The number in the corner: small enough to leave the square writable. */
+const NUMBER_TO_EM = 0.3;
+/** How far the number sits in from the corner, as a share of the square. */
+const NUMBER_INSET = 0.1;
+
+export function Crossword({ block, metrics }: BlockProps<"crossword">) {
+  const rows = block.cells.length;
+  const columns = block.cells.reduce(
+    (most, row) => Math.max(most, row.length),
+    0,
+  );
+  if (rows === 0 || columns === 0) return <Omitted words={block.omitted} />;
+
+  // The same cell size the family reserved the page against — see the note in
+  // `WordSearch` for why this is asked of the engine rather than declared here.
+  const cell = searchCell(metrics.box.width, columns);
+  const width = columns * cell;
+  const height = rows * cell;
+  const centre = (index: number) => (index + 0.5) * cell;
+
+  return (
+    <div className="sheet__block">
+      <svg
+        className="sheet__ink"
+        width={inch(width)}
+        height={inch(height)}
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label={`Crossword, ${columns} by ${rows}`}
+      >
+        {block.cells.flatMap((row, y) =>
+          row.map((square, x) =>
+            square === null ? null : (
+              <g key={`${x}-${y}`}>
+                <rect
+                  className="sheet__box"
+                  x={x * cell}
+                  y={y * cell}
+                  width={cell}
+                  height={cell}
+                  strokeWidth={HAIRLINE}
+                />
+                {square.number !== undefined && (
+                  <text
+                    className="sheet__cell sheet__cell--start"
+                    x={x * cell + cell * NUMBER_INSET}
+                    y={y * cell + cell * NUMBER_INSET}
+                    fontSize={Math.round(cell * NUMBER_TO_EM)}
+                    dominantBaseline="hanging"
+                  >
+                    {square.number}
+                  </text>
+                )}
+                {/* The letter is on the square whether or not this is a key;
+                    `answers` decides whether it is printed. Same bargain as a
+                    ruled slot, and the reason a key cannot disagree with the
+                    sheet it came from. */}
+                {metrics.answers && (
+                  <text
+                    className="sheet__cell sheet__cell--answered"
+                    x={centre(x)}
+                    y={centre(y)}
+                    fontSize={Math.round(cell * LETTER_TO_EM)}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                  >
+                    {square.letter}
+                  </text>
+                )}
+              </g>
+            ),
+          ),
+        )}
+      </svg>
+
+      <div className="sheet__clues">
+        <Clues heading="Across" entries={block.across} />
+        <Clues heading="Down" entries={block.down} />
+      </div>
+
+      <Omitted words={block.omitted} />
+    </div>
+  );
+}
+
+/**
+ * One direction's clues, numbered as the grid numbered them.
+ *
+ * The number is a `<span>` rather than a list marker for the reason every
+ * numbered list on a sheet is: markers are stripped site-wide, a marker sits
+ * outside the box and therefore outside the margin, and "do 4, 7 and 12" needs
+ * its numbers to be text somebody can select.
+ */
+function Clues({
+  heading,
+  entries,
+}: {
+  heading: string;
+  entries: CrosswordEntry[];
+}) {
+  if (entries.length === 0) return null;
+  return (
+    <div>
+      <p className="sheet__clue-head">{heading}</p>
+      <ul className="sheet__clue-list">
+        {entries.map((entry) => (
+          <li key={`${heading}-${entry.number}`}>
+            <span className="sheet__number">{entry.number}.</span>
+            {entry.clue}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/sheet/blocks/Crossword.tsx
+++ b/src/components/sheet/blocks/Crossword.tsx
@@ -32,7 +32,15 @@ export function Crossword({ block, metrics }: BlockProps<"crossword">) {
     (most, row) => Math.max(most, row.length),
     0,
   );
-  if (rows === 0 || columns === 0) return <Omitted words={block.omitted} />;
+  // A grid with nothing in it is still a block: the line under it is the whole
+  // of the sheet's content, and it gets the same air around it as a puzzle
+  // would have had.
+  if (rows === 0 || columns === 0)
+    return (
+      <div className="sheet__block">
+        <Omitted words={block.omitted} more={block.omittedMore} />
+      </div>
+    );
 
   // The same cell size the family reserved the page against — see the note in
   // `WordSearch` for why this is asked of the engine rather than declared here.
@@ -101,7 +109,7 @@ export function Crossword({ block, metrics }: BlockProps<"crossword">) {
         <Clues heading="Down" entries={block.down} />
       </div>
 
-      <Omitted words={block.omitted} />
+      <Omitted words={block.omitted} more={block.omittedMore} />
     </div>
   );
 }

--- a/src/components/sheet/blocks/Omitted.tsx
+++ b/src/components/sheet/blocks/Omitted.tsx
@@ -12,8 +12,20 @@
  * and it has to be the same sentence: "not in the grid" is the only thing the
  * person marking the sheet needs to know, and it is equally true of a word the
  * placer could not fit and one the page had no room for.
+ *
+ * The sentence itself comes from the engine (`missingTokens`) rather than from
+ * here, for the reason `searchCell` does: the family reserves the page against
+ * the rows this line will wrap onto, and a paragraph measured at one length and
+ * printed at another is the last line of a sheet on a second sheet of paper.
+ * `more` is what the reservation could not name — see `Block.omittedMore`.
  */
-export function Omitted({ words }: { words?: string[] }) {
-  if (!words || words.length === 0) return null;
-  return <p className="sheet__missing">Not in the grid: {words.join(", ")}</p>;
+import { missingTokens } from "@/engine/sheets/words/puzzles";
+
+export function Omitted({ words, more }: { words?: string[]; more?: number }) {
+  const named = words ?? [];
+  const rest = more ?? 0;
+  if (named.length === 0 && rest === 0) return null;
+  return (
+    <p className="sheet__missing">{missingTokens(named, rest).join(" ")}</p>
+  );
 }

--- a/src/components/sheet/blocks/Omitted.tsx
+++ b/src/components/sheet/blocks/Omitted.tsx
@@ -1,0 +1,19 @@
+/**
+ * The words a puzzle could not hold, printed under it.
+ *
+ * The one line on a sheet whose whole job is to admit a failure, and it earns
+ * its ink twice over. A word that silently vanished out of a word search is a
+ * child hunting for something that was never there, and a parent marking
+ * against a key that does not mention it — the failure looks exactly like
+ * success from every angle except the one nobody checks, which is the paper.
+ * Naming it turns an invisible bug into a visible one.
+ *
+ * Shared by both grids rather than written twice, because it is one sentence
+ * and it has to be the same sentence: "not in the grid" is the only thing the
+ * person marking the sheet needs to know, and it is equally true of a word the
+ * placer could not fit and one the page had no room for.
+ */
+export function Omitted({ words }: { words?: string[] }) {
+  if (!words || words.length === 0) return null;
+  return <p className="sheet__missing">Not in the grid: {words.join(", ")}</p>;
+}

--- a/src/components/sheet/blocks/WordSearch.tsx
+++ b/src/components/sheet/blocks/WordSearch.tsx
@@ -82,7 +82,7 @@ export function WordSearch({ block, metrics }: BlockProps<"wordsearch">) {
         ))}
       </ul>
 
-      <Omitted words={block.omitted} />
+      <Omitted words={block.omitted} more={block.omittedMore} />
     </div>
   );
 }

--- a/src/components/sheet/blocks/WordSearch.tsx
+++ b/src/components/sheet/blocks/WordSearch.tsx
@@ -1,13 +1,9 @@
-import { inches } from "@/engine/sheets/paper";
+import { searchCell } from "@/engine/sheets/words/search";
 
 import { HEAVY, inch } from "../units";
 import type { BlockProps } from "./block";
+import { Omitted } from "./Omitted";
 
-/**
- * A letter big enough for a five-year-old to find and small enough that a
- * ten-by-ten puzzle doesn't take the whole page.
- */
-const MAX_CELL = inches(0.34);
 const CELL_TO_EM = 0.62;
 
 /**
@@ -17,6 +13,12 @@ const CELL_TO_EM = 0.62;
  * The letters are `<text>` rather than a table so the solution can be drawn
  * over them in the same coordinate system. They are still selectable, readable
  * text; an `<svg>` is not an image unless it contains one.
+ *
+ * How big a cell is comes from the engine (`searchCell`) rather than from a
+ * constant here, because the family reserved the page against exactly that
+ * number before the grid existed. Two copies of it would be a grid an eighth of
+ * an inch taller than the room made for it — which looks right on screen and
+ * puts the word list on a second sheet of paper.
  */
 export function WordSearch({ block, metrics }: BlockProps<"wordsearch">) {
   const rows = block.letters.length;
@@ -26,7 +28,7 @@ export function WordSearch({ block, metrics }: BlockProps<"wordsearch">) {
   );
   if (rows === 0 || columns === 0) return null;
 
-  const cell = Math.min(MAX_CELL, Math.floor(metrics.box.width / columns));
+  const cell = searchCell(metrics.box.width, columns);
   const width = columns * cell;
   const height = rows * cell;
   const centre = (index: number) => (index + 0.5) * cell;
@@ -79,6 +81,8 @@ export function WordSearch({ block, metrics }: BlockProps<"wordsearch">) {
           <li key={word}>{word}</li>
         ))}
       </ul>
+
+      <Omitted words={block.omitted} />
     </div>
   );
 }

--- a/src/components/sheet/blocks/index.tsx
+++ b/src/components/sheet/blocks/index.tsx
@@ -18,6 +18,7 @@ import { Blanks } from "./Blanks";
 import { Choice } from "./Choice";
 import { Clock } from "./Clock";
 import { Copywork } from "./Copywork";
+import { Crossword } from "./Crossword";
 import { Cutline } from "./Cutline";
 import { Grid } from "./Grid";
 import { Matching } from "./Matching";
@@ -49,6 +50,8 @@ export function BlockView({
       return <Grid block={block} metrics={metrics} />;
     case "wordsearch":
       return <WordSearch block={block} metrics={metrics} />;
+    case "crossword":
+      return <Crossword block={block} metrics={metrics} />;
     case "matching":
       return <Matching block={block} metrics={metrics} />;
     case "blanks":

--- a/src/engine/decks/words.ts
+++ b/src/engine/decks/words.ts
@@ -1,7 +1,7 @@
 import type { Card, WordConfig } from "@/engine/types";
 
 import { mulberry32, shuffled } from "@/engine/random";
-import { WORD_LISTS_BY_ID } from "./wordlists";
+import { WORD_LISTS, WORD_LISTS_BY_ID } from "./wordlists";
 import type { DeckSpec } from "./spec";
 
 /**
@@ -114,6 +114,33 @@ export function clueParts(clue: string): [string, string] {
   const at = clue.indexOf(CLUE_SLOT);
   return at < 0 ? [clue, ""] : [clue.slice(0, at), clue.slice(at + 1)];
 }
+
+/**
+ * Every sentence this build ships, by the word it is about.
+ *
+ * Indexed across all the lists at once rather than looked up inside one,
+ * because the caller that needs it doesn't have a list to look in: the Print
+ * Shop's crossword is set on whatever words a parent pasted into a box, and if
+ * `because` happens to be one of the words the jungle already teaches then the
+ * sentence somebody wrote for it is the clue that crossword should use. Which
+ * is the whole of "clues from the list's own definitions where available" —
+ * available means somebody wrote one, and this is where they are.
+ *
+ * Normalised on the way in and on the way out, so a list typed in capitals
+ * still finds its sentence. A few hundred entries, built once at load.
+ */
+const SHIPPED_CLUES = new Map<string, string>(
+  WORD_LISTS.flatMap((list) =>
+    list.entries.map((entry): [string, string] => [
+      normaliseWord(entry.word),
+      entry.clue,
+    ]),
+  ),
+);
+
+/** The sentence a shipped list gives this word, if any list gives it one. */
+export const shippedClue = (word: string): string | undefined =>
+  SHIPPED_CLUES.get(normaliseWord(word));
 
 /**
  * What the voice says for a card: the word, then the word in a sentence.

--- a/src/engine/sheets/chrome.ts
+++ b/src/engine/sheets/chrome.ts
@@ -83,8 +83,14 @@ const em = (fontPt: number, rows: number): Mil => points(fontPt * rows);
  * mean advance `handwriting.ts` packs a row of letters by: characters times the
  * face's own declared mean, at whatever share of the body size sheet.css sets
  * this part of the chrome in. There is no DOM at build time to ask instead.
+ *
+ * Exported because the header and footer stopped being the only wrapping rows
+ * on a sheet: a word search prints its word list as a wrapping flex row and a
+ * crossword prints its clues as wrapping paragraphs, and both have to be
+ * reserved for before the words are known. A family's own copy of this would be
+ * a second declared mean advance to keep in step with `faces.ts`.
  */
-const declaredWidth = (
+export const declaredWidth = (
   text: string,
   options: SheetOptions,
   share: number,
@@ -102,8 +108,12 @@ const declaredWidth = (
  * breaks *inside* an item: a field rule and a credit line are atomic, so a page
  * too narrow for one whole item still prints one per row rather than looping
  * forever, which is what `used > 0` is for.
+ *
+ * Exported alongside `declaredWidth`, and for the same reason: the word list
+ * under a word search is the third wrapping flex row on a sheet, and it wraps
+ * by exactly this rule.
  */
-function packRows(widths: Mil[], limit: Mil, gap: Mil): number {
+export function packRows(widths: Mil[], limit: Mil, gap: Mil): number {
   if (widths.length === 0) return 0;
   let rows = 1;
   let used = 0;

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -33,6 +33,7 @@ import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
 import { PAPER_SHEET } from "./templates/paper";
 import { HANDWRITING_SHEET } from "./writing/handwriting";
 import { MEMORY_SHEET } from "./writing/memory";
+import { PUZZLE_SHEET } from "./words/puzzles";
 import { WORDS_SHEET } from "./words/spelling";
 import { WORD_STUDY_SHEET } from "./words/study";
 
@@ -54,6 +55,7 @@ const SHEETS: Record<string, SheetSpec> = {
   [WORD_PROBLEMS_SHEET.id]: WORD_PROBLEMS_SHEET,
   [WORDS_SHEET.id]: WORDS_SHEET,
   [WORD_STUDY_SHEET.id]: WORD_STUDY_SHEET,
+  [PUZZLE_SHEET.id]: PUZZLE_SHEET,
   [HANDWRITING_SHEET.id]: HANDWRITING_SHEET,
   [MEMORY_SHEET.id]: MEMORY_SHEET,
 };

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -414,6 +414,59 @@ export type Figure = {
   labels?: string[];
 };
 
+/**
+ * One word read out of a finished grid: where it starts, and which way it runs.
+ *
+ * "Read out of", not "written into", and the distinction is the whole of the
+ * answer key on a word search. A puzzle whose key is its own placement record
+ * is a key that agrees with the generator rather than with the paper — it says
+ * a word is at (3, 4) because that is where the code meant to put it, which is
+ * exactly the claim that is wrong when a later word overwrote a letter. So the
+ * key is derived by searching the grid it is a key to (`findWord`), and this is
+ * what that search returns.
+ */
+export type Found = {
+  word: string;
+  column: number;
+  row: number;
+  /** One step along the word, per letter. `(1, 0)` reads left to right. */
+  dx: number;
+  dy: number;
+};
+
+/**
+ * One square of a crossword. `null` in the grid is a blocked square — no
+ * letter, no ink, nothing written in it.
+ *
+ * The letter is on the square whether or not the sheet is a key: it is what the
+ * square *is*, and `Sheet.answers` decides whether it is printed. Same bargain
+ * as every other answer place, and the reason a key cannot disagree with its
+ * sheet.
+ */
+export type CrosswordCell = {
+  letter: string;
+  /** The small number in the corner, where an entry starts on this square. */
+  number?: number;
+};
+
+/**
+ * One clue and the entry it belongs to.
+ *
+ * `column` and `row` are where the answer starts, so a test can hold the clue
+ * list against the grid letter for letter rather than against the placement the
+ * generator remembers making. That is the same independence `Found` buys the
+ * word search, and it is what makes "the crossings agree" a checkable claim:
+ * two entries that cross share one square, so if both spell their own answer
+ * out of the grid then the crossing agrees by construction.
+ */
+export type CrosswordEntry = {
+  number: number;
+  clue: string;
+  answer: string;
+  column: number;
+  row: number;
+};
+
 export type Block =
   | { kind: "problems"; columns: number; items: Problem[] }
   | { kind: "rules"; rule: Rule; lines: number }
@@ -423,15 +476,34 @@ export type Block =
   | {
       kind: "wordsearch";
       letters: string[][];
+      /**
+       * The words to look for, exactly as they appear in the grid — upper case,
+       * and with anything that is not a letter taken out. A grid has nowhere to
+       * put the apostrophe in "don't", so the list says `DONT`: what is printed
+       * under the puzzle is what is findable in it.
+       */
       find: string[];
-      /** Where each word was placed, for the key. `dx`/`dy` are per step. */
-      solution?: Array<{
-        word: string;
-        column: number;
-        row: number;
-        dx: number;
-        dy: number;
-      }>;
+      /** Where each word was found, for the key. Derived from `letters`. */
+      solution?: Found[];
+      /**
+       * Words the grid could not hold, printed on the sheet rather than quietly
+       * dropped.
+       *
+       * The classic silent bug in a word search is a word that failed to place
+       * and vanished: the child hunts for something that is not there, and the
+       * answer key is wrong about a word it never mentions. A word that could
+       * not be placed is not on the `find` list, and it is named here instead.
+       */
+      omitted?: string[];
+    }
+  | {
+      kind: "crossword";
+      /** Row-major. `null` is a blocked square. */
+      cells: Array<Array<CrosswordCell | null>>;
+      across: CrosswordEntry[];
+      down: CrosswordEntry[];
+      /** Words the grid had no room for — see `wordsearch.omitted`. */
+      omitted?: string[];
     }
   | {
       kind: "matching";
@@ -1374,6 +1446,87 @@ export type WordStudyConfig = SheetOptions & {
   columns: number;
 };
 
+/* ── Puzzles ───────────────────────────────────────────────────────────────
+   The third of the words shelf, and the one where a sheet can look completely
+   right and be completely wrong. A page of sums is checked by doing the sums;
+   a word search is checked by *reading the paper*, which nobody does, so a word
+   that failed to place looks exactly like a word that placed well. The whole
+   design of this family is arranged around that one failure:
+
+   - Nothing on the page is trusted to the generator's own bookkeeping. The key
+     to a word search is found by searching the finished grid, and a crossword's
+     entries are read out of the finished squares. If the letters on the paper
+     say something different from what the placer intended, the paper wins.
+   - A word that could not be placed is **named on the sheet**. Not logged, not
+     dropped — printed, under the puzzle, where the person marking it will see
+     it.
+   - Everything terminates. There is no "shuffle and try again until it works"
+     anywhere in here: a candidate position is tried at most once, so a list of
+     twenty words that cannot possibly fit produces a sheet rather than a hung
+     tab (`puzzles.test.ts` is what holds it to that).                       */
+
+/**
+ * Which puzzle.
+ *
+ * `search` is a letter grid with the words hidden in it; `crossword` is the
+ * numbered squares, clued from the list's own sentences where it has them; and
+ * `scramble` is the letters of a word out of order, which is the one of the
+ * three that is a plain list of problems and needs no grid at all.
+ */
+export type PuzzleStyle = "search" | "crossword" | "scramble";
+
+/**
+ * Which ways a word may run in a word-search grid.
+ *
+ * A stated set rather than a count, because the three are not degrees of
+ * difficulty so much as three different exercises: `across` is a reading
+ * exercise a five-year-old can do, `across-down` is the usual school puzzle,
+ * and `all` adds the two diagonals, which is where a word search stops being
+ * about reading and starts being about scanning. `reverse` is separate for the
+ * same reason — a backwards word is a different kind of hard from a diagonal
+ * one, and a parent setting one of them is not asking for the other.
+ */
+export type SearchDirections = "across" | "across-down" | "all";
+
+export type PuzzleConfig = SheetOptions & {
+  kind: "puzzle";
+  style: PuzzleStyle;
+  /**
+   * The list, in the order it was given — the same field `WordsConfig` carries,
+   * and for the same reasons: there is no name for it here, because a config
+   * travels in a URL and a child must never be in one (§14).
+   */
+  words: string[];
+  /**
+   * How many cells across and down. Square, and a request rather than a
+   * promise: a grid that would not fit the paper with its word list under it is
+   * shrunk until it does (`searchLayout`).
+   *
+   * The crossword reads it too, as the largest grid it may lay words out in.
+   * The finished puzzle is cropped to the words that actually landed, so this
+   * is a bound rather than a size — but it is the same question asked of the
+   * same paper, and two fields for it would be two things a saved config could
+   * disagree about.
+   */
+  size: number;
+  /** `search` only. */
+  directions: SearchDirections;
+  /** `search` only: words may be written backwards. */
+  reverse: boolean;
+  /**
+   * `search` only: words may cross, sharing a letter where they meet.
+   *
+   * Off makes a sparser, easier grid and a harder placement problem — every
+   * word needs a clear run of its own — so this is the setting most likely to
+   * leave a word unplaced, which is exactly why the sheet says when it has.
+   */
+  overlap: boolean;
+  /** How many words to use. Capped at what the page holds. */
+  count: number;
+  /** `scramble` only — a grid and a clue list are the width of the page. */
+  columns: number;
+};
+
 /* ── Handwriting ───────────────────────────────────────────────────────────
    The family where the ruling stops being the paper and becomes the exercise.
    Every sheet above this line could be printed a thousandth of an inch out and
@@ -1585,6 +1738,7 @@ export type SheetConfig =
   | WordProblemConfig
   | WordsConfig
   | WordStudyConfig
+  | PuzzleConfig
   | HandwritingConfig
   | MemoryConfig;
 

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -493,8 +493,22 @@ export type Block =
        * and vanished: the child hunts for something that is not there, and the
        * answer key is wrong about a word it never mentions. A word that could
        * not be placed is not on the `find` list, and it is named here instead.
+       *
+       * Only as many as the family reserved room to print. The line is set
+       * under a block already trimmed to the page, so what it holds is capped —
+       * and the rest are counted in `omittedMore` rather than named.
        */
       omitted?: string[];
+      /**
+       * How many more there were than the page could name.
+       *
+       * A count is a poor substitute for a name and it is only ever reached by
+       * a config at the far end — the largest type, the longest list — where
+       * naming them all would be a page with no puzzle on it. The alternative
+       * is a paragraph below the bottom margin, which names them on a sheet of
+       * paper nobody prints.
+       */
+      omittedMore?: number;
     }
   | {
       kind: "crossword";
@@ -504,6 +518,8 @@ export type Block =
       down: CrosswordEntry[];
       /** Words the grid had no room for — see `wordsearch.omitted`. */
       omitted?: string[];
+      /** And how many more than it could name — see `wordsearch.omittedMore`. */
+      omittedMore?: number;
     }
   | {
       kind: "matching";

--- a/src/engine/sheets/words/crossword.test.ts
+++ b/src/engine/sheets/words/crossword.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from "vitest";
+
+import { mulberry32 } from "@/engine/random";
+
+import type { CrosswordCell, CrosswordEntry } from "../types";
+
+import { MIN_ENTRY, buildCrossword, type Clued } from "./crossword";
+
+/**
+ * A crossword, checked against its own squares.
+ *
+ * The same discipline as `search.test.ts` and the same reason for it: the clue
+ * list is derived from the finished grid, so a test that trusted the generator
+ * to say where its words went would be agreeing with the thing it is meant to
+ * catch. Everything below reads the cells.
+ *
+ * Four claims, and each of them is a real way a crossword ships broken:
+ *
+ * - **Every entry spells its answer** where its number says it starts.
+ * - **The numbering is the grid's** — recomputed here from the squares alone,
+ *   by the rule every crossword in the world is numbered by, and compared.
+ * - **The crossings agree.** Two entries that meet share a square, and both
+ *   read their own answer out of it.
+ * - **It is one puzzle.** Flood fill from any letter reaches every letter; two
+ *   unconnected islands is two half-crosswords on one page.
+ */
+
+const clued = (...words: string[]): Clued[] =>
+  words.map((word) => ({ word, clue: `clue for ${word}` }));
+
+const WORDS = clued("BECAUSE", "THOUGHT", "FRIEND", "PEOPLE", "THROUGH", "CAT");
+
+const build = (entries: Clued[], size = 13, seed = 1) =>
+  buildCrossword(entries, size, mulberry32(seed));
+
+const letterAt = (
+  cells: Array<Array<CrosswordCell | null>>,
+  x: number,
+  y: number,
+): string | null => cells[y]?.[x]?.letter ?? null;
+
+/** Reads an entry out of the squares, the long way. */
+function spell(
+  cells: Array<Array<CrosswordCell | null>>,
+  entry: CrosswordEntry,
+  down: boolean,
+): string {
+  let out = "";
+  for (let i = 0; i < entry.answer.length; i++) {
+    out +=
+      letterAt(
+        cells,
+        entry.column + (down ? 0 : i),
+        entry.row + (down ? i : 0),
+      ) ?? "";
+  }
+  return out;
+}
+
+/**
+ * Every run of two letters or more in the grid, both ways — an independent
+ * walk of the squares, so it can be held against what the block claims.
+ */
+function maximalRuns(cells: Array<Array<CrosswordCell | null>>): string[] {
+  const out: string[] = [];
+  const height = cells.length;
+  const width = cells[0]?.length ?? 0;
+  for (const [dx, dy] of [
+    [1, 0],
+    [0, 1],
+  ]) {
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        if (letterAt(cells, x, y) === null) continue;
+        if (letterAt(cells, x - dx, y - dy) !== null) continue;
+        let word = "";
+        for (let i = 0; letterAt(cells, x + dx * i, y + dy * i) !== null; i++)
+          word += letterAt(cells, x + dx * i, y + dy * i);
+        if (word.length >= MIN_ENTRY) out.push(word);
+      }
+    }
+  }
+  return out;
+}
+
+/** Every square that holds a letter, as `"x,y"`. */
+function filled(cells: Array<Array<CrosswordCell | null>>): string[] {
+  const out: string[] = [];
+  cells.forEach((row, y) =>
+    row.forEach((square, x) => {
+      if (square !== null) out.push(`${x},${y}`);
+    }),
+  );
+  return out;
+}
+
+describe("every entry", () => {
+  it("spells its answer where its clue says it starts", () => {
+    const puzzle = build(WORDS);
+    expect(puzzle.across.length + puzzle.down.length).toBeGreaterThan(1);
+    for (const entry of puzzle.across)
+      expect(spell(puzzle.cells, entry, false)).toBe(entry.answer);
+    for (const entry of puzzle.down)
+      expect(spell(puzzle.cells, entry, true)).toBe(entry.answer);
+  });
+
+  it("carries the clue its word was given", () => {
+    const puzzle = build(WORDS);
+    for (const entry of [...puzzle.across, ...puzzle.down])
+      expect(entry.clue).toBe(`clue for ${entry.answer}`);
+  });
+
+  it("is a word somebody asked for", () => {
+    // The other half of "no unintended words": a run of letters in the grid
+    // that is not one of the answers is a question with no answer on the key.
+    const asked = new Set(WORDS.map((entry) => entry.word));
+    const puzzle = build(WORDS);
+    for (const entry of [...puzzle.across, ...puzzle.down])
+      expect(asked.has(entry.answer)).toBe(true);
+  });
+
+  it("holds over a run of seeds and grid sizes", () => {
+    for (const seed of [0, 1, 2, 3, 7, 99]) {
+      for (const size of [9, 13, 18]) {
+        const puzzle = build(WORDS, size, seed);
+        for (const entry of puzzle.across)
+          expect(spell(puzzle.cells, entry, false)).toBe(entry.answer);
+        for (const entry of puzzle.down)
+          expect(spell(puzzle.cells, entry, true)).toBe(entry.answer);
+      }
+    }
+  });
+});
+
+describe("the numbering", () => {
+  it("is the one the squares themselves imply", () => {
+    // Recomputed from the cells by the standard rule — a square starts an entry
+    // across when there is nothing to its left and something to its right, and
+    // down when there is nothing above and something below — then compared with
+    // what the block carries. Two independent walks of the same grid.
+    const puzzle = build(WORDS);
+    const expected = new Map<string, number>();
+    let number = 0;
+    for (let y = 0; y < puzzle.cells.length; y++) {
+      for (let x = 0; x < puzzle.cells[y].length; x++) {
+        if (letterAt(puzzle.cells, x, y) === null) continue;
+        const startsAcross =
+          letterAt(puzzle.cells, x - 1, y) === null &&
+          letterAt(puzzle.cells, x + 1, y) !== null;
+        const startsDown =
+          letterAt(puzzle.cells, x, y - 1) === null &&
+          letterAt(puzzle.cells, x, y + 1) !== null;
+        if (!startsAcross && !startsDown) continue;
+        number += 1;
+        expected.set(`${x},${y}`, number);
+        expect(puzzle.cells[y][x]?.number).toBe(number);
+      }
+    }
+
+    for (const [entries, list] of [
+      [puzzle.across, "across"],
+      [puzzle.down, "down"],
+    ] as const) {
+      for (const entry of entries)
+        expect({
+          list,
+          number: entry.number,
+        }).toEqual({
+          list,
+          number: expected.get(`${entry.column},${entry.row}`),
+        });
+    }
+  });
+
+  it("puts a number only where an entry starts", () => {
+    const puzzle = build(WORDS);
+    const starts = new Set(
+      [...puzzle.across, ...puzzle.down].map(
+        (entry) => `${entry.column},${entry.row}`,
+      ),
+    );
+    puzzle.cells.forEach((row, y) =>
+      row.forEach((square, x) => {
+        if (square?.number === undefined) return;
+        expect(starts.has(`${x},${y}`)).toBe(true);
+      }),
+    );
+  });
+
+  it("runs in reading order, one number to a square", () => {
+    const puzzle = build(WORDS);
+    const seen = [...puzzle.across, ...puzzle.down]
+      .slice()
+      .sort((a, b) => a.row - b.row || a.column - b.column)
+      .map((entry) => entry.number);
+    expect(seen).toEqual([...seen].sort((a, b) => a - b));
+  });
+});
+
+describe("the crossings", () => {
+  it("agree letter for letter", () => {
+    const puzzle = build(WORDS);
+    let met = 0;
+    for (const one of puzzle.across) {
+      for (const other of puzzle.down) {
+        // Where the two would meet: `one`'s row, `other`'s column.
+        const alongAcross = other.column - one.column;
+        const alongDown = one.row - other.row;
+        if (alongAcross < 0 || alongAcross >= one.answer.length) continue;
+        if (alongDown < 0 || alongDown >= other.answer.length) continue;
+        met += 1;
+        expect(one.answer[alongAcross]).toBe(other.answer[alongDown]);
+        // And both of them agree with the square, which is the only letter
+        // there is: one square, one letter, no third opinion.
+        expect(letterAt(puzzle.cells, other.column, one.row)).toBe(
+          one.answer[alongAcross],
+        );
+      }
+    }
+    // A crossword with no crossings in it is a word list in boxes.
+    expect(met).toBeGreaterThan(0);
+  });
+});
+
+describe("the shape of it", () => {
+  it("is one connected puzzle, not two islands", () => {
+    for (const seed of [1, 2, 3, 4, 5]) {
+      const puzzle = build(WORDS, 13, seed);
+      const squares = new Set(filled(puzzle.cells));
+      const [first] = squares;
+      const reached = new Set<string>();
+      const queue = [first];
+      while (queue.length > 0) {
+        const key = queue.pop() as string;
+        if (reached.has(key) || !squares.has(key)) continue;
+        reached.add(key);
+        const [x, y] = key.split(",").map(Number);
+        queue.push(
+          `${x + 1},${y}`,
+          `${x - 1},${y}`,
+          `${x},${y + 1}`,
+          `${x},${y - 1}`,
+        );
+      }
+      expect(reached.size).toBe(squares.size);
+    }
+  });
+
+  it("is cropped to the words in it", () => {
+    // No blank row or column round the edge: the reservation is made against
+    // the bound, and the paper is spent on squares rather than on nothing.
+    const puzzle = build(WORDS, 18);
+    expect(puzzle.cells[0].some((square) => square !== null)).toBe(true);
+    expect(
+      puzzle.cells[puzzle.cells.length - 1].some((square) => square !== null),
+    ).toBe(true);
+    expect(puzzle.cells.some((row) => row[0] !== null)).toBe(true);
+    expect(puzzle.cells.some((row) => row[row.length - 1] !== null)).toBe(true);
+  });
+
+  it("is the same puzzle twice from the same seed", () => {
+    for (const seed of [0, 1, 4242])
+      expect(build(WORDS, 13, seed)).toEqual(build(WORDS, 13, seed));
+  });
+});
+
+describe("a word that cannot be crossed in", () => {
+  it("is reported rather than dropped", () => {
+    // Nothing shares a letter with anything, so only the first can be placed
+    // and the rest have nowhere to cross.
+    const puzzle = build(clued("ABC", "DEF", "GHI"));
+    expect(puzzle.omitted).toHaveLength(2);
+    expect(puzzle.across.length + puzzle.down.length).toBe(1);
+  });
+
+  it("counts a word too short to be an entry", () => {
+    const puzzle = build(clued("BECAUSE", "I"));
+    expect(puzzle.omitted).toContain("I");
+    expect("I".length).toBeLessThan(MIN_ENTRY);
+  });
+
+  it("counts a word longer than the grid", () => {
+    const puzzle = build(clued("CAT", "EXTRAORDINARILY"), 9);
+    expect(puzzle.omitted).toEqual(["EXTRAORDINARILY"]);
+  });
+
+  it("reports them in the order the parent typed them", () => {
+    const puzzle = build(clued("ABC", "DEF", "GHI", "JKL"));
+    expect(puzzle.omitted).toEqual(
+      ["ABC", "DEF", "GHI", "JKL"].filter((word) =>
+        puzzle.omitted.includes(word),
+      ),
+    );
+  });
+
+  it("tells the truth about it, checked against the squares", () => {
+    // The bug this is here for: AS sits inside ASK letter for letter, so ASK
+    // written over an AS that is already in the grid leaves every letter on the
+    // paper and AS with no squares of its own — a word that is neither clued
+    // nor reported. The placer refuses to swallow an entry, and the missing
+    // list is read back off the grid rather than off the placer's notes, so
+    // this holds either way round.
+    const nested = clued("ASK", "AS", "SKY", "MASK", "SO");
+    for (const seed of [1, 2, 3, 4, 5, 6]) {
+      const puzzle = build(nested, 9, seed);
+      const runs = maximalRuns(puzzle.cells);
+      // Nothing on the paper twice, and nothing on it that nobody asked for.
+      expect(new Set(runs).size).toBe(runs.length);
+      for (const run of runs)
+        expect(nested.map((entry) => entry.word)).toContain(run);
+      // What the sheet says is missing is missing, and what it clues is there.
+      for (const word of puzzle.omitted) expect(runs).not.toContain(word);
+      for (const entry of [...puzzle.across, ...puzzle.down])
+        expect(runs).toContain(entry.answer);
+    }
+  });
+
+  it("never leaves a word both in the grid and on the missing list", () => {
+    for (const seed of [1, 2, 3]) {
+      const puzzle = build(WORDS, 9, seed);
+      const placed = new Set(
+        [...puzzle.across, ...puzzle.down].map((entry) => entry.answer),
+      );
+      for (const word of puzzle.omitted) expect(placed.has(word)).toBe(false);
+      expect(placed.size + puzzle.omitted.length).toBe(WORDS.length);
+    }
+  });
+
+  it("returns on a list where nothing can be placed at all", () => {
+    // Every word is longer than the grid. The passes end because a pass that
+    // places nothing is the last one.
+    const puzzle = build(clued("ELEPHANTS", "BUTTERFLY", "ORCHESTRA"), 4);
+    expect(puzzle.omitted).toHaveLength(3);
+    expect(puzzle.cells).toEqual([]);
+    expect(puzzle.across).toEqual([]);
+  });
+
+  it("survives being asked for nothing", () => {
+    const puzzle = build([]);
+    expect(puzzle.cells).toEqual([]);
+    expect(puzzle.omitted).toEqual([]);
+  });
+});

--- a/src/engine/sheets/words/crossword.ts
+++ b/src/engine/sheets/words/crossword.ts
@@ -1,0 +1,424 @@
+/**
+ * A crossword, grown outwards from the longest word.
+ *
+ * Same bargain as the word search next door and the same reason for it: the
+ * squares are filled in by a placer that remembers nothing, and the numbered
+ * clue list is then **read back out of the finished squares**. Nothing on the
+ * sheet is taken on the placer's word.
+ *
+ * That buys the three properties a crossword can silently lose:
+ *
+ * **The crossings agree.** A square holds one letter. If 3 Across spells its
+ * answer out of the grid and 1 Down spells its answer out of the same grid,
+ * then wherever they meet they agree — there is only one letter there to read.
+ * A generator that wrote both words into its own bookkeeping could have them
+ * disagreeing about a square and never notice.
+ *
+ * **The numbering is the grid's.** Numbers are assigned by scanning the
+ * finished squares in reading order, which is what a crossword's numbers mean.
+ * They are not handed out as words are placed, which would number them in the
+ * order the algorithm happened to work in.
+ *
+ * **It is one puzzle, not several.** Every word after the first is placed only
+ * where it crosses a word already in the grid, so the finished thing is
+ * connected by construction — the classic wrong answer here is a grid with two
+ * unrelated islands in it, which is two half-crosswords on one page.
+ *
+ * And the work is bounded twice over. A word is offered the positions its own
+ * letters allow, once per pass; there are at most `PASSES` passes and at most
+ * `ATTEMPTS` layouts, and both stop early when they stop helping. Nothing in
+ * here waits for a random draw to come good, so a list of twenty words that
+ * share no letters produces a sheet naming nineteen of them rather than a tab
+ * that never finishes.
+ */
+import { shuffled } from "@/engine/random";
+
+import type { CrosswordCell, CrosswordEntry } from "../types";
+
+/**
+ * The shortest thing that can be an entry.
+ *
+ * Two, not three. Three is the convention in a newspaper, but this is a sheet
+ * set on a child's spelling list, and half of the first Dolch list — go, in,
+ * is, it, me, my, to, up, we — is two letters long. Refusing them would report
+ * most of a sight-word list as unusable. One-letter words really are unusable:
+ * there is no such thing as an entry with no direction.
+ */
+export const MIN_ENTRY = 2;
+
+/** A word waiting for a home, and the clue that will be printed against it. */
+export type Clued = { word: string; clue: string };
+
+type Cells = Array<Array<string | null>>;
+type Step = { dx: number; dy: number };
+
+const ACROSS: Step = { dx: 1, dy: 0 };
+const DOWN: Step = { dx: 0, dy: 1 };
+
+const at = (cells: Cells, x: number, y: number): string | null =>
+  y >= 0 && y < cells.length && x >= 0 && x < cells[y].length
+    ? cells[y][x]
+    : null;
+
+/**
+ * Whether a word may be written here, and how many letters it would share.
+ *
+ * The four rules are what keep the grid a crossword rather than a pile of
+ * words:
+ *
+ * - The squares immediately before and after the word must be empty, or the
+ *   entry would run on into its neighbour and the answer read off the grid
+ *   would be longer than the answer in the clue list.
+ * - A square that already holds a letter must hold *this* letter. That is a
+ *   crossing, and it is the only way two words may touch.
+ * - A square this word brings with it must have nothing either side of it,
+ *   across the word's own direction. Two words lying side by side spell
+ *   two-letter nonsense down every pair of columns they share, and a child
+ *   reading the grid cannot tell that from an entry.
+ * - **It may not swallow an entry already in the grid.** AS sits inside ASK
+ *   letter for letter, so an ASK written over an AS that a previous pass put
+ *   down costs a word: every letter is still on the paper, and AS has no
+ *   squares of its own to be written in and no number to be clued by. Two
+ *   letters or more running the word's own way inside its span *is* an existing
+ *   entry, so that is what is refused — a lone occupied square is a crossing,
+ *   which is the whole point. (The sheet would still tell the truth about it
+ *   without this rule, because the missing list is read off the grid. This is
+ *   about keeping the word, not about admitting to losing it.)
+ *
+ * `undefined` for "no", a crossing count for "yes" — one return rather than a
+ * boolean and a second pass, because the count is what the placement is scored
+ * on and counting it twice is how the two answers drift apart.
+ */
+function crossings(
+  cells: Cells,
+  word: string,
+  x: number,
+  y: number,
+  step: Step,
+): number | undefined {
+  const size = cells.length;
+  const endX = x + step.dx * (word.length - 1);
+  const endY = y + step.dy * (word.length - 1);
+  if (x < 0 || y < 0 || endX < 0 || endY < 0) return undefined;
+  if (endX >= size || endY >= size) return undefined;
+  if (at(cells, x - step.dx, y - step.dy) !== null) return undefined;
+  if (at(cells, endX + step.dx, endY + step.dy) !== null) return undefined;
+
+  // Across a word running across is up and down; across one running down is
+  // left and right. One rotation, written once.
+  const side: Step = { dx: step.dy, dy: step.dx };
+  let shared = 0;
+  let run = 0;
+  for (let i = 0; i < word.length; i++) {
+    const cx = x + step.dx * i;
+    const cy = y + step.dy * i;
+    const held = at(cells, cx, cy);
+    if (held !== null) {
+      if (held !== word[i]) return undefined;
+      shared += 1;
+      run += 1;
+      if (run >= MIN_ENTRY) return undefined;
+      continue;
+    }
+    run = 0;
+    if (at(cells, cx - side.dx, cy - side.dy) !== null) return undefined;
+    if (at(cells, cx + side.dx, cy + side.dy) !== null) return undefined;
+  }
+  return shared;
+}
+
+function write(cells: Cells, word: string, x: number, y: number, step: Step) {
+  for (let i = 0; i < word.length; i++)
+    cells[y + step.dy * i][x + step.dx * i] = word[i];
+}
+
+type Spot = { x: number; y: number; step: Step; shared: number; near: number };
+
+/**
+ * Every place this word could go, crossing something already placed.
+ *
+ * Enumerated from the letters in the grid rather than from every square: a word
+ * has to cross, so its start is fixed by *which* of its letters is doing the
+ * crossing and where that letter already is. That is at most
+ * `letters in grid × length of word × 2` positions, each considered once, which
+ * is what makes this terminate on a list it cannot fit.
+ */
+function spotsFor(cells: Cells, word: string): Spot[] {
+  const size = cells.length;
+  const middle = (size - 1) / 2;
+  const seen = new Set<string>();
+  const out: Spot[] = [];
+
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const held = cells[y][x];
+      if (held === null) continue;
+      for (let i = 0; i < word.length; i++) {
+        if (word[i] !== held) continue;
+        for (const step of [ACROSS, DOWN]) {
+          const sx = x - step.dx * i;
+          const sy = y - step.dy * i;
+          const key = `${sx},${sy},${step.dx}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          const shared = crossings(cells, word, sx, sy, step);
+          if (shared === undefined || shared === 0) continue;
+          // How far the middle of the word sits from the middle of the grid.
+          // A crossword that drifts into one corner wastes the paper it was
+          // given and crops to a long thin thing nobody can write in.
+          const near =
+            Math.abs(sx + (step.dx * (word.length - 1)) / 2 - middle) +
+            Math.abs(sy + (step.dy * (word.length - 1)) / 2 - middle);
+          out.push({ x: sx, y: sy, step, shared, near });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** The best of them: most crossings, then closest to the middle. */
+const bestSpot = (spots: Spot[]): Spot | undefined =>
+  spots.reduce<Spot | undefined>(
+    (best, spot) =>
+      !best ||
+      spot.shared > best.shared ||
+      (spot.shared === best.shared && spot.near < best.near)
+        ? spot
+        : best,
+    undefined,
+  );
+
+export type Crossword = {
+  cells: Array<Array<CrosswordCell | null>>;
+  across: CrosswordEntry[];
+  down: CrosswordEntry[];
+  /** Words that could not be crossed into the grid — named on the sheet. */
+  omitted: string[];
+};
+
+/**
+ * Reads the finished squares: which of them start an entry, what that entry
+ * spells, and what number it gets.
+ *
+ * A square starts an entry across when there is nothing to its left and
+ * something to its right, and down when there is nothing above and something
+ * below — the rule every crossword in the world is numbered by. Numbers run in
+ * reading order and a square that starts both directions takes one number for
+ * the pair, which is why this is one pass and not two.
+ */
+function readEntries(
+  cells: Cells,
+  clues: Map<string, string>,
+): Pick<Crossword, "cells" | "across" | "down"> {
+  const height = cells.length;
+  const width = height === 0 ? 0 : cells[0].length;
+  const grid: Array<Array<CrosswordCell | null>> = cells.map((row) =>
+    row.map((letter) => (letter === null ? null : { letter })),
+  );
+  const across: CrosswordEntry[] = [];
+  const down: CrosswordEntry[] = [];
+  let number = 0;
+
+  const runFrom = (x: number, y: number, step: Step): string => {
+    let word = "";
+    for (let i = 0; ; i++) {
+      const letter = at(cells, x + step.dx * i, y + step.dy * i);
+      if (letter === null) return word;
+      word += letter;
+    }
+  };
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (cells[y][x] === null) continue;
+      const startsAcross =
+        at(cells, x - 1, y) === null && at(cells, x + 1, y) !== null;
+      const startsDown =
+        at(cells, x, y - 1) === null && at(cells, x, y + 1) !== null;
+      if (!startsAcross && !startsDown) continue;
+
+      number += 1;
+      grid[y][x] = { letter: cells[y][x] as string, number };
+      for (const [starts, step, list] of [
+        [startsAcross, ACROSS, across],
+        [startsDown, DOWN, down],
+      ] as const) {
+        if (!starts) continue;
+        const answer = runFrom(x, y, step);
+        list.push({
+          number,
+          // A run the clue list has never heard of cannot happen while the
+          // adjacency rules above hold — every run *is* a placed word. Saying
+          // so out loud rather than asserting it: an entry with no clue is
+          // still an entry, and a sheet with a blank clue on it is a bug
+          // somebody can see, which is better than one that throws at build.
+          clue: clues.get(answer) ?? "",
+          answer,
+          column: x,
+          row: y,
+        });
+      }
+    }
+  }
+  return { cells: grid, across, down };
+}
+
+/** The grid trimmed to the words in it, so no page is spent on empty squares. */
+function crop(cells: Cells): Cells {
+  let top = cells.length;
+  let bottom = -1;
+  let left = cells.length;
+  let right = -1;
+  for (let y = 0; y < cells.length; y++) {
+    for (let x = 0; x < cells[y].length; x++) {
+      if (cells[y][x] === null) continue;
+      top = Math.min(top, y);
+      bottom = Math.max(bottom, y);
+      left = Math.min(left, x);
+      right = Math.max(right, x);
+    }
+  }
+  if (bottom < 0) return [];
+  return cells.slice(top, bottom + 1).map((row) => row.slice(left, right + 1));
+}
+
+/**
+ * One go at laying the words out, inside a `size` by `size` grid.
+ *
+ * Longest first, which matters more here than it does in a word search: the
+ * long words are the ones with the crossings in them, so a grid that starts
+ * with three-letter words has nothing for the nine-letter one to hang on. The
+ * seed shuffles first and the sort is stable, so equal-length words are ordered
+ * by the seed.
+ *
+ * Then the words that found nowhere to go are offered the grid again, up to
+ * `PASSES` times over. That is not the "shuffle and try again" this file is at
+ * pains to avoid — nothing is re-randomised and nothing is undone. It is that
+ * the question genuinely changes: a word needs a letter to cross, and every
+ * word placed after it put more letters on the board. BECAUSE with no U to hang
+ * on when its turn came may well have one by the time DOG and THE have landed.
+ * The loop stops the moment a whole pass places nothing, so the work is bounded
+ * by the words rather than by the constant.
+ */
+const PASSES = 3;
+
+function attempt(
+  entries: Clued[],
+  size: number,
+  clues: Map<string, string>,
+  rand: () => number,
+): Crossword {
+  const cells: Cells = Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => null),
+  );
+
+  const order = shuffled(entries, rand)
+    .map((entry, at) => ({ entry, at }))
+    .sort((a, b) => b.entry.word.length - a.entry.word.length || a.at - b.at)
+    .map(({ entry }) => entry.word);
+
+  // Too short to be an entry, or too long for the grid: no pass will change
+  // either, so they are out before the first one starts.
+  let waiting = order.filter(
+    (word) => word.length >= MIN_ENTRY && word.length <= size,
+  );
+
+  let anchored = false;
+  for (let pass = 0; pass < PASSES && waiting.length > 0; pass++) {
+    const stuck: string[] = [];
+    for (const word of waiting) {
+      if (!anchored) {
+        // The first word has nothing to cross, so it is laid across the middle
+        // and everything else grows off it.
+        write(
+          cells,
+          word,
+          Math.floor((size - word.length) / 2),
+          Math.floor(size / 2),
+          ACROSS,
+        );
+        anchored = true;
+        continue;
+      }
+      const spot = bestSpot(spotsFor(cells, word));
+      if (!spot) {
+        stuck.push(word);
+        continue;
+      }
+      write(cells, word, spot.x, spot.y, spot.step);
+    }
+    if (stuck.length === waiting.length) break;
+    waiting = stuck;
+  }
+
+  // **The missing list is read off the finished grid, not off the placer.** A
+  // word is on the sheet when it has squares of its own and a number to be
+  // clued by, and that is a question about the grid rather than about whether
+  // `write` was called — the two came apart the first time ASK was laid over an
+  // AS that was already there. Asking the paper is the same discipline the
+  // answer key is derived by, and it cannot make that mistake.
+  //
+  // In the order the parent typed them, because the list on the sheet is a list
+  // of their words rather than of the placer's regrets.
+  const grid = readEntries(crop(cells), clues);
+  const present = new Set(
+    [...grid.across, ...grid.down].map((entry) => entry.answer),
+  );
+  return {
+    ...grid,
+    omitted: entries
+      .map((entry) => entry.word)
+      .filter((word) => !present.has(word)),
+  };
+}
+
+/**
+ * How many layouts are tried before the best of them is kept.
+ *
+ * Which words land is decided almost entirely by which word is laid down first:
+ * COULD shares not one letter with AFTER, AGAIN or EVERY, so a sight-word list
+ * anchored on COULD places three of its twelve words and the same list anchored
+ * on AFTER places nine. That is not a flaw in the placer, it is the shape of
+ * English — and the fix is not a cleverer placer but a second opinion.
+ *
+ * Six goes, each off the same seeded stream, and the one with the most words in
+ * it wins. Bounded work, still a pure function of `(config, seed)`, and it
+ * stops early the moment a layout takes every word there is — there is nothing
+ * left to beat.
+ */
+const ATTEMPTS = 6;
+
+/**
+ * A crossword over `entries`, laid out inside a `size` by `size` grid and
+ * cropped to what landed.
+ *
+ * Ties are broken on the *smaller* grid, which is the right way round: two
+ * layouts holding the same nine words are the same sheet's worth of work, and
+ * the compact one leaves room on the page and is easier to write in. Then on
+ * the earlier attempt, so the choice never depends on iteration order.
+ */
+export function buildCrossword(
+  entries: Clued[],
+  size: number,
+  rand: () => number,
+): Crossword {
+  const clues = new Map(entries.map((entry) => [entry.word, entry.clue]));
+  let best: Crossword | undefined;
+  let most = -1;
+  let smallest = Infinity;
+
+  for (let go = 0; go < ATTEMPTS; go++) {
+    const laid = attempt(entries, size, clues, rand);
+    const placed = entries.length - laid.omitted.length;
+    const area = laid.cells.length * (laid.cells[0]?.length ?? 0);
+    if (placed > most || (placed === most && area < smallest)) {
+      best = laid;
+      most = placed;
+      smallest = area;
+    }
+    if (most === entries.length) break;
+  }
+
+  return best ?? { cells: [], across: [], down: [], omitted: [] };
+}

--- a/src/engine/sheets/words/puzzles.test.ts
+++ b/src/engine/sheets/words/puzzles.test.ts
@@ -5,7 +5,7 @@ import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
 import type { Block, Paper, PuzzleConfig } from "../types";
 
-import { SEARCH_CELL, searchCell } from "./search";
+import { SEARCH_CELL, findWord, searchCell, searchSteps } from "./search";
 import {
   MAX_GRID,
   MIN_GRID,
@@ -182,14 +182,72 @@ describe("a word the puzzle could not hold", () => {
   it("counts the words the page had no room for as well", () => {
     // Two ways to be missing and one thing the marker needs to know. At the
     // largest type on the smallest usable grid, most of a long list has to go.
+    const over = {
+      words: listWords(WORD_LISTS[2]).slice(0, 30),
+      count: 30,
+      fontPt: 24,
+      paper: paper({ margin: "wide" }),
+    };
+    const block = blockOf("wordsearch", over);
+    expect(block.omitted?.length).toBeGreaterThan(0);
+    expect(block.find.length).toBeGreaterThan(0);
+    // Every word is accounted for: on the list, named, or counted.
+    expect(
+      block.find.length +
+        (block.omitted?.length ?? 0) +
+        (block.omittedMore ?? 0),
+    ).toBe(30);
+  });
+
+  it("counts the ones the page cannot even name", () => {
+    // At the largest type an 8 × 8 grid is nearly the whole writing space, and
+    // naming thirty words under it would be nine rows of italic text on a page
+    // with no puzzle left on it. So the line names what it was reserved room
+    // for and counts the rest. A count is a poor substitute for a name; a
+    // paragraph on a second sheet of paper is worse.
     const block = blockOf("wordsearch", {
       words: listWords(WORD_LISTS[2]).slice(0, 30),
       count: 30,
       fontPt: 36,
       paper: paper({ margin: "wide" }),
     });
-    expect(block.omitted?.length).toBeGreaterThan(0);
-    expect((block.omitted?.length ?? 0) + block.find.length).toBe(30);
+    expect(block.omittedMore ?? 0).toBeGreaterThan(0);
+    expect(
+      block.find.length +
+        (block.omitted?.length ?? 0) +
+        (block.omittedMore ?? 0),
+    ).toBe(30);
+  });
+
+  it("is never named on a sheet whose grid holds it", () => {
+    // The lie the family exists to prevent, at the layout boundary rather than
+    // the placer's: the page trims the word list to what fits, and the filler
+    // was only ever told about the words that survived — so it was free to
+    // spell the rest, and the sheet said "Not in the grid: HAS" over a grid
+    // with HAS in it.
+    const over = {
+      words: listWords(WORD_LISTS[2]).slice(0, 30),
+      count: 30,
+      fontPt: 36,
+      paper: paper({ margin: "wide" }),
+    };
+    const { dropped } = searchLayout(config(over));
+    for (let seed = 1; seed <= 10; seed++) {
+      const block = blockOf("wordsearch", over, seed);
+      for (const word of block.omitted ?? []) {
+        // Not findable the way the sheet says the words run …
+        expect(
+          findWord(block.letters, word, searchSteps("across-down", false)),
+        ).toBeUndefined();
+        // … and a word the *page* dropped is not there in any direction at
+        // all. It is on no list, so a child who spots it running up a diagonal
+        // has found something the sheet just called absent.
+        if (dropped.includes(word))
+          expect(
+            findWord(block.letters, word, searchSteps("all", true)),
+          ).toBeUndefined();
+      }
+    }
   });
 });
 
@@ -226,6 +284,40 @@ describe("what fits on the paper", () => {
       const height = block.cells.length * searchCell(box.width, columns);
       expect(height).toBeLessThanOrEqual(size * SEARCH_CELL);
       expect(height).toBeLessThanOrEqual(box.height);
+    }
+  });
+
+  it("reserves the line that admits a word did not fit", () => {
+    // The line `<Omitted>` prints under the puzzle, which had no reserved
+    // height at all — and it only ever appears on a page the trim loop has just
+    // shrunk to exactly its capacity, because trimming is what creates it. It
+    // was guaranteed to overflow precisely when it was guaranteed to be there.
+    const words = listWords(WORD_LISTS[2]).slice(0, 30);
+    for (const size of ["letter", "a4", "legal"] as const) {
+      for (const margin of ["narrow", "normal", "wide"] as const) {
+        for (const fontPt of [10, 12, 18, 24, 36]) {
+          const over = {
+            words,
+            count: 30,
+            fontPt,
+            paper: paper({ size, margin }),
+            size: MAX_GRID,
+          };
+          for (const layout of [
+            searchLayout(config(over)),
+            crosswordLayout(config({ ...over, style: "crossword" })),
+          ]) {
+            if (layout.height <= layout.box.height) continue;
+            // The one page the arithmetic cannot rescue: at the largest type
+            // the grid at MIN_GRID is already almost the whole writing space,
+            // and the sheet is still not allowed to stay silent about the
+            // twenty-odd words it dropped. Over by that single row, never by
+            // the nine the whole list would have taken.
+            expect(layout.missingRows).toBe(1);
+            expect(fontPt).toBe(36);
+          }
+        }
+      }
     }
   });
 

--- a/src/engine/sheets/words/puzzles.test.ts
+++ b/src/engine/sheets/words/puzzles.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from "vitest";
+
+import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import type { Block, Paper, PuzzleConfig } from "../types";
+
+import { SEARCH_CELL, searchCell } from "./search";
+import {
+  MAX_GRID,
+  MIN_GRID,
+  crosswordClue,
+  crosswordLayout,
+  letterHint,
+  puzzleWords,
+  scramble,
+  searchLayout,
+} from "./puzzles";
+
+/**
+ * The puzzle family, from the front door.
+ *
+ * `search.test.ts` and `crossword.test.ts` hold the two generators to their own
+ * grids. This is the layer above: that the family routes, that a sheet is a
+ * pure function of `(config, seed)`, that the key is the same build, that a
+ * word which did not make it onto the page is *on the page saying so* — and
+ * that nothing here can be handed a list it hangs on.
+ */
+
+const paper = (over: Partial<Paper> = {}): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+  ...over,
+});
+
+const WORDS = ["because", "thought", "friend", "people", "through", "cat"];
+
+const config = (over: Partial<PuzzleConfig> = {}): PuzzleConfig => ({
+  kind: "puzzle",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style: "search",
+  words: WORDS,
+  size: 12,
+  directions: "across-down",
+  reverse: false,
+  overlap: true,
+  count: WORDS.length,
+  columns: 2,
+  ...over,
+});
+
+function blockOf<K extends Block["kind"]>(
+  kind: K,
+  over: Partial<PuzzleConfig>,
+  seed = 1,
+): Extract<Block, { kind: K }> {
+  const block = buildSheet(config(over), seed).blocks[0];
+  if (block.kind !== kind)
+    throw new Error(`expected ${kind}, got ${block.kind}`);
+  return block as Extract<Block, { kind: K }>;
+}
+
+describe("the family", () => {
+  it("is in the registry, under the kind a saved sheet carries", () => {
+    expect(sheetSpec("puzzle").id).toBe("puzzle");
+    expect(sheetSpec("puzzle").label).toBe("Word puzzle");
+  });
+
+  it("makes one block, whichever puzzle it is", () => {
+    expect(blockOf("wordsearch", {}).kind).toBe("wordsearch");
+    expect(blockOf("crossword", { style: "crossword" }).kind).toBe("crossword");
+    expect(blockOf("problems", { style: "scramble" }).kind).toBe("problems");
+  });
+
+  it("falls back to a word search for a style this build never had", () => {
+    // A sheet saved in March opens in June, the same promise `sheetSpec` makes.
+    const stale = { style: "acrostic" as PuzzleConfig["style"] };
+    expect(buildSheet(config(stale), 1).blocks[0].kind).toBe("wordsearch");
+  });
+
+  it("is a pure function of its config and seed", () => {
+    for (const style of ["search", "crossword", "scramble"] as const) {
+      for (const seed of [0, 1, 4242]) {
+        const once = buildSheet(config({ style }), seed);
+        const twice = buildSheet(config({ style }), seed);
+        expect(once).not.toBe(twice);
+        expect(once).toEqual(twice);
+      }
+    }
+  });
+
+  it("stays deterministic across papers and type sizes", () => {
+    for (const size of ["letter", "a4", "legal"] as const) {
+      for (const fontPt of [10, 12, 18]) {
+        const over = { paper: paper({ size }), fontPt };
+        expect(buildSheet(config(over), 7)).toEqual(
+          buildSheet(config(over), 7),
+        );
+      }
+    }
+  });
+
+  it("says in one line what it is about to print", () => {
+    expect(describeSheet(config())).toBe("Word search — 6 words — 12 × 12");
+    expect(describeSheet(config({ style: "scramble" }))).toBe(
+      "Word scramble — 6 words",
+    );
+    expect(describeSheet(config({ reverse: true }))).toContain(
+      "some backwards",
+    );
+  });
+
+  it("marks the sheet out of what is on it, not out of what was asked for", () => {
+    const sheet = buildSheet(config(), 1);
+    const block = sheet.blocks[0];
+    if (block.kind !== "wordsearch") throw new Error("expected a word search");
+    expect(sheet.header.score).toEqual({ outOf: block.find.length });
+  });
+});
+
+describe("the list a puzzle is given", () => {
+  it("is held to the same shape a spelling sheet holds it to", () => {
+    const { words } = puzzleWords(
+      config({ words: ["  cat ", "", "cat", "Cat", "dog"] }),
+    );
+    expect(words.map((word) => word.given)).toEqual(["cat", "dog"]);
+  });
+
+  it("folds two words a grid cannot tell apart into one", () => {
+    // "its" and "it's" are two words to a marker and one word to a letter
+    // grid. Printing ITS twice on the word list would ask a child to find the
+    // same squares again.
+    const { words } = puzzleWords(config({ words: ["it's", "its", "sun"] }));
+    expect(words.map((word) => word.form)).toEqual(["ITS", "SUN"]);
+  });
+
+  it("reports a word with no letters in it rather than swallowing it", () => {
+    const { words, unusable } = puzzleWords(config({ words: ["cat", "123"] }));
+    expect(words.map((word) => word.form)).toEqual(["CAT"]);
+    expect(unusable).toEqual(["123"]);
+  });
+
+  it("prints on the sheet the same forms it hid in the grid", () => {
+    const block = blockOf("wordsearch", { words: ["don't", "sun"], count: 2 });
+    expect(block.find).toEqual(["DONT", "SUN"]);
+    for (const row of block.letters)
+      for (const letter of row) expect(letter).toMatch(/^[A-Z]$/);
+  });
+});
+
+describe("a word the puzzle could not hold", () => {
+  it("is named on the word search rather than dropped", () => {
+    // The whole story. A word that vanishes is a child hunting for something
+    // that is not there and a key that never mentions it.
+    const block = blockOf("wordsearch", {
+      words: ["extraordinarily", "cat"],
+      size: MIN_GRID,
+      count: 2,
+    });
+    expect(block.find).toEqual(["CAT"]);
+    expect(block.omitted).toEqual(["EXTRAORDINARILY"]);
+  });
+
+  it("is named on the crossword rather than dropped", () => {
+    const block = blockOf("crossword", {
+      style: "crossword",
+      words: ["abc", "def"],
+      count: 2,
+    });
+    expect(block.omitted).toEqual(["DEF"]);
+  });
+
+  it("says nothing at all when every word landed", () => {
+    // A line admitting a failure that did not happen is noise on a child's
+    // page, so the field is absent rather than empty.
+    expect(blockOf("wordsearch", {}).omitted).toBeUndefined();
+  });
+
+  it("counts the words the page had no room for as well", () => {
+    // Two ways to be missing and one thing the marker needs to know. At the
+    // largest type on the smallest usable grid, most of a long list has to go.
+    const block = blockOf("wordsearch", {
+      words: listWords(WORD_LISTS[2]).slice(0, 30),
+      count: 30,
+      fontPt: 36,
+      paper: paper({ margin: "wide" }),
+    });
+    expect(block.omitted?.length).toBeGreaterThan(0);
+    expect((block.omitted?.length ?? 0) + block.find.length).toBe(30);
+  });
+});
+
+describe("what fits on the paper", () => {
+  it("shrinks the grid rather than running off the page", () => {
+    for (const size of ["letter", "a4", "legal"] as const) {
+      for (const fontPt of [10, 12, 18, 24, 36]) {
+        for (const margin of ["narrow", "normal", "wide"] as const) {
+          const over = {
+            paper: paper({ size, margin }),
+            fontPt,
+            size: MAX_GRID,
+          };
+          const grid = searchLayout(config(over));
+          expect(grid.size).toBeGreaterThanOrEqual(MIN_GRID);
+          expect(grid.size).toBeLessThanOrEqual(MAX_GRID);
+          // The grid alone, before the word list under it, is inside the box.
+          expect(grid.size * grid.cell).toBeLessThanOrEqual(grid.box.height);
+        }
+      }
+    }
+  });
+
+  it("keeps the crossword inside the height it reserved", () => {
+    // The reservation is made against `size × SEARCH_CELL` before the puzzle
+    // exists; the finished grid is cropped, and a cropped grid has fewer
+    // columns and therefore *bigger* squares. This is the assertion that would
+    // fail if that were reserved at the bound's own square size.
+    for (const fontPt of [10, 12, 18]) {
+      const over = { style: "crossword" as const, fontPt, size: MAX_GRID };
+      const { box, size } = crosswordLayout(config(over));
+      const block = blockOf("crossword", over);
+      const columns = block.cells[0]?.length ?? 0;
+      const height = block.cells.length * searchCell(box.width, columns);
+      expect(height).toBeLessThanOrEqual(size * SEARCH_CELL);
+      expect(height).toBeLessThanOrEqual(box.height);
+    }
+  });
+
+  it("never prints more scrambles than the page holds", () => {
+    const many = listWords(WORD_LISTS[2]).slice(0, 30);
+    const block = blockOf("problems", {
+      style: "scramble",
+      words: many,
+      count: 30,
+      fontPt: 36,
+      columns: 1,
+    });
+    expect(block.items.length).toBeGreaterThan(0);
+    expect(block.items.length).toBeLessThan(many.length);
+  });
+});
+
+describe("the scramble", () => {
+  it("prints an anagram of the word, never the word", () => {
+    for (const seed of [1, 2, 3, 4, 5]) {
+      const block = blockOf("problems", { style: "scramble" }, seed);
+      for (const item of block.items) {
+        const shown = item.prompt.replaceAll(" ", "");
+        expect([...shown].sort().join("")).toBe(
+          [...item.answer].sort().join(""),
+        );
+        expect(shown).not.toBe(item.answer);
+      }
+    }
+  });
+
+  it("keeps every character, punctuation included", () => {
+    // A permutation of the whole string, so a child rearranging what they can
+    // see arrives at exactly the word on the key.
+    const block = blockOf("problems", {
+      style: "scramble",
+      words: ["don't"],
+      count: 1,
+    });
+    expect(block.items[0].prompt.replaceAll(" ", "")).toHaveLength(5);
+    expect(block.items[0].answer).toBe("don't");
+  });
+
+  it("gives up on a word that has nothing to rearrange", () => {
+    // `aa` has one anagram and it is itself. Eight draws and a swap cannot
+    // change that, and the honest answer is the word — not a hung loop.
+    const rand = () => 0.5;
+    expect(scramble("aa", rand)).toBe("aa");
+    expect(scramble("a", rand)).toBe("a");
+    expect(scramble("", rand)).toBe("");
+  });
+
+  it("differs even where a shuffle keeps landing where it started", () => {
+    // A rand that never moves anything: the fallback swap is what saves it.
+    const stuck = () => 0;
+    expect(scramble("ab", stuck)).toBe("ba");
+    expect(scramble("aab", stuck)).not.toBe("aab");
+  });
+});
+
+describe("a crossword's clues", () => {
+  it("come from the sentence the list already gives the word", () => {
+    // "Fish _ chips for tea." is what the jungle says when it reads `and`
+    // aloud, and it is exactly the shape of a crossword clue (§11).
+    expect(crosswordClue({ given: "and", form: "AND" })).toBe(
+      "Fish ___ chips for tea.",
+    );
+    // Found on the grid form too, so a list typed in capitals still gets them.
+    expect(crosswordClue({ given: "AND", form: "AND" })).toContain("chips");
+  });
+
+  it("fall back to the word's own letters where nobody wrote one", () => {
+    const clue = crosswordClue({ given: "quokka", form: "QUOKKA" });
+    expect(clue).toMatch(/^Jumbled: /);
+    expect(clue.replace("Jumbled: ", "").replaceAll(" ", "")).not.toBe(
+      "QUOKKA",
+    );
+    expect(
+      [...clue.replace("Jumbled: ", "").replaceAll(" ", "")].sort().join(""),
+    ).toBe([..."QUOKKA"].sort().join(""));
+  });
+
+  it("do not depend on the seed, because the layout has to measure them", () => {
+    expect(letterHint("THROUGH")).toBe(letterHint("THROUGH"));
+    expect(letterHint("CAT")).not.toBe("CAT");
+    expect(letterHint("ABAB")).not.toBe("ABAB");
+    // Nothing to disguise, so nothing is claimed.
+    expect(letterHint("AA")).toBe("AA");
+  });
+
+  it("are on every entry the grid ended up with", () => {
+    const block = blockOf("crossword", { style: "crossword" });
+    for (const entry of [...block.across, ...block.down])
+      expect(entry.clue.length).toBeGreaterThan(0);
+  });
+});
+
+describe("the answer key", () => {
+  it("is the same sheet with the answers turned on", () => {
+    for (const style of ["search", "crossword", "scramble"] as const) {
+      const sheet = buildSheet(config({ style }), 3);
+      const key = answerKey(config({ style }), 3);
+      // The blocks are identical — the answers were decided when the sheet was
+      // built, so there is no second generation to disagree with the first.
+      expect(key.blocks).toEqual(sheet.blocks);
+      expect(sheet.answers).toBe(false);
+      expect(key.answers).toBe(true);
+      expect(key.footer.note).toBe("Answer key");
+    }
+  });
+
+  it("carries a stroke for every word on the list and no others", () => {
+    const block = blockOf("wordsearch", {});
+    expect(block.solution?.map((found) => found.word)).toEqual(block.find);
+  });
+});
+
+describe("a list nothing can be done with", () => {
+  it("still produces a sheet", () => {
+    // Twenty words as long as the grid, none allowed to touch: the pathological
+    // case, and every one of these has to come back rather than spin.
+    const impossible = Array.from(
+      { length: 20 },
+      (_, at) => `zzzzzzz${String.fromCharCode(97 + at)}`,
+    );
+    for (const style of ["search", "crossword", "scramble"] as const) {
+      const sheet = buildSheet(
+        config({
+          style,
+          words: impossible,
+          count: 20,
+          size: 8,
+          overlap: false,
+        }),
+        1,
+      );
+      expect(sheet.blocks).toHaveLength(1);
+      expect(sheet.header.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("still produces a sheet when there is no list at all", () => {
+    for (const style of ["search", "crossword", "scramble"] as const) {
+      const sheet = buildSheet(config({ style, words: [], count: 0 }), 1);
+      expect(sheet.blocks).toHaveLength(1);
+      expect(sheet.header.score).toEqual({ outOf: 0 });
+    }
+  });
+});

--- a/src/engine/sheets/words/puzzles.ts
+++ b/src/engine/sheets/words/puzzles.ts
@@ -1,0 +1,597 @@
+/**
+ * Puzzles, over whatever list a parent already has.
+ *
+ * The third family on the words shelf, and the sibling of `words/spelling.ts`
+ * rather than a replacement for it: the same box of words, set as a game
+ * instead of as an exercise. Three of them — a letter grid to hunt in, a
+ * crossword clued from the sentences the sight-word lists already carry, and
+ * the letters of a word out of order.
+ *
+ * Everything the shelf promises holds here unchanged. The page comes out of
+ * `(config, seed)` and nothing else; the answers are computed when the sheet is
+ * built and the key only decides to print them; no row goes on the page that
+ * the capacity arithmetic did not reserve room for.
+ *
+ * What is different is where the risk sits. A page of sums is checked by doing
+ * the sums, and a page of spellings is checked by reading them. A word search
+ * is checked by *finding twelve words in a grid*, which nobody does — so a word
+ * that quietly failed to place looks exactly like a word that placed well, and
+ * the sheet goes out asking a child to find something that is not there. That
+ * is the failure this family is built around, and the two generators it leans
+ * on (`search.ts`, `crossword.ts`) answer it the same way: the answer key is
+ * read out of the finished puzzle, and a word the finished puzzle does not
+ * contain is **named on the sheet** rather than dropped.
+ */
+import { fillClue, shippedClue } from "@/engine/decks/words";
+import { mulberry32, shuffled } from "@/engine/random";
+
+import type {
+  Block,
+  Mil,
+  Problem,
+  PuzzleConfig,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { declaredWidth, packRows, sheetBlockBox } from "../chrome";
+import { PROBLEM_GAP, columnWidth, fitAcross, type Box } from "../layout";
+import { inches, points } from "../paper";
+import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
+import { buildCrossword, type Clued } from "./crossword";
+import {
+  SEARCH_CELL,
+  buildSearch,
+  gridForm,
+  searchCell,
+  searchSteps,
+} from "./search";
+import { wordsOf } from "./spelling";
+
+/* ── What a puzzle takes on the page ──────────────────────────────────────
+   Declared, not measured (§4), and every number here trails sheet.css. The
+   failure is the usual one and it is silent on screen: a block an eighth of an
+   inch taller than the space reserved for it prints its last row on a second
+   sheet of paper.                                                           */
+
+/** A scrambled word and the rule it is written on: one line of body type. */
+const ROW_EMS = 1.7;
+
+/** `.sheet__words` and `.sheet__clues` are both set at nine tenths. */
+const SMALL_EM = 0.9;
+/** Which is a line box of `0.9 × 1.35` at the sheet's own line height. */
+const SMALL_ROW_EMS = 1.22;
+
+/** `.sheet__words`: the word list under a grid, and the air around it. */
+const LIST_GAP = inches(0.28);
+const LIST_ROW_GAP = inches(0.06);
+const LIST_MARGIN = inches(0.12);
+
+/** `.sheet__clues`: two columns of clues, and the heading over each. */
+const CLUE_GAP = inches(0.3);
+const CLUE_ROW_GAP = inches(0.05);
+const CLUE_MARGIN = inches(0.12);
+const CLUE_HEAD_EMS = 1.4;
+/** Room for the number in front of a clue, which is not known until it is one. */
+const CLUE_NUMBER = "88. ";
+
+/** More than three columns of scrambled words is a page nobody can write on. */
+const MAX_COLUMNS = 3;
+
+/**
+ * How big a grid may be asked for.
+ *
+ * Eight is the smallest square that holds a word a child of this age is likely
+ * to be given; twenty is where a cell stops being a square somebody can write a
+ * letter in on Letter paper. A config outside that is clamped rather than
+ * refused, and a grid that still would not fit *with its word list under it* is
+ * shrunk again by `searchLayout` — the paper has the last word.
+ */
+export const MIN_GRID = 8;
+export const MAX_GRID = 20;
+
+/**
+ * How many words one puzzle may carry.
+ *
+ * Well under the two hundred a list may hold, and the cap is about the child
+ * rather than the paper: thirty words in one grid is not a harder puzzle, it is
+ * an afternoon. What the page holds caps it again below this.
+ */
+export const MAX_PUZZLE_WORDS = 30;
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/** A height quoted in ems of the body size, in the unit the page is in. */
+const em = (fontPt: number, rows: number): Mil => points(fontPt * rows);
+
+/** Letters with air between them, which is how a jumble is always printed. */
+const spaced = (text: string): string => [...text].join(" ");
+
+/* ── The list ──────────────────────────────────────────────────────────── */
+
+export type PuzzleWord = {
+  /** As the parent typed it — what a scramble's answer is, and its key. */
+  given: string;
+  /** As a grid can hold it: upper case, letters only (`gridForm`). */
+  form: string;
+};
+
+/**
+ * The words this family works in, and the ones it cannot use at all.
+ *
+ * Sanitised by the spelling family's own `wordsOf`, because a puzzle config
+ * comes through the same three doors a spelling one does — a parent's paste, a
+ * saved sheet, a link somebody was sent — and two sanitisers would be two
+ * answers to whether `Cat` and `cat` are one word.
+ *
+ * Then de-duplicated a second time, on the *grid* form. "its" and "it's" are
+ * two words to a marker and one word to a letter grid, and a puzzle that
+ * printed ITS twice on its word list would be asking a child to find the same
+ * squares again. The first of the pair keeps the place.
+ *
+ * A "word" with no letters in it — a stray `123` off the end of a pasted list —
+ * has no grid form at all, and is reported rather than swallowed.
+ */
+export function puzzleWords(config: PuzzleConfig): {
+  words: PuzzleWord[];
+  unusable: string[];
+} {
+  const seen = new Set<string>();
+  const words: PuzzleWord[] = [];
+  const unusable: string[] = [];
+  for (const given of wordsOf(config)) {
+    const form = gridForm(given);
+    if (form.length === 0) {
+      unusable.push(given);
+      continue;
+    }
+    if (seen.has(form)) continue;
+    seen.add(form);
+    words.push({ given, form });
+  }
+  const wanted = clamp(config.count ?? words.length, 0, MAX_PUZZLE_WORDS);
+  return { words: words.slice(0, wanted), unusable };
+}
+
+/* ── Clues ─────────────────────────────────────────────────────────────── */
+
+/** What a crossword prints where the answer goes in its own clue. */
+const CLUE_BLANK = "___";
+
+/**
+ * The word's own letters, turned so they no longer spell it.
+ *
+ * The clue for a word this build has never met. A crossword needs a clue for
+ * every entry and a parent's list of Tuesday's spellings comes with none, so
+ * the honest fallback is the one clue that can be written for any word at all:
+ * its letters, out of order. It is a real clue — the crossings and the square
+ * count settle it — and it is the same question the scramble style asks, which
+ * is the right kind of coincidence on a shelf where one list makes seven
+ * sheets.
+ *
+ * A rotation rather than a shuffle, because the *layout* has to measure the
+ * clue list before a seed has chosen anything, and a clue whose length depends
+ * on the seed would be a page whose capacity does too. Half the word round,
+ * falling back to reversing it in the one case where that lands where it
+ * started ("abab"). A word of one repeated letter cannot be disguised, and is
+ * printed as it is.
+ */
+export function letterHint(word: string): string {
+  const letters = [...word];
+  const shift = Math.max(1, Math.floor(letters.length / 2));
+  const turned = [...letters.slice(shift), ...letters.slice(0, shift)].join("");
+  return turned === word ? letters.reverse().join("") : turned;
+}
+
+/**
+ * The clue for one entry: the list's own sentence where there is one.
+ *
+ * Every shipped sight-word list gives each of its words a short sentence with
+ * the word taken out of it — written for the race, where it is what makes a
+ * homophone answerable at all — and a crossword clue is *exactly* that shape.
+ * So the sheet and the game ask one question of one list, and a crossword set
+ * on "First words" is clued in sentences somebody wrote for a five-year-old
+ * rather than in dictionary definitions nobody would.
+ *
+ * Looked up on the word as typed first and on the grid form second, so a list
+ * written in capitals still finds its sentences and `DONT` still finds the one
+ * written for `don't`.
+ */
+export function crosswordClue({ given, form }: PuzzleWord): string {
+  const sentence = shippedClue(given) ?? shippedClue(form);
+  if (sentence) return fillClue(sentence, CLUE_BLANK);
+  return `Jumbled: ${spaced(letterHint(form))}`;
+}
+
+/* ── Scrambling ────────────────────────────────────────────────────────── */
+
+/** How many draws before a word that keeps coming back as itself is fixed. */
+const SCRAMBLE_TRIES = 8;
+
+/**
+ * The word's characters in another order — never the same order.
+ *
+ * A permutation of the whole string rather than of its letters, so what is
+ * printed is a genuine anagram of what the key says: the answer to `n ' t d o`
+ * is `don't`, apostrophe included, and a child rearranging the characters they
+ * can see arrives at exactly the word on the key.
+ *
+ * Bounded, and this is the one place in the family where an unbounded loop
+ * would be the obvious way to write it. "Shuffle until it differs" is a
+ * one-in-two coin toss on a two-letter word and never terminates on `aa`, so
+ * after eight goes the letters are simply swapped into a position they cannot
+ * have started in. A word of one repeated letter is returned as it is, because
+ * there is nothing else it can be.
+ */
+export function scramble(word: string, rand: () => number): string {
+  const letters = [...word];
+  if (new Set(letters).size < 2) return word;
+  for (let tries = 0; tries < SCRAMBLE_TRIES; tries++) {
+    const out = shuffled(letters, rand).join("");
+    if (out !== word) return out;
+  }
+  const different = letters.findIndex((letter) => letter !== letters[0]);
+  const swapped = [...letters];
+  [swapped[0], swapped[different]] = [swapped[different], swapped[0]];
+  return swapped.join("");
+}
+
+/* ── What fits ─────────────────────────────────────────────────────────── */
+
+/** The wrapping word list under a grid, at the height it will actually take. */
+function listHeight(words: string[], head: SheetOptions, width: Mil): Mil {
+  if (words.length === 0) return 0;
+  const rows = packRows(
+    words.map((word) => declaredWidth(word, head, SMALL_EM)),
+    width,
+    LIST_GAP,
+  );
+  return (
+    LIST_MARGIN +
+    em(head.fontPt, SMALL_ROW_EMS * rows) +
+    LIST_ROW_GAP * Math.max(0, rows - 1)
+  );
+}
+
+/**
+ * The grid, and the words there is room to hunt for in it.
+ *
+ * Two passes, and they are in this order because they are not equally cheap to
+ * be wrong about. A grid one row smaller is a puzzle nobody notices; a word
+ * list one word shorter is a word the parent asked for and did not get. So the
+ * grid gives way first, down to `MIN_GRID`, and only then are words dropped —
+ * and the ones dropped are reported on the sheet with the ones the placer could
+ * not fit, because "not in the grid" is true of both and is the only thing the
+ * person marking it needs to know.
+ */
+export function searchLayout(config: PuzzleConfig): {
+  box: Box;
+  size: number;
+  cell: Mil;
+  words: PuzzleWord[];
+  dropped: string[];
+} {
+  const head = headerOf(config);
+  const box = sheetBlockBox(head, true);
+  const { words, unusable } = puzzleWords(config);
+
+  const heightOf = (size: number, some: PuzzleWord[]): Mil =>
+    size * searchCell(box.width, size) +
+    listHeight(
+      some.map((word) => word.form),
+      head,
+      box.width,
+    );
+
+  let size = clamp(config.size ?? MIN_GRID, MIN_GRID, MAX_GRID);
+  while (size > MIN_GRID && heightOf(size, words) > box.height) size -= 1;
+
+  let fit = words;
+  while (fit.length > 0 && heightOf(size, fit) > box.height)
+    fit = fit.slice(0, -1);
+
+  return {
+    box,
+    size,
+    cell: searchCell(box.width, size),
+    words: fit,
+    dropped: [...words.slice(fit.length).map((word) => word.form), ...unusable],
+  };
+}
+
+/** The reserved height of a crossword's clue list, both columns in one. */
+function clueHeight(clues: string[], head: SheetOptions, width: Mil): Mil {
+  if (clues.length === 0) return 0;
+  const column = columnWidth({ x: 0, y: 0, width, height: 0 }, 2, CLUE_GAP);
+  const rows = clues.reduce(
+    (total, clue) =>
+      total +
+      Math.max(
+        1,
+        Math.ceil(
+          declaredWidth(`${CLUE_NUMBER}${clue}`, head, SMALL_EM) /
+            Math.max(1, column),
+        ),
+      ),
+    0,
+  );
+  return (
+    CLUE_MARGIN +
+    em(head.fontPt, CLUE_HEAD_EMS * 2 + SMALL_ROW_EMS * rows) +
+    CLUE_ROW_GAP * Math.max(0, clues.length - 1)
+  );
+}
+
+/**
+ * The crossword's bound, and the clues there is room to print under it.
+ *
+ * Reserved against the **largest** grid the config allows rather than against
+ * the one the words turn out to need, because the finished grid is cropped to
+ * what landed and cannot be known before it is built. That over-reserves — a
+ * dozen short words in a thirteen-square bound crop to eight or nine — and
+ * over-reserving costs a row of white space at the foot of the page, where
+ * under-reserving costs a second sheet of paper. `chrome.ts` makes the same
+ * trade for the same reason.
+ *
+ * The clue list is reserved as though every clue landed in one column, for the
+ * same reason again: it prints in two, and which of them a clue falls in is a
+ * question about how many across entries there turned out to be.
+ *
+ * And the square is reserved at `SEARCH_CELL` rather than at the size the bound
+ * would come out at, which is the one piece of this that is not merely
+ * cautious. A cropped grid has *fewer columns*, and fewer columns is a bigger
+ * square — ten columns of a twenty-square bound get the full 0.34in where the
+ * bound itself would have got 0.325in — so a reservation made at the bound's
+ * own square would be a grid taller than the room made for it, which is exactly
+ * the failure this arithmetic exists to prevent.
+ */
+export function crosswordLayout(config: PuzzleConfig): {
+  box: Box;
+  /** The largest grid the words may be laid out in, not the one they need. */
+  size: number;
+  entries: Clued[];
+  dropped: string[];
+} {
+  const head = headerOf(config);
+  const box = sheetBlockBox(head, true);
+  const { words, unusable } = puzzleWords(config);
+  const clued: Clued[] = words.map((word) => ({
+    word: word.form,
+    clue: crosswordClue(word),
+  }));
+
+  const heightOf = (size: number, some: Clued[]): Mil =>
+    size * SEARCH_CELL +
+    clueHeight(
+      some.map((entry) => entry.clue),
+      head,
+      box.width,
+    );
+
+  let size = clamp(config.size ?? MIN_GRID, MIN_GRID, MAX_GRID);
+  while (size > MIN_GRID && heightOf(size, clued) > box.height) size -= 1;
+
+  let fit = clued;
+  while (fit.length > 0 && heightOf(size, fit) > box.height)
+    fit = fit.slice(0, -1);
+
+  return {
+    box,
+    size,
+    entries: fit,
+    dropped: [
+      ...clued.slice(fit.length).map((entry) => entry.word),
+      ...unusable,
+    ],
+  };
+}
+
+/** How many scrambles the paper holds, and how wide a column of them is. */
+export function scrambleLayout(config: PuzzleConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  const box = sheetBlockBox(headerOf(config), true);
+  const columns = clamp(config.columns ?? 1, 1, MAX_COLUMNS);
+  const row = em(config.fontPt, ROW_EMS);
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, PROBLEM_GAP.y),
+  };
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+function searchBlocks(
+  config: PuzzleConfig,
+  seed: number,
+): { blocks: Block[]; outOf: number } {
+  const { size, words, dropped } = searchLayout(config);
+  const puzzle = buildSearch(
+    words.map((word) => word.form),
+    size,
+    {
+      steps: searchSteps(
+        config.directions ?? "across-down",
+        Boolean(config.reverse),
+      ),
+      overlap: config.overlap !== false,
+    },
+    mulberry32(seed),
+  );
+  const omitted = [...puzzle.omitted, ...dropped];
+  return {
+    blocks: [
+      {
+        kind: "wordsearch",
+        letters: puzzle.letters,
+        find: puzzle.find,
+        solution: puzzle.solution,
+        ...(omitted.length > 0 ? { omitted } : {}),
+      },
+    ],
+    // Out of what is findable, never out of what was asked for: a sheet marked
+    // "/ 12" over eleven hidden words is wrong twice over.
+    outOf: puzzle.find.length,
+  };
+}
+
+function crosswordBlocks(
+  config: PuzzleConfig,
+  seed: number,
+): { blocks: Block[]; outOf: number } {
+  const { size, entries, dropped } = crosswordLayout(config);
+  const puzzle = buildCrossword(entries, size, mulberry32(seed));
+  const omitted = [...puzzle.omitted, ...dropped];
+  return {
+    blocks: [
+      {
+        kind: "crossword",
+        cells: puzzle.cells,
+        across: puzzle.across,
+        down: puzzle.down,
+        ...(omitted.length > 0 ? { omitted } : {}),
+      },
+    ],
+    outOf: puzzle.across.length + puzzle.down.length,
+  };
+}
+
+function scrambleBlocks(
+  config: PuzzleConfig,
+  seed: number,
+): { blocks: Block[]; outOf: number } {
+  const rand = mulberry32(seed);
+  const { columns, perPage } = scrambleLayout(config);
+  const { words } = puzzleWords(config);
+  const items: Problem[] = words.slice(0, perPage).map(({ given }) => ({
+    prompt: spaced(scramble(given, rand)),
+    answer: given,
+  }));
+  return {
+    blocks: [{ kind: "problems", columns, items }],
+    outOf: items.length,
+  };
+}
+
+function bodyOf(
+  config: PuzzleConfig,
+  seed: number,
+): { blocks: Block[]; outOf: number } {
+  switch (config.style) {
+    case "crossword":
+      return crosswordBlocks(config, seed);
+    case "scramble":
+      return scrambleBlocks(config, seed);
+    default:
+      return searchBlocks(config, seed);
+  }
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const TITLE: Record<PuzzleConfig["style"], string> = {
+  search: "Word search",
+  crossword: "Crossword",
+  scramble: "Word scramble",
+};
+
+/** How the grid's directions read in a sentence a child is given. */
+const WHICH_WAY: Record<string, string> = {
+  across: "across",
+  "across-down": "across and down",
+  all: "across, down and diagonally",
+};
+
+function instructionOf(config: PuzzleConfig): string {
+  switch (config.style) {
+    case "crossword":
+      return "Write one letter in each square. The number in the corner is where the answer starts.";
+    case "scramble":
+      return "Put the letters back in order and write the word.";
+    default: {
+      const way = WHICH_WAY[config.directions] ?? WHICH_WAY["across-down"];
+      const back = config.reverse ? ", and some are backwards" : "";
+      return `Find and circle each word. Words run ${way}${back}.`;
+    }
+  }
+}
+
+/**
+ * The header this sheet will actually print.
+ *
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page — the instruction line wraps,
+ * and a line the layout did not know about is the last row of the puzzle below
+ * the bottom margin.
+ */
+function headerOf(config: PuzzleConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? TITLE[config.style] ?? TITLE.search,
+    instructions: config.instructions ?? instructionOf(config),
+  };
+}
+
+/** One line naming what the sheet holds, in the terms it was chosen by. */
+export function describePuzzle(config: PuzzleConfig): string {
+  const { words } = puzzleWords(config);
+  const size = clamp(config.size ?? MIN_GRID, MIN_GRID, MAX_GRID);
+  return [
+    TITLE[config.style] ?? TITLE.search,
+    `${words.length} ${words.length === 1 ? "word" : "words"}`,
+    config.style === "search" ? `${size} × ${size}` : null,
+    config.style === "search" && config.reverse ? "some backwards" : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" — ");
+}
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+export function buildPuzzleSheet(config: PuzzleConfig, seed: number): Sheet {
+  const head = headerOf(config);
+  const { blocks, outOf } = bodyOf(config, seed);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      score: { outOf },
+    },
+    blocks,
+    // The jungle, as the spelling sheet's is: a puzzle made of a word list is
+    // the same list the jungle races, and it is the one game a child holding
+    // this page would recognise the words from (§16).
+    footer: { credit: SHEET_CREDIT, url: gameUrl("jungle"), seed },
+    answers: false,
+  };
+}
+
+export const PUZZLE_SHEET: SheetSpec<PuzzleConfig> = {
+  id: "puzzle",
+  label: "Word puzzle",
+  world: SHEET_WORLD,
+  build: buildPuzzleSheet,
+  // Every answer here was decided when the sheet was built — which is to say,
+  // read out of the finished puzzle — so a key cannot disagree with the paper
+  // it belongs to. `key` only turns the printing on.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describePuzzle,
+};

--- a/src/engine/sheets/words/puzzles.ts
+++ b/src/engine/sheets/words/puzzles.ts
@@ -67,6 +67,26 @@ const LIST_GAP = inches(0.28);
 const LIST_ROW_GAP = inches(0.06);
 const LIST_MARGIN = inches(0.12);
 
+/** `.sheet__missing`: the italic line that admits a word did not fit. */
+const MISSING_EM = 0.85;
+/** Which is a line box of `0.85 × 1.35` at the sheet's own line height. */
+const MISSING_ROW_EMS = 1.15;
+const MISSING_MARGIN = inches(0.1);
+
+/**
+ * How much of the page the sheet may spend talking about itself.
+ *
+ * Three rows names thirty words at body size, which is the whole list a puzzle
+ * may carry — so on an ordinary sheet the cap is not reached and every missing
+ * word is named. It bites at the far end, where the type is large and the list
+ * is long: at 36pt on a wide margin a single row is a fifth of the writing
+ * space, and thirty words would be nine of them. A puzzle that gave nine rows
+ * to a paragraph about what is *not* on the page would be a page with no puzzle
+ * on it, so past this the line says "… and 22 more" and the count carries what
+ * the names cannot.
+ */
+const MISSING_ROWS = 3;
+
 /** `.sheet__clues`: two columns of clues, and the heading over each. */
 const CLUE_GAP = inches(0.3);
 const CLUE_ROW_GAP = inches(0.05);
@@ -254,6 +274,143 @@ function listHeight(words: string[], head: SheetOptions, width: Mil): Mil {
   );
 }
 
+/* ── The line that admits a word did not fit ──────────────────────────────
+   Declared like every other row on a sheet, which for a while it was not, and
+   this is the one row where that could not come out in the wash: `<Omitted>`
+   renders it *under* a block the trim loops below have just shrunk to exactly
+   the room available, and the trimming is what creates the list it prints. An
+   unreserved line was guaranteed to be there precisely when there was nothing
+   left to put it in. So both halves are here, and they have to agree — what
+   the arithmetic measures and what the renderer sets are the same tokens, out
+   of the same function.                                                      */
+
+/** What `<Omitted>` puts in front of the list. */
+const MISSING_HEAD = "Not in the grid:";
+
+/** As much of the list as the page can hold, and a count of the rest. */
+type Missing = { words: string[]; more: number };
+
+/**
+ * The missing line, as the words it is set from.
+ *
+ * Tokens rather than a sentence because both halves need it in this shape: the
+ * renderer joins them with a space, and the reservation packs them the way a
+ * wrapping line of text packs — by whole words, greedily, exactly as
+ * `packRows` does for the three wrapping rows in the chrome. A copy of the
+ * sentence in `Omitted.tsx` would be a paragraph measured at one length and
+ * printed at another, which on this shelf is a line below the bottom margin.
+ */
+export function missingTokens(words: string[], more: number): string[] {
+  return [
+    MISSING_HEAD,
+    // The last word takes no comma, the tail included: "CAT, DOG … and 3 more"
+    // is a list that ran out, and "DOG, … and 3 more" is a typo.
+    ...words.map((word, at) => (at === words.length - 1 ? word : `${word},`)),
+    ...(more > 0 ? [`… and ${more} more`] : []),
+  ];
+}
+
+/** How many rows those tokens wrap onto, in the room they are given. */
+function missingRowsOf(
+  words: string[],
+  more: number,
+  head: SheetOptions,
+  width: Mil,
+): number {
+  return packRows(
+    missingTokens(words, more).map((token) =>
+      declaredWidth(`${token} `, head, MISSING_EM),
+    ),
+    width,
+    0,
+  );
+}
+
+/** What a line of `rows` rows takes, and nothing at all for none of them. */
+function missingHeight(rows: number, fontPt: number): Mil {
+  return rows === 0 ? 0 : MISSING_MARGIN + em(fontPt, MISSING_ROW_EMS * rows);
+}
+
+/**
+ * How many rows to hold back, before it is known there will be a line at all.
+ *
+ * The two things that put a word on this line are decided at different times,
+ * so the reservation answers them differently. The page's own drops are known
+ * right here — the trim loops below are what create them — and are measured.
+ * The placer's are not known until the grid has been built, by which point the
+ * room is spent, and they get **one row, always**: a sheet where everything
+ * fits gives up a row it will not use, which costs a line of white space, and
+ * the other side of that trade is a paragraph on a second sheet of paper.
+ *
+ * `anyWords` is what distinguishes "nothing could go wrong" from "nothing has
+ * yet": a puzzle with no words at all reserves nothing, because there is
+ * nothing that could fail to be in it.
+ */
+function missingReserve(
+  known: string[],
+  anyWords: boolean,
+  head: SheetOptions,
+  width: Mil,
+): number {
+  if (known.length === 0) return anyWords ? 1 : 0;
+  return Math.min(MISSING_ROWS, missingRowsOf(known, 0, head, width));
+}
+
+/**
+ * The rows the line actually gets: what was reserved, or what is left over.
+ *
+ * The reservation is made against `MISSING_ROWS`, and a page can be too small
+ * to honour it even with the grid at `MIN_GRID` and no word list at all. Then
+ * the line takes what remains rather than what it asked for — never none of it,
+ * because a page whose grid alone overspills has already lost, and the one
+ * thing worse than a line below the bottom margin is a word that vanished
+ * without one.
+ */
+function missingRoom(reserve: number, left: Mil, fontPt: number): number {
+  if (reserve === 0) return 0;
+  const room = Math.floor(
+    Math.max(0, left - MISSING_MARGIN) /
+      Math.max(1, em(fontPt, MISSING_ROW_EMS)),
+  );
+  return Math.max(1, Math.min(reserve, room));
+}
+
+/**
+ * As much of the list as `rows` rows will hold, and a count of the rest.
+ *
+ * Searched downwards from "all of them" rather than solved, because the tail is
+ * part of what has to fit and its own width moves with the number in it — a
+ * word gained is sometimes a digit lost. Naming one fewer word can only ever
+ * help, so the first count that fits is the largest one that does.
+ */
+function packMissing(
+  words: string[],
+  head: SheetOptions,
+  width: Mil,
+  rows: number,
+): Missing {
+  if (words.length === 0 || rows <= 0) return { words: [], more: 0 };
+  if (missingRowsOf(words, 0, head, width) <= rows) return { words, more: 0 };
+  for (let named = words.length - 1; named > 0; named--)
+    if (
+      missingRowsOf(words.slice(0, named), words.length - named, head, width) <=
+      rows
+    )
+      return { words: words.slice(0, named), more: words.length - named };
+  return { words: [], more: words.length };
+}
+
+/** What a block records about the words it could not hold. */
+function omittedOf({ words, more }: Missing): {
+  omitted?: string[];
+  omittedMore?: number;
+} {
+  return {
+    ...(words.length > 0 ? { omitted: words } : {}),
+    ...(more > 0 ? { omittedMore: more } : {}),
+  };
+}
+
 /**
  * The grid, and the words there is room to hunt for in it.
  *
@@ -271,18 +428,38 @@ export function searchLayout(config: PuzzleConfig): {
   cell: Mil;
   words: PuzzleWord[];
   dropped: string[];
+  /** Rows held back for the "not in the grid" line, whether or not there is one. */
+  missingRows: number;
+  /**
+   * Everything the block will take: the grid, the word list, and the line that
+   * admits what is not in either. Inside `box.height` unless the grid alone is
+   * not — the one thing `MIN_GRID` will not give way on.
+   */
+  height: Mil;
 } {
   const head = headerOf(config);
   const box = sheetBlockBox(head, true);
   const { words, unusable } = puzzleWords(config);
 
-  const heightOf = (size: number, some: PuzzleWord[]): Mil =>
-    size * searchCell(box.width, size) +
+  // Measured against the drops *this* step would make, so a page that keeps
+  // every word gives up one row rather than three.
+  const reserveOf = (some: PuzzleWord[]): number =>
+    missingReserve(
+      [...words.slice(some.length).map((word) => word.form), ...unusable],
+      words.length > 0,
+      head,
+      box.width,
+    );
+  const listOf = (some: PuzzleWord[]): Mil =>
     listHeight(
       some.map((word) => word.form),
       head,
       box.width,
     );
+  const heightOf = (size: number, some: PuzzleWord[]): Mil =>
+    size * searchCell(box.width, size) +
+    listOf(some) +
+    missingHeight(reserveOf(some), head.fontPt);
 
   let size = clamp(config.size ?? MIN_GRID, MIN_GRID, MAX_GRID);
   while (size > MIN_GRID && heightOf(size, words) > box.height) size -= 1;
@@ -291,12 +468,21 @@ export function searchLayout(config: PuzzleConfig): {
   while (fit.length > 0 && heightOf(size, fit) > box.height)
     fit = fit.slice(0, -1);
 
+  const cell = searchCell(box.width, size);
+  const above = size * cell + listOf(fit);
+  const missingRows = missingRoom(
+    reserveOf(fit),
+    box.height - above,
+    head.fontPt,
+  );
   return {
     box,
     size,
-    cell: searchCell(box.width, size),
+    cell,
     words: fit,
     dropped: [...words.slice(fit.length).map((word) => word.form), ...unusable],
+    missingRows,
+    height: above + missingHeight(missingRows, head.fontPt),
   };
 }
 
@@ -352,6 +538,10 @@ export function crosswordLayout(config: PuzzleConfig): {
   size: number;
   entries: Clued[];
   dropped: string[];
+  /** Rows held back for the "not in the grid" line, whether or not there is one. */
+  missingRows: number;
+  /** The bound, the clues and the missing line — see `searchLayout.height`. */
+  height: Mil;
 } {
   const head = headerOf(config);
   const box = sheetBlockBox(head, true);
@@ -361,13 +551,23 @@ export function crosswordLayout(config: PuzzleConfig): {
     clue: crosswordClue(word),
   }));
 
-  const heightOf = (size: number, some: Clued[]): Mil =>
-    size * SEARCH_CELL +
+  const reserveOf = (some: Clued[]): number =>
+    missingReserve(
+      [...clued.slice(some.length).map((entry) => entry.word), ...unusable],
+      clued.length > 0,
+      head,
+      box.width,
+    );
+  const cluesOf = (some: Clued[]): Mil =>
     clueHeight(
       some.map((entry) => entry.clue),
       head,
       box.width,
     );
+  const heightOf = (size: number, some: Clued[]): Mil =>
+    size * SEARCH_CELL +
+    cluesOf(some) +
+    missingHeight(reserveOf(some), head.fontPt);
 
   let size = clamp(config.size ?? MIN_GRID, MIN_GRID, MAX_GRID);
   while (size > MIN_GRID && heightOf(size, clued) > box.height) size -= 1;
@@ -376,6 +576,12 @@ export function crosswordLayout(config: PuzzleConfig): {
   while (fit.length > 0 && heightOf(size, fit) > box.height)
     fit = fit.slice(0, -1);
 
+  const above = size * SEARCH_CELL + cluesOf(fit);
+  const missingRows = missingRoom(
+    reserveOf(fit),
+    box.height - above,
+    head.fontPt,
+  );
   return {
     box,
     size,
@@ -384,6 +590,8 @@ export function crosswordLayout(config: PuzzleConfig): {
       ...clued.slice(fit.length).map((entry) => entry.word),
       ...unusable,
     ],
+    missingRows,
+    height: above + missingHeight(missingRows, head.fontPt),
   };
 }
 
@@ -413,7 +621,8 @@ function searchBlocks(
   config: PuzzleConfig,
   seed: number,
 ): { blocks: Block[]; outOf: number } {
-  const { size, words, dropped } = searchLayout(config);
+  const head = headerOf(config);
+  const { box, size, words, dropped, missingRows } = searchLayout(config);
   const puzzle = buildSearch(
     words.map((word) => word.form),
     size,
@@ -423,10 +632,13 @@ function searchBlocks(
         Boolean(config.reverse),
       ),
       overlap: config.overlap !== false,
+      // The words the *page* had no room for. `buildSearch` keeps the filler
+      // off them and then reads the grid to see which are genuinely absent, so
+      // what comes back on `omitted` is both kinds of missing and no lies.
+      avoid: dropped,
     },
     mulberry32(seed),
   );
-  const omitted = [...puzzle.omitted, ...dropped];
   return {
     blocks: [
       {
@@ -434,7 +646,7 @@ function searchBlocks(
         letters: puzzle.letters,
         find: puzzle.find,
         solution: puzzle.solution,
-        ...(omitted.length > 0 ? { omitted } : {}),
+        ...omittedOf(packMissing(puzzle.omitted, head, box.width, missingRows)),
       },
     ],
     // Out of what is findable, never out of what was asked for: a sheet marked
@@ -447,7 +659,8 @@ function crosswordBlocks(
   config: PuzzleConfig,
   seed: number,
 ): { blocks: Block[]; outOf: number } {
-  const { size, entries, dropped } = crosswordLayout(config);
+  const head = headerOf(config);
+  const { box, size, entries, dropped, missingRows } = crosswordLayout(config);
   const puzzle = buildCrossword(entries, size, mulberry32(seed));
   const omitted = [...puzzle.omitted, ...dropped];
   return {
@@ -457,7 +670,7 @@ function crosswordBlocks(
         cells: puzzle.cells,
         across: puzzle.across,
         down: puzzle.down,
-        ...(omitted.length > 0 ? { omitted } : {}),
+        ...omittedOf(packMissing(omitted, head, box.width, missingRows)),
       },
     ],
     outOf: puzzle.across.length + puzzle.down.length,

--- a/src/engine/sheets/words/search.test.ts
+++ b/src/engine/sheets/words/search.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+
+import { mulberry32 } from "@/engine/random";
+
+import type { Found } from "../types";
+
+import {
+  SEARCH_CELL,
+  buildSearch,
+  findWord,
+  gridForm,
+  searchCell,
+  searchSteps,
+  type Step,
+} from "./search";
+
+/**
+ * A word search, held to the one bar that matters: **the paper is right.**
+ *
+ * Every claim below is checked by reading the finished grid with a reader
+ * written here, in the test, rather than by asking the generator what it thinks
+ * it did. That is not ceremony. `buildSearch` derives its own answer key by
+ * searching the grid, so a test that called `findWord` to check `solution`
+ * would be comparing a function against itself and would pass on a `findWord`
+ * that was wrong in exactly the same direction. `spell` below walks the letters
+ * and joins them, and that is all it does.
+ *
+ * The three failures this is aimed at are the three a word search actually
+ * ships with: a word that isn't in the grid at all, a key that points at the
+ * wrong squares, and a generator that never returns on a list it cannot fit.
+ */
+
+const WORDS = ["BECAUSE", "THOUGHT", "FRIEND", "PEOPLE", "THROUGH"];
+
+const across = searchSteps("across", false);
+const usual = searchSteps("across-down", false);
+const every = searchSteps("all", true);
+
+/** Reads a word out of the grid the long way. The whole point of this file. */
+function spell(letters: string[][], found: Found): string {
+  let out = "";
+  for (let i = 0; i < found.word.length; i++) {
+    out +=
+      letters[found.row + found.dy * i]?.[found.column + found.dx * i] ?? "";
+  }
+  return out;
+}
+
+const build = (
+  words: string[],
+  size: number,
+  steps: Step[] = usual,
+  overlap = true,
+  seed = 1,
+) => buildSearch(words, size, { steps, overlap }, mulberry32(seed));
+
+describe("the grid form of a word", () => {
+  it("is upper case, and only letters", () => {
+    // A square holds one letter, so there is nowhere for an apostrophe or a
+    // space to go. The word list under the puzzle prints the same form, which
+    // is what keeps "printed" and "findable" the same set.
+    expect(gridForm("don't")).toBe("DONT");
+    expect(gridForm("ice cream")).toBe("ICECREAM");
+    expect(gridForm("Because")).toBe("BECAUSE");
+    expect(gridForm("123")).toBe("");
+  });
+});
+
+describe("which ways a word may run", () => {
+  it("is one direction across, two down the page, and four with diagonals", () => {
+    expect(searchSteps("across", false)).toHaveLength(1);
+    expect(searchSteps("across-down", false)).toHaveLength(2);
+    expect(searchSteps("all", false)).toHaveLength(4);
+  });
+
+  it("doubles when words may be backwards", () => {
+    expect(searchSteps("across", true)).toHaveLength(2);
+    expect(searchSteps("all", true)).toHaveLength(8);
+    // Each backwards step is exactly some forwards step negated, which is what
+    // makes "reversed" mean the same thing on every direction set.
+    for (const step of searchSteps("all", true)) {
+      expect(
+        searchSteps("all", true).some(
+          (other) => other.dx === -step.dx && other.dy === -step.dy,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("falls back to the usual set for a direction this build never had", () => {
+    // A saved sheet outlives the options it was made with, the same as a kind.
+    expect(searchSteps("sideways-only" as "all", false)).toEqual(
+      searchSteps("across-down", false),
+    );
+  });
+});
+
+describe("the answer key", () => {
+  it("points at squares that really do spell the word", () => {
+    const puzzle = build(WORDS, 12);
+    expect(puzzle.solution).toHaveLength(WORDS.length);
+    for (const found of puzzle.solution) {
+      expect(spell(puzzle.letters, found)).toBe(found.word);
+    }
+  });
+
+  it("names every word it hid, and hides every word it names", () => {
+    const puzzle = build(WORDS, 12);
+    expect(puzzle.find).toEqual(WORDS);
+    expect(puzzle.solution.map((found) => found.word)).toEqual(puzzle.find);
+    expect(puzzle.omitted).toEqual([]);
+  });
+
+  it("holds at every direction set, and backwards", () => {
+    for (const steps of [across, usual, every]) {
+      for (const seed of [1, 2, 7, 4242]) {
+        const puzzle = build(WORDS, 14, steps, true, seed);
+        for (const found of puzzle.solution)
+          expect(spell(puzzle.letters, found)).toBe(found.word);
+        expect(puzzle.omitted).toEqual([]);
+      }
+    }
+  });
+
+  it("only ever runs a word the way the puzzle said it could", () => {
+    const puzzle = build(WORDS, 14, across);
+    for (const found of puzzle.solution) {
+      expect(found.dy).toBe(0);
+      // Not backwards: `reverse` was off, so left-to-right is the only run.
+      expect(found.dx).toBe(1);
+    }
+  });
+});
+
+describe("a word that cannot be placed", () => {
+  it("is reported rather than dropped", () => {
+    // Nine letters will not go in a six-square grid however hard it is tried,
+    // and the honest answer is to say so on the sheet.
+    const puzzle = build(["ELEPHANTS", "CAT"], 6);
+    expect(puzzle.omitted).toContain("ELEPHANTS");
+    expect(puzzle.find).not.toContain("ELEPHANTS");
+    expect(puzzle.find).toContain("CAT");
+  });
+
+  it("never appears on the word list without appearing in the grid", () => {
+    // The property the whole design rests on: `find` is derived from the
+    // search, so a word on the list is a word the letters contain.
+    const crowded = ["ABANDONING", "BUTTERFLY", "MOUNTAIN", "ORCHESTRA", "CAT"];
+    const puzzle = build(crowded, 8, across, false);
+    expect(puzzle.find.length + puzzle.omitted.length).toBe(crowded.length);
+    for (const word of puzzle.find) {
+      expect(findWord(puzzle.letters, word, across)).toBeDefined();
+    }
+    for (const word of puzzle.omitted) {
+      expect(findWord(puzzle.letters, word, across)).toBeUndefined();
+    }
+  });
+
+  it("returns on a list that cannot possibly fit", () => {
+    // No retry loop anywhere: every position is offered once. Twenty words of
+    // exactly the grid's width, none allowed to touch another, is the worst
+    // case there is — and it produces a sheet rather than a hung tab.
+    const impossible = Array.from({ length: 20 }, (_, at) =>
+      `WORD${String(at).padStart(4, "X")}`.slice(0, 8),
+    );
+    const puzzle = build(impossible, 8, across, false);
+    expect(puzzle.find.length + puzzle.omitted.length).toBe(impossible.length);
+    expect(puzzle.omitted.length).toBeGreaterThan(0);
+  });
+});
+
+describe("the grid itself", () => {
+  it("is square, and has a letter in every square", () => {
+    const puzzle = build(WORDS, 11);
+    expect(puzzle.letters).toHaveLength(11);
+    for (const row of puzzle.letters) {
+      expect(row).toHaveLength(11);
+      for (const letter of row) expect(letter).toMatch(/^[A-Z]$/);
+    }
+  });
+
+  it("does not spell a listed word anywhere the key does not say it is", () => {
+    // The other half of a right key. A word that turns up twice makes the
+    // stroke through one of them look like a mistake — and the filler is what
+    // would put it there, so the filler is what refuses to.
+    for (const seed of [1, 2, 3, 99]) {
+      const puzzle = build(WORDS, 12, every, true, seed);
+      for (const word of WORDS) {
+        const hits = [];
+        for (let row = 0; row < puzzle.letters.length; row++)
+          for (let column = 0; column < puzzle.letters[row].length; column++)
+            for (const { dx, dy } of every)
+              if (spell(puzzle.letters, { word, column, row, dx, dy }) === word)
+                hits.push({ column, row });
+        expect(hits).toHaveLength(1);
+      }
+    }
+  });
+
+  it("keeps words off each other when they may not cross", () => {
+    const puzzle = build(WORDS, 14, usual, false);
+    const used = new Set<string>();
+    for (const found of puzzle.solution) {
+      for (let i = 0; i < found.word.length; i++) {
+        const key = `${found.column + found.dx * i},${found.row + found.dy * i}`;
+        expect(used.has(key)).toBe(false);
+        used.add(key);
+      }
+    }
+  });
+
+  it("is the same grid twice from the same seed", () => {
+    // §7, and the reason a shared link and an answer key are the same sheet.
+    for (const seed of [0, 1, 4242]) {
+      expect(build(WORDS, 12, every, true, seed)).toEqual(
+        build(WORDS, 12, every, true, seed),
+      );
+    }
+  });
+
+  it("is a different grid from a different seed", () => {
+    expect(build(WORDS, 12, usual, true, 1).letters).not.toEqual(
+      build(WORDS, 12, usual, true, 2).letters,
+    );
+  });
+
+  it("survives being asked for nothing", () => {
+    const puzzle = build([], 8);
+    expect(puzzle.find).toEqual([]);
+    expect(puzzle.solution).toEqual([]);
+    expect(puzzle.letters).toHaveLength(8);
+  });
+});
+
+describe("how big a square is", () => {
+  it("never grows past what a child needs, and shrinks to fit", () => {
+    // The renderer asks the same question of the same function, which is the
+    // whole reason it is here rather than in the component (§4).
+    expect(searchCell(10_000, 10)).toBe(SEARCH_CELL);
+    expect(searchCell(1_000, 10)).toBe(100);
+    expect(searchCell(1_000, 0)).toBe(0);
+  });
+});

--- a/src/engine/sheets/words/search.test.ts
+++ b/src/engine/sheets/words/search.test.ts
@@ -169,6 +169,61 @@ describe("a word that cannot be placed", () => {
   });
 });
 
+describe("a word the page had no room to list", () => {
+  const avoided = (avoid: string[], seed: number) =>
+    buildSearch(
+      WORDS,
+      12,
+      { steps: usual, overlap: true, avoid },
+      mulberry32(seed),
+    );
+
+  it("is never spelled out by the filler", () => {
+    // The failure this exists for: the family trims the word list to what the
+    // paper holds, prints "Not in the grid: HAS" under the puzzle, and the
+    // random letters spell HAS three rows down. The filler has to know about
+    // the words it is not being given.
+    const avoid = ["HAS", "BY", "OF", "MAY", "PUT", "OLD"];
+    for (const seed of [1, 2, 3, 8, 9, 99]) {
+      const puzzle = avoided(avoid, seed);
+      for (const word of avoid) {
+        const hits = [];
+        for (let row = 0; row < puzzle.letters.length; row++)
+          for (let column = 0; column < puzzle.letters[row].length; column++)
+            for (const { dx, dy } of every)
+              if (spell(puzzle.letters, { word, column, row, dx, dy }) === word)
+                hits.push({ column, row });
+        expect(hits).toEqual([]);
+      }
+    }
+  });
+
+  it("is named as missing, but never put on the word list", () => {
+    // Two lists and a word may only be on one of them. `find` is what the page
+    // asks a child to hunt for and the page has no room for this word;
+    // `omitted` is what the sheet admits it does not hold.
+    const puzzle = avoided(["HAS", "BY"], 4);
+    expect(puzzle.find).toEqual(WORDS);
+    expect(puzzle.omitted).toEqual(["HAS", "BY"]);
+  });
+
+  it("is not called missing when the grid turns out to hold it", () => {
+    // The filler is not the only way a word can appear: two placed words
+    // crossing spell a third nobody asked for, and no care over the *empty*
+    // squares undoes that. So the claim is read off the finished grid — a word
+    // the letters contain goes on neither list rather than onto a lie.
+    const puzzle = avoided(["BECAUSE", "OUGH"], 1);
+    expect(puzzle.omitted).toEqual([]);
+    expect(puzzle.find).toEqual(WORDS);
+  });
+
+  it("passes through a word with no grid form at all", () => {
+    // `123` off the end of a pasted list. It cannot be in the grid, so it is
+    // named — and nothing here has to special-case it.
+    expect(avoided(["123"], 1).omitted).toEqual(["123"]);
+  });
+});
+
 describe("the grid itself", () => {
   it("is square, and has a letter in every square", () => {
     const puzzle = build(WORDS, 11);

--- a/src/engine/sheets/words/search.ts
+++ b/src/engine/sheets/words/search.ts
@@ -268,7 +268,16 @@ export type WordSearch = {
   find: string[];
   /** Where each of them is, found by reading the grid. */
   solution: Found[];
-  /** The rest, named on the sheet rather than dropped. */
+  /**
+   * The rest, named on the sheet rather than dropped.
+   *
+   * Read out of the finished grid exactly as `find` is, and for the same
+   * reason: "not in the grid" is a claim about the letters, so the letters are
+   * what settles it. A word the placer could not fit is here; so is a word from
+   * `avoid` the grid turned out not to hold. One it *does* hold is on neither
+   * list — the page has no room to ask for it, and the sheet will not say it is
+   * absent while a child can see it.
+   */
   omitted: string[];
 };
 
@@ -280,11 +289,24 @@ export type WordSearch = {
  * ordering that matters: a nine-letter word has a handful of legal positions
  * and a three-letter word has hundreds, so placing the short ones first is how
  * a generator paints itself into a corner and drops the long ones.
+ *
+ * `avoid` is the other half of the sheet's honesty and it comes from outside,
+ * because it has to. A word the *page* had no room for never reaches the placer
+ * — the family trims the word list to what fits before the grid is built — and
+ * yet it is named on the sheet as missing, in the same sentence as a word the
+ * placer could not fit. So this function is told about it, and does two things
+ * with it. The filler is kept from spelling it, or the sheet would print "Not
+ * in the grid: HAS" over a grid with HAS in it. And the finished grid is then
+ * searched for it anyway, because the filler is not the only way a word can
+ * turn up: two placed words crossing spell a third nobody asked for, and no
+ * amount of care over the *empty* squares can undo that. What the grid holds
+ * goes on neither list; what it does not is named. Either way `find` is
+ * untouched — a word the page cannot list does not get listed.
  */
 export function buildSearch(
   words: string[],
   size: number,
-  options: { steps: Step[]; overlap: boolean },
+  options: { steps: Step[]; overlap: boolean; avoid?: string[] },
   rand: () => number,
 ): WordSearch {
   const cells: Cells = Array.from({ length: size }, () =>
@@ -311,10 +333,12 @@ export function buildSearch(
     if (spot) write(cells, word, spot.x, spot.y, spot.step);
   }
 
-  // Every word, not only the ones that were placed: a word the grid has no room
-  // for must not be spelled out by the filler either, or the sheet would name it
-  // as missing while a child stares straight at it.
-  fill(cells, words, rand);
+  // Every word, not only the ones that were placed, and not only the ones this
+  // grid was given: a word the grid has no room for — or that the page had no
+  // room for, which is what `avoid` carries — must not be spelled out by the
+  // filler either, or the sheet would name it as missing while a child stares
+  // straight at it.
+  fill(cells, [...words, ...(options.avoid ?? [])], rand);
   const letters = cells.map((row) => row.map((letter) => letter ?? "A"));
 
   const find: string[] = [];
@@ -329,6 +353,12 @@ export function buildSearch(
     find.push(word);
     solution.push(found);
   }
+
+  // And the words the page had no room to list, in every direction rather than
+  // this puzzle's own: a child who spots OF running up a diagonal on an
+  // across-only sheet has found something the sheet just called missing.
+  for (const word of options.avoid ?? [])
+    if (!findWord(letters, word, EVERY_STEP)) omitted.push(word);
 
   return { letters, find, solution, omitted };
 }

--- a/src/engine/sheets/words/search.ts
+++ b/src/engine/sheets/words/search.ts
@@ -1,0 +1,334 @@
+/**
+ * A word search, and — separately — the answer key to one.
+ *
+ * The two halves of this file barely speak to each other, and that is the whole
+ * point of it. `place` writes words into a grid and remembers nothing;
+ * `findWord` reads a finished grid and reports what is in it. The key is the
+ * second of those, never the first.
+ *
+ * That separation is not fussiness. The classic word-search bug is a key that
+ * agrees with the generator instead of with the paper: a word that failed to
+ * place is still in the list of "placements" the code made a note of, or a
+ * later word overwrote a letter of an earlier one and the note was never
+ * corrected, and the sheet goes out claiming ROBIN is at row 4 when row 4 says
+ * ROBIM. Deriving the key by searching the grid cannot make that mistake —
+ * whatever the placer meant, the key says what the letters say. Which is also
+ * why a word that cannot be found is *reported* rather than dropped: the search
+ * is the only thing that decides which words are on the sheet's list, so a word
+ * that isn't in the grid can't get onto it.
+ *
+ * Nothing here retries. A word is offered every position it could occupy, in a
+ * seeded order, and takes the first that is legal; if none is, it is omitted.
+ * There is no outer loop that shuffles and starts again, so a pathological list
+ * — twelve nine-letter words in an eight-by-eight grid — produces a sheet that
+ * says so instead of a tab that never finishes.
+ */
+import { shuffled } from "@/engine/random";
+
+import type { Found, Mil, SearchDirections } from "../types";
+
+import { inches } from "../paper";
+
+/** One step along a word, per letter. `(1, 0)` reads left to right. */
+export type Step = { dx: number; dy: number };
+
+/**
+ * A letter big enough for a five-year-old to find, and small enough that a
+ * ten-by-ten puzzle doesn't take the whole page.
+ *
+ * Here rather than in `WordSearch.tsx` because both halves need it and they
+ * have to agree: the family reserves the page against the height the grid will
+ * take, and the renderer draws it. A copy in each would be a grid an eighth of
+ * an inch taller than the space reserved for it — invisible on screen, and the
+ * word list on a second sheet of paper.
+ */
+export const SEARCH_CELL: Mil = inches(0.34);
+
+/** How wide one cell comes out at, given the room and the number of them. */
+export const searchCell = (width: Mil, size: number): Mil =>
+  size <= 0 ? 0 : Math.min(SEARCH_CELL, Math.floor(width / size));
+
+/**
+ * The directions a word may run, before `reverse` is applied.
+ *
+ * Down-and-right and up-and-right are the two diagonals; their opposites are
+ * the same two read backwards, which is what `reverse` adds. So `all` without
+ * `reverse` is four directions and `all` with it is the full eight.
+ */
+const FORWARD: Record<SearchDirections, Step[]> = {
+  across: [{ dx: 1, dy: 0 }],
+  "across-down": [
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: 1 },
+  ],
+  all: [
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: 1 },
+    { dx: 1, dy: 1 },
+    { dx: 1, dy: -1 },
+  ],
+};
+
+/** Every step a word may take on this puzzle, in a fixed order. */
+export function searchSteps(
+  directions: SearchDirections,
+  reverse: boolean,
+): Step[] {
+  const forward = FORWARD[directions] ?? FORWARD["across-down"];
+  if (!reverse) return forward;
+  return [...forward, ...forward.map(({ dx, dy }) => ({ dx: -dx, dy: -dy }))];
+}
+
+/**
+ * All eight, for the filler to avoid spelling into.
+ *
+ * Wider than the puzzle's own set on purpose. A word the grid was not supposed
+ * to contain is a distraction whichever way round it reads, and a child who
+ * spots CAT running up a diagonal on an across-only sheet has found something
+ * the answer key will not admit exists.
+ */
+const EVERY_STEP: Step[] = searchSteps("all", true);
+
+/**
+ * The word as a grid can hold it: upper case, and nothing that is not a letter.
+ *
+ * A square holds one letter, so there is nowhere to put the apostrophe in
+ * "don't" or the space in "ice cream" — and a puzzle that quietly searched for
+ * DON'T while printing "don't" under it would be asking for something that
+ * cannot be there. So the transformation is done once, here, and the *grid
+ * form* is what goes in the grid, on the word list and in the answer key alike:
+ * what is printed under the puzzle is exactly what is findable in it.
+ *
+ * Upper case for the same reason every word search ever printed is: a grid is
+ * read letter by letter rather than word by word, and a lower-case `l` beside
+ * an upper-case `I` is a square a child cannot mark with confidence.
+ */
+export const gridForm = (word: string): string =>
+  word.toUpperCase().replace(/\P{L}/gu, "");
+
+/** The letters a blank square may be filled with. */
+const ALPHABET = [..."ABCDEFGHIJKLMNOPQRSTUVWXYZ"];
+
+type Cells = Array<Array<string | null>>;
+
+const inside = (cells: Cells, x: number, y: number): boolean =>
+  y >= 0 && y < cells.length && x >= 0 && x < cells[y].length;
+
+/** Reads whatever is at a square, or `null` for "off the grid or empty". */
+const at = (cells: Cells, x: number, y: number): string | null =>
+  inside(cells, x, y) ? cells[y][x] : null;
+
+/**
+ * Every position a word of this length could occupy, in a seeded order.
+ *
+ * Enumerated rather than guessed at, which is what makes this terminate: there
+ * are `steps × size²` places a word can start and each is offered exactly once,
+ * so the worst case is a word that is tried everywhere and placed nowhere. A
+ * generator that instead picked a random spot and tried again on a clash is the
+ * one that hangs on a list it cannot fit.
+ */
+function positions(
+  size: number,
+  length: number,
+  steps: Step[],
+  rand: () => number,
+): Array<{ x: number; y: number; step: Step }> {
+  const out: Array<{ x: number; y: number; step: Step }> = [];
+  for (const step of steps) {
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        const endX = x + step.dx * (length - 1);
+        const endY = y + step.dy * (length - 1);
+        if (endX < 0 || endX >= size || endY < 0 || endY >= size) continue;
+        out.push({ x, y, step });
+      }
+    }
+  }
+  return shuffled(out, rand);
+}
+
+/** Whether a word can be written here: empty squares, or letters that agree. */
+function legal(
+  cells: Cells,
+  word: string,
+  x: number,
+  y: number,
+  step: Step,
+  overlap: boolean,
+): boolean {
+  for (let i = 0; i < word.length; i++) {
+    const held = cells[y + step.dy * i][x + step.dx * i];
+    if (held === null) continue;
+    // A square already written in is a crossing, which is the thing `overlap`
+    // is about: off, no word may share a square with another at all; on, it may
+    // share one only where both want the same letter there.
+    if (!overlap || held !== word[i]) return false;
+  }
+  return true;
+}
+
+function write(cells: Cells, word: string, x: number, y: number, step: Step) {
+  for (let i = 0; i < word.length; i++)
+    cells[y + step.dy * i][x + step.dx * i] = word[i];
+}
+
+/**
+ * Whether writing `letter` here would spell one of the words through this
+ * square.
+ *
+ * Only runs that pass through `(x, y)` are checked, which is what makes it
+ * cheap and what makes it complete: every occurrence a filler could create has
+ * a last square to be filled in, and that square's own check is where it is
+ * caught. Squares that are still empty read as `null` and match nothing, so a
+ * half-filled run is never mistaken for a word.
+ */
+function spells(
+  cells: Cells,
+  x: number,
+  y: number,
+  letter: string,
+  words: string[],
+): boolean {
+  for (const step of EVERY_STEP) {
+    for (const word of words) {
+      for (let k = 0; k < word.length; k++) {
+        if (word[k] !== letter) continue;
+        const startX = x - step.dx * k;
+        const startY = y - step.dy * k;
+        let all = true;
+        for (let i = 0; i < word.length && all; i++) {
+          if (i === k) continue;
+          all =
+            at(cells, startX + step.dx * i, startY + step.dy * i) === word[i];
+        }
+        if (all) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Fills the empty squares without spelling anything.
+ *
+ * An even draw from the alphabet rather than from the letters the words happen
+ * to use. Reusing the words' own letters makes a harder puzzle — a lone Q gives
+ * QUEEN away — but it also makes an accidental word far likelier, and this is
+ * the one file where "looks fine" and "is right" come apart. An even draw is
+ * the one that can be reasoned about, and the check below is what keeps it
+ * honest.
+ *
+ * Every letter is tried at most once per square, so a square hemmed in on all
+ * sides settles for the first of them rather than looping. That square is then
+ * a genuine second occurrence of some word, and it will show up in the key,
+ * because the key reads the grid — which is the entire reason the key reads the
+ * grid.
+ */
+function fill(cells: Cells, words: string[], rand: () => number) {
+  for (let y = 0; y < cells.length; y++) {
+    for (let x = 0; x < cells[y].length; x++) {
+      if (cells[y][x] !== null) continue;
+      const draw = shuffled(ALPHABET, rand);
+      cells[y][x] =
+        draw.find((letter) => !spells(cells, x, y, letter, words)) ?? draw[0];
+    }
+  }
+}
+
+/**
+ * Where a word is in a finished grid, or `undefined` if it is not in it.
+ *
+ * The answer key, and the only thing that decides what goes on the word list.
+ * Top-left first, then along the row, then by direction, so the same grid always
+ * reports the same occurrence — a word that turns up twice (see `fill`) gets one
+ * stroke through it rather than a key that changes its mind between builds.
+ */
+export function findWord(
+  letters: string[][],
+  word: string,
+  steps: Step[],
+): Found | undefined {
+  if (word.length === 0) return undefined;
+  for (let row = 0; row < letters.length; row++) {
+    for (let column = 0; column < letters[row].length; column++) {
+      for (const { dx, dy } of steps) {
+        let all = true;
+        for (let i = 0; i < word.length && all; i++)
+          all = at(letters, column + dx * i, row + dy * i) === word[i];
+        if (all) return { word, column, row, dx, dy };
+      }
+    }
+  }
+  return undefined;
+}
+
+export type WordSearch = {
+  letters: string[][];
+  /** The words the finished grid actually holds, in the order they were given. */
+  find: string[];
+  /** Where each of them is, found by reading the grid. */
+  solution: Found[];
+  /** The rest, named on the sheet rather than dropped. */
+  omitted: string[];
+};
+
+/**
+ * A word search over `words`, in a `size` by `size` grid.
+ *
+ * The words arrive as grid forms (`gridForm`), de-duplicated, and in the order
+ * they should be printed. They are *placed* longest first, which is the one
+ * ordering that matters: a nine-letter word has a handful of legal positions
+ * and a three-letter word has hundreds, so placing the short ones first is how
+ * a generator paints itself into a corner and drops the long ones.
+ */
+export function buildSearch(
+  words: string[],
+  size: number,
+  options: { steps: Step[]; overlap: boolean },
+  rand: () => number,
+): WordSearch {
+  const cells: Cells = Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => null),
+  );
+
+  const byLength = words
+    .map((word, given) => ({ word, given }))
+    .sort((a, b) => b.word.length - a.word.length || a.given - b.given);
+
+  for (const { word } of byLength) {
+    if (word.length === 0 || word.length > size) continue;
+    const spot = positions(size, word.length, options.steps, rand).find(
+      (position) =>
+        legal(
+          cells,
+          word,
+          position.x,
+          position.y,
+          position.step,
+          options.overlap,
+        ),
+    );
+    if (spot) write(cells, word, spot.x, spot.y, spot.step);
+  }
+
+  // Every word, not only the ones that were placed: a word the grid has no room
+  // for must not be spelled out by the filler either, or the sheet would name it
+  // as missing while a child stares straight at it.
+  fill(cells, words, rand);
+  const letters = cells.map((row) => row.map((letter) => letter ?? "A"));
+
+  const find: string[] = [];
+  const solution: Found[] = [];
+  const omitted: string[] = [];
+  for (const word of words) {
+    const found = findWord(letters, word, options.steps);
+    if (!found) {
+      omitted.push(word);
+      continue;
+    }
+    find.push(word);
+    solution.push(found);
+  }
+
+  return { letters, find, solution, omitted };
+}

--- a/src/engine/sheets/words/spelling.ts
+++ b/src/engine/sheets/words/spelling.ts
@@ -98,8 +98,14 @@ const clamp = (value: number, low: number, high: number): number =>
  * paste, a saved sheet, and a link somebody was sent — and only one of those
  * has ever been near a validator. Duplicates go the way the marker sees them,
  * so "Because" and "because" are one word on the page rather than two.
+ *
+ * Takes a list-carrying config rather than a `WordsConfig`, because the puzzle
+ * family is handed a list through the same three doors and must hold it to the
+ * same shape. A second sanitiser would be a second answer to "is `Cat` the same
+ * word as `cat`", and the two sheets would disagree about a list they were both
+ * given.
  */
-export function wordsOf(config: WordsConfig): string[] {
+export function wordsOf(config: { words?: string[] }): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const raw of config.words ?? []) {

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -263,6 +263,26 @@ const DEFAULTS: Record<string, SheetConfig> = {
     // list down the page whatever this says (`studyLayout`).
     columns: 2,
   },
+  puzzle: {
+    ...BASE,
+    kind: "puzzle",
+    // A word search, because it is the one of the three a parent recognises
+    // from across the room — and the bench's first job is to show a sheet
+    // rather than a form. The same starter list as the spelling family, so
+    // switching between the two shelves keeps the words a parent is looking at.
+    style: "search",
+    words: STARTER_WORDS,
+    // Twelve squares holds a ten-letter word with room to hide it, and comes
+    // out at the full cell size on both stocks.
+    size: 12,
+    // The usual school puzzle. Diagonals and backwards words are each one
+    // control away, and each is a different kind of harder.
+    directions: "across-down",
+    reverse: false,
+    overlap: true,
+    count: STARTER_WORDS.length,
+    columns: 2,
+  },
   handwriting: {
     ...BASE,
     kind: "handwriting",

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -31,6 +31,7 @@ import { MoneyPanel } from "./money";
 import { MultiplicationPanel } from "./multiplication";
 import { PaperPanel } from "./paper";
 import { PreAlgebraPanel } from "./prealgebra";
+import { PuzzlesPanel } from "./puzzles";
 import { RatioPanel } from "./ratio";
 import { StatisticsPanel } from "./statistics";
 import { TimePanel } from "./time";
@@ -90,6 +91,7 @@ const PANELS: Record<string, FamilyPanel> = {
   "word-problems": panel(WordProblemsPanel),
   words: panel(WordsPanel),
   "word-study": panel(WordStudyPanel),
+  puzzle: panel(PuzzlesPanel),
   handwriting: panel(HandwritingPanel),
   memory: panel(MemoryPanel),
 };

--- a/src/games/printshop/options/puzzles.tsx
+++ b/src/games/printshop/options/puzzles.tsx
@@ -1,0 +1,120 @@
+/**
+ * A list, and which puzzle to make out of it.
+ *
+ * The second panel whose first control is the *content* of the sheet rather
+ * than a setting on it, and it is the same box the spelling panel and the
+ * bootstrap use — one `WordList`, one rule about what counts as a word.
+ *
+ * Four of the controls are the word search's alone, and they disappear on the
+ * other two styles rather than greying out. There is no grid on a scramble
+ * sheet for a direction to run in, and an option that does nothing teaches a
+ * parent that the panel doesn't do what it says. The grid stepper is a request
+ * either way — `searchLayout` shrinks a grid that will not fit the paper with
+ * its word list under it — which is why the hint says so.
+ */
+import { Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
+import type {
+  PuzzleConfig,
+  PuzzleStyle,
+  SearchDirections,
+} from "@/engine/sheets/types";
+import { MAX_GRID, MIN_GRID } from "@/engine/sheets/words/puzzles";
+import { parseWords } from "@/services/decks";
+
+import { Choice, Sizing, WordList, opt, type PanelProps } from "./parts";
+
+/** The three, easiest first: hunt for it, unjumble it, then work it out. */
+const STYLES = [
+  opt<PuzzleStyle>("search", "Word search"),
+  opt<PuzzleStyle>("scramble", "Word scramble"),
+  opt<PuzzleStyle>("crossword", "Crossword"),
+];
+
+const DIRECTIONS = [
+  opt<SearchDirections>("across", "Across"),
+  opt<SearchDirections>("across-down", "Across and down"),
+  opt<SearchDirections>("all", "Diagonals too"),
+];
+
+export function PuzzlesPanel({ config, set }: PanelProps<PuzzleConfig>) {
+  const search = config.style === "search";
+
+  return (
+    <>
+      <WordList
+        label="Words"
+        // Joined back out of the config rather than held as text beside it: the
+        // config is the state (`useBuilder`), and a second copy of the list
+        // would be the one the sheet was not built from.
+        text={config.words.join("\n")}
+        onChange={(text) => {
+          const words = parseWords(text);
+          set({ words, count: words.length });
+        }}
+        hint="One a line, or separated by commas. Anything that isn't a letter is left out of a grid — a square holds one letter."
+      />
+
+      <Choice
+        label="Puzzle"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+
+      {config.style === "crossword" && (
+        <p className="picker__line">
+          Clued from the sentence each word already has in the sight-word lists.
+          A word from your own list is clued by its letters, jumbled.
+        </p>
+      )}
+
+      {search && (
+        <>
+          <FieldSet
+            legend="Grid"
+            hint="Squares across and down. Shrunk if it won't fit the page with the word list under it."
+          >
+            <NumberStepper
+              label="Squares across and down"
+              value={config.size}
+              min={MIN_GRID}
+              max={MAX_GRID}
+              onChange={(size) => set({ size })}
+            />
+          </FieldSet>
+
+          <Choice
+            label="Which way words run"
+            value={config.directions}
+            onChange={(directions) => set({ directions })}
+            options={DIRECTIONS}
+          />
+
+          <Checkbox
+            label="Some words written backwards"
+            checked={config.reverse}
+            onChange={(reverse) => set({ reverse })}
+          />
+
+          <Checkbox
+            label="Words may cross each other"
+            checked={config.overlap}
+            hint="Off makes a sparser grid — and the likeliest way a word ends up with nowhere to go."
+            onChange={(overlap) => set({ overlap })}
+          />
+        </>
+      )}
+
+      {/* Only a scramble lays its words out across the page: a grid and a clue
+          list are each the width of the paper. */}
+      <Sizing
+        label="Words"
+        count={config.count}
+        columns={config.style === "scramble" ? config.columns : undefined}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={3}
+      />
+    </>
+  );
+}

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -204,6 +204,7 @@
 .sheet__questions,
 .sheet__options,
 .sheet__wordshapes,
+.sheet__clue-list,
 .sheet__words {
   list-style: none;
   padding-left: 0;
@@ -628,6 +629,43 @@
   gap: 0.06in 0.28in;
   margin-top: 0.12in;
   font-size: 0.9em;
+}
+
+/* ── Puzzles ────────────────────────────────────────────────────────────────
+   Every number here is trailed by `words/puzzles.ts`, which reserves the page
+   against it before the puzzle exists — the same bargain `chrome.ts` and
+   `layout.ts` strike, and the same silent failure when it is broken: a clue
+   list an eighth of an inch taller than the room made for it looks perfect on
+   screen and prints its last clue on a second sheet of paper.               */
+
+.sheet__clues {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.05in 0.3in;
+  margin-top: 0.12in;
+  font-size: 0.9em;
+  /* A clue list splits between two columns and a column may not split between
+     two pages: half a crossword's clues overleaf is a puzzle nobody can do. */
+  break-inside: avoid;
+}
+
+.sheet__clue-head {
+  font-weight: 700;
+}
+
+.sheet__clue-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05in;
+}
+
+/* The line that admits a word did not fit. Set apart from the puzzle it is
+   about — italic and a size down — because it is the sheet talking about
+   itself rather than something a child is asked to do. */
+.sheet__missing {
+  margin-top: 0.1in;
+  font-size: 0.85em;
+  font-style: italic;
 }
 
 /* ── Word shapes ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #65.

## What

A fourth family on the words shelf — `puzzle` — with three styles built from whatever list a parent already has: **word search**, **crossword**, and **word scramble**. One panel on the bench (`options/puzzles.tsx`), one block renderer each, and every puzzle carries a printable answer key.

## Why this shape

A puzzle is the one kind of sheet that can look completely right and be completely wrong. A page of sums is checked by doing the sums; a word search is checked by finding twelve words in a grid, which nobody does. So a word that quietly failed to place is indistinguishable from one that placed well — and the answer key is then wrong about a word it never mentions. That failure is what the whole family is arranged around:

- **The key is derived by searching the finished puzzle.** `findWord` reads the grid; `readEntries` reads the squares. Neither consults the placer's notes, so whatever the placer *meant*, the paper wins. The word list printed under a search is the search's own output — a word on the list is a word the letters contain, by construction.
- **A word that did not make it is named on the sheet**, via the new `<Omitted>` block: "Not in the grid: …", covering both what the placer could not fit and what the page had no room for. Both are the same fact to whoever is marking it.
- **Everything terminates.** No shuffle-and-retry anywhere: every position is offered once, the crossword's passes and attempts are bounded and stop early, and `scramble` falls back to a swap rather than redrawing. Tests drive each generator with a list that cannot fit.
- **Deterministic in `(config, seed)`**, so the key matches the build and a shared link is the same puzzle.

## Acceptance criteria

| Criterion | Where |
| --- | --- |
| Word search: grid size, direction set, overlap, reverse | `PuzzleConfig` + `options/puzzles.tsx`; the four search-only controls disappear on the other styles rather than greying out |
| Crossword clued from the list's own definitions | `crossword.ts` reuses `shippedClue` — the sentences the shipped sight-word lists already carry for the race |
| Word scramble | `puzzles.ts` |
| Printable answer key | read off the finished puzzle for all three |
| Deterministic and terminating, test on a pathological list | `puzzles.test.ts:440`, plus same-seed tests in `search.test.ts` and `crossword.test.ts` |
| Unplaceable word reported, not dropped | `<Omitted>`, fed from a grid search rather than the placer |

## Two silent bugs found and fixed while building it

- **A cropped crossword grid has fewer columns and therefore *bigger* squares**, so the height reservation is made at `SEARCH_CELL` rather than at the bound's own cell — reserving at the bound would have printed a grid taller than the room made for it.
- **`AS` sits inside `ASK` letter for letter.** An `ASK` laid over an `AS` from an earlier pass leaves every letter on the paper and `AS` with no squares of its own. The placer now refuses to swallow an entry, and because the missing list is read off the grid, the sheet would have told the truth either way.

## And the follow-up commit: the missing line tells the truth, and has somewhere to sit

Two more ways the "Not in the grid" line could have been wrong, both on the boundary between the page and the placer:

- **It could be a lie.** The family trims a word list to what the paper holds *before* the grid is built, so dropped words never reached `buildSearch` — and the filler, told only about the survivors, was free to spell them into the empty squares. The sheet printed "Not in the grid: HAS" over a grid containing HAS, on seeds 8 and 9 of a config the tests already used. `buildSearch` now takes those words as `avoid`: the filler keeps off them, and the finished grid is then searched for them anyway, because the filler is not the only way a word appears — two placed words crossing spell a third nobody asked for.
- **It had nowhere to sit.** Neither `heightOf` reserved space for the paragraph `<Omitted>` renders, and the trim loop is what *creates* the list — so the unreserved line was guaranteed to be there precisely when the page had been shrunk to exactly its capacity. It is reserved now, measured off the same tokens the renderer sets, capped at three rows so a page cannot become a paragraph about what is not on it; past the cap the line counts what it cannot name ("… and 22 more").

## Reused rather than rebuilt

Crossword clues are the sentences the shipped sight-word lists already carry, so a printed puzzle and a played round ask one question of one list. The list is sanitised by the spelling family's own `wordsOf`, and `SEARCH_CELL` moved into the engine so the family reserves the height the renderer draws. `.sheet__clue-list` joins the existing marker-stripping rule in `sheet.css` instead of re-declaring `list-style`/`padding-left`.

## Validation

`type-check`, `lint`, `test:unit` (1042 passing, 51 files), `build` (static, 135 pages), and the browser smoke test all pass locally — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
