### PR TITLE
PRINT22: grammar worksheets, where the answers were written down

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -512,8 +512,9 @@ rhyming · syllables · word families · prefixes and suffixes · plurals ·
 contractions · homophones · synonyms and antonyms.
 
 **Grammar.** Parts of speech · subject and predicate · sentence types ·
-punctuation · capitalisation. Generatable from a tagged sentence bank, which is
-authored content but small and reusable.
+punctuation · capitalisation. Not generated from a rule but drawn from a tagged
+sentence bank — authored content, small and reusable, because grammar is a
+judgement rather than a calculation.
 
 **What shipped (PRINT20).** The words shelf, and it is two families rather than
 one because the two halves are mirror images. `words/spelling.ts` is a list
@@ -535,6 +536,38 @@ round ask one question of one list. And a sight word to _trace_ is the
 handwriting family with a word list on it, so the shelf's tracing page is a
 `HandwritingConfig` rather than an eighth spelling style: two families that draw
 letterforms would be one too many. Word search and crossword stay PRINT21.
+
+**What shipped (PRINT22).** Grammar: one family, five topics, one bank. The
+bank is the story. Spelling is authored because **English will not yield to a
+rule**; grammar is authored because **grammar is a judgement** — whether a word
+is an adverb, whether a comma is needed, which half of a sentence is the
+subject, each decidable in a particular sentence and arguable in general. A
+parser would be right most of the time, and a sheet that marks a defensible
+answer wrong teaches a child something false, which is worse than no sheet. So
+`engine/sheets/grammar/bank.ts` is sentences written down once and **tagged** —
+what the sentence is for, where it divides, which one word can be named without
+argument, which word has lost its capital — and the five topics are five views
+of those tags rather than five parses. Nothing in `grammar.ts` analyses English.
+
+The house rules are the feature, and they are all of the form _leave it out_. No
+article or possessive is ever the tagged word, because the schemes disagree
+about what those are; verbs are past tense or the word that opens a command,
+which is the cheapest way to make a word class unarguable; a split is exhaustive
+or absent, which is what stops "complete subject" and "simple subject" being two
+right answers to one question; an exclamation is exclamative in _form_, so the
+mark on the end is grammar rather than tone. Those rules are what decide the
+shape of the shelf too: there is no `match` style, because pairing a word to a
+class is the same judgement with a worse layout; there is no comma topic and no
+exclamation-mark topic, because neither has a key; and end punctuation asks only
+for a full stop or a question mark for the same reason.
+
+Five catalog pages, and five is the point rather than a start. "Noun
+worksheets", "verb worksheets" and "adjective worksheets" are all real queries
+and all three would be this one sheet with a filter on it — the doorway-page
+farm §8 argues against. Two things the pages are held to mechanically: a drawn
+page covers the closed list it prints down every line (a types sheet with no
+command on it is correct in every item and no longer the exercise), and every
+sentence the prose quotes is a sentence the sheet under it prints.
 
 ### Templates — blank forms, high value, low effort
 

--- a/src/engine/sheets/grammar/bank.ts
+++ b/src/engine/sheets/grammar/bank.ts
@@ -122,6 +122,12 @@ export type Tagged = {
    * The capitals sheet prints the sentence with this word in lower case and
    * asks for it back, so it is never the first word — a lower-cased opening
    * word is two mistakes wearing one coat.
+   *
+   * It is also the tag that sizes the smallest topic in the bank, so a
+   * sentence that can honestly carry a name, a place or a day should carry
+   * one. `grammar.test.ts` holds every topic above a full page of itself for
+   * exactly this reason — a capitals supply of thirteen against a page that
+   * holds seventeen is the same sheet whatever seed a parent rerolls to.
    */
   proper?: string;
 };
@@ -245,6 +251,50 @@ const STATEMENTS: Tagged[] = [
     focus: { word: "us", part: "pronoun" },
     proper: "Scotland",
   },
+  {
+    text: "The lesson finished early on Thursday.",
+    kind: "statement",
+    split: { subject: "The lesson", predicate: "finished early on Thursday" },
+    focus: { word: "finished", part: "verb" },
+    proper: "Thursday",
+  },
+  {
+    text: "My cousin posted the letter to Ireland.",
+    kind: "statement",
+    split: { subject: "My cousin", predicate: "posted the letter to Ireland" },
+    focus: { word: "posted", part: "verb" },
+    proper: "Ireland",
+  },
+  {
+    text: "The gentle donkey carried our bags to Dover.",
+    kind: "statement",
+    split: {
+      subject: "The gentle donkey",
+      predicate: "carried our bags to Dover",
+    },
+    focus: { word: "gentle", part: "adjective" },
+    proper: "Dover",
+  },
+  {
+    text: "The noisy seagulls followed us to Bristol.",
+    kind: "statement",
+    split: {
+      subject: "The noisy seagulls",
+      predicate: "followed us to Bristol",
+    },
+    focus: { word: "noisy", part: "adjective" },
+    proper: "Bristol",
+  },
+  {
+    text: "The scouts marched proudly through Norway.",
+    kind: "statement",
+    split: {
+      subject: "The scouts",
+      predicate: "marched proudly through Norway",
+    },
+    focus: { word: "proudly", part: "adverb" },
+    proper: "Norway",
+  },
 ];
 
 /* ── Questions ─────────────────────────────────────────────────────────────
@@ -292,6 +342,24 @@ const QUESTIONS: Tagged[] = [
     kind: "question",
     focus: { word: "safely", part: "adverb" },
   },
+  {
+    text: "Did they remember the tickets for Wednesday?",
+    kind: "question",
+    focus: { word: "they", part: "pronoun" },
+    proper: "Wednesday",
+  },
+  {
+    text: "Why is the castle in Denmark so famous?",
+    kind: "question",
+    focus: { word: "famous", part: "adjective" },
+    proper: "Denmark",
+  },
+  {
+    text: "Has the parcel arrived in Kenya?",
+    kind: "question",
+    focus: { word: "arrived", part: "verb" },
+    proper: "Kenya",
+  },
 ];
 
 /* ── Commands ──────────────────────────────────────────────────────────────
@@ -328,6 +396,18 @@ const COMMANDS: Tagged[] = [
     kind: "command",
     focus: { word: "clearly", part: "adverb" },
   },
+  {
+    text: "Deliver these letters to Harriet.",
+    kind: "command",
+    focus: { word: "Deliver", part: "verb" },
+    proper: "Harriet",
+  },
+  {
+    text: "Describe the journey to Iceland.",
+    kind: "command",
+    focus: { word: "Describe", part: "verb" },
+    proper: "Iceland",
+  },
 ];
 
 /* ── Exclamations ──────────────────────────────────────────────────────────
@@ -357,6 +437,12 @@ const EXCLAMATIONS: Tagged[] = [
     text: "How chilly the water felt!",
     kind: "exclamation",
     focus: { word: "chilly", part: "adjective" },
+  },
+  {
+    text: "How brightly the lights of Oslo shone!",
+    kind: "exclamation",
+    focus: { word: "brightly", part: "adverb" },
+    proper: "Oslo",
   },
 ];
 

--- a/src/engine/sheets/grammar/bank.ts
+++ b/src/engine/sheets/grammar/bank.ts
@@ -1,0 +1,400 @@
+/**
+ * The tagged sentences a grammar sheet is made of.
+ *
+ * The second bank in the shop, after `words/bank.ts`, and it is here for a
+ * sharper version of the same reason. Spelling could not be generated because
+ * **English will not yield to a rule**; grammar cannot be generated because
+ * **grammar is a judgement**. Whether a word is a noun or a verb, whether a
+ * comma is needed, what a pronoun refers back to — every one of those is
+ * decidable in a particular sentence and undecidable in general, and a sheet
+ * that marks a defensible answer wrong teaches a child something false. That is
+ * a worse outcome than no sheet at all (§11).
+ *
+ * So a sentence is written down once and **tagged**, and every question on
+ * every grammar sheet is a view of a tag rather than a parse. Nothing in
+ * `grammar.ts` analyses English; it draws sentences and reads what was written
+ * about them. Five topics come out of the one bank — parts of speech, subject
+ * and predicate, sentence types, the end mark, and the word that needs a
+ * capital — which is what "authored once, reusable" means concretely: a
+ * sentence carries as many of the five as it can honestly carry.
+ *
+ * ── House rules for adding one ──────────────────────────────────────────────
+ *   - **One defensible answer, in the sentence as printed.** Not "usually a
+ *     noun" — the only question is what it is *here*, and if two readings are
+ *     both fair the entry does not go in.
+ *   - **Never tag a word whose class is disputed by the schemes.** `the`, `a`,
+ *     `my`, `his` are determiners to one scheme and adjectives to another, so
+ *     no article or possessive is ever the tagged word. Nor is a noun used as a
+ *     modifier (`school bus`), a participle (`the running water`) or a gerund.
+ *   - **Verbs are past tense or imperative.** `walk` is a noun and a verb;
+ *     `walked` is only ever a verb, and so is the `Put` that opens a command.
+ *     The `-ed` form is the cheapest way to make a tag unarguable.
+ *   - **Adjectives and adverbs that are nothing else.** Not `fast`, `hard`,
+ *     `well` or `light`; not a colour, which is a noun as often as a modifier.
+ *     Adverbs are `-ly` adverbs of manner, and never the `-ly` words that are
+ *     adjectives (`friendly`, `lonely`, `early`).
+ *   - **Pronouns that are only pronouns.** `her` and `his` are pronouns in one
+ *     position and determiners in another, so neither is ever tagged; `she`,
+ *     `they`, `them`, `us`, `you` are safe wherever they stand.
+ *   - **A split is exhaustive or it is absent.** `subject` and `predicate`
+ *     together are the whole sentence, which is what stops "complete subject"
+ *     and "simple subject" being two right answers to one question: every word
+ *     has to go somewhere, so `dog` alone leaves `The big brown` homeless.
+ *     Only plain statements get one — a command's subject is not on the page,
+ *     and a question's is inside the verb phrase.
+ *   - **An exclamation is exclamative in form.** `What a …!` and `How …!`,
+ *     never a statement with an exclamation mark on it, because "should this
+ *     be a full stop or a bang?" is exactly the judgement a key cannot make.
+ *   - **One word to capitalise, and it is never the first.** The capitals sheet
+ *     lower-cases `proper` and asks for it back, so a second capital anywhere
+ *     in the sentence would be a second thing a child could point at.
+ *     `grammar.test.ts` holds the bank to that mechanically, along with the
+ *     split rejoining, the tagged word appearing exactly once, and the end mark
+ *     agreeing with the kind.
+ *   - **British spelling**, as everywhere in this repo — and nothing whose
+ *     spelling differs between the two, because a sheet is printed on both
+ *     sides of the Atlantic.
+ */
+
+/**
+ * The five word classes a sheet may ask about.
+ *
+ * Five rather than the eight or nine a grammar names, and the four that are
+ * missing are missing on purpose. Determiners, prepositions and conjunctions
+ * are all words a primary scheme teaches, and all three are words the schemes
+ * disagree about: `the` is a determiner in one classroom and an adjective in
+ * the next, and a sheet cannot mark a child on which classroom they are in.
+ */
+export type Part = "noun" | "verb" | "adjective" | "adverb" | "pronoun";
+
+/** In the order a scheme meets them, which is the order they are printed in. */
+export const PARTS: Part[] = ["noun", "verb", "adjective", "adverb", "pronoun"];
+
+/**
+ * What a sentence is *for*, which is a different question from what it says.
+ *
+ * A command and a statement both end in a full stop, and telling them apart is
+ * the whole of the exercise. The other two carry their mark, which makes them
+ * the easy half — and the easy half is what makes the sheet answerable by a
+ * six-year-old rather than only by a nine-year-old.
+ */
+export type SentenceKind = "statement" | "question" | "command" | "exclamation";
+
+/** In the order they are taught, and the order the options are printed in. */
+export const KINDS: SentenceKind[] = [
+  "statement",
+  "question",
+  "command",
+  "exclamation",
+];
+
+/** The mark each kind ends on. One place, so the bank cannot drift from it. */
+export const END_MARK: Record<SentenceKind, string> = {
+  statement: ".",
+  question: "?",
+  command: ".",
+  exclamation: "!",
+};
+
+/**
+ * The whole sentence, cut once.
+ *
+ * `subject` and `predicate` are the *complete* subject and predicate — every
+ * word of the sentence is in one or the other — and that exhaustiveness is what
+ * makes the question markable at all. See the house rules above.
+ */
+export type Split = { subject: string; predicate: string };
+
+/** The one word this sentence is asked about, and what it is here. */
+export type Focus = { word: string; part: Part };
+
+export type Tagged = {
+  /** The sentence, written correctly: capital at the front, mark at the end. */
+  text: string;
+  kind: SentenceKind;
+  /** Absent unless the sentence is a plain statement — see `Split`. */
+  split?: Split;
+  /** Absent where no word in it can be tagged without argument. */
+  focus?: Focus;
+  /**
+   * A proper noun in it, written as it is spelt correctly.
+   *
+   * The capitals sheet prints the sentence with this word in lower case and
+   * asks for it back, so it is never the first word — a lower-cased opening
+   * word is two mistakes wearing one coat.
+   */
+  proper?: string;
+};
+
+/* ── Statements ────────────────────────────────────────────────────────────
+   The only kind with a split, and the reason they are the largest group: a
+   subject-and-predicate sheet has nothing else to draw from, and a page whose
+   twelve sentences are the bank's whole supply is the same page every week. */
+
+const STATEMENTS: Tagged[] = [
+  {
+    text: "The tall giraffe ate the leaves.",
+    kind: "statement",
+    split: { subject: "The tall giraffe", predicate: "ate the leaves" },
+    focus: { word: "tall", part: "adjective" },
+  },
+  {
+    text: "My sister carried the heavy basket for Rosie.",
+    kind: "statement",
+    split: {
+      subject: "My sister",
+      predicate: "carried the heavy basket for Rosie",
+    },
+    focus: { word: "carried", part: "verb" },
+    proper: "Rosie",
+  },
+  {
+    text: "The old tractor belonged to Jack.",
+    kind: "statement",
+    split: { subject: "The old tractor", predicate: "belonged to Jack" },
+    focus: { word: "tractor", part: "noun" },
+    proper: "Jack",
+  },
+  {
+    text: "She whispered the answer politely.",
+    kind: "statement",
+    split: { subject: "She", predicate: "whispered the answer politely" },
+    focus: { word: "politely", part: "adverb" },
+  },
+  {
+    text: "The hungry kitten slept in the cupboard.",
+    kind: "statement",
+    split: { subject: "The hungry kitten", predicate: "slept in the cupboard" },
+    focus: { word: "hungry", part: "adjective" },
+  },
+  {
+    text: "We climbed the steep hill on Tuesday.",
+    kind: "statement",
+    split: { subject: "We", predicate: "climbed the steep hill on Tuesday" },
+    focus: { word: "climbed", part: "verb" },
+    proper: "Tuesday",
+  },
+  {
+    text: "The postman knocked loudly on the door.",
+    kind: "statement",
+    split: { subject: "The postman", predicate: "knocked loudly on the door" },
+    focus: { word: "loudly", part: "adverb" },
+  },
+  {
+    text: "Our new puppy chewed my slipper.",
+    kind: "statement",
+    split: { subject: "Our new puppy", predicate: "chewed my slipper" },
+    focus: { word: "puppy", part: "noun" },
+  },
+  {
+    text: "The enormous whale dived under the boat.",
+    kind: "statement",
+    split: {
+      subject: "The enormous whale",
+      predicate: "dived under the boat",
+    },
+    focus: { word: "enormous", part: "adjective" },
+  },
+  {
+    text: "The farmer told them a funny story.",
+    kind: "statement",
+    split: { subject: "The farmer", predicate: "told them a funny story" },
+    focus: { word: "them", part: "pronoun" },
+  },
+  {
+    text: "They painted the shed on Saturday.",
+    kind: "statement",
+    split: { subject: "They", predicate: "painted the shed on Saturday" },
+    focus: { word: "They", part: "pronoun" },
+    proper: "Saturday",
+  },
+  {
+    text: "A wooden bridge crossed the stream at Oxford.",
+    kind: "statement",
+    split: {
+      subject: "A wooden bridge",
+      predicate: "crossed the stream at Oxford",
+    },
+    focus: { word: "stream", part: "noun" },
+    proper: "Oxford",
+  },
+  {
+    text: "The children waited quietly for the bus.",
+    kind: "statement",
+    split: { subject: "The children", predicate: "waited quietly for the bus" },
+    focus: { word: "quietly", part: "adverb" },
+  },
+  {
+    text: "Emma visited her cousin in Wales.",
+    kind: "statement",
+    split: { subject: "Emma", predicate: "visited her cousin in Wales" },
+    focus: { word: "visited", part: "verb" },
+    proper: "Wales",
+  },
+  {
+    text: "The early train arrived in Cardiff.",
+    kind: "statement",
+    split: { subject: "The early train", predicate: "arrived in Cardiff" },
+    focus: { word: "arrived", part: "verb" },
+    proper: "Cardiff",
+  },
+  {
+    text: "My uncle drove us to Scotland.",
+    kind: "statement",
+    split: { subject: "My uncle", predicate: "drove us to Scotland" },
+    focus: { word: "us", part: "pronoun" },
+    proper: "Scotland",
+  },
+];
+
+/* ── Questions ─────────────────────────────────────────────────────────────
+   Every one of them inverted or opened by a question word, so what makes it a
+   question is on the page rather than in the reader's voice. "You are coming"
+   is a question or a statement depending on how it is said, which is precisely
+   the sentence that cannot be printed with a key.                           */
+
+const QUESTIONS: Tagged[] = [
+  {
+    text: "Where did you put the tickets for Friday?",
+    kind: "question",
+    focus: { word: "you", part: "pronoun" },
+    proper: "Friday",
+  },
+  {
+    text: "Did she deliver the parcel this morning?",
+    kind: "question",
+    focus: { word: "she", part: "pronoun" },
+  },
+  {
+    text: "Why is the kitchen so untidy?",
+    kind: "question",
+    focus: { word: "untidy", part: "adjective" },
+  },
+  {
+    text: "Have you ever visited Egypt?",
+    kind: "question",
+    focus: { word: "visited", part: "verb" },
+    proper: "Egypt",
+  },
+  {
+    text: "Who left the muddy footprints on the carpet?",
+    kind: "question",
+    focus: { word: "muddy", part: "adjective" },
+  },
+  {
+    text: "When does the library open on Sunday?",
+    kind: "question",
+    focus: { word: "library", part: "noun" },
+    proper: "Sunday",
+  },
+  {
+    text: "How did they carry the ladder safely?",
+    kind: "question",
+    focus: { word: "safely", part: "adverb" },
+  },
+];
+
+/* ── Commands ──────────────────────────────────────────────────────────────
+   The kind that shares its mark with a statement, and therefore the whole
+   reason a sentence-types sheet is an exercise rather than a look at the last
+   character. Every one opens on a verb that is not also a noun: `Put`, not
+   `Pass`; `Choose`, not `Close`.                                            */
+
+const COMMANDS: Tagged[] = [
+  {
+    text: "Put the muddy boots outside the door.",
+    kind: "command",
+    focus: { word: "Put", part: "verb" },
+  },
+  {
+    text: "Bring the shopping into the kitchen.",
+    kind: "command",
+    focus: { word: "kitchen", part: "noun" },
+  },
+  {
+    text: "Remember your lunchbox on Monday.",
+    kind: "command",
+    focus: { word: "Remember", part: "verb" },
+    proper: "Monday",
+  },
+  {
+    text: "Choose a book for Amir.",
+    kind: "command",
+    focus: { word: "book", part: "noun" },
+    proper: "Amir",
+  },
+  {
+    text: "Explain your answer clearly to the class.",
+    kind: "command",
+    focus: { word: "clearly", part: "adverb" },
+  },
+];
+
+/* ── Exclamations ──────────────────────────────────────────────────────────
+   All four are exclamative clauses — `What a …!` or `How …!` — which is what
+   makes the mark on the end a fact about the grammar rather than a decision
+   about tone. It is also why they are the one kind the punctuation sheet never
+   draws from: "What a mess" takes a bang, and a child who wrote a full stop
+   after it has not made a mistake anybody can point to.                     */
+
+const EXCLAMATIONS: Tagged[] = [
+  {
+    text: "What a tremendous splash that was!",
+    kind: "exclamation",
+    focus: { word: "tremendous", part: "adjective" },
+  },
+  {
+    text: "How quickly the storm arrived!",
+    kind: "exclamation",
+    focus: { word: "quickly", part: "adverb" },
+  },
+  {
+    text: "What a clever idea you had!",
+    kind: "exclamation",
+    focus: { word: "you", part: "pronoun" },
+  },
+  {
+    text: "How chilly the water felt!",
+    kind: "exclamation",
+    focus: { word: "chilly", part: "adjective" },
+  },
+];
+
+/**
+ * The bank, in one list.
+ *
+ * Grouped above by kind because that is how it is *read* — the constraints on a
+ * command are not the constraints on a statement — and flattened here because
+ * that is how it is *used*: a topic is a filter over the whole bank, and a
+ * topic that had to know which array to look in would be a topic that could
+ * look in the wrong one.
+ */
+export const SENTENCES: Tagged[] = [
+  ...STATEMENTS,
+  ...QUESTIONS,
+  ...COMMANDS,
+  ...EXCLAMATIONS,
+];
+
+/** The sentence without the mark on the end — what a punctuation sheet asks. */
+export const stem = (entry: Tagged): string => entry.text.slice(0, -1);
+
+/**
+ * The sentence with its proper noun knocked down to lower case.
+ *
+ * The one place a sentence is printed as something other than what it says, and
+ * it is done by lower-casing the first letter of the word rather than the word
+ * itself: `text` is the truth and this is the exercise made out of it, so the
+ * two can only ever differ by that one character — which is what makes "exactly
+ * one word to put right" a property a test can check rather than a promise.
+ */
+export function lowered(entry: Tagged): string {
+  if (!entry.proper) return entry.text;
+  const at = entry.text.indexOf(entry.proper);
+  if (at < 0) return entry.text;
+  return (
+    entry.text.slice(0, at) +
+    entry.proper[0].toLowerCase() +
+    entry.text.slice(at + 1)
+  );
+}

--- a/src/engine/sheets/grammar/grammar.test.ts
+++ b/src/engine/sheets/grammar/grammar.test.ts
@@ -7,6 +7,7 @@ import { END_MARK, KINDS, PARTS, SENTENCES, type Tagged } from "./bank";
 import {
   GRAMMAR_SHEET,
   GRAMMAR_TOPICS,
+  grammarColumns,
   grammarLayout,
   grammarStyles,
   topicOf,
@@ -144,9 +145,21 @@ describe("the sentence bank", () => {
     }
   });
 
-  it("has enough of every topic to fill a page of it", () => {
+  it("has more of every topic than a page of it holds", () => {
+    // The bank's own header names this as the failure to avoid: a page whose
+    // sentences are the topic's whole supply is the same page every week,
+    // whatever seed a parent rerolls to. Measured against what the paper holds
+    // rather than against a number somebody typed, so the bar moves the day a
+    // row gets shorter — and against the *widest* style a topic offers, since a
+    // "write" page fits half again as many as a "circle one" page.
     for (const topic of GRAMMAR_TOPICS) {
-      expect(topicOf(topic).questions.length, topic).toBeGreaterThan(11);
+      const page = Math.max(
+        ...grammarStyles(topic).map(
+          (style) =>
+            grammarLayout(config({ topic, style, columns: 1 })).perPage,
+        ),
+      );
+      expect(topicOf(topic).questions.length, topic).toBeGreaterThan(page);
     }
   });
 
@@ -254,6 +267,9 @@ describe("the grammar family", () => {
       if (!grammarStyles(topic).includes("write")) continue;
       const wide = grammarLayout(config({ topic, style: "write", columns: 6 }));
       expect(wide.columns, topic).toBe(topic === "subject" ? 1 : 2);
+      // And the number the options panel builds its stepper out of is the one
+      // the paper obeys, rather than a second copy of the same rule.
+      expect(grammarColumns(topic), topic).toBe(wide.columns);
     }
     // And a circled sheet is a list down the page whatever the config says.
     expect(grammarLayout(config({ topic: "parts", columns: 2 })).columns).toBe(
@@ -357,6 +373,32 @@ describe("the answers on a grammar sheet", () => {
 });
 
 describe("circling one of a closed list", () => {
+  it("puts every name on the list on the page, at every seed", () => {
+    // The variety is asserted rather than hoped for, as `wordproblems.test.ts`
+    // puts it. A shuffle is fair across many pages and silent about any one of
+    // them: before this was drawn deliberately, one page in six of "kinds of
+    // sentence" came up with no command on it — every item correct, and the
+    // sheet no longer the exercise its own instruction line describes.
+    for (const topic of GRAMMAR_TOPICS) {
+      if (!grammarStyles(topic).includes("choose")) continue;
+      const scale = topicOf(topic).options;
+      if (!scale) throw new Error(`${topic} circles nothing`);
+      for (let seed = 1; seed <= 50; seed++) {
+        const block = blockOf(
+          config({ topic, style: "choose", count: 12 }),
+          seed,
+        );
+        if (block.kind !== "choice") throw new Error("expected choice");
+        const drawn = new Set(
+          block.questions.map((question) => question.options[question.answer]),
+        );
+        expect([...drawn].sort(), `${topic} @${seed}`).toEqual(
+          [...scale].sort(),
+        );
+      }
+    }
+  });
+
   it("prints the whole scale, in order, and marks the tagged answer", () => {
     for (const topic of GRAMMAR_TOPICS) {
       if (!grammarStyles(topic).includes("choose")) continue;

--- a/src/engine/sheets/grammar/grammar.test.ts
+++ b/src/engine/sheets/grammar/grammar.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import type { Block, GrammarConfig, GrammarStyle, Paper } from "../types";
+
+import { END_MARK, KINDS, PARTS, SENTENCES, type Tagged } from "./bank";
+import {
+  GRAMMAR_SHEET,
+  GRAMMAR_TOPICS,
+  grammarLayout,
+  grammarStyles,
+  topicOf,
+} from "./grammar";
+
+/**
+ * Grammar, held to the bar every other family meets — and to the one that only
+ * bites here.
+ *
+ * On a maths sheet "verified by an independent path" means the answer is worked
+ * out a second way. There is no second way to work out whether a word is an
+ * adverb: the answer is a **tag somebody wrote down**, so what this file proves
+ * is that the tags are sound and that the sheet prints them faithfully.
+ *
+ * **The bank.** Every sentence ends on the mark its kind takes, every split
+ * rejoins to the sentence it came from with nothing added and nothing lost,
+ * every tagged word is in its sentence exactly once, and every capitals
+ * sentence has exactly one word to put right.
+ *
+ * **The sheet.** Every answer on every page is recovered from the bank *here*,
+ * by this file's own arithmetic rather than by anything `grammar.ts` exports —
+ * the prompt is parsed back to the entry it was made from and the answer is
+ * re-derived from the tag. A generator that agreed with itself and disagreed
+ * with the bank would pass every other assertion in this file and fail these.
+ */
+
+const paper: Paper = {
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+};
+
+const config = (over: Partial<GrammarConfig> = {}): GrammarConfig => ({
+  kind: "grammar",
+  paper,
+  fontPt: 12,
+  fields: ["name", "date"],
+  topic: "parts",
+  style: "choose",
+  count: 10,
+  columns: 1,
+  ...over,
+});
+
+/** Every topic in every style it offers — the whole surface, as configs. */
+const EVERY_SHEET: GrammarConfig[] = GRAMMAR_TOPICS.flatMap((topic) =>
+  grammarStyles(topic).map((style) => config({ topic, style, count: 10 })),
+);
+
+const where = (one: GrammarConfig) => `${one.topic}/${one.style}`;
+
+const blockOf = (one: GrammarConfig, seed = 1): Block =>
+  buildSheet(one, seed).blocks[0];
+
+/** The bank by the sentence it holds, which is how a prompt finds its way home. */
+const BY_TEXT = new Map(SENTENCES.map((entry) => [entry.text, entry]));
+
+/** The words of a sentence, with the punctuation taken off each of them. */
+const wordsOf = (text: string): string[] =>
+  text.split(/\s+/).map((word) => word.replaceAll(/[^A-Za-z]/g, ""));
+
+/** How many times a word stands on its own in a sentence, case and all. */
+const occurrences = (text: string, word: string): number =>
+  wordsOf(text).filter((one) => one === word).length;
+
+/* ── The bank ──────────────────────────────────────────────────────────── */
+
+describe("the sentence bank", () => {
+  it("writes every sentence once, with a capital and the right mark", () => {
+    const texts = SENTENCES.map((entry) => entry.text);
+    expect(new Set(texts).size).toBe(texts.length);
+    for (const entry of SENTENCES) {
+      expect(entry.text.trim(), entry.text).toBe(entry.text);
+      expect(entry.text[0], entry.text).toBe(entry.text[0].toUpperCase());
+      // The mark is derived from the kind here and read off the string in
+      // `endMarks()` — the two ends of the same claim, meeting in the middle.
+      expect(entry.text.slice(-1), entry.text).toBe(END_MARK[entry.kind]);
+      expect(KINDS, entry.text).toContain(entry.kind);
+    }
+  });
+
+  it("cuts a statement in two, and cuts nothing else", () => {
+    // The property that makes "write the subject" markable at all: the split is
+    // exhaustive, so a child who writes the head noun alone has left words with
+    // nowhere to go. Checked by rejoining, which no amount of care in the
+    // authoring can be trusted to have got right.
+    for (const entry of SENTENCES) {
+      if (entry.kind !== "statement") {
+        expect(entry.split, entry.text).toBeUndefined();
+        continue;
+      }
+      const split = entry.split;
+      if (!split) throw new Error(`no split on "${entry.text}"`);
+      expect(`${split.subject} ${split.predicate}.`, entry.text) //
+        .toBe(entry.text);
+      expect(split.subject.trim(), entry.text).not.toBe("");
+      expect(split.predicate.trim(), entry.text).not.toBe("");
+      // A subject the sentence does not open on is a subject somebody moved.
+      expect(entry.text.startsWith(split.subject), entry.text).toBe(true);
+    }
+  });
+
+  it("tags one word, and finds it once in its own sentence", () => {
+    // The whole question a parts-of-speech sheet asks is "this word, here", so
+    // a word that turns up twice is a question with two subjects and one
+    // answer. Case-sensitive, because the printed prompt quotes the word as it
+    // is written — "They" at the front of a sentence is not "they".
+    for (const entry of SENTENCES) {
+      const focus = entry.focus;
+      if (!focus) continue;
+      expect(PARTS, entry.text).toContain(focus.part);
+      expect(occurrences(entry.text, focus.word), entry.text).toBe(1);
+    }
+    // And every part of speech is somewhere in the bank, or a sheet drawn from
+    // it teaches four of the five.
+    const tagged = SENTENCES.flatMap((entry) => entry.focus?.part ?? []);
+    expect(new Set(tagged)).toEqual(new Set(PARTS));
+  });
+
+  it("leaves exactly one word to capitalise, and never the first", () => {
+    for (const entry of SENTENCES) {
+      const [first, ...rest] = wordsOf(entry.text);
+      expect(first, entry.text).not.toBe("");
+      // Whatever else is capitalised inside the sentence is the proper noun and
+      // nothing else — an "I" or a second name would be a second thing a child
+      // could point at and be right about.
+      const capitalised = rest.filter(
+        (word) => word !== "" && word[0] === word[0].toUpperCase(),
+      );
+      expect(capitalised, entry.text).toEqual(
+        entry.proper ? [entry.proper] : [],
+      );
+      if (!entry.proper) continue;
+      expect(occurrences(entry.text, entry.proper), entry.text).toBe(1);
+    }
+  });
+
+  it("has enough of every topic to fill a page of it", () => {
+    for (const topic of GRAMMAR_TOPICS) {
+      expect(topicOf(topic).questions.length, topic).toBeGreaterThan(11);
+    }
+  });
+
+  it("never asks which mark an exclamation ends on", () => {
+    // "What a mess" takes a bang and a full stop is not a mistake anybody can
+    // point to, so the one judgement call in end punctuation is left out of the
+    // topic rather than guessed at.
+    const asked = topicOf("punctuation").questions.map((one) => one.answer);
+    expect(new Set(asked)).toEqual(new Set([".", "?"]));
+  });
+
+  it("keeps the four kinds of sentence in play", () => {
+    // A types sheet drawn from a bank of statements is a page with one answer.
+    for (const kind of KINDS) {
+      const many = SENTENCES.filter((entry) => entry.kind === kind).length;
+      expect(many, kind).toBeGreaterThan(3);
+    }
+  });
+});
+
+/* ── The family ────────────────────────────────────────────────────────── */
+
+describe("the grammar family", () => {
+  it("is in the registry under the kind its config carries", () => {
+    expect(sheetSpec("grammar")).toBe(GRAMMAR_SHEET);
+    expect(sheetSpec("grammar").label).toBe("Grammar");
+  });
+
+  it("prints a titled, marked page for every topic and style", () => {
+    for (const one of EVERY_SHEET) {
+      const sheet = buildSheet(one, 1);
+      expect(sheet.header.title, where(one)).not.toBe("");
+      expect(sheet.header.instructions, where(one)).toBeTruthy();
+      // Marked out of what is on the page rather than out of what was asked
+      // for: a subject-and-predicate sheet spends three lines on every sentence
+      // and holds eight of them, and "/ 10" over eight is wrong twice.
+      const room = Math.min(
+        one.count,
+        grammarLayout(one).perPage,
+        topicOf(one.topic).questions.length,
+      );
+      expect(room, where(one)).toBeGreaterThan(5);
+      expect(sheet.header.score?.outOf, where(one)).toBe(room);
+      expect(sheet.blocks, where(one)).toHaveLength(1);
+      // No game on the other side of a grammar sheet, so the footer says the
+      // site rather than sending a parent to the times tables (§16).
+      expect(sheet.footer.url, where(one)).toBe("schoolskills.app");
+    }
+  });
+
+  it("names what it prints, in the terms it was chosen by", () => {
+    expect(describeSheet(config({ topic: "capitals", style: "write" }))) //
+      .toBe("Capital letters — 10 sentences — written in");
+    expect(describeSheet(config({ topic: "types", style: "choose" }))) //
+      .toBe("Kinds of sentence — 10 sentences — circled");
+  });
+
+  it("falls back to a style the topic has rather than throwing", () => {
+    // A saved sheet outlives the table it was made from (§7): there has never
+    // been a list of capital letters to circle, and a config that says so still
+    // has to print something.
+    const circled = config({ topic: "capitals", style: "choose" });
+    expect(blockOf(circled).kind).toBe("problems");
+    // As does a topic this build has never heard of.
+    const unknown = config({ topic: "clauses" as never });
+    expect(() => buildSheet(unknown, 1)).not.toThrow();
+  });
+
+  it("builds the same sheet twice, and a different one next seed", () => {
+    for (const one of EVERY_SHEET) {
+      expect(JSON.stringify(buildSheet(one, 5)), where(one)) //
+        .toBe(JSON.stringify(buildSheet(one, 5)));
+      expect(JSON.stringify(buildSheet(one, 6)), where(one)) //
+        .not.toBe(JSON.stringify(buildSheet(one, 5)));
+    }
+  });
+
+  it("never prints more sentences than the paper holds", () => {
+    for (const size of ["letter", "a4"] as const) {
+      for (const fontPt of [10, 12, 18, 36]) {
+        for (const one of EVERY_SHEET) {
+          const big = {
+            ...one,
+            paper: { ...paper, size },
+            fontPt,
+            count: 200,
+            columns: 2,
+          };
+          const { perPage } = grammarLayout(big);
+          const printed = countOf(blockOf(big));
+          expect(printed, `${where(one)} ${size}@${fontPt}`) //
+            .toBeLessThanOrEqual(perPage);
+          // And never more than the bank has, which is the other cap.
+          expect(printed, where(one)) //
+            .toBeLessThanOrEqual(topicOf(one.topic).questions.length);
+        }
+      }
+    }
+  });
+
+  it("lays a sentence out one or two across, and a split only one", () => {
+    // Two ruled lines that do not wrap in a half-width column is a predicate
+    // with its end cut off, which reads as a sheet rather than as a bug.
+    for (const topic of GRAMMAR_TOPICS) {
+      if (!grammarStyles(topic).includes("write")) continue;
+      const wide = grammarLayout(config({ topic, style: "write", columns: 6 }));
+      expect(wide.columns, topic).toBe(topic === "subject" ? 1 : 2);
+    }
+    // And a circled sheet is a list down the page whatever the config says.
+    expect(grammarLayout(config({ topic: "parts", columns: 2 })).columns).toBe(
+      1,
+    );
+  });
+});
+
+/** How many questions a block put on the paper. */
+function countOf(block: Block): number {
+  if (block.kind === "problems") return block.items.length;
+  if (block.kind === "choice") return block.questions.length;
+  throw new Error(`unexpected block ${block.kind}`);
+}
+
+/* ── The answers, checked against the tags ─────────────────────────────────
+   The story's own condition, and the reason this section does not import a
+   single helper out of `grammar.ts`: a prompt is taken apart here, matched to
+   the bank entry it was built from, and the answer re-derived from the tag by
+   this file. Anything the generator believes about its own output is beside
+   the point.                                                               */
+
+/** The entry a printed prompt came from, and the tag it was asked about. */
+function entryOf(prompt: string, find: (entry: Tagged) => string): Tagged {
+  const found = SENTENCES.find((entry) => find(entry) === prompt);
+  if (!found) throw new Error(`no sentence prints "${prompt}"`);
+  return found;
+}
+
+/** The `problems` block of a written sheet, narrowed. */
+function itemsOf(topic: string) {
+  const block = blockOf(config({ topic: topic as never, style: "write" }), 3);
+  if (block.kind !== "problems") throw new Error(`got ${block.kind}`);
+  expect(block.items.length, topic).toBeGreaterThan(0);
+  return block.items;
+}
+
+describe("the answers on a grammar sheet", () => {
+  it("names the part of speech the bank tagged, for the word it quoted", () => {
+    for (const item of itemsOf("parts")) {
+      const split = /^(.*) — “(.+)”$/.exec(item.prompt);
+      if (!split) throw new Error(`unquoted prompt "${item.prompt}"`);
+      const entry = BY_TEXT.get(split[1]);
+      if (!entry?.focus) throw new Error(`no tag for "${split[1]}"`);
+      expect(split[2], item.prompt).toBe(entry.focus.word);
+      expect(item.answer, item.prompt).toBe(entry.focus.part);
+    }
+  });
+
+  it("cuts each sentence where the bank cuts it, and writes both halves", () => {
+    for (const item of itemsOf("subject")) {
+      const entry = BY_TEXT.get(item.prompt);
+      if (!entry?.split) throw new Error(`no split for "${item.prompt}"`);
+      expect(item.answers, item.prompt) //
+        .toEqual([entry.split.subject, entry.split.predicate]);
+      // Rejoined here as well as in the bank's own test, because what is being
+      // checked now is the pair that reached the paper.
+      expect(`${item.answers?.join(" ")}.`, item.prompt).toBe(entry.text);
+      // Two ruled lines and no slot: exactly one place to write the answer.
+      expect(item.workspace, item.prompt).toBeGreaterThan(0);
+    }
+  });
+
+  it("says what each sentence is for, from the kind it was tagged with", () => {
+    for (const item of itemsOf("types")) {
+      const entry = BY_TEXT.get(item.prompt);
+      if (!entry) throw new Error(`no sentence "${item.prompt}"`);
+      expect(item.answer, item.prompt).toBe(entry.kind);
+    }
+  });
+
+  it("asks for the mark the sentence's own kind takes", () => {
+    for (const item of itemsOf("punctuation")) {
+      const entry = entryOf(item.prompt, (one) => one.text.slice(0, -1));
+      expect(entry.kind, item.prompt).not.toBe("exclamation");
+      // Derived from the tag rather than from the string the sheet was built
+      // out of, which is the whole point of the tag being there.
+      expect(item.answer, item.prompt).toBe(END_MARK[entry.kind]);
+    }
+  });
+
+  it("lower-cases one proper noun and asks for exactly it back", () => {
+    for (const item of itemsOf("capitals")) {
+      // The printed sentence is recomputed here rather than imported, so the
+      // exercise and the answer are checked against the bank instead of against
+      // each other.
+      const entry = entryOf(item.prompt, (one) =>
+        one.proper
+          ? one.text.replace(one.proper, one.proper.toLowerCase())
+          : one.text,
+      );
+      if (!entry.proper) throw new Error(`no proper noun in "${item.prompt}"`);
+      expect(item.answer, item.prompt).toBe(entry.proper);
+      // One character apart, and that character is a case change: a sheet that
+      // had rewritten anything else would be asking a different question.
+      expect(item.prompt.toLowerCase(), item.prompt) //
+        .toBe(entry.text.toLowerCase());
+      expect(item.prompt, item.prompt).not.toBe(entry.text);
+    }
+  });
+});
+
+describe("circling one of a closed list", () => {
+  it("prints the whole scale, in order, and marks the tagged answer", () => {
+    for (const topic of GRAMMAR_TOPICS) {
+      if (!grammarStyles(topic).includes("choose")) continue;
+      const scale = topicOf(topic).options;
+      if (!scale) throw new Error(`${topic} circles nothing`);
+      const block = blockOf(config({ topic, style: "choose", count: 12 }));
+      if (block.kind !== "choice") throw new Error("expected choice");
+      expect(block.questions.length, topic).toBeGreaterThan(0);
+
+      for (const question of block.questions) {
+        // The same list on every line, in the same order — a page whose options
+        // moved about is a page a child has to read five times.
+        expect(question.options, question.prompt).toEqual(scale);
+        expect(question.answer, question.prompt).toBeGreaterThanOrEqual(0);
+        const chosen = question.options[question.answer];
+        const entry =
+          topic === "parts"
+            ? BY_TEXT.get(/^(.*) — “.+”$/.exec(question.prompt)?.[1] ?? "")
+            : BY_TEXT.get(question.prompt);
+        if (!entry) throw new Error(`no sentence for "${question.prompt}"`);
+        expect(chosen, question.prompt) //
+          .toBe(topic === "parts" ? entry.focus?.part : entry.kind);
+      }
+    }
+  });
+});
+
+/* ── The key ───────────────────────────────────────────────────────────── */
+
+describe("the answer key", () => {
+  it("is the same sheet keyed, never a second generation", () => {
+    for (const one of EVERY_SHEET) {
+      const sheet = buildSheet(one, 7);
+      const key = answerKey(one, 7);
+      expect(key.answers, where(one)).toBe(true);
+      expect(key.footer.note, where(one)).toBe("Answer key");
+      expect({ ...key, answers: false, footer: sheet.footer }, where(one)) //
+        .toEqual(sheet);
+    }
+  });
+});
+
+/* ── What a panel is allowed to offer ──────────────────────────────────── */
+
+describe("the styles a topic offers", () => {
+  it("gives every topic at least one, and only where it has a list", () => {
+    const known: GrammarStyle[] = ["write", "choose"];
+    for (const topic of GRAMMAR_TOPICS) {
+      const styles = grammarStyles(topic);
+      expect(styles.length, topic).toBeGreaterThan(0);
+      for (const style of styles) expect(known, topic).toContain(style);
+      expect(new Set(styles).size, topic).toBe(styles.length);
+      // A topic offers "circle one" exactly when there is something closed to
+      // circle. An end mark, a capitalised word and a sentence cut in half are
+      // none of them one of four things.
+      expect(styles.includes("choose"), topic) //
+        .toBe(topicOf(topic).options !== undefined);
+    }
+  });
+});

--- a/src/engine/sheets/grammar/grammar.ts
+++ b/src/engine/sheets/grammar/grammar.ts
@@ -1,0 +1,566 @@
+/**
+ * Grammar: five views of one tagged sentence.
+ *
+ * The third family whose content is authored rather than generated, and the
+ * one with the sharpest reason for it. `words/bank.ts` is written out because
+ * English spelling will not yield to a rule; this bank is written out because
+ * **grammar is a judgement**, and a worksheet that marks a defensible answer
+ * wrong teaches a child something false. Nothing in this module analyses a
+ * sentence: it draws entries out of `bank.ts` and reads what somebody wrote
+ * down about them.
+ *
+ * One family rather than five, in the same way `words/study.ts` is one family
+ * rather than ten: the five topics differ only in which tag they read and how
+ * the answer is written. Two shapes of question fall out — a ruled place to
+ * write in, or a fixed set of names to circle one of — and a topic offers the
+ * second only where the answer really is one of a closed list. There are five
+ * parts of speech and four kinds of sentence; there is no closed list of
+ * capital letters, end marks or ways to cut a sentence in half.
+ *
+ * Everything the other families promise holds: the page comes out of
+ * `(config, seed)` and nothing else, the answers are decided when the sheet is
+ * built and the key only prints them, and no row goes on the page that the
+ * capacity arithmetic did not reserve.
+ */
+import { mulberry32, shuffled } from "@/engine/random";
+
+import type {
+  Block,
+  Choice,
+  GrammarConfig,
+  GrammarStyle,
+  GrammarTopic,
+  Mil,
+  Problem,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+import { declaredWidth, packRows, sheetBlockBox } from "../chrome";
+import { faceOf, fittedCharacters } from "../faces";
+import {
+  LIST_GAP,
+  PROBLEM_GAP,
+  WRAP_GAP,
+  answerLine,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { inches, own, points } from "../paper";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+
+import { KINDS, PARTS, SENTENCES, lowered, stem } from "./bank";
+
+/* ── What a row takes on the page ─────────────────────────────────────────
+   Declared, not measured (§4), and the same three numbers `words/study.ts`
+   reserves by, because it prints through the same two blocks.               */
+
+/** A sentence and its ruled slot, on one line of body type. */
+const ROW_EMS = 1.7;
+
+/** The row of options under a question — see `optionRows` for how many. */
+const OPTIONS_EMS = 1.4;
+
+/** `.sheet__slot` in sheet.css is this wide before anything is written in it. */
+const SLOT_WIDTH: Mil = inches(0.8);
+
+/** Room for the "12." a numbered list prints in front of every sentence. */
+const NUMBER_CHARACTERS = 3;
+
+/** `.sheet__options` indents by this and sets this between its items. */
+const OPTIONS_INDENT: Mil = inches(0.3);
+const OPTIONS_GAP: Mil = inches(0.3);
+
+/** The `A`, `B`, `C` in front of an option, and the air after it. */
+const MARK_TEXT = "A";
+const MARK_GAP: Mil = inches(0.05);
+
+/**
+ * More than two columns of sentences is a page nobody can read.
+ *
+ * Lower than every maths family's cap and lower than word study's three,
+ * because what is in the cell is a whole sentence rather than a sum: at three
+ * columns on Letter a cell holds about twenty characters, so every row wraps to
+ * four lines and the page holds five questions. The cap is not a taste
+ * judgement — it is where the arithmetic stops giving anything back.
+ */
+const MAX_COLUMNS = 2;
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/* ── A question, whatever topic it came from ──────────────────────────────── */
+
+/**
+ * One thing to ask about one sentence.
+ *
+ * `ask` is what is printed, and unlike `words/study.ts` there is no second
+ * "cue" field beside it: a grammar question is the sentence, and the sentence
+ * reads the same above a row of options as it does in front of a ruled slot.
+ * The verb that changes between the two shapes lives in the instruction line
+ * where it belongs.
+ *
+ * `lines` is where the answer is more than one thing to write — the two halves
+ * of a sentence, a ruled line each. `answer` carries the same halves on one
+ * line for anything that wants the answer as a string, built from the same
+ * array so the two cannot disagree (`Problem.answers`).
+ */
+type Question = { ask: string; answer: string; lines?: string[] };
+
+type Topic = {
+  /** How the topic is named in a picker and in `describe`. */
+  label: string;
+  /** The sheet's own title. */
+  title: string;
+  /**
+   * The styles this topic can honestly be asked in, its default first.
+   *
+   * A style a topic does not offer is not an error — a saved sheet outlives the
+   * table below (§7) — so `styleOf` resolves it to the first of these rather
+   * than refusing to print.
+   */
+  styles: GrammarStyle[];
+  /** The line at the top of the page. Per style, because the verb changes. */
+  instruction: Partial<Record<GrammarStyle, string>>;
+  questions: Question[];
+  /**
+   * The closed list of names this topic's answer is one of.
+   *
+   * Always a scale, never a draw of near misses, which is the one way a grammar
+   * `choose` sheet is *safer* than a word-study one: the five parts of speech
+   * are the options on every line whatever the sentence, so there is no
+   * distractor that could quietly also be right. A topic with no such list is a
+   * topic with no `choose` style.
+   */
+  options?: string[];
+  /**
+   * How many ruled lines the answer is written on, when it is not a slot.
+   *
+   * Zero everywhere but the subject-and-predicate sheet, and that sheet's two
+   * lines are the whole reason the question is markable: the split has to be
+   * exhaustive, so a child who writes only the head noun has left the rest of
+   * the subject with nowhere to go. See the house rules in `bank.ts`.
+   */
+  lines: number;
+};
+
+/* ── The five topics ─────────────────────────────────────────────────────── */
+
+/**
+ * The word being asked about, printed after the sentence it sits in.
+ *
+ * In quotation marks rather than bold, because a `Problem.prompt` is plain text
+ * and always will be — a renderer that took markup would be a renderer that
+ * could be handed a sentence with a tag in it. The quotes ride on the prompt
+ * for the same reason a homophone's pair does in `words/study.ts`: the choice
+ * belongs to the sentence, and every sentence marks a different word.
+ */
+const asked = (text: string, word: string): string => `${text} — “${word}”`;
+
+const partsOfSpeech = (): Question[] =>
+  SENTENCES.flatMap((entry) =>
+    entry.focus
+      ? [{ ask: asked(entry.text, entry.focus.word), answer: entry.focus.part }]
+      : [],
+  );
+
+const subjects = (): Question[] =>
+  SENTENCES.flatMap((entry) =>
+    entry.split
+      ? [
+          {
+            ask: entry.text,
+            answer: `${entry.split.subject} / ${entry.split.predicate}`,
+            lines: [entry.split.subject, entry.split.predicate],
+          },
+        ]
+      : [],
+  );
+
+const kinds = (): Question[] =>
+  SENTENCES.map((entry) => ({ ask: entry.text, answer: entry.kind }));
+
+/**
+ * The sentence with its end mark taken off, and the mark as the answer.
+ *
+ * The mark is read off the *sentence* rather than looked up from its kind, and
+ * that is deliberate: what a child writes has to match what the sentence
+ * actually ends on, so the answer is the character the bank wrote. That the
+ * character always agrees with the kind is then a claim about the bank which
+ * `grammar.test.ts` checks from the other side — the tag, not the string.
+ *
+ * Exclamations are left out entirely. "What a mess" takes a bang and a full
+ * stop is not a mistake anybody can point to, and a topic that cannot say which
+ * of two marks is right has no business printing a key.
+ */
+const endMarks = (): Question[] =>
+  SENTENCES.filter((entry) => entry.kind !== "exclamation").map((entry) => ({
+    ask: stem(entry),
+    answer: entry.text.slice(-1),
+  }));
+
+const capitals = (): Question[] =>
+  SENTENCES.flatMap((entry) =>
+    entry.proper ? [{ ask: lowered(entry), answer: entry.proper }] : [],
+  );
+
+const TOPICS: Record<GrammarTopic, Topic> = {
+  parts: {
+    label: "Parts of speech",
+    title: "Parts of speech",
+    styles: ["choose", "write"],
+    instruction: {
+      choose:
+        "Circle what the word in quotation marks is in the sentence beside it.",
+      write:
+        "Write what the word in quotation marks is: noun, verb, adjective, adverb or pronoun.",
+    },
+    questions: partsOfSpeech(),
+    options: PARTS,
+    lines: 0,
+  },
+  subject: {
+    label: "Subject and predicate",
+    title: "Subject and predicate",
+    styles: ["write"],
+    instruction: {
+      write:
+        "Write the subject of each sentence on the first line and the predicate on the second. Every word goes on one line or the other.",
+    },
+    questions: subjects(),
+    lines: 2,
+  },
+  types: {
+    label: "Kinds of sentence",
+    title: "Kinds of sentence",
+    styles: ["choose", "write"],
+    instruction: {
+      choose:
+        "Circle what each sentence is: a statement, a question, a command or an exclamation.",
+      write:
+        "Write what each sentence is: a statement, a question, a command or an exclamation.",
+    },
+    questions: kinds(),
+    options: KINDS,
+    lines: 0,
+  },
+  punctuation: {
+    label: "End punctuation",
+    title: "The mark at the end",
+    styles: ["write"],
+    instruction: {
+      write:
+        "Write the full stop or the question mark that belongs at the end of each sentence.",
+    },
+    questions: endMarks(),
+    lines: 0,
+  },
+  capitals: {
+    label: "Capital letters",
+    title: "Capital letters",
+    styles: ["write"],
+    instruction: {
+      write:
+        "One word in each sentence should start with a capital letter. Write that word correctly on the line.",
+    },
+    questions: capitals(),
+    lines: 0,
+  },
+};
+
+/** Every topic, for a picker and for the catalog. */
+export const GRAMMAR_TOPICS: GrammarTopic[] = Object.keys(
+  TOPICS,
+) as GrammarTopic[];
+
+/**
+ * The topic a config names, or parts of speech if this build has never heard of
+ * it. Never throws, for the reason `sheetSpec` doesn't.
+ */
+export const topicOf = (topic: string): Topic =>
+  own(TOPICS, topic, TOPICS.parts);
+
+/** What a topic is called, and which styles it can be asked in. */
+export const grammarTopicLabel = (topic: string): string =>
+  topicOf(topic).label;
+export const grammarStyles = (topic: string): GrammarStyle[] =>
+  topicOf(topic).styles;
+
+/** The style this config will actually print in — see `Topic.styles`. */
+export const styleOf = (config: GrammarConfig): GrammarStyle => {
+  const { styles } = topicOf(config.topic);
+  return styles.includes(config.style) ? config.style : styles[0];
+};
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+/**
+ * How many lines the longest sentence in a topic wraps onto.
+ *
+ * Taken over the whole bank rather than over the sentences that were drawn,
+ * because the reservation is made before the draw: a row height that depended
+ * on the seed would be a layout that disagreed with `grammarQuestions`' own
+ * arithmetic from one sheet to the next. It over-reserves on a page whose
+ * longest sentence stayed in the bank, which is the cheap side to be wrong on
+ * (`chrome.ts`).
+ */
+function promptRows(
+  topic: Topic,
+  config: GrammarConfig,
+  cell: Mil,
+  slot: boolean,
+): number {
+  const across = fittedCharacters(
+    Math.max(1, cell - (slot ? SLOT_WIDTH : 0)),
+    points(config.fontPt),
+    faceOf(config.font),
+  );
+  const longest = topic.questions.reduce(
+    (most, question) => Math.max(most, question.ask.length),
+    0,
+  );
+  return Math.max(1, Math.ceil((longest + NUMBER_CHARACTERS) / across));
+}
+
+/**
+ * How many rows the options wrap onto.
+ *
+ * `words/study.ts` reserves one flat row for four short words and gets away
+ * with it; four sentence-type names run to thirty-five characters, which is
+ * wider than either stock at the largest type a config may ask for. So it is
+ * counted the way `.sheet__options` actually packs — greedily, item by item,
+ * each item its own label plus its `A.` mark — rather than assumed.
+ */
+function optionRows(topic: Topic, config: GrammarConfig, cell: Mil): number {
+  const options = topic.options ?? [];
+  if (options.length === 0) return 0;
+  const mark = declaredWidth(MARK_TEXT, config, 1) + MARK_GAP;
+  return packRows(
+    options.map((option) => declaredWidth(option, config, 1) + mark),
+    Math.max(1, cell - OPTIONS_INDENT),
+    OPTIONS_GAP,
+  );
+}
+
+/**
+ * How many across this topic may be laid out.
+ *
+ * One for the sentence that is cut in half, whatever the config says. Its
+ * answer is two ruled lines the width of the column, and `.sheet__answer-line`
+ * does not wrap — so a predicate in a half-width column is a predicate with its
+ * end cut off, which looks like a sheet rather than like a bug.
+ */
+const columnsFor = (topic: Topic): number =>
+  topic.lines > 0 ? 1 : MAX_COLUMNS;
+
+/**
+ * How many sentences the paper holds, and how wide a column of them is.
+ *
+ * Arithmetic rather than measurement, so a unit test, a catalog page built at
+ * build time and the builder's live preview all get the same answer (§4).
+ */
+export function grammarLayout(config: GrammarConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print rather than the one the config
+  // holds, and with the score box, because a grammar sheet is marked out of its
+  // sentences. Reserving for the wrong header is a last row below the bottom
+  // margin — invisible on screen, and a second sheet out of the printer.
+  const box = sheetBlockBox(headerOf(config), true);
+  const topic = topicOf(config.topic);
+  const write = styleOf(config) === "write";
+  const columns = write ? clamp(config.columns, 1, columnsFor(topic)) : 1;
+  const cell = columnWidth(box, columns, PROBLEM_GAP.x);
+  // The slot is only on the end of a prompt that has no ruled lines under it:
+  // a problem has exactly one place to write the answer (`Problems.tsx`).
+  const prompt = promptRows(topic, config, cell, write && topic.lines === 0);
+
+  const row = write
+    ? points(config.fontPt * ROW_EMS * prompt) +
+      (topic.lines > 0 ? WRAP_GAP + topic.lines * answerLine(config.fontPt) : 0)
+    : points(
+        config.fontPt *
+          (ROW_EMS * prompt + OPTIONS_EMS * optionRows(topic, config, cell)),
+      );
+
+  return {
+    box,
+    columns,
+    cell,
+    row,
+    perPage:
+      columns * fitAcross(box.height, row, write ? PROBLEM_GAP.y : LIST_GAP),
+  };
+}
+
+/**
+ * The sentences this sheet asks about, drawn from the topic by the seed.
+ *
+ * Shuffled rather than taken in order, because the bank is written in kind
+ * order — every statement first — and a sentence-types sheet of the first
+ * twelve would be a sheet with one answer on it. Never more than the bank holds
+ * and never more than the page holds, so the count is a request exactly as it
+ * is everywhere else in the shop.
+ */
+export function grammarQuestions(
+  config: GrammarConfig,
+  seed: number,
+): Question[] {
+  const { questions } = topicOf(config.topic);
+  const { perPage } = grammarLayout(config);
+  const room = Math.min(perPage, questions.length);
+  const wanted = clamp(config.count ?? room, 0, room);
+  return shuffled(questions, mulberry32(seed)).slice(0, wanted);
+}
+
+/** A sentence and the place its answer goes: a ruled slot, or ruled lines. */
+const written = (question: Question, config: GrammarConfig): Problem =>
+  question.lines
+    ? {
+        prompt: question.ask,
+        answer: question.answer,
+        answers: question.lines,
+        // The height those lines share, not blank paper under them —
+        // `grammarLayout` reserves exactly this number.
+        workspace: question.lines.length * answerLine(config.fontPt),
+      }
+    : { prompt: question.ask, answer: question.answer };
+
+/**
+ * A sentence with the closed list of names beside it.
+ *
+ * The options are the topic's whole vocabulary in the topic's own order, on
+ * every line of the sheet: no shuffle, and no near misses drawn from the other
+ * questions. A page whose five options moved about from line to line would be a
+ * page a child has to re-read five times, and a distractor drawn from another
+ * sentence's answer would be the one thing this family cannot risk — an option
+ * that is also right.
+ */
+const circled = (question: Question, topic: Topic): Choice => {
+  const options = topic.options ?? [];
+  return {
+    prompt: question.ask,
+    options,
+    answer: options.indexOf(question.answer),
+  };
+};
+
+function bodyOf(
+  config: GrammarConfig,
+  seed: number,
+): { blocks: Block[]; outOf: number } {
+  const topic = topicOf(config.topic);
+  const drawn = grammarQuestions(config, seed);
+  const outOf = drawn.length;
+
+  if (styleOf(config) === "choose") {
+    return {
+      blocks: [
+        {
+          kind: "choice",
+          questions: drawn.map((question) => circled(question, topic)),
+        },
+      ],
+      outOf,
+    };
+  }
+
+  const { columns } = grammarLayout(config);
+  return {
+    blocks: [
+      {
+        kind: "problems",
+        columns,
+        items: drawn.map((question) => written(question, config)),
+      },
+    ],
+    outOf,
+  };
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+/** How the style reads in a description, in the terms a parent chose it by. */
+const STYLE_WORDS: Record<GrammarStyle, string> = {
+  write: "written in",
+  choose: "circled",
+};
+
+/**
+ * The header this sheet will actually print.
+ *
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page.
+ */
+function headerOf(config: GrammarConfig): SheetOptions {
+  const topic = topicOf(config.topic);
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? topic.title,
+    instructions: config.instructions ?? topic.instruction[styleOf(config)],
+  };
+}
+
+/** One line naming what the sheet holds, in the terms it was chosen by. */
+export function describeGrammar(config: GrammarConfig): string {
+  const topic = topicOf(config.topic);
+  // What the sheet will print rather than what was asked for, and by the same
+  // arithmetic the build uses — a line that promised twenty over a page of
+  // fourteen would be wrong in the record book and in the picker at once.
+  const room = Math.min(grammarLayout(config).perPage, topic.questions.length);
+  const asked = clamp(config.count ?? room, 0, room);
+  return [
+    topic.label,
+    `${asked} ${asked === 1 ? "sentence" : "sentences"}`,
+    STYLE_WORDS[styleOf(config)],
+  ].join(" — ");
+}
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+export function buildGrammarSheet(config: GrammarConfig, seed: number): Sheet {
+  const head = headerOf(config);
+  const { blocks, outOf } = bodyOf(config, seed);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Out of what is on the page rather than what was asked for: a sheet
+      // that says "/ 20" over eighteen questions is wrong twice.
+      score: { outOf },
+    },
+    blocks,
+    // The site itself, not a game. There is no grammar race, and §16 is
+    // explicit that a footer sending a parent to the times tables from a sheet
+    // that has nothing to do with them is an advert rather than a route back.
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+export const GRAMMAR_SHEET: SheetSpec<GrammarConfig> = {
+  id: "grammar",
+  label: "Grammar",
+  world: SHEET_WORLD,
+  build: buildGrammarSheet,
+  // Every answer was decided when the sheet was built — which sentences were
+  // drawn, and which tag each of them was asked about — so a key cannot
+  // disagree with the sheet it belongs to.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeGrammar,
+};

--- a/src/engine/sheets/grammar/grammar.ts
+++ b/src/engine/sheets/grammar/grammar.ts
@@ -355,6 +355,18 @@ const columnsFor = (topic: Topic): number =>
   topic.lines > 0 ? 1 : MAX_COLUMNS;
 
 /**
+ * The widest a topic may be laid out, for a panel that has to offer it.
+ *
+ * Exported for the same reason `grammarStyles` is: the options panel needs the
+ * rule, and a panel that restated it would be a second place for it to be true.
+ * A sixth topic with ruled answer lines would otherwise get a columns stepper
+ * that the engine silently ignores — the panel and the paper disagreeing, which
+ * is the one thing the builder's live preview cannot show a parent.
+ */
+export const grammarColumns = (topic: string): number =>
+  columnsFor(topicOf(topic));
+
+/**
  * How many sentences the paper holds, and how wide a column of them is.
  *
  * Arithmetic rather than measurement, so a unit test, a catalog page built at
@@ -406,16 +418,44 @@ export function grammarLayout(config: GrammarConfig): {
  * twelve would be a sheet with one answer on it. Never more than the bank holds
  * and never more than the page holds, so the count is a request exactly as it
  * is everywhere else in the shop.
+ *
+ * **The scale is covered rather than hoped for.** A shuffle-and-slice is fair
+ * over many pages and says nothing about any one of them: a sentence-types
+ * sheet drawn at random comes up with no command about one page in six, on the
+ * page whose own instruction prints "statement, question, command or
+ * exclamation" down every line and whose whole exercise is telling the first
+ * two of those apart. Every item on such a page is still correct, which is what
+ * makes it the worse bug — it is a page that has quietly stopped being the
+ * lesson it claims to be. So where the topic answers to a closed list and there
+ * is room for one of each, one of each is drawn first, off the same stream; the
+ * rest of the page is filled from what is left and the whole is shuffled again,
+ * so the guaranteed items are not the first `options.length` rows every time.
  */
 export function grammarQuestions(
   config: GrammarConfig,
   seed: number,
 ): Question[] {
-  const { questions } = topicOf(config.topic);
+  const { questions, options } = topicOf(config.topic);
   const { perPage } = grammarLayout(config);
   const room = Math.min(perPage, questions.length);
   const wanted = clamp(config.count ?? room, 0, room);
-  return shuffled(questions, mulberry32(seed)).slice(0, wanted);
+
+  const rand = mulberry32(seed);
+  const pool = shuffled(questions, rand);
+  // Too small a page to hold the scale: a four-question sheet cannot show five
+  // parts of speech, and pretending otherwise would be dropping a question.
+  if (!options || wanted < options.length) return pool.slice(0, wanted);
+
+  const covered = new Set<string>();
+  const first: Question[] = [];
+  const rest: Question[] = [];
+  for (const question of pool) {
+    const fresh =
+      options.includes(question.answer) && !covered.has(question.answer);
+    if (fresh) covered.add(question.answer);
+    (fresh ? first : rest).push(question);
+  }
+  return shuffled([...first, ...rest.slice(0, wanted - first.length)], rand);
 }
 
 /** A sentence and the place its answer goes: a ruled slot, or ruled lines. */

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -16,6 +16,7 @@
 import type { Sheet, SheetConfig } from "./types";
 
 import { BLANK_SHEET } from "./blank";
+import { GRAMMAR_SHEET } from "./grammar/grammar";
 import { ARITHMETIC_SHEET } from "./maths/arithmetic";
 import { DECIMALS_SHEET } from "./maths/decimals";
 import { FRACTIONS_SHEET } from "./maths/fractions";
@@ -56,6 +57,7 @@ const SHEETS: Record<string, SheetSpec> = {
   [WORDS_SHEET.id]: WORDS_SHEET,
   [WORD_STUDY_SHEET.id]: WORD_STUDY_SHEET,
   [PUZZLE_SHEET.id]: PUZZLE_SHEET,
+  [GRAMMAR_SHEET.id]: GRAMMAR_SHEET,
   [HANDWRITING_SHEET.id]: HANDWRITING_SHEET,
   [MEMORY_SHEET.id]: MEMORY_SHEET,
 };

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -1543,6 +1543,67 @@ export type PuzzleConfig = SheetOptions & {
   columns: number;
 };
 
+/* ── Grammar ───────────────────────────────────────────────────────────────
+   The third bank-backed family, and the one where being wrong costs the most.
+   A page of sums is right or wrong and nobody argues; a page of grammar can be
+   *defensibly* answered two ways, and a sheet that marks the second way wrong
+   has taught a child something false. So nothing here parses English. Every
+   sentence is written down once and tagged in `grammar/bank.ts` — what it is
+   for, where it divides, which one word can be named without argument, which
+   word needs its capital back — and the five topics below are five views of
+   those tags rather than five analyses.
+
+   Which is also why there is no `match` style, unlike word study: four kinds of
+   sentence over twelve rows is a matching column with three right answers on
+   every line.                                                               */
+
+/**
+ * Which lesson the sheet is about.
+ *
+ * The five §11 names, and each is one topic rather than several because they
+ * are one week's teaching each: the parts of speech, the two halves of a
+ * sentence, what a sentence is *for*, the mark it ends on, and the word inside
+ * it that takes a capital.
+ */
+export type GrammarTopic =
+  "parts" | "subject" | "types" | "punctuation" | "capitals";
+
+/**
+ * How the question is put.
+ *
+ * `write` gives the sentence and a ruled place to answer; `choose` gives the
+ * sentence and the fixed set of names to circle one of. Both sets are a scale
+ * rather than a draw of near misses — there are five parts of speech and four
+ * kinds of sentence, and those are the options on every line — so unlike word
+ * study a `choose` sheet here never has to be checked for a second right
+ * answer among its distractors: the options are the whole vocabulary.
+ *
+ * A topic states which of the two it can honestly be asked in (`GRAMMAR_TOPICS`
+ * / `grammarStyles`). Three of them are `write` only, because the answer is a
+ * mark, a word out of the sentence, or the sentence itself cut in half — and
+ * none of those is a list of options.
+ */
+export type GrammarStyle = "write" | "choose";
+
+export type GrammarConfig = SheetOptions & {
+  kind: "grammar";
+  topic: GrammarTopic;
+  /**
+   * Resolved against what the topic supports rather than trusted, exactly as
+   * `WordStudyConfig.style` is: a saved sheet outlives the table it was made
+   * from, for the same reason `sheetSpec` never throws.
+   */
+  style: GrammarStyle;
+  /** How many sentences to ask about. Capped at what the page holds. */
+  count: number;
+  /**
+   * How many across. A sentence is a long thing to print, so this caps lower
+   * than the maths families do — and the subject-and-predicate sheet ignores it
+   * entirely, because its answer is two ruled lines the width of the column.
+   */
+  columns: number;
+};
+
 /* ── Handwriting ───────────────────────────────────────────────────────────
    The family where the ruling stops being the paper and becomes the exercise.
    Every sheet above this line could be printed a thousandth of an inch out and
@@ -1755,6 +1816,7 @@ export type SheetConfig =
   | WordsConfig
   | WordStudyConfig
   | PuzzleConfig
+  | GrammarConfig
   | HandwritingConfig
   | MemoryConfig;
 

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -283,6 +283,20 @@ const DEFAULTS: Record<string, SheetConfig> = {
     count: STARTER_WORDS.length,
     columns: 2,
   },
+  grammar: {
+    ...BASE,
+    kind: "grammar",
+    // Parts of speech, circled: the topic a parent recognises the name of, and
+    // the one shape of grammar question that looks like a worksheet at a
+    // glance. The other four are one control away, and the control lists them
+    // in the order they are taught.
+    topic: "parts",
+    style: "choose",
+    count: 12,
+    // What the written topics get when a parent switches to one — a circle-one
+    // sheet is a list down the page whatever this says (`grammarLayout`).
+    columns: 1,
+  },
   handwriting: {
     ...BASE,
     kind: "handwriting",

--- a/src/games/printshop/options/grammar.tsx
+++ b/src/games/printshop/options/grammar.tsx
@@ -17,6 +17,7 @@
 import type { GrammarConfig, GrammarStyle } from "@/engine/sheets/types";
 import {
   GRAMMAR_TOPICS,
+  grammarColumns,
   grammarStyles,
   grammarTopicLabel,
 } from "@/engine/sheets/grammar/grammar";
@@ -36,6 +37,7 @@ const STYLE_LABELS: Record<GrammarStyle, string> = {
 export function GrammarPanel({ config, set }: PanelProps<GrammarConfig>) {
   const styles = grammarStyles(config.topic);
   const style = styles.includes(config.style) ? config.style : styles[0];
+  const across = grammarColumns(config.topic);
 
   return (
     <>
@@ -64,18 +66,17 @@ export function GrammarPanel({ config, set }: PanelProps<GrammarConfig>) {
 
       {/* Columns only where a sentence and a slot share a line. A row of
           options is the width of the paper, and so are the two ruled lines a
-          subject-and-predicate sheet writes its answer on. */}
+          subject-and-predicate sheet writes its answer on — which is why both
+          the offer and the cap are `grammarColumns` rather than a topic named
+          here: the engine already decides this, and a second copy of the rule
+          is a stepper that moves a number the paper ignores. */}
       <Sizing
         label="Sentences"
         count={config.count}
-        columns={
-          style === "write" && config.topic !== "subject"
-            ? config.columns
-            : undefined
-        }
+        columns={style === "write" && across > 1 ? config.columns : undefined}
         onCount={(count) => set({ count })}
         onColumns={(columns) => set({ columns })}
-        maxColumns={2}
+        maxColumns={across}
       />
     </>
   );

--- a/src/games/printshop/options/grammar.tsx
+++ b/src/games/printshop/options/grammar.tsx
@@ -1,0 +1,82 @@
+/**
+ * Which lesson about sentences, and how the question is put.
+ *
+ * The same two controls the word-study panel has, and the second depends on the
+ * first for the same reason: a topic states which shapes it can honestly be
+ * asked in (`grammarStyles`), so the row of shapes is built from the topic
+ * rather than being a fixed pair with one of them greyed out. Three of the five
+ * topics have no closed list of answers to circle — an end mark, a capitalised
+ * word and a sentence cut in half are none of them a multiple choice — so those
+ * three show no shape control at all.
+ *
+ * Switching to a topic that cannot do the style already chosen sets the style as
+ * well, in the same patch. The engine resolves it either way (`styleOf` never
+ * throws), but a panel showing "Circle one" over a sheet that plainly writes the
+ * answer out is the panel disagreeing with the paper.
+ */
+import type { GrammarConfig, GrammarStyle } from "@/engine/sheets/types";
+import {
+  GRAMMAR_TOPICS,
+  grammarStyles,
+  grammarTopicLabel,
+} from "@/engine/sheets/grammar/grammar";
+
+import { Choice, Sizing, opt, type PanelProps } from "./parts";
+
+/** The five topics, in the order the engine lists them — roughly by age. */
+const TOPICS = GRAMMAR_TOPICS.map((topic) =>
+  opt(topic, grammarTopicLabel(topic)),
+);
+
+const STYLE_LABELS: Record<GrammarStyle, string> = {
+  write: "Write it",
+  choose: "Circle one",
+};
+
+export function GrammarPanel({ config, set }: PanelProps<GrammarConfig>) {
+  const styles = grammarStyles(config.topic);
+  const style = styles.includes(config.style) ? config.style : styles[0];
+
+  return (
+    <>
+      <Choice
+        label="Topic"
+        value={config.topic}
+        onChange={(topic) =>
+          set(
+            grammarStyles(topic).includes(style)
+              ? { topic }
+              : { topic, style: grammarStyles(topic)[0] },
+          )
+        }
+        options={TOPICS}
+        hint="One topic to a sheet. The instruction line at the top of the page can only say one thing."
+      />
+
+      {styles.length > 1 && (
+        <Choice
+          label="How it is asked"
+          value={style}
+          onChange={(next) => set({ style: next })}
+          options={styles.map((one) => opt(one, STYLE_LABELS[one]))}
+        />
+      )}
+
+      {/* Columns only where a sentence and a slot share a line. A row of
+          options is the width of the paper, and so are the two ruled lines a
+          subject-and-predicate sheet writes its answer on. */}
+      <Sizing
+        label="Sentences"
+        count={config.count}
+        columns={
+          style === "write" && config.topic !== "subject"
+            ? config.columns
+            : undefined
+        }
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={2}
+      />
+    </>
+  );
+}

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -23,6 +23,7 @@ import { ArithmeticPanel } from "./arithmetic";
 import { DecimalsPanel } from "./decimals";
 import { FractionsPanel } from "./fractions";
 import { GeometryPanel } from "./geometry";
+import { GrammarPanel } from "./grammar";
 import { HandwritingPanel } from "./handwriting";
 import { IntegersPanel } from "./integers";
 import { MeasurePanel } from "./measure";
@@ -92,6 +93,7 @@ const PANELS: Record<string, FamilyPanel> = {
   words: panel(WordsPanel),
   "word-study": panel(WordStudyPanel),
   puzzle: panel(PuzzlesPanel),
+  grammar: panel(GrammarPanel),
   handwriting: panel(HandwritingPanel),
   memory: panel(MemoryPanel),
 };

--- a/src/pages/printables/_grammar.test.ts
+++ b/src/pages/printables/_grammar.test.ts
@@ -58,6 +58,34 @@ function items(block: Block): number {
   return 0;
 }
 
+/** What a block printed, in the words a reader sees down the page. */
+function prompts(block: Block): string[] {
+  if (block.kind === "problems") return block.items.map((item) => item.prompt);
+  if (block.kind === "choice") return block.questions.map((one) => one.prompt);
+  return [];
+}
+
+/** Everything the prose puts in curly quotes. */
+const QUOTED = /“([^”]+)”/g;
+
+/**
+ * How long a quotation has to be before it is read as a claim about the sheet.
+ *
+ * The prose quotes two different things. A word or a phrase is an example of a
+ * *kind* of sentence — “Close the gate”, “What a mess” — and is deliberately
+ * one the sheet does not print. A whole sentence is the page itself being
+ * pointed at. Five words is the line between them, and it is a house rule of
+ * `_grammar.ts` rather than a fact about English: keep a hypothetical short.
+ */
+const CLAIMED = 5;
+
+/** A quotation and a prompt compared as the same sentence. */
+const same = (text: string): string =>
+  text
+    .trim()
+    .replace(/[.?!]$/, "")
+    .toLowerCase();
+
 const built = (sheet: GrammarSheet) => buildSheet(sheet.config, GRAMMAR_SEED);
 
 describe("the grammar catalog", () => {
@@ -147,6 +175,26 @@ describe("the sheet on a catalog page", () => {
       );
       expect(printed, sheet.slug).toBe(sheet.config.count);
       expect(printed, sheet.slug).toBeGreaterThan(7);
+    }
+  });
+
+  it("quotes only sentences the sheet printed under the prose says", () => {
+    // The page IS the sheet (§8), so a note that quotes a sentence is telling a
+    // reader to look down the page and find it. Three of them did not: the
+    // sentences were real bank sentences, and the seed-1 draw simply did not
+    // contain them. Nothing but a test can keep the two together, because a
+    // count or a seed moving is what breaks it and neither looks like prose.
+    for (const sheet of GRAMMAR_SHEETS) {
+      const printed = built(sheet).blocks.flatMap(prompts).map(same);
+      const prose = [sheet.lead, sheet.summary, ...sheet.notes];
+      for (const [, quote] of prose.join(" ").matchAll(QUOTED)) {
+        if (quote.trim().split(/\s+/).length < CLAIMED) continue;
+        const wanted = same(quote);
+        expect(
+          printed.some((prompt) => prompt.includes(wanted)),
+          `${sheet.slug} quotes “${quote}”, which it does not print`,
+        ).toBe(true);
+      }
     }
   });
 

--- a/src/pages/printables/_grammar.test.ts
+++ b/src/pages/printables/_grammar.test.ts
@@ -1,0 +1,222 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet } from "@/engine/sheets";
+import { GRAMMAR_TOPICS } from "@/engine/sheets/grammar/grammar";
+import type { Block } from "@/engine/sheets/types";
+
+import { BIBLE_SHEETS, hrefFor as bibleHref } from "./_bible";
+import { PAPER_SHEETS, STOCKS, pathFor as paperPath } from "./_catalog";
+import { CURSIVE_SHEETS, hrefFor as cursiveHref } from "./_cursive";
+import {
+  GRAMMAR_GROUPS,
+  GRAMMAR_SEED,
+  GRAMMAR_SHEETS,
+  builderHref,
+  grammarShelf,
+  pathFor,
+  type GrammarSheet,
+} from "./_grammar";
+import { HANDWRITING_SHEETS, hrefFor as handwritingHref } from "./_handwriting";
+import { MATHS_SHEETS, pathFor as mathsPath } from "./_maths";
+import { SPELLING_SHEETS, pathFor as spellingPath } from "./_spelling";
+
+/**
+ * The grammar catalog, held to the four things a catalog page has to be — and
+ * to a fifth this shelf adds.
+ *
+ * **It has to be a worksheet.** Every entry is prerendered as the page a parent
+ * lands on (§8), so an entry whose config produces an empty page is a URL in the
+ * sitemap with nothing on it.
+ *
+ * **It has to print everything it promised.** The prose says "twelve sentences"
+ * in as many words, and a sheet that quietly dropped two off the bottom would
+ * look exactly like a sheet that didn't. So every entry is checked against its
+ * own config rather than against the family's cap.
+ *
+ * **It has to be curated.** No two entries print the same sheet, no two answer
+ * the same query, and every one carries prose somebody wrote.
+ *
+ * **It has to be reachable.** Every slug in the sitemap, and every slug distinct
+ * from the six catalogs that share the prefix.
+ *
+ * **And it has to have a key on every page.** This is the shelf where being
+ * wrong costs the most, and it is also the shelf with no sheet that legitimately
+ * has nothing to mark — no copying page, no write-your-own-sentence page. A
+ * grammar sheet without a key would be a page of judgements with nobody to
+ * settle them.
+ */
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/** How many things a block puts on the paper, whichever kind it is. */
+function items(block: Block): number {
+  if (block.kind === "problems") return block.items.length;
+  if (block.kind === "choice") return block.questions.length;
+  return 0;
+}
+
+const built = (sheet: GrammarSheet) => buildSheet(sheet.config, GRAMMAR_SEED);
+
+describe("the grammar catalog", () => {
+  it("is bounded, and every slug is a route somebody could type", () => {
+    for (const sheet of GRAMMAR_SHEETS) {
+      expect(sheet.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+    expect(new Set(GRAMMAR_SHEETS.map((sheet) => sheet.slug)).size).toBe(
+      GRAMMAR_SHEETS.length,
+    );
+  });
+
+  it("never claims a path another shelf already prints on", () => {
+    // Seven route patterns over one prefix. They only coexist because the paths
+    // they emit are disjoint; the day they are not, Astro has two routes for one
+    // URL and picks one of them.
+    const taken = new Set([
+      ...PAPER_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => `/printables/${paperPath(sheet, stock)}`),
+      ),
+      ...MATHS_SHEETS.map((sheet) => mathsPath(sheet)),
+      ...HANDWRITING_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => handwritingHref(sheet, stock)),
+      ),
+      ...CURSIVE_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => cursiveHref(sheet, stock)),
+      ),
+      ...BIBLE_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => bibleHref(sheet, stock)),
+      ),
+      ...SPELLING_SHEETS.map((sheet) => spellingPath(sheet)),
+    ]);
+    for (const sheet of GRAMMAR_SHEETS) {
+      expect(taken.has(pathFor(sheet)), sheet.slug).toBe(false);
+    }
+  });
+
+  it("answers a different query on every page", () => {
+    const fields = ["keyword", "heading", "name", "short"] as const;
+    for (const field of fields) {
+      const values = GRAMMAR_SHEETS.map((sheet) => sheet[field]);
+      expect(new Set(values).size, `duplicate ${field}`).toBe(values.length);
+    }
+  });
+
+  it("prints a different sheet on every page", () => {
+    const configs = GRAMMAR_SHEETS.map((sheet) => JSON.stringify(sheet.config));
+    expect(new Set(configs).size).toBe(configs.length);
+  });
+
+  it("carries prose on every page rather than a filled-in template", () => {
+    for (const sheet of GRAMMAR_SHEETS) {
+      expect(sheet.notes.length, sheet.slug).toBeGreaterThanOrEqual(2);
+      for (const note of sheet.notes) {
+        expect(note.length, sheet.slug).toBeGreaterThan(200);
+      }
+      expect(sheet.lead.length, sheet.slug).toBeGreaterThan(80);
+      expect(sheet.summary.length, sheet.slug).toBeGreaterThan(40);
+      expect(sheet.teaches, sheet.slug).not.toBe("");
+      expect(sheet.ages, sheet.slug).toMatch(/^Ages /);
+    }
+  });
+
+  it("shelves every sheet exactly once", () => {
+    const shelved = grammarShelf().flatMap((group) => group.sheets);
+    expect(shelved).toHaveLength(GRAMMAR_SHEETS.length);
+    expect(grammarShelf().every((group) => group.sheets.length > 0)).toBe(true);
+    expect(GRAMMAR_GROUPS).toHaveLength(grammarShelf().length);
+  });
+
+  it("covers the whole of what the story asked for", () => {
+    // Parts of speech, subject and predicate, sentence types, punctuation and
+    // capitalisation — one page each, so every one of them is a thing a parent
+    // can print rather than a thing the engine can do.
+    const topics = GRAMMAR_SHEETS.map((sheet) => sheet.config.topic);
+    expect(new Set(topics)).toEqual(new Set(GRAMMAR_TOPICS));
+    expect(topics).toHaveLength(GRAMMAR_TOPICS.length);
+  });
+});
+
+describe("the sheet on a catalog page", () => {
+  it("prints every sentence it promised", () => {
+    for (const sheet of GRAMMAR_SHEETS) {
+      const printed = built(sheet).blocks.reduce(
+        (total, block) => total + items(block),
+        0,
+      );
+      expect(printed, sheet.slug).toBe(sheet.config.count);
+      expect(printed, sheet.slug).toBeGreaterThan(7);
+    }
+  });
+
+  it("has a title, an instruction and a score box on it", () => {
+    for (const sheet of GRAMMAR_SHEETS) {
+      const header = built(sheet).header;
+      expect(header.title, sheet.slug).not.toBe("");
+      expect(header.instructions, sheet.slug).toBeTruthy();
+      expect(header.score?.outOf, sheet.slug).toBe(sheet.config.count);
+    }
+  });
+
+  it("is the same sheet on every build", () => {
+    for (const sheet of GRAMMAR_SHEETS) {
+      expect(JSON.stringify(built(sheet)), sheet.slug) //
+        .toBe(JSON.stringify(buildSheet(sheet.config, GRAMMAR_SEED)));
+    }
+  });
+
+  it("has an answer key on every page, and it is the same build keyed", () => {
+    for (const sheet of GRAMMAR_SHEETS) {
+      const key = answerKey(sheet.config, GRAMMAR_SEED);
+      const blank = built(sheet);
+      // The key is the same build with `answers` flipped, never a second
+      // generation of the answers — so the two can never disagree (§7).
+      expect({ ...key, answers: false, footer: blank.footer }, sheet.slug) //
+        .toEqual(blank);
+      expect(key.answers, sheet.slug).toBe(true);
+      expect(key.footer.note, sheet.slug).toBe("Answer key");
+    }
+  });
+});
+
+describe("the link into the builder", () => {
+  it("opens the bench on the sheet that was printed", () => {
+    for (const sheet of GRAMMAR_SHEETS) {
+      const href = builderHref(sheet);
+      expect(href.startsWith("/printables/make#s=")).toBe(true);
+
+      const payload = href.slice("/printables/make#s=".length);
+      const base64 = payload.replaceAll("-", "+").replaceAll("_", "/");
+      const shared = JSON.parse(
+        atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")),
+      );
+      expect(shared).toEqual({ config: sheet.config, seed: GRAMMAR_SEED });
+    }
+  });
+});
+
+describe("the sitemap", () => {
+  /*
+   * A URL missing from the sitemap is the failure nobody notices — nothing
+   * breaks, the page is simply never submitted. Skipped when there is no
+   * `dist/`, exactly as the other catalogs' are; CI builds before it runs the
+   * suite.
+   */
+  it("carries every grammar slug and the hub", () => {
+    const file = `${ROOT}/dist/sitemap-0.xml`;
+    if (!existsSync(file)) return; // `npm run build` hasn't run yet.
+
+    const xml = readFileSync(file, "utf8");
+    const found = new Set(
+      [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) =>
+        new URL(match[1]).pathname.replace(/\/$/, ""),
+      ),
+    );
+
+    expect(found.has("/printables/grammar")).toBe(true);
+    for (const sheet of GRAMMAR_SHEETS) {
+      expect(found.has(pathFor(sheet)), sheet.slug).toBe(true);
+    }
+  });
+});

--- a/src/pages/printables/_grammar.ts
+++ b/src/pages/printables/_grammar.ts
@@ -56,7 +56,16 @@ export type GrammarSheet = {
   summary: string;
   /** The lead paragraph: what the sheet asks for, stated plainly. */
   lead: string;
-  /** Two things that are true of this sheet and not of the one beside it. */
+  /**
+   * Two things that are true of this sheet and not of the one beside it.
+   *
+   * The sheet is prerendered directly under this prose (§8), which makes a
+   * quoted sentence a claim about the paper rather than an illustration — a
+   * reader can look down the page and check it. So anything quoted here at five
+   * words or more has to be a sentence this page really draws, and
+   * `_grammar.test.ts` holds it there; a hypothetical the sheet never prints
+   * (“Close the gate”) stays shorter than that.
+   */
   notes: string[];
   /** For the `LearningResource` block. */
   teaches: string;
@@ -143,8 +152,8 @@ export const GRAMMAR_SHEETS: GrammarSheet[] = [
       "Twelve sentences to sort into statements, questions, commands and exclamations, with four names to circle on every line and the key behind.",
     lead: "A sentence on each line and four things it could be underneath: a statement, a question, a command or an exclamation. Two of the four announce themselves with the mark on the end; the other two do not, and that is where the work is.",
     notes: [
-      "Statements and commands both end in a full stop, and telling them apart is the whole exercise. “The children waited quietly for the bus” and “Bring the shopping into the kitchen” look identical at the end of the line, and the only way through is to ask what the sentence is for — one of them says how the world is, and the other tells somebody to change it. Questions and exclamations are the easy half, and they are there so a six-year-old can start.",
-      "Every exclamation on this sheet is an exclamation by its grammar rather than by its tone: “What a tremendous splash that was!” and “How quickly the storm arrived!” cannot be written any other way. That rules out a whole class of sentence a worksheet usually smuggles in — the plain statement with a bang on the end, where whether it should have been a full stop is a matter of how loudly you were imagining it. There is no right answer to that, so it is not asked.",
+      "Statements and commands both end in a full stop, and telling them apart is the whole exercise. “The old tractor belonged to Jack” and “Put the muddy boots outside the door” look identical at the end of the line, and the only way through is to ask what the sentence is for — one of them says how the world is, and the other tells somebody to change it. Questions and exclamations are the easy half, and they are there so a six-year-old can start.",
+      "Every exclamation on this sheet is an exclamation by its grammar rather than by its tone: “What a tremendous splash that was!” and “How brightly the lights of Oslo shone!” cannot be written any other way. That rules out a whole class of sentence a worksheet usually smuggles in — the plain statement with a bang on the end, where whether it should have been a full stop is a matter of how loudly you were imagining it. There is no right answer to that, so it is not asked.",
     ],
     teaches: "Statements, questions, commands and exclamations",
     ages: "Ages 6–10",

--- a/src/pages/printables/_grammar.ts
+++ b/src/pages/printables/_grammar.ts
@@ -1,0 +1,227 @@
+/**
+ * The grammar sheets the Print Shop has set, and the words that go round them.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data two pages
+ * share — `grammar/[slug].astro`, which prerenders one sheet per topic, and
+ * `grammar/index.astro`, which is the subject hub — rather than a route of its
+ * own. `_catalog.ts` does that job for paper, `_maths.ts` for maths,
+ * `_spelling.ts` for words, and `_handwriting.ts`, `_cursive.ts` and
+ * `_bible.ts` for the writing shelves.
+ *
+ * **One page per topic, and that is the whole shelf.** §8 asks for the catalog
+ * to be bounded, and grammar is the shelf where being greedy would cost the
+ * most: "noun worksheets", "verb worksheets", "adjective worksheets" and the
+ * rest are all real queries, and all of them would be this same sheet with a
+ * filter on it. Five pages, five lessons, each one a thing somebody teaches in
+ * a week — and everything else through the builder, which is where choosing
+ * belongs.
+ *
+ * **Why the sheets are short.** A grammar answer can be *defensibly* wrong,
+ * which is not true of a column of sums: whether a word is an adverb, whether a
+ * comma is needed, which half of a sentence is the subject. So the sentences
+ * are authored and tagged in `engine/sheets/grammar/bank.ts` under house rules
+ * written down there, the questions are views of those tags, and the shelf is
+ * deliberately smaller than it could be. A sheet that marks a defensible answer
+ * wrong teaches a child something false, and that is worse than no sheet.
+ *
+ * **One stock, as with maths and spelling.** Nothing on a grammar sheet is a
+ * measurement — there is no ⅝ rule to be scaled into a ⅗ rule by a printer
+ * loaded with A4 — so the sheet is correct on either stock and the A4 switch
+ * lives in the builder with the other options.
+ */
+import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
+import type {
+  GrammarConfig,
+  GrammarStyle,
+  GrammarTopic,
+} from "@/engine/sheets/types";
+
+import { SHEET_FIELDS as FIELDS, benchHref, paperOf, shelve } from "./_catalog";
+
+/** How the hub groups the shelf: what the sheet is really about. */
+export type GrammarGroup = "words" | "marks";
+
+export type GrammarSheet = {
+  /** The route under /printables/grammar, and the head term it answers. */
+  slug: string;
+  /** How it is listed on a hub. */
+  name: string;
+  /** How it is labelled in the row of neighbouring sheets. A few words. */
+  short: string;
+  /** The page's `<h1>`. */
+  heading: string;
+  /** The query this page exists to answer, in the words a parent types. */
+  keyword: string;
+  /** One sentence of what is on the sheet. Used in the description and hubs. */
+  summary: string;
+  /** The lead paragraph: what the sheet asks for, stated plainly. */
+  lead: string;
+  /** Two things that are true of this sheet and not of the one beside it. */
+  notes: string[];
+  /** For the `LearningResource` block. */
+  teaches: string;
+  ages: string;
+  group: GrammarGroup;
+  /** The sheet itself. Prerendered at build time — this IS the page (§8). */
+  config: GrammarConfig;
+};
+
+/**
+ * The seed every sheet on this shelf is built from, and it never moves.
+ *
+ * It decides which of the bank's sentences land on each page and in what order,
+ * and nothing else — the answers travel with the sentences. Which is what §7
+ * promises stays put: the sheet a parent printed in March is the sheet they
+ * print in June, down to the order of the questions.
+ */
+export const GRAMMAR_SEED = 1;
+
+/** A grammar sheet on Letter, with the name and date line printed blank. */
+const grammar = (
+  topic: GrammarTopic,
+  style: GrammarStyle,
+  count: number,
+  columns = 1,
+): GrammarConfig => ({
+  kind: "grammar",
+  paper: paperOf("letter"),
+  fontPt: DEFAULT_FONT_PT,
+  fields: FIELDS,
+  topic,
+  style,
+  count,
+  columns,
+});
+
+export const GRAMMAR_SHEETS: GrammarSheet[] = [
+  /* ── Words in a sentence ────────────────────────────────────────────── */
+  {
+    slug: "parts-of-speech-worksheets",
+    name: "Parts of speech",
+    short: "Parts of speech",
+    heading: "Parts of speech worksheets",
+    keyword: "Free printable parts of speech worksheets",
+    summary:
+      "Twelve sentences, each with one word marked, and five names to circle: noun, verb, adjective, adverb or pronoun. The answer key is the page behind.",
+    lead: "One sentence to a question, with a single word quoted after it, and the five word classes underneath to circle between. The question is never what a word usually is — it is what that word is doing in that sentence.",
+    notes: [
+      "The word being asked about is chosen so that it cannot honestly be called anything else, and that took more discarding than choosing. “Play”, “run”, “walk” and “watch” are nouns as often as verbs; “fast”, “hard” and “well” are adjectives and adverbs both; “light” is three things. None of them is on this sheet. The verbs here are past tense or the opening word of a command, which is the cheapest way in English to make a word class unarguable.",
+      "Articles and possessives are not asked about either, and that is a deliberate gap rather than an oversight. Whether “the” is an adjective or a determiner depends entirely on which scheme a child is being taught, and a sheet cannot mark a child on which classroom they happen to be sitting in. Five classes, all of them agreed on, is worth more than nine with two arguments buried in them.",
+    ],
+    teaches: "Naming parts of speech in a sentence",
+    ages: "Ages 7–11",
+    group: "words",
+    config: grammar("parts", "choose", 12),
+  },
+  {
+    slug: "subject-and-predicate-worksheets",
+    name: "Subject and predicate",
+    short: "Subject & predicate",
+    heading: "Subject and predicate worksheets",
+    keyword: "Free printable subject and predicate worksheets",
+    summary:
+      "Eight sentences to divide in two, with a ruled line for the subject and a ruled line for the predicate, and the key on the page behind.",
+    lead: "Each sentence has two ruled lines under it: the subject on the first, the predicate on the second. Every word in the sentence goes on one line or the other, which is what makes the division a question with a single right answer.",
+    notes: [
+      "Asking for both halves rather than one is the whole design of this page. “Write the subject” is a question with two defensible answers — the complete subject and the simple subject — and a child taught one of them would be marked wrong for giving it. Asking a child to place every word closes that door: “dog” on its own cannot be right, because “The big brown” would then have nowhere to go.",
+      "The sentences are all plain statements, which is also deliberate. A command has no subject on the page at all — “Close the gate” is addressed to somebody who is never named — and a question keeps its subject inside the verb phrase, where a nine-year-old cannot fairly be asked to find it. Those are good things to talk about and bad things to mark, so they are on the sentence-types page instead.",
+    ],
+    teaches: "Dividing a sentence into subject and predicate",
+    ages: "Ages 8–11",
+    group: "words",
+    config: grammar("subject", "write", 8),
+  },
+
+  /* ── Sentences and their marks ──────────────────────────────────────── */
+  {
+    slug: "types-of-sentences-worksheets",
+    name: "Kinds of sentence",
+    short: "Kinds of sentence",
+    heading: "Types of sentences worksheets",
+    keyword: "Free printable types of sentences worksheets",
+    summary:
+      "Twelve sentences to sort into statements, questions, commands and exclamations, with four names to circle on every line and the key behind.",
+    lead: "A sentence on each line and four things it could be underneath: a statement, a question, a command or an exclamation. Two of the four announce themselves with the mark on the end; the other two do not, and that is where the work is.",
+    notes: [
+      "Statements and commands both end in a full stop, and telling them apart is the whole exercise. “The children waited quietly for the bus” and “Bring the shopping into the kitchen” look identical at the end of the line, and the only way through is to ask what the sentence is for — one of them says how the world is, and the other tells somebody to change it. Questions and exclamations are the easy half, and they are there so a six-year-old can start.",
+      "Every exclamation on this sheet is an exclamation by its grammar rather than by its tone: “What a tremendous splash that was!” and “How quickly the storm arrived!” cannot be written any other way. That rules out a whole class of sentence a worksheet usually smuggles in — the plain statement with a bang on the end, where whether it should have been a full stop is a matter of how loudly you were imagining it. There is no right answer to that, so it is not asked.",
+    ],
+    teaches: "Statements, questions, commands and exclamations",
+    ages: "Ages 6–10",
+    group: "marks",
+    config: grammar("types", "choose", 12),
+  },
+  {
+    slug: "punctuation-worksheets",
+    name: "The mark at the end",
+    short: "End marks",
+    heading: "Punctuation worksheets",
+    keyword: "Free printable punctuation worksheets",
+    summary:
+      "Twenty sentences printed with nothing on the end and a ruled space for the mark that belongs there — a full stop or a question mark, and the key behind.",
+    lead: "Each sentence stops where its punctuation should be, and there is a ruled space for the mark. A full stop or a question mark: which one is decided by the way the sentence is built, not by how it is read aloud.",
+    notes: [
+      "Only two marks are asked for, and the reason is the same one that shapes the rest of this shelf. Whether a sentence deserves an exclamation mark is a judgement about tone — “What a mess” is right with a bang and not wrong with a full stop — so an answer key cannot honestly claim either. A full stop against a question mark is decided by grammar instead: a sentence that inverts its verb or opens on a question word is a question, and nothing else is.",
+      "Commands are on this sheet on purpose, and they are the reason it is worth doing at all. “Put the muddy boots outside the door” takes a full stop although it is not a statement, which is exactly the case a child gets wrong after being taught that questions get question marks and everything else is a statement. Twenty short sentences in two columns is about five minutes, which is the right length for a thing that is mostly about noticing.",
+    ],
+    teaches: "Choosing the mark at the end of a sentence",
+    ages: "Ages 5–9",
+    group: "marks",
+    config: grammar("punctuation", "write", 20, 2),
+  },
+  {
+    slug: "capitalization-worksheets",
+    name: "Capital letters",
+    short: "Capital letters",
+    heading: "Capitalization worksheets",
+    keyword: "Free printable capitalization worksheets",
+    summary:
+      "Twelve sentences with one word printed in lower case that should not be — a name, a place or a day — and a ruled line to write it correctly on.",
+    lead: "Every sentence has exactly one word that has lost its capital letter: a person, a place, or a day of the week. Find it, and write it properly on the line beside the sentence.",
+    notes: [
+      "One word to a sentence, and never the first, which is what makes this markable rather than a hunt. A sheet that lower-cases everything and asks a child to “rewrite it correctly” has as many right answers as it has readers — one child fixes four words, another fixes six, and the parent marking it has to adjudicate. Here the first letter of the sentence is already a capital, one word inside it is not, and there is one thing to point at.",
+      "Names, places and days are the three that carry nearly all the work in a primary classroom, and they are the three on this page. What is not here is the harder half — titles, the first word of speech, the “I” that is capital wherever it stands — not because they do not matter but because each of them brings a second word into the sentence that also wants a capital, and this sheet's whole promise is that there is exactly one.",
+    ],
+    teaches: "Capital letters for names, places and days",
+    ages: "Ages 5–9",
+    group: "marks",
+    config: grammar("capitals", "write", 12),
+  },
+];
+
+/** What each group is called on a hub, in the order they are listed. */
+export const GRAMMAR_GROUPS: Array<{
+  id: GrammarGroup;
+  label: string;
+  blurb: string;
+}> = [
+  {
+    id: "words",
+    label: "Words in a sentence",
+    blurb: "What each word is doing, and where the sentence divides in two.",
+  },
+  {
+    id: "marks",
+    label: "Sentences and their marks",
+    blurb:
+      "What a sentence is for, the mark it ends on, and the letters that have to be capital.",
+  },
+];
+
+/** The route a sheet prints at. One stock, so one route — see the note above. */
+export const pathFor = (sheet: GrammarSheet): string =>
+  `/printables/grammar/${sheet.slug}`;
+
+/** The builder, opened on this sheet. */
+export const builderHref = (sheet: GrammarSheet): string =>
+  benchHref(sheet.config, GRAMMAR_SEED);
+
+/** The shelf, grouped — the shape every page lists it in. */
+export function grammarShelf(): Array<{
+  id: GrammarGroup;
+  label: string;
+  blurb: string;
+  sheets: GrammarSheet[];
+}> {
+  return shelve(GRAMMAR_GROUPS, GRAMMAR_SHEETS);
+}

--- a/src/pages/printables/grammar/[slug].astro
+++ b/src/pages/printables/grammar/[slug].astro
@@ -1,0 +1,215 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { answerKey, buildSheet } from "@/engine/sheets";
+import {
+  GRAMMAR_SEED,
+  GRAMMAR_SHEETS,
+  builderHref,
+  grammarShelf,
+  pathFor,
+  type GrammarSheet,
+} from "../_grammar";
+
+/**
+ * One prerendered grammar sheet per topic — and the page is the sheet.
+ *
+ * The shape §8 describes, on the shelf where the *lesson* is the thing somebody
+ * searched for: "free printable parts of speech worksheets" and "punctuation
+ * worksheets" are queries a parent types, and a page that answers one of them
+ * has prose above the sheet, the sheet itself as HTML under it, and nothing to
+ * click before pressing ⌘P.
+ *
+ * **Every page here has a key, unlike the spelling shelf.** There is no
+ * copying sheet and no write-your-own-sentence sheet in this family: all five
+ * topics withhold an answer the bank knows, so `answerKey` prints on every one
+ * of them. It is the same build with `answers` flipped, so it cannot disagree
+ * with the sheet it belongs to (§7).
+ *
+ * **One stock, as with maths and spelling.** Nothing on a grammar sheet is a
+ * measurement, so there is no A4 twin to keep in step — which is also why this
+ * is a single-segment `[slug]` under `grammar/` rather than a rest pattern:
+ * there is no second segment to carry.
+ *
+ * **No client directive on `SheetView`, ever.** `@astrojs/react` renders a
+ * component with no `client:*` to HTML at build time, so these pages ship zero
+ * JavaScript — the whole SEO argument of §2. `Sheet.test.tsx` holds every page
+ * in this directory to it, against the source and against `dist/`.
+ *
+ * **Everything that is not the sheet carries `.no-print`.** `@page` cannot be
+ * scoped to a class, so the zeroed page margin a sheet needs applies to the
+ * prose as well and it would print off the edge.
+ */
+
+type Props = { sheet: GrammarSheet };
+
+export function getStaticPaths() {
+  return GRAMMAR_SHEETS.map((sheet) => ({
+    params: { slug: sheet.slug },
+    props: { sheet },
+  }));
+}
+
+const { sheet } = Astro.props;
+
+const printed = buildSheet(sheet.config, GRAMMAR_SEED);
+const key = answerKey(sheet.config, GRAMMAR_SEED);
+
+const title = `${sheet.keyword} | School Skills`;
+const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const url = `https://schoolskills.app${pathFor(sheet)}`;
+
+const groups = grammarShelf();
+const group = groups.find((entry) => entry.id === sheet.group)!;
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    name: sheet.heading,
+    description,
+    url,
+    learningResourceType: "Worksheet",
+    educationalUse: "Practice",
+    teaches: sheet.teaches,
+    typicalAgeRange: sheet.ages,
+    isAccessibleForFree: true,
+    inLanguage: "en",
+  }}
+>
+  <header class="hero wrap no-print">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Grammar &middot; {group.label}
+    </p>
+    <h1 class="hero__title">{sheet.heading}</h1>
+    <p class="hero__lead">{sheet.lead}</p>
+    <p class="aside">
+      The sheet below <strong>is</strong> the printout, and the page behind it is
+      the answer key. Press <strong>&#8984;P</strong> &mdash; <strong
+        >Ctrl+P</strong
+      >
+      on Windows &mdash; and everything but the paper disappears. To keep a copy instead,
+      pick <em>Save as PDF</em> in the print dialog and your browser writes one.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  {
+    /*
+      The sheets, outside `.wrap` deliberately. A wrap adds an inline padding
+      that print.css cannot take back off, and a sheet printed a centimetre in
+      from where it says it is has the wrong geometry everywhere at once. The
+      key is a sibling of the sheet with nothing between them, because
+      print.css breaks pages on `.sheet + .sheet` as well.
+    */
+  }
+  <div class="sheet-frame">
+    <SheetView sheet={printed} />
+    <SheetView sheet={key} />
+  </div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">What is on this sheet</h2>
+    <div class="prose">
+      {sheet.notes.map((note) => <p>{note}</p>)}
+      <p>
+        The answers were not worked out by a program reading the sentences.
+        Every sentence on this page was written down and tagged &mdash; what it
+        is for, where it divides, which one word can be named without argument
+        &mdash; and the questions are views of those tags. That is the only
+        honest way to print a grammar key: a sheet that marks a defensible
+        answer wrong teaches a child something false, which is worse than no
+        sheet at all. The number in the footer is the seed the sheet was built
+        from, so the identical sheet can be had again next week.
+      </p>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Change what is on it</h2>
+    <div class="prose">
+      <p>
+        This page is one sheet out of a family that prints five lessons. The
+        topic is a setting rather than a different worksheet: parts of speech,
+        subject and predicate, kinds of sentence, the mark at the end, and the
+        word that needs a capital. Two of the five can be asked either way
+        &mdash; circled from a list of names, or written out on a ruled line
+        &mdash; and how many sentences and how many columns are switches beside
+        them.
+      </p>
+      <p class="aside">
+        The settings travel in the link rather than on a server, so a sheet you
+        make can be bookmarked or sent to another family as it stands &mdash;
+        and the <em>Name:</em> line is printed blank, because there is nowhere in
+        a shared link to put a child&rsquo;s name. See{" "}
+        <a href="/privacy">what we don&rsquo;t collect</a>.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href={builderHref(sheet)}>
+        Open this sheet in the builder
+      </a>
+      <a class="cta cta--quiet" href="/printables/grammar">
+        All the grammar sheets
+      </a>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">The words the sentences are made of</h2>
+    <div class="prose">
+      <p>
+        A sentence is only as good as its spelling, and the shelf next door
+        prints that half: this week&rsquo;s list in five shapes, sight words to
+        trace and find, and ten pages on how words work. Word Jungle then reads
+        the same lists aloud, which is the one thing paper cannot do &mdash; and
+        the record book keeps track of which words a child keeps missing, so the
+        next sheet can be exactly those.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/spelling">Spelling worksheets</a>
+      <a class="cta cta--quiet" href="/spelling">Spelling and sight words</a>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Every grammar sheet</h2>
+    <p class="h2__sub">
+      {GRAMMAR_SHEETS.length} pages, each one a sheet like this one. Nothing is locked
+      and nothing needs an account.
+    </p>
+    {
+      groups.map((entry) => (
+        <>
+          <h3 class="h2 h2--next">{entry.label}</h3>
+          <p class="h2__sub">{entry.blurb}</p>
+          <nav class="stones" aria-label={entry.label}>
+            {entry.sheets.map((candidate) => (
+              <a
+                class="stone"
+                href={pathFor(candidate)}
+                aria-current={
+                  candidate.slug === sheet.slug ? "page" : undefined
+                }
+              >
+                {candidate.short}
+              </a>
+            ))}
+          </nav>
+        </>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/grammar/index.astro
+++ b/src/pages/printables/grammar/index.astro
@@ -1,0 +1,178 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { GRAMMAR_SHEETS, grammarShelf, pathFor } from "../_grammar";
+
+/**
+ * The grammar subject hub — a peer of `/printables/spelling`,
+ * `/printables/math`, `/printables/handwriting`, `/printables/cursive` and
+ * `/printables/bible`.
+ *
+ * A listing rather than a sheet, like the other hubs, and that is the right
+ * split: nobody searches for "printable list of grammar worksheets". What it is
+ * for is the two jobs a hub does — giving a parent who arrived on
+ * `/printables/grammar/punctuation-worksheets` somewhere to go next, and giving
+ * the five topic pages a crawlable parent that says what they have in common.
+ *
+ * What they have in common is worth a section of its own here, because it is
+ * the argument for the whole shelf being small: grammar answers are judgements
+ * in a way arithmetic is not, so the sentences are written down and tagged and
+ * the questions are views of those tags. A page that says so is a page a parent
+ * can decide to trust.
+ */
+const title =
+  "Free printable grammar worksheets — parts of speech, sentences and punctuation | School Skills";
+const description =
+  "Printable grammar practice: parts of speech, subject and predicate, statements and questions and commands, end punctuation and capital letters. Every sheet prints its answer key on the page behind — free, no account, no download.";
+
+const groups = grammarShelf();
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Printable grammar worksheets",
+    description,
+    url: "https://schoolskills.app/printables/grammar",
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    hasPart: GRAMMAR_SHEETS.map((sheet) => ({
+      "@type": "LearningResource",
+      name: sheet.heading,
+      url: `https://schoolskills.app${pathFor(sheet)}`,
+      learningResourceType: "Worksheet",
+      teaches: sheet.teaches,
+      typicalAgeRange: sheet.ages,
+      isAccessibleForFree: true,
+    })),
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Grammar
+    </p>
+    <h1 class="hero__title">Printable grammar worksheets</h1>
+    <p class="hero__lead">
+      {GRAMMAR_SHEETS.length} sheets on how a sentence is put together: what each
+      word is doing, where the sentence divides, what it is for, and the two marks
+      that finish it. Every one of them prints its answer key on the page behind.
+    </p>
+    <p class="hero__note">Free &middot; answer keys &middot; no download</p>
+  </header>
+
+  {
+    /*
+      What exists, first — before the page explains itself. Somebody who came
+      looking for punctuation should be one link from punctuation, and the
+      argument for how these sheets are built reads better after you have seen
+      one than before.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">On the shelf now</h2>
+    <p class="h2__sub">
+      Each of these is a page that is itself the worksheet &mdash; open it,
+      press print, and that is the whole of it. The answer key is the page
+      behind the sheet, on every one of them.
+    </p>
+    {
+      groups.map((group) => (
+        <>
+          <h3 class="h2 h2--next">{group.label}</h3>
+          <p class="h2__sub">{group.blurb}</p>
+          <div class="prose">
+            <ul>
+              {group.sheets.map((sheet) => (
+                <li>
+                  <a href={pathFor(sheet)}>{sheet.name}</a> &mdash;{" "}
+                  {sheet.summary}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      ))
+    }
+  </section>
+
+  <div class="wrap"><AdSlot name="article" /></div>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">Five lessons, and a smaller shelf than it could be</h2>
+      <p class="h2__sub">
+        Grammar answers are judgements in a way that arithmetic answers are not,
+        and that decided the size of this section.
+      </p>
+      <div class="prose">
+        <p>
+          Seven times eight is fifty-six wherever you ask it. Whether a word is
+          an adverb, whether a comma is needed, which half of a sentence is the
+          subject &mdash; every one of those is decidable in a particular
+          sentence and arguable in general. A worksheet that marks a defensible
+          answer wrong does more harm than a worksheet that was never printed,
+          because a child learns from it that they were wrong when they were
+          not.
+        </p>
+        <p>
+          So the sentences on these five pages are written down and tagged, one
+          at a time, and every question is a view of a tag rather than a piece
+          of parsing. The rules that decide what may be tagged are strict on
+          purpose: no article or possessive, because the schemes disagree about
+          what those are; no word that is a noun in one line and a verb in the
+          next; and no exclamation mark asked for, because whether a sentence
+          deserves one is a question about tone rather than about grammar.
+        </p>
+        <p>
+          The same rules are why there are five pages rather than fifty.
+          &ldquo;Noun worksheets&rdquo;, &ldquo;verb worksheets&rdquo; and
+          &ldquo;adjective worksheets&rdquo; are all things people look for, and
+          all of them would be this same sheet with a filter on it. Five
+          lessons, each one a week&rsquo;s teaching, and everything else through
+          the builder &mdash; which is where choosing belongs.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">And the words the sentences are made of</h2>
+    <div class="prose">
+      <p>
+        Grammar is what a sentence does with words; spelling is the words
+        themselves. The shelf next door prints this week&rsquo;s list in five
+        shapes, the first sight words to trace and find, and ten pages on how
+        words work &mdash; rhyme, syllables, prefixes and suffixes, plurals,
+        contractions, homophones, synonyms and antonyms. It is the same bargain
+        as this one: the answers are written by a person, because English will
+        not yield to a rule.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/spelling">Spelling and word study</a>
+      <a class="cta cta--quiet" href="/printables/make"
+        >Open the sheet builder</a
+      >
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Your child&rsquo;s name is not in the file</h2>
+    <div class="prose">
+      <p>
+        The <em>Name:</em> line is printed blank and filled in with a pencil. Nothing
+        is uploaded to make a sheet, no account is needed to print one, and a sheet
+        you send to another family carries the settings you chose and nothing else
+        &mdash; see <a href="/privacy">what we don&rsquo;t collect</a>.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -8,6 +8,11 @@ import {
   hrefFor as cursiveHref,
 } from "./_cursive";
 import {
+  GRAMMAR_SHEETS,
+  grammarShelf,
+  pathFor as grammarPath,
+} from "./_grammar";
+import {
   HANDWRITING_SHEETS,
   handwritingShelf,
   hrefFor as handwritingHref,
@@ -32,13 +37,14 @@ import {
  * It lists what exists and nothing else. A shelf of links to sheets that
  * haven't been built is the thin-content pattern Base.astro's `noindex` block
  * already argues against, and a catalog page here is meant to BE the worksheet
- * — real prerendered HTML a parent can print without touching anything. Six
+ * — real prerendered HTML a parent can print without touching anything. Seven
  * families fill it: every ruling in §5 on both stocks, the curated maths topics
  * of §8, each of which prints its own answer key, the handwriting and cursive
  * sheets, which come on both stocks for the same reason the paper does, the
- * Scripture shelf, which is those same families with a passage on them, and the
+ * Scripture shelf, which is those same families with a passage on them, the
  * spelling shelf, which is the one whose content a parent can replace with their
- * own list.
+ * own list, and the grammar shelf, which is the one whose answers had to be
+ * written down because they cannot be worked out.
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
@@ -52,6 +58,7 @@ const writing = handwritingShelf();
 const joined = cursiveShelf();
 const scripture = bibleShelf();
 const words = spellingShelf();
+const sentences = grammarShelf();
 ---
 
 <Content
@@ -94,10 +101,11 @@ const words = spellingShelf();
   <section class="band band--tight wrap">
     <h2 class="h2">On the shelf now</h2>
     <p class="h2__sub">
-      Six families: maths worksheets, each with its answer key on the page
+      Seven families: maths worksheets, each with its answer key on the page
       behind it, handwriting practice that traces before it copies, the same
       progression again in cursive, Scripture copywork and memory work, spelling
-      and word study on this week&rsquo;s list or your own, and paper in every
+      and word study on this week&rsquo;s list or your own, grammar whose
+      answers were written down rather than worked out, and paper in every
       ruling. Each of these is a page that is itself the sheet &mdash; open it,
       press print, and that is the whole of it. Everything ruled comes on both
       stocks, because a ruling shrunk to fit whatever is in the tray is no
@@ -207,12 +215,33 @@ const words = spellingShelf();
       <a class="cta" href="/printables/spelling">All the spelling sheets</a>
     </div>
 
+    <h3 class="h2 h2--next">Grammar</h3>
+    <p class="h2__sub">
+      {GRAMMAR_SHEETS.length} sheets on how a sentence is put together &mdash; the
+      parts of speech, the two halves of a sentence, what it is for, and the marks
+      that finish it. Every one prints its answer key.
+    </p>
+    {
+      sentences.map((group) => (
+        <nav class="stones" aria-label={`Grammar — ${group.label}`}>
+          {group.sheets.map((sheet) => (
+            <a class="stone" href={grammarPath(sheet)}>
+              {sheet.short}
+            </a>
+          ))}
+        </nav>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta" href="/printables/grammar">All the grammar sheets</a>
+    </div>
+
     {
       /*
-        Paper keeps its groups and its one-line summaries; maths gets a row of
-        links and a hub. Not an inconsistency — a ruling is chosen by reading
-        what makes it different from the ruling beside it, and a worksheet is
-        chosen by recognising the name of the topic.
+        Paper keeps its groups and its one-line summaries; every subject shelf
+        above gets a row of links and a hub. Not an inconsistency — a ruling is
+        chosen by reading what makes it different from the ruling beside it, and
+        a worksheet is chosen by recognising the name of the topic.
       */
     }
     {
@@ -264,15 +293,16 @@ const words = spellingShelf();
       <p class="h2__sub">
         The Print Shop is opening a family at a time, and this page lists what
         exists rather than what is planned. Paper, maths, handwriting, cursive,
-        copywork and spelling are open. Phonics is next.
+        copywork, spelling and grammar are open. Phonics is next.
       </p>
       <div class="prose">
         <p>
           The order it opens in: the paper, the maths sheets, the handwriting
           and the cursive above, then the copywork &mdash; a few hundred
           passages from the public domain, Scripture among them &mdash; then the
-          spelling and word-study shelf, and after that phonics and the charts,
-          certificates and planners that are simply blank forms.
+          spelling and word-study shelf and the grammar sheets beside it, and
+          after that phonics and the charts, certificates and planners that are
+          simply blank forms.
         </p>
         <p>
           The one it is really being built for comes with the sheet builder:


### PR DESCRIPTION
Closes #66.

Grammar sheets — parts of speech, subject and predicate, sentence types, punctuation and capitals — with five catalog pages at `/printables/grammar`.

## Why the sentences are written down and not generated

Spelling could not be generated because English will not yield to a rule. Grammar fails for a sharper reason: grammar is a judgement. Whether a word is an adverb, whether a comma is needed, which half of a sentence is the subject — each is decidable in a particular sentence and arguable in general, and a sheet that marks a defensible answer wrong teaches a child something false.

So `src/engine/sheets/grammar/bank.ts` holds sentences written once and tagged — what the sentence is for, where it divides, which one word can be named without argument, which word has lost its capital — and the five topics are five views of those tags rather than five parses. Nothing in `grammar.ts` analyses English.

## The house rules are the feature

- No article or possessive is ever tagged, because the schemes disagree about what those are.
- Verbs are past tense or the opening word of a command — the cheapest way to make a word class unarguable.
- A split is exhaustive or absent, which is what stops "complete subject" and "simple subject" being two right answers to one question.
- An exclamation is exclamative in form, so the mark on the end is grammar rather than tone.
- The punctuation sheet asks only for a full stop or a question mark, because whether a sentence deserves a bang has no key.

## Answer keys checked against the tags, not re-derived

`grammar.test.ts` parses each printed prompt back to the bank entry it came from and re-derives the answer itself, by a path that never touches the generator. The bank's own invariants are mechanical too: every split rejoins to its sentence, every tagged word stands in it exactly once, every capitals sentence has exactly one word to put right, and every end mark agrees with the kind it was tagged with.

## Coverage, because a shuffle is silent about any one page

A fair shuffle is fair over many pages and says nothing about the one in your hand. One sentence-types sheet in six came up with no command on it — every item correct, on the page whose own instruction line reads "statement, question, command or exclamation". A parts-of-speech sheet with no verb on it is the same failure: nothing to fix in the key, and the page has quietly stopped being the lesson it claims to be.

Where a topic answers to a closed list and there is room for one of each, one of each is now drawn first off the same stream, the rest fills up behind it, and the whole is shuffled again. Asserted over fifty seeds rather than hoped for.

The capitals topic had thirteen sentences against a page that holds seventeen, so every capitals sheet a parent could print was the same thirteen reordered — the exact failure the bank's own header names. Eleven more sentences carrying a name, a place or a day take it to twenty-four, and the supply floor is now measured against what the paper holds rather than against a number somebody typed, for every topic at once.

## Catalog notes that match the paper

Three notes quoted sentences the sheet under them does not print. The page is prerendered at one seed and the sheet *is* the page, so a reader can check the prose against the paper and find "Bring the shopping into the kitchen" nowhere on it. Rewritten to sentences the draw really contains, and locked: a quotation of five words or more is now read as a claim about the sheet and has to appear in its prompts. A hypothetical the sheet never prints stays shorter than that — a house rule of the notes, not a fact about English.

Five catalog pages rather than fifty: "noun worksheets" and "verb worksheets" are real queries and both would be this sheet with a filter on it, which is the doorway-page farm §8 argues against.

## Also

- The column cap reads `grammarColumns` out of the engine rather than naming a topic in the panel, so a sixth topic with ruled answer lines cannot get a stepper that moves a number the paper ignores.
- §11 of `docs/printables.md` carries what shipped, in place of a Grammar bullet that still read as a plan.
- quick-win: the Print Shop hub's comment about how the shelves are listed named maths alone when six subject shelves now list the same way.

## Validation

`type-check`, `lint`, `test:unit` (1079 tests, 53 files), `build` (static, 141 pages) and the browser smoke test all pass — smoke run against this build with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
