### PR TITLE
PRINT23: Bible vocabulary and books of the Bible as word lists

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -610,8 +610,8 @@ rather than a section off to one side.
   handwriting practice" are queries with genuine homeschool volume.
 - **Grade hubs list Scripture sheets** with everything else for that age.
 - **Words and vocabulary.** Books of the Bible (in order — a memory-work
-  staple), key names and places, catechism vocabulary, as shipped lists
-  alongside Dolch.
+  staple), key names and places, and the words the stories are told in, as
+  shipped lists alongside Dolch.
 - **Templates.** Memory-verse cards to cut out, verse-of-the-week wall chart,
   Scripture bookmarks, a reading-plan grid, a Bible-study journal page.
 
@@ -700,6 +700,26 @@ says the words are left out for the exercise and the key prints the passage
 whole — both halves, in the engine, so neither is a page's decision to forget.
 The shelf is `/printables/bible`, a peer of `/printables/math` and
 `/printables/handwriting`; the maths sheets stay clear of it, as above.
+
+**What shipped (PRINT23), and the one thing that didn't.** Five word lists in
+`engine/decks/biblelists.ts` — the thirty-nine and the twenty-seven in canonical
+order, people, places, and Bible words — as ordinary `WordList`s, so they print
+as any of the seven spelling styles and any of the three puzzles and are played
+by the word deck without being authored twice. The books say **which canon** in
+the blurb a parent reads: sixty-six is the Protestant count, a family whose
+Bible has seventy-three would be taught something to unlearn, and the release we
+quote ships the deuterocanon itself, so sixty-six is our editorial choice and is
+stated as one.
+
+**Catechism vocabulary, promised above, is declined.** Not an oversight and not
+a scheduling call: a word list is a list of definitions a child memorises, and
+the catechism words worth listing are the ones the traditions answer
+differently — what baptism accomplishes, what happens at communion. A
+seven-year-old handed one side of that as a fact to learn, who later finds it
+was one side, learns to distrust the sheet. "Bible words" is what shipped
+instead, and every entry on it is a definition the churches agree on. Anything
+past that line is a parent's own list to paste in, which is a door that is
+already open.
 
 ### Scripture on the front door: content, never a credential
 

--- a/src/components/sheet/blocks/WordShapes.tsx
+++ b/src/components/sheet/blocks/WordShapes.tsx
@@ -84,6 +84,11 @@ function Boxes({
       <title>{`Boxes for the letters of "${shape.word}"`}</title>
 
       {shape.letters.map((letter, at) => {
+        // A gap keeps its slot and loses its box: "1 Samuel" reads as two words
+        // because the space between them is empty paper, and there is nothing
+        // to write on the key either. The `left` below is still `at`-based, so
+        // the boxes after a space land exactly where they always did.
+        if (letter === "gap") return null;
         const band = shapeBand(letter);
         const top = Math.round(height * band.top);
         const tall = Math.round(height * band.bottom) - top;

--- a/src/engine/decks/biblelists.test.ts
+++ b/src/engine/decks/biblelists.test.ts
@@ -1,0 +1,422 @@
+/**
+ * The canon, as a failing build.
+ *
+ * A spelling list that has drifted teaches a child a word wrong once. A books-
+ * of-the-Bible list that has drifted teaches them an order they will recite for
+ * the rest of their life, and the mistake is invisible in review because one
+ * proper noun looks much like another. So the list is pinned from two
+ * directions rather than trusted:
+ *
+ *   - **Against `CANON` below**, which is eBible's own file order for the
+ *     release the passage library quotes — name for name, position for
+ *     position. Two files would have to be edited identically for a book to
+ *     move, which is the same mechanism `scripture.test.ts` gives the verses.
+ *   - **Against the passage library itself.** Forty-seven of the sixty-six are
+ *     already named in a `ScriptureEntry.ref`, and those verses are checked
+ *     character for character against the release. A book spelt one way on a
+ *     copywork sheet and another on a memory list is a contradiction inside one
+ *     build, and this is where it fails.
+ *
+ * The rest is the mechanical half of the house rules — the half a machine can
+ * see. Whether Amos really kept sheep stays a human's job, and the sources for
+ * that are in `biblelists.ts`.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildSheet } from "@/engine/sheets";
+import { SCRIPTURE } from "@/engine/sheets/passages/scripture";
+import type {
+  Paper,
+  PuzzleConfig,
+  PuzzleStyle,
+  WordSheetStyle,
+  WordsConfig,
+} from "@/engine/sheets/types";
+
+import { BIBLE_LISTS } from "./biblelists";
+import {
+  CLUE_SLOT,
+  buildWordDeck,
+  fillClue,
+  wordDeckSpec,
+  wordMode,
+} from "./words";
+import { SHIPPED_LISTS, WORD_LISTS_BY_ID, listWords } from "./wordlists";
+
+/**
+ * The sixty-six, in the order eBible files them.
+ *
+ * Read off the USFM release — `02-GENengwebu.usfm` through `96-REVengwebu.usfm`,
+ * each file's own `\h` running head — with the deuterocanonical books the
+ * release also ships (Tobit through 4 Maccabees, filed between Malachi and
+ * Matthew) left out, which is the Protestant canon and is stated as a choice in
+ * `biblelists.ts` rather than implied here.
+ */
+const CANON = [
+  "Genesis",
+  "Exodus",
+  "Leviticus",
+  "Numbers",
+  "Deuteronomy",
+  "Joshua",
+  "Judges",
+  "Ruth",
+  "1 Samuel",
+  "2 Samuel",
+  "1 Kings",
+  "2 Kings",
+  "1 Chronicles",
+  "2 Chronicles",
+  "Ezra",
+  "Nehemiah",
+  "Esther",
+  "Job",
+  "Psalms",
+  "Proverbs",
+  "Ecclesiastes",
+  "Song of Solomon",
+  "Isaiah",
+  "Jeremiah",
+  "Lamentations",
+  "Ezekiel",
+  "Daniel",
+  "Hosea",
+  "Joel",
+  "Amos",
+  "Obadiah",
+  "Jonah",
+  "Micah",
+  "Nahum",
+  "Habakkuk",
+  "Zephaniah",
+  "Haggai",
+  "Zechariah",
+  "Malachi",
+  "Matthew",
+  "Mark",
+  "Luke",
+  "John",
+  "Acts",
+  "Romans",
+  "1 Corinthians",
+  "2 Corinthians",
+  "Galatians",
+  "Ephesians",
+  "Philippians",
+  "Colossians",
+  "1 Thessalonians",
+  "2 Thessalonians",
+  "1 Timothy",
+  "2 Timothy",
+  "Titus",
+  "Philemon",
+  "Hebrews",
+  "James",
+  "1 Peter",
+  "2 Peter",
+  "1 John",
+  "2 John",
+  "3 John",
+  "Jude",
+  "Revelation",
+];
+
+/** Where `CANON` divides. Thirty-nine and twenty-seven is itself memory work. */
+const OLD_TESTAMENT = 39;
+
+const listById = (id: string) => {
+  const list = BIBLE_LISTS.find((one) => one.id === id);
+  if (!list) throw new Error(`No Bible list "${id}"`);
+  return list;
+};
+
+const BOOKS = [
+  ...listWords(listById("bible-books-ot")),
+  ...listWords(listById("bible-books-nt")),
+];
+
+describe("the books of the Bible", () => {
+  it("ships the sixty-six of the Protestant canon", () => {
+    expect(listWords(listById("bible-books-ot"))).toHaveLength(OLD_TESTAMENT);
+    expect(listWords(listById("bible-books-nt"))).toHaveLength(
+      CANON.length - OLD_TESTAMENT,
+    );
+    expect(BOOKS).toHaveLength(66);
+  });
+
+  it("names them the way the release does, in the release's order", () => {
+    expect(BOOKS).toEqual(CANON);
+  });
+
+  it("keeps a numbered book with the one it is numbered against", () => {
+    // Mechanical, and it catches the transposition nobody spots by reading: a
+    // "2 Kings" that has drifted above "1 Kings" still looks like a list of
+    // kings. Every numbered book is immediately after its predecessor.
+    for (const [at, book] of BOOKS.entries()) {
+      const number = /^([23]) (.+)$/.exec(book);
+      if (!number) continue;
+      const before = `${Number(number[1]) - 1} ${number[2]}`;
+      expect(BOOKS[at - 1], `${book} follows ${before}`).toBe(before);
+    }
+  });
+
+  it("spells every book the passage library quotes the same way", () => {
+    const spelt = new Set(BOOKS);
+    for (const entry of SCRIPTURE) {
+      // "Genesis 1:1", "1 Corinthians 13:4-8", "Psalm 23" — the reference off
+      // the front, which is the book as a sheet prints it.
+      const book = entry.ref.replace(/\s+\d+(:\d+(-\d+)?)?$/, "");
+      // One exception, and it is a fact about English rather than a drift: the
+      // book is Psalms and a single one of them is cited as "Psalm 23".
+      const named = book === "Psalm" ? "Psalms" : book;
+      expect(spelt.has(named), `${entry.id} · ${entry.ref}`).toBe(true);
+    }
+  });
+
+  it("is checked against the passage library on most of the canon", () => {
+    // The guard above only guards the books something quotes. This says how
+    // many that is, so the day it stops being most of them is a day somebody
+    // reads about rather than assumes.
+    const referenced = new Set(
+      SCRIPTURE.map((entry) =>
+        entry.ref
+          .replace(/\s+\d+(:\d+(-\d+)?)?$/, "")
+          .replace(/^Psalm$/, "Psalms"),
+      ),
+    );
+    expect(referenced.size).toBeGreaterThanOrEqual(47);
+  });
+});
+
+describe("the Bible lists", () => {
+  it("gives every list an id of its own, and a name and a blurb", () => {
+    const ids = BIBLE_LISTS.map((list) => list.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const list of BIBLE_LISTS) {
+      // The id is in `Session.mode` and in every saved sheet's link, so it is
+      // the one field that cannot be renamed later.
+      expect(list.id).toMatch(/^bible-[a-z-]+$/);
+      expect(list.name).not.toBe("");
+      expect(list.blurb).not.toBe("");
+      expect(list.entries.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("says which canon the books follow, where a parent will read it", () => {
+    // Sixty-six against seventy-three is the difference between two families'
+    // Bibles, and a list that doesn't say which one it is teaches the wrong
+    // one to whichever family it isn't (see the header of biblelists.ts).
+    expect(listById("bible-books-ot").blurb).toContain("Protestant");
+  });
+
+  it("has no blank, untrimmed or repeated entry", () => {
+    for (const list of BIBLE_LISTS) {
+      const words = listWords(list);
+      expect(new Set(words).size, list.id).toBe(words.length);
+      for (const word of words) {
+        expect(word.trim(), list.id).toBe(word);
+        expect(word).not.toBe("");
+      }
+    }
+  });
+
+  it("puts every word in exactly one shipped list", () => {
+    // `shippedClue` indexes every sentence in the build by its word, so a word
+    // in two lists would have two clues and a crossword would print whichever
+    // was registered last. Which is why Ruth, Daniel, Esther, Jonah, Joshua and
+    // Job are books here and not also people.
+    const owner = new Map<string, string>();
+    for (const list of SHIPPED_LISTS) {
+      for (const word of listWords(list)) {
+        const key = word.toLowerCase();
+        expect(
+          owner.get(key),
+          `"${word}" is already ${owner.get(key)}'s`,
+        ).toBeUndefined();
+        owner.set(key, list.id);
+      }
+    }
+  });
+});
+
+/**
+ * The same rules `words.test.ts` holds the Dolch sentences to, over these. A
+ * clue is what makes a word answerable when it is heard rather than seen, and
+ * a printed crossword reads the same sentences (`crosswordClue`) — so the
+ * mechanical half is checked in both places or in neither.
+ */
+describe("the sentence on every Bible word", () => {
+  it("gives every word exactly one slot to fill", () => {
+    for (const list of BIBLE_LISTS) {
+      for (const { word, clue } of list.entries) {
+        expect(clue.split(CLUE_SLOT), `${list.id} · ${word}`).toHaveLength(2);
+      }
+    }
+  });
+
+  it("never spells the word out in its own sentence", () => {
+    for (const list of BIBLE_LISTS) {
+      for (const { word, clue } of list.entries) {
+        const rest = clue.replace(CLUE_SLOT, " ").toLowerCase();
+        // Every part of the word, not just the whole of it: "Song of Solomon"
+        // would be given away by a sentence that mentioned Solomon.
+        for (const part of word.toLowerCase().split(" ")) {
+          if (!/^\p{L}/u.test(part)) continue;
+          const words = rest.split(/[^a-z']+/).filter(Boolean);
+          expect(words, `${list.id} · ${word}`).not.toContain(part);
+        }
+      }
+    }
+  });
+
+  it("keeps them short enough to read out on a clock", () => {
+    for (const list of BIBLE_LISTS) {
+      for (const { word, clue } of list.entries) {
+        const length = fillClue(clue, word).split(/\s+/).length;
+        expect(length, `${list.id} · ${word}`).toBeLessThanOrEqual(8);
+      }
+    }
+  });
+
+  it("gives every word a sentence of its own, across the whole shelf", () => {
+    const seen = new Map<string, string>();
+    for (const list of SHIPPED_LISTS) {
+      for (const { word, clue } of list.entries) {
+        const key = clue.toLowerCase();
+        const owner = seen.get(key);
+        expect(owner, `"${clue}" is also ${owner}'s`).toBeUndefined();
+        seen.set(key, `${list.id}:${word}`);
+      }
+    }
+  });
+});
+
+/* ── One list, every sheet on the words shelf ────────────────────────────────
+   The story's actual promise: a Bible list is a word list, so it prints as any
+   of the seven spelling styles (PRINT20) and any of the three puzzles
+   (PRINT21). Nothing below is a Bible-shaped code path — that is the point, and
+   this is what would catch one appearing.                                    */
+
+const paper = (): Paper => ({
+  size: "letter",
+  orientation: "portrait",
+  margin: "normal",
+});
+
+const spelling = (style: WordSheetStyle, words: string[]): WordsConfig => ({
+  kind: "words",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style,
+  words,
+  times: 3,
+  gaps: 2,
+  count: words.length,
+  columns: 2,
+});
+
+const puzzle = (style: PuzzleStyle, words: string[]): PuzzleConfig => ({
+  kind: "puzzle",
+  paper: paper(),
+  fontPt: 12,
+  fields: ["name", "date"],
+  style,
+  words,
+  size: 15,
+  directions: "across-down",
+  reverse: false,
+  overlap: true,
+  count: words.length,
+  columns: 2,
+});
+
+const STYLES: WordSheetStyle[] = [
+  "copy",
+  "missing",
+  "test",
+  "abc",
+  "shapes",
+  "sentence",
+  "find",
+];
+
+const PUZZLES: PuzzleStyle[] = ["search", "crossword", "scramble"];
+
+describe("every Bible list, on every sheet style", () => {
+  for (const list of BIBLE_LISTS) {
+    const words = listWords(list);
+
+    for (const style of STYLES) {
+      it(`prints ${list.id} as a ${style} sheet`, () => {
+        const config = spelling(style, words);
+        const sheet = buildSheet(config, 7);
+        expect(sheet.blocks.length).toBeGreaterThan(0);
+        expect(sheet.header.title).not.toBe("");
+        // A page of nothing is the failure mode a long list would hide: a
+        // capacity that came out at zero still builds, and still prints.
+        expect(sheet.header.score?.outOf).toBeGreaterThan(0);
+        // `(config, seed)` and nothing else (§7).
+        expect(buildSheet(config, 7)).toEqual(sheet);
+      });
+    }
+
+    for (const style of PUZZLES) {
+      it(`prints ${list.id} as a ${style}`, () => {
+        const config = puzzle(style, words);
+        const sheet = buildSheet(config, 7);
+        expect(sheet.blocks.length).toBeGreaterThan(0);
+        expect(buildSheet(config, 7)).toEqual(sheet);
+      });
+    }
+  }
+
+  it("clues a Bible crossword out of the list's own sentences", () => {
+    // The sentences above are what a crossword prints, rather than the jumbled
+    // letters `letterHint` falls back to for a word this build has never met.
+    const sheet = buildSheet(
+      puzzle("crossword", listWords(listById("bible-people"))),
+      3,
+    );
+    const clues = sheet.blocks.find((block) => block.kind === "crossword");
+    expect(clues).toBeDefined();
+    if (clues?.kind !== "crossword") throw new Error("no crossword block");
+    expect(
+      clues.across
+        .concat(clues.down)
+        .some((entry) => entry.clue.startsWith("Jumbled:")),
+    ).toBe(false);
+  });
+});
+
+/**
+ * And the other half of "authored once": Word Jungle takes these by id, with
+ * the sentences attached, without a line of this data being written twice
+ * (PRINT31 is the picker; the deck already resolves).
+ */
+describe("a Bible list as a deck", () => {
+  it("resolves by id, and names itself", () => {
+    for (const list of BIBLE_LISTS) {
+      expect(WORD_LISTS_BY_ID.get(list.id)).toBe(list);
+      expect(wordDeckSpec(wordMode(list.id)).label).toBe(list.name);
+      expect(wordDeckSpec(wordMode(list.id)).world).toBe("jungle");
+    }
+  });
+
+  it("deals cards that carry the sentence they were written with", () => {
+    const cards = buildWordDeck(
+      {
+        kind: "words",
+        listId: "bible-books-nt",
+        cardCount: 8,
+        inputMode: "type",
+      },
+      5,
+    );
+    expect(cards).toHaveLength(8);
+    for (const card of cards) {
+      expect(card.clue).toBeDefined();
+      expect(card.speak).toContain(card.answer);
+    }
+  });
+});

--- a/src/engine/decks/biblelists.test.ts
+++ b/src/engine/decks/biblelists.test.ts
@@ -11,7 +11,7 @@
  *     release the passage library quotes — name for name, position for
  *     position. Two files would have to be edited identically for a book to
  *     move, which is the same mechanism `scripture.test.ts` gives the verses.
- *   - **Against the passage library itself.** Forty-seven of the sixty-six are
+ *   - **Against the passage library itself.** Forty-eight of the sixty-six are
  *     already named in a `ScriptureEntry.ref`, and those verses are checked
  *     character for character against the release. A book spelt one way on a
  *     copywork sheet and another on a memory list is a contradiction inside one
@@ -176,7 +176,11 @@ describe("the books of the Bible", () => {
   it("is checked against the passage library on most of the canon", () => {
     // The guard above only guards the books something quotes. This says how
     // many that is, so the day it stops being most of them is a day somebody
-    // reads about rather than assumes.
+    // reads about rather than assumes. Forty-eight today, and a floor rather
+    // than an equality because adding a passage from the eighteen unquoted
+    // books is a good day and should not be a red suite — but the number in
+    // this file's header and in `biblelists.ts` is the count, so raise both
+    // when it moves.
     const referenced = new Set(
       SCRIPTURE.map((entry) =>
         entry.ref
@@ -184,7 +188,7 @@ describe("the books of the Bible", () => {
           .replace(/^Psalm$/, "Psalms"),
       ),
     );
-    expect(referenced.size).toBeGreaterThanOrEqual(47);
+    expect(referenced.size).toBeGreaterThanOrEqual(48);
   });
 });
 

--- a/src/engine/decks/biblelists.ts
+++ b/src/engine/decks/biblelists.ts
@@ -36,7 +36,7 @@
  *               spelt on a memory list cannot be two different spellings.
  *
  * `biblelists.test.ts` pins that: every book the passage library references —
- * forty-seven of the sixty-six, each already checked character for character
+ * forty-eight of the sixty-six, each already checked character for character
  * against the release — must appear in these lists spelt identically. Rename
  * one and the suite fails, which is the same mechanism the verses have.
  *
@@ -50,6 +50,12 @@
  * that cannot say which Samuel it means, and the seven spelling styles — which
  * are where a memory list actually gets used — print every one of the sixty-six
  * as it is written here.
+ *
+ * One of those seven had to learn what a space is to do that. Word shapes draws
+ * a box per character, and a box is a thing a child writes a letter into — so
+ * `1 Samuel` used to ask for a letter in the box where the space is. A space is
+ * a `gap` in `words/shapes.ts` now: the slot is still reserved, so the boxes
+ * either side of it stay where they were, and nothing is drawn in it.
  *
  * ── Why these lists break two of the Dolch rules ────────────────────────────
  * `wordlists.ts` holds its entries to lower case and to one word each, and the
@@ -150,7 +156,7 @@ export const BIBLE_LISTS: WordList[] = [
       { word: "Obadiah", clue: "_ is the shortest Old Testament book." },
       { word: "Jonah", clue: "_ was swallowed by a great fish." },
       { word: "Micah", clue: "_ said the king would come from Bethlehem." },
-      { word: "Nahum", clue: "_ warned Nineveh a second time." },
+      { word: "Nahum", clue: "_ said Nineveh would fall." },
       { word: "Habakkuk", clue: "_ asked God why the wicked win." },
       { word: "Zephaniah", clue: "_ wrote about a coming day of judgement." },
       { word: "Haggai", clue: "_ told the people to rebuild the temple." },
@@ -241,12 +247,12 @@ export const BIBLE_LISTS: WordList[] = [
       { word: "Andrew", clue: "_ was the brother of Peter." },
       { word: "Thomas", clue: "_ wanted to see for himself." },
       { word: "Nicodemus", clue: "_ came to Jesus at night." },
-      { word: "Martha", clue: "_ was busy while Mary listened." },
+      { word: "Martha", clue: "_ was busy with the serving." },
       { word: "Lazarus", clue: "_ came out of the tomb." },
       { word: "Zacchaeus", clue: "_ climbed a tree to see." },
       { word: "Paul", clue: "_ was blinded on the Damascus road." },
       { word: "Barnabas", clue: "_ travelled with Paul." },
-      { word: "Timothy", clue: "_ was taught by his grandmother." },
+      { word: "Timothy", clue: "_ had a mother and grandmother of faith." },
       { word: "Lydia", clue: "_ sold purple cloth." },
     ],
   },
@@ -254,8 +260,14 @@ export const BIBLE_LISTS: WordList[] = [
     id: "bible-places",
     name: "Places in the Bible",
     group: "Names to know",
-    blurb: "Eden to Rome — where the story happens, in the order it happens.",
+    blurb: "Eden to Patmos — where the story happens, in the order it happens.",
     emoji: "🗺️",
+    // "In the order it happens" is a promise the list has to keep, and the order
+    // is the one the sentence beside each place puts it in rather than a rough
+    // sense of era: Nineveh before Babylon because Jonah is generations before
+    // the exile, the Jordan before Capernaum because the baptism is what Jesus
+    // goes to Galilee from, Athens before Corinth and Ephesus because that is
+    // Acts 17, 18 and 19 in that order.
     entries: [
       { word: "Eden", clue: "God planted a garden in _." },
       { word: "Ararat", clue: "The ark came to rest on _." },
@@ -267,20 +279,20 @@ export const BIBLE_LISTS: WordList[] = [
       { word: "Bethlehem", clue: "David and Jesus were both born in _." },
       { word: "Jerusalem", clue: "David made _ his capital city." },
       { word: "Zion", clue: "Another name for Jerusalem is _." },
-      { word: "Babylon", clue: "Daniel was carried away to _." },
       { word: "Nineveh", clue: "Jonah did not want to go to _." },
+      { word: "Babylon", clue: "Daniel was carried away to _." },
       { word: "Nazareth", clue: "Jesus grew up in _." },
+      { word: "Jordan", clue: "Jesus was baptised in the river _." },
       { word: "Galilee", clue: "Jesus called fishermen beside the sea of _." },
       { word: "Capernaum", clue: "Jesus made his home in _." },
-      { word: "Jordan", clue: "Jesus was baptised in the river _." },
       { word: "Samaria", clue: "The woman at the well came from _." },
       { word: "Bethany", clue: "Lazarus and Martha lived in _." },
       { word: "Gethsemane", clue: "Jesus prayed in the garden of _." },
       { word: "Damascus", clue: "Paul saw a bright light near _." },
       { word: "Antioch", clue: "Believers were first called Christians at _." },
-      { word: "Corinth", clue: "Paul wrote two letters to _." },
-      { word: "Ephesus", clue: "Paul stayed two years at _." },
       { word: "Athens", clue: "Paul preached about the unknown god in _." },
+      { word: "Corinth", clue: "Paul wrote two letters to _." },
+      { word: "Ephesus", clue: "Paul stayed three years at _." },
       { word: "Rome", clue: "Paul was kept under guard in _." },
       { word: "Patmos", clue: "John saw his visions on _." },
     ],
@@ -311,8 +323,8 @@ export const BIBLE_LISTS: WordList[] = [
       { word: "sacrifice", clue: "Something given up for God is a _." },
       { word: "priest", clue: "A _ offered gifts for the people." },
       { word: "angel", clue: "A messenger from heaven is an _." },
-      { word: "ark", clue: "Noah built a great wooden _." },
-      { word: "manger", clue: "Jesus was laid in a _." },
+      { word: "ark", clue: "A big wooden boat is an _." },
+      { word: "manger", clue: "A box animals eat from is a _." },
       { word: "shepherd", clue: "A _ looks after the sheep." },
       { word: "miracle", clue: "Something only God could do is a _." },
       { word: "faith", clue: "Trusting what you cannot see is _." },

--- a/src/engine/decks/biblelists.ts
+++ b/src/engine/decks/biblelists.ts
@@ -1,0 +1,339 @@
+/**
+ * Bible memory work as word lists: the books in order, the names, the places,
+ * and the words the stories are told in.
+ *
+ * The same `WordList` shape the Dolch lists are, and that is the whole design.
+ * A list in this file is picked from the same control, printed by the same
+ * seven spelling styles and the same three puzzles, resolved by the same
+ * `WORD_LISTS_BY_ID`, and — when the games take them (PRINT31) — played by the
+ * same deck family. Nothing here is a second kind of list, because a second
+ * kind of list would be a second picker, a second sanitiser and a second answer
+ * to what a word is (docs/printables.md §12).
+ *
+ * ── Which Bible, and why that has to be said ────────────────────────────────
+ * These are the **sixty-six books of the Protestant canon** — thirty-nine in
+ * the Old Testament, twenty-seven in the New. Catholic Bibles carry seventy-
+ * three, adding Tobit, Judith, Wisdom, Sirach, Baruch and 1–2 Maccabees and
+ * the longer Esther and Daniel; Orthodox canons carry more again, and differ
+ * between churches. This is not a footnote to be tidied away: a child learns
+ * this list by heart, and a child taught sixty-six books from a family whose
+ * Bible has seventy-three has been taught something they will have to unlearn.
+ * The list says which canon it follows, in the blurb a parent reads before
+ * pressing anything.
+ *
+ * The release these names come from ships the deuterocanon itself, filed
+ * between Malachi and Matthew, which is the plainest evidence that sixty-six is
+ * an editorial choice rather than the shape of the file. It is our choice, and
+ * it is stated.
+ *
+ * ── Where the spellings come from ───────────────────────────────────────────
+ *   Source      the running heads (`\h`) and long titles (`\toc1`) of eBible's
+ *               own USFM release of the World English Bible Updated —
+ *               https://ebible.org/Scriptures/engwebu_usfm.zip, files dated
+ *               14 August 2026, pulled 17 August 2026.
+ *   Why that    it is the same release `sheets/passages/scripture.ts` quotes,
+ *               so the book named at the top of a copywork sheet and the book
+ *               spelt on a memory list cannot be two different spellings.
+ *
+ * `biblelists.test.ts` pins that: every book the passage library references —
+ * forty-seven of the sixty-six, each already checked character for character
+ * against the release — must appear in these lists spelt identically. Rename
+ * one and the suite fails, which is the same mechanism the verses have.
+ *
+ * A numbered book is written as the release writes it: `1 Samuel`, not `First
+ * Samuel` and not `I Samuel`. Two consequences on the puzzle shelf, both
+ * deliberate and neither hidden. `puzzleWords` folds a list onto its grid form
+ * — letters only, upper case — so a numbered pair is one entry on all three
+ * puzzles: a books word search holds SAMUEL once, and so does a scramble. And
+ * in a jumble the digit and the space are shuffled in with the letters, which
+ * is a fair puzzle and an odd-looking one. Both are better than a books list
+ * that cannot say which Samuel it means, and the seven spelling styles — which
+ * are where a memory list actually gets used — print every one of the sixty-six
+ * as it is written here.
+ *
+ * ── Why these lists break two of the Dolch rules ────────────────────────────
+ * `wordlists.ts` holds its entries to lower case and to one word each, and the
+ * reason is stated there: a spoken spelling card cannot signal that a capital
+ * or a space is expected, so a proper noun on one is a trap. That reasoning is
+ * about the card, not about the list. Here the capital *is* the fact — Nahum
+ * is a name and not a noun — and the exercise is remembering which books there
+ * are and in what order, which is a memory-work exercise a sheet of paper does
+ * better than a microphone. Marking, when the games do take these, forgives
+ * case and collapsed spacing (`normaliseWord`), so nothing a child types is
+ * marked wrong for a capital nobody told them about.
+ *
+ * ── The house rules for a clue, and two this file adds ──────────────────────
+ * Everything `wordlists.ts` says about a sentence holds: one `_`, the word
+ * never printed beside its own gap, short enough to read out on a clock, and
+ * no sentence used twice anywhere in the build. Two more, because these lists
+ * make factual claims where Dolch's make none:
+ *
+ *   1. **A word belongs to exactly one shipped list.** `shippedClue` indexes
+ *      every sentence this build ships by its word, so a word in two lists
+ *      would have two clues and a crossword would print whichever was
+ *      registered last. Which is why Ruth, Esther, Daniel, Jonah, Joshua and
+ *      Job are books here and not also people: the book is named after the
+ *      person, so one entry carries both and its sentence is written to be
+ *      true of each.
+ *   2. **Nothing that is a matter of dispute between traditions.** Every claim
+ *      below is one the text states and the churches agree on — Noah built a
+ *      boat, Amos kept sheep, Obadiah is the shortest book in the Old
+ *      Testament. What baptism accomplishes, what happens at communion, how
+ *      the days of Genesis 1 are counted: all real questions, none of them a
+ *      thing to hand a seven-year-old as a definition to memorise. The
+ *      vocabulary list is short for exactly that reason, and it is the right
+ *      trade — a definition a child learns and later finds was one side of an
+ *      argument teaches them to distrust the sheet.
+ */
+import type { WordList } from "./wordlists";
+
+/**
+ * The books, in order, with the five groupings memory work actually uses.
+ *
+ * The comment headings below are the divisions every "books of the Bible" song
+ * and wall chart uses — Law, History, Poetry, Major and Minor Prophets — and
+ * they are comments rather than data because a division is how the list is
+ * *taught*, not what it is. A child recites sixty-six names in one run; a
+ * parent chunks them into five. Splitting the list into five shipped lists
+ * would make the recitation impossible to practise, which is the exercise.
+ */
+export const BIBLE_LISTS: WordList[] = [
+  {
+    id: "bible-books-ot",
+    name: "Books of the Old Testament",
+    group: "Memory work",
+    blurb:
+      "Genesis to Malachi, in order — the thirty-nine books of the Protestant Old Testament.",
+    emoji: "📜",
+    entries: [
+      /* ── The Law ─────────────────────────────────────────────────────── */
+      { word: "Genesis", clue: "_ is the first book of the Bible." },
+      { word: "Exodus", clue: "_ tells how Israel left Egypt." },
+      { word: "Leviticus", clue: "_ gives the laws for the priests." },
+      { word: "Numbers", clue: "_ counts the tribes in the desert." },
+      { word: "Deuteronomy", clue: "In _, Moses speaks one last time." },
+
+      /* ── History ─────────────────────────────────────────────────────── */
+      { word: "Joshua", clue: "_ led Israel into the promised land." },
+      { word: "Judges", clue: "_ tells about Gideon and Samson." },
+      { word: "Ruth", clue: "_ gleaned in the fields of Boaz." },
+      // The clue goes round the front of a numbered book rather than starting
+      // with it: "1 Samuel" fills two slots of the eight a sentence may run to.
+      { word: "1 Samuel", clue: "Saul is made king in _." },
+      { word: "2 Samuel", clue: "David reigns as king in _." },
+      { word: "1 Kings", clue: "Solomon builds the temple in _." },
+      { word: "2 Kings", clue: "Elijah goes up to heaven in _." },
+      { word: "1 Chronicles", clue: "David's line is listed in _." },
+      { word: "2 Chronicles", clue: "The kings of Judah fill _." },
+      { word: "Ezra", clue: "_ led exiles home from Babylon." },
+      { word: "Nehemiah", clue: "_ rebuilt the wall of Jerusalem." },
+      { word: "Esther", clue: "_ became queen and saved her people." },
+
+      /* ── Poetry and wisdom ───────────────────────────────────────────── */
+      { word: "Job", clue: "_ lost everything and kept trusting God." },
+      { word: "Psalms", clue: "_ is the songbook of the Bible." },
+      { word: "Proverbs", clue: "_ is full of short wise sayings." },
+      { word: "Ecclesiastes", clue: "There is a time for everything in _." },
+      { word: "Song of Solomon", clue: "_ is a poem about love." },
+
+      /* ── The major prophets ──────────────────────────────────────────── */
+      { word: "Isaiah", clue: "_ promised a child would be born." },
+      { word: "Jeremiah", clue: "_ warned Jerusalem before it fell." },
+      { word: "Lamentations", clue: "_ is a sad song for Jerusalem." },
+      { word: "Ezekiel", clue: "_ saw a valley of dry bones." },
+      { word: "Daniel", clue: "_ was thrown to the lions." },
+
+      /* ── The minor prophets ──────────────────────────────────────────── */
+      { word: "Hosea", clue: "_ is first of the twelve minor prophets." },
+      { word: "Joel", clue: "_ wrote about locusts eating the crops." },
+      { word: "Amos", clue: "_ was a shepherd who spoke for God." },
+      { word: "Obadiah", clue: "_ is the shortest Old Testament book." },
+      { word: "Jonah", clue: "_ was swallowed by a great fish." },
+      { word: "Micah", clue: "_ said the king would come from Bethlehem." },
+      { word: "Nahum", clue: "_ warned Nineveh a second time." },
+      { word: "Habakkuk", clue: "_ asked God why the wicked win." },
+      { word: "Zephaniah", clue: "_ wrote about a coming day of judgement." },
+      { word: "Haggai", clue: "_ told the people to rebuild the temple." },
+      { word: "Zechariah", clue: "_ saw visions of a coming king." },
+      { word: "Malachi", clue: "_ ends the Old Testament." },
+    ],
+  },
+  {
+    id: "bible-books-nt",
+    name: "Books of the New Testament",
+    group: "Memory work",
+    blurb:
+      "Matthew to Revelation, in order — the Gospels, Acts, the letters, and one book of visions.",
+    emoji: "📖",
+    entries: [
+      /* ── The Gospels, and what happened next ─────────────────────────── */
+      { word: "Matthew", clue: "_ opens the New Testament." },
+      { word: "Mark", clue: "_ is the shortest of the four Gospels." },
+      { word: "Luke", clue: "_ was a doctor who wrote carefully." },
+      { word: "John", clue: "_ was written so people would believe." },
+      { word: "Acts", clue: "_ tells what the apostles did next." },
+
+      /* ── The letters Paul wrote ──────────────────────────────────────── */
+      { word: "Romans", clue: "_ is the longest letter Paul wrote." },
+      { word: "1 Corinthians", clue: "The chapter about love is in _." },
+      { word: "2 Corinthians", clue: "God loves a cheerful giver, says _." },
+      { word: "Galatians", clue: "The fruit of the Spirit is in _." },
+      { word: "Ephesians", clue: "The armour of God is in _." },
+      { word: "Philippians", clue: "Paul wrote _ from a prison cell." },
+      { word: "Colossians", clue: "_ says Christ is over everything." },
+      { word: "1 Thessalonians", clue: "Pray without ceasing comes from _." },
+      { word: "2 Thessalonians", clue: "_ tells the lazy to work." },
+      { word: "1 Timothy", clue: "Paul wrote _ to a young pastor." },
+      { word: "2 Timothy", clue: "Every Scripture is God-breathed, says _." },
+      { word: "Titus", clue: "Paul left _ on the island of Crete." },
+      { word: "Philemon", clue: "_ asks mercy for a runaway servant." },
+
+      /* ── The letters everyone else wrote, and the visions ─────────────── */
+      { word: "Hebrews", clue: "_ says Jesus is the better priest." },
+      { word: "James", clue: "_ says faith without works is dead." },
+      { word: "1 Peter", clue: "Cast your worries on him, says _." },
+      { word: "2 Peter", clue: "The Lord is patient, says _." },
+      { word: "1 John", clue: "God is love, says _." },
+      { word: "2 John", clue: "_ is written to a chosen lady." },
+      { word: "3 John", clue: "_ praises a friend called Gaius." },
+      { word: "Jude", clue: "_ warns about false teachers creeping in." },
+      { word: "Revelation", clue: "_ is the last book of the Bible." },
+    ],
+  },
+  {
+    id: "bible-people",
+    name: "People in the Bible",
+    group: "Names to know",
+    blurb: "Adam to Lydia — the names a child meets first, and one fact each.",
+    emoji: "👥",
+    // Names only, and never one that is also a book: see rule 1 in the header.
+    // The Bible reuses its names — there are three Marys at the cross and two
+    // Josephs in the Christmas story — so each sentence names the one meant.
+    entries: [
+      { word: "Adam", clue: "God made _ from the dust." },
+      { word: "Eve", clue: "_ was the first woman." },
+      { word: "Noah", clue: "_ built a boat before the flood." },
+      { word: "Abraham", clue: "God promised _ a great family." },
+      { word: "Sarah", clue: "_ laughed when she heard the news." },
+      { word: "Isaac", clue: "_ was the son God promised." },
+      { word: "Jacob", clue: "_ had twelve sons." },
+      { word: "Joseph", clue: "_ was sold by his brothers." },
+      { word: "Moses", clue: "_ was found in a basket." },
+      { word: "Aaron", clue: "_ was the first high priest." },
+      { word: "Miriam", clue: "_ sang after crossing the sea." },
+      { word: "Rahab", clue: "_ hid the spies in Jericho." },
+      { word: "Deborah", clue: "_ judged Israel under a palm tree." },
+      { word: "Gideon", clue: "_ won with three hundred men." },
+      { word: "Samson", clue: "_ was the strongest man." },
+      { word: "Naomi", clue: "_ went home to Bethlehem with Ruth." },
+      { word: "Hannah", clue: "_ prayed for a son." },
+      { word: "Samuel", clue: "_ heard God call at night." },
+      { word: "Saul", clue: "_ was the first king of Israel." },
+      { word: "David", clue: "_ killed a giant with a sling." },
+      { word: "Goliath", clue: "_ was the giant from Gath." },
+      { word: "Solomon", clue: "_ asked God for wisdom." },
+      { word: "Elijah", clue: "_ was fed by ravens." },
+      { word: "Elisha", clue: "_ took over from Elijah." },
+      { word: "Mary", clue: "_ was the mother of Jesus." },
+      { word: "Elizabeth", clue: "_ was the mother of John the Baptist." },
+      { word: "Jesus", clue: "_ was born in Bethlehem." },
+      { word: "Peter", clue: "_ walked on the water." },
+      { word: "Andrew", clue: "_ was the brother of Peter." },
+      { word: "Thomas", clue: "_ wanted to see for himself." },
+      { word: "Nicodemus", clue: "_ came to Jesus at night." },
+      { word: "Martha", clue: "_ was busy while Mary listened." },
+      { word: "Lazarus", clue: "_ came out of the tomb." },
+      { word: "Zacchaeus", clue: "_ climbed a tree to see." },
+      { word: "Paul", clue: "_ was blinded on the Damascus road." },
+      { word: "Barnabas", clue: "_ travelled with Paul." },
+      { word: "Timothy", clue: "_ was taught by his grandmother." },
+      { word: "Lydia", clue: "_ sold purple cloth." },
+    ],
+  },
+  {
+    id: "bible-places",
+    name: "Places in the Bible",
+    group: "Names to know",
+    blurb: "Eden to Rome — where the story happens, in the order it happens.",
+    emoji: "🗺️",
+    entries: [
+      { word: "Eden", clue: "God planted a garden in _." },
+      { word: "Ararat", clue: "The ark came to rest on _." },
+      { word: "Ur", clue: "Abraham left the city of _." },
+      { word: "Canaan", clue: "The promised land was called _." },
+      { word: "Egypt", clue: "Joseph was taken down to _." },
+      { word: "Sinai", clue: "The commandments were given at _." },
+      { word: "Jericho", clue: "The walls fell down at _." },
+      { word: "Bethlehem", clue: "David and Jesus were both born in _." },
+      { word: "Jerusalem", clue: "David made _ his capital city." },
+      { word: "Zion", clue: "Another name for Jerusalem is _." },
+      { word: "Babylon", clue: "Daniel was carried away to _." },
+      { word: "Nineveh", clue: "Jonah did not want to go to _." },
+      { word: "Nazareth", clue: "Jesus grew up in _." },
+      { word: "Galilee", clue: "Jesus called fishermen beside the sea of _." },
+      { word: "Capernaum", clue: "Jesus made his home in _." },
+      { word: "Jordan", clue: "Jesus was baptised in the river _." },
+      { word: "Samaria", clue: "The woman at the well came from _." },
+      { word: "Bethany", clue: "Lazarus and Martha lived in _." },
+      { word: "Gethsemane", clue: "Jesus prayed in the garden of _." },
+      { word: "Damascus", clue: "Paul saw a bright light near _." },
+      { word: "Antioch", clue: "Believers were first called Christians at _." },
+      { word: "Corinth", clue: "Paul wrote two letters to _." },
+      { word: "Ephesus", clue: "Paul stayed two years at _." },
+      { word: "Athens", clue: "Paul preached about the unknown god in _." },
+      { word: "Rome", clue: "Paul was kept under guard in _." },
+      { word: "Patmos", clue: "John saw his visions on _." },
+    ],
+  },
+  {
+    id: "bible-words",
+    name: "Bible words",
+    group: "Words to know",
+    blurb:
+      "Covenant, parable, disciple — the words the stories are told in, each with what it means.",
+    emoji: "🕊️",
+    // The one list here a spelling card could take as it stands: ordinary
+    // lower-case words, one each, and a sentence that is a definition rather
+    // than a context. Nothing on it is disputed between traditions — see rule 2
+    // in the header for what that leaves out and why.
+    entries: [
+      { word: "covenant", clue: "A promise God makes is a _." },
+      { word: "disciple", clue: "A follower who learns is a _." },
+      { word: "apostle", clue: "An _ was sent out with the news." },
+      { word: "gospel", clue: "The good news about Jesus is the _." },
+      { word: "parable", clue: "A short story that teaches is a _." },
+      { word: "psalm", clue: "A song sung to God is a _." },
+      { word: "proverb", clue: "A short wise saying is a _." },
+      { word: "prophet", clue: "A _ spoke God's messages to people." },
+      { word: "temple", clue: "God's house in Jerusalem was the _." },
+      { word: "tabernacle", clue: "The tent they carried was the _." },
+      { word: "altar", clue: "Offerings were laid on the _." },
+      { word: "sacrifice", clue: "Something given up for God is a _." },
+      { word: "priest", clue: "A _ offered gifts for the people." },
+      { word: "angel", clue: "A messenger from heaven is an _." },
+      { word: "ark", clue: "Noah built a great wooden _." },
+      { word: "manger", clue: "Jesus was laid in a _." },
+      { word: "shepherd", clue: "A _ looks after the sheep." },
+      { word: "miracle", clue: "Something only God could do is a _." },
+      { word: "faith", clue: "Trusting what you cannot see is _." },
+      { word: "grace", clue: "A kindness nobody has earned is _." },
+      { word: "mercy", clue: "Not being punished as you deserve is _." },
+      { word: "forgive", clue: "To let a wrong go is to _." },
+      { word: "repent", clue: "To turn away from wrong is to _." },
+      { word: "worship", clue: "Giving God honour and praise is _." },
+      { word: "praise", clue: "Saying how great God is means _." },
+      { word: "prayer", clue: "Talking with God is called _." },
+      { word: "blessing", clue: "A good gift from God is a _." },
+      { word: "holy", clue: "Set apart for God means _." },
+      { word: "commandment", clue: "A rule God gave is a _." },
+      { word: "scripture", clue: "Words written in the Bible are _." },
+      { word: "salvation", clue: "Being rescued from sin is _." },
+      { word: "resurrection", clue: "Coming back to life is the _." },
+      { word: "exile", clue: "Being taken far from home is _." },
+      { word: "idol", clue: "A statue people worship is an _." },
+      { word: "sin", clue: "Going against what God says is _." },
+      { word: "testament", clue: "Each half of the Bible is a _." },
+      { word: "amen", clue: "Saying _ means let it be so." },
+    ],
+  },
+];

--- a/src/engine/decks/wordlists.ts
+++ b/src/engine/decks/wordlists.ts
@@ -60,6 +60,8 @@
  * `wordlists.test.ts` enforces the mechanical half of that list.
  */
 
+import { BIBLE_LISTS } from "./biblelists";
+
 export type WordEntry = {
   word: string;
   /**
@@ -74,7 +76,10 @@ export type WordEntry = {
 export type WordList = {
   id: string;
   name: string;
-  /** Who it's for, in the terms a parent will pick by. */
+  /**
+   * Who it's for, in the terms a parent will pick by — an age band on a graded
+   * list, and what the list is for on one that isn't graded ("Memory work").
+   */
   group: string;
   blurb: string;
   emoji: string;
@@ -460,7 +465,29 @@ export const WORD_LISTS: WordList[] = [
   },
 ];
 
-export const WORD_LISTS_BY_ID = new Map(WORD_LISTS.map((l) => [l.id, l]));
+/**
+ * Every list this build ships, whatever it teaches.
+ *
+ * `WORD_LISTS` is the graded sight-word set and stays that: the typing pools,
+ * the age lookup below and the spelling shelf all mean *Dolch* when they say
+ * word list, and a Bible book in a "common words" typing level would be a
+ * proper noun in a pool of the hundred commonest words. What every list has in
+ * common is the machinery — one picker, one id space, one sentence per word —
+ * and that is what this is for. The Bible lists are `biblelists.ts`, one source
+ * among several (docs/printables.md §12).
+ */
+export const SHIPPED_LISTS: WordList[] = [...WORD_LISTS, ...BIBLE_LISTS];
+
+/**
+ * By id, across every shipped list.
+ *
+ * The id is what a saved session, a saved sheet and a shared link all carry, so
+ * this is the lookup that decides whether a list is one of ours or one a parent
+ * typed in (`services/decks.ts`). Built from the whole shelf rather than from
+ * Dolch alone: a run saved on a books-of-the-Bible list has to be able to name
+ * itself in the record book.
+ */
+export const WORD_LISTS_BY_ID = new Map(SHIPPED_LISTS.map((l) => [l.id, l]));
 
 /** The list a child of this age is most likely to be working on. */
 export function wordListForAge(age: number): WordList {

--- a/src/engine/decks/words.ts
+++ b/src/engine/decks/words.ts
@@ -1,7 +1,7 @@
 import type { Card, WordConfig } from "@/engine/types";
 
 import { mulberry32, shuffled } from "@/engine/random";
-import { WORD_LISTS, WORD_LISTS_BY_ID } from "./wordlists";
+import { SHIPPED_LISTS, WORD_LISTS_BY_ID } from "./wordlists";
 import type { DeckSpec } from "./spec";
 
 /**
@@ -128,9 +128,15 @@ export function clueParts(clue: string): [string, string] {
  *
  * Normalised on the way in and on the way out, so a list typed in capitals
  * still finds its sentence. A few hundred entries, built once at load.
+ *
+ * Across every shipped list rather than the graded ones, for the same reason:
+ * a parent who pasted the books of the Bible into the box gets the sentences
+ * `biblelists.ts` wrote for them. No word is in two shipped lists — the rule is
+ * that file's, and `biblelists.test.ts` holds the whole shelf to it — so this
+ * map has one sentence per word rather than whichever list was registered last.
  */
 const SHIPPED_CLUES = new Map<string, string>(
-  WORD_LISTS.flatMap((list) =>
+  SHIPPED_LISTS.flatMap((list) =>
     list.entries.map((entry): [string, string] => [
       normaliseWord(entry.word),
       entry.clue,

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -276,8 +276,15 @@ export type Problem = {
  *
  * Punctuation counts as `small`. An apostrophe is not a letter with a body, and
  * a box drawn for it at any other height would be a shape a child cannot match.
+ *
+ * A space is `gap`, and it is the one that is not a box at all. Every other
+ * value is something a child writes into the box drawn for it — a letter, a
+ * numeral, an apostrophe — and a space is nothing to write, so `1 Samuel` with
+ * a box over its space would be asking for a ninth letter that does not exist.
+ * The slot is still counted, because the boxes either side of a space have to
+ * land where they would have anyway; only the rectangle goes.
  */
-export type LetterShape = "tall" | "small" | "tail";
+export type LetterShape = "tall" | "small" | "tail" | "gap";
 
 /**
  * One word as a row of boxes, plus the word those boxes were drawn from.

--- a/src/engine/sheets/words/shapes.ts
+++ b/src/engine/sheets/words/shapes.ts
@@ -41,6 +41,11 @@ const TAIL = new Set([..."gjpqy"]);
 export function letterShape(letter: string): LetterShape {
   if (TAIL.has(letter)) return "tail";
   if (TALL.has(letter)) return "tall";
+  // A space is not a band, it is the absence of one: a box is a thing a child
+  // writes a letter into, and a two-word entry like "1 Samuel" or "Song of
+  // Solomon" would otherwise print boxes nothing can go in. The slot is still
+  // counted so the boxes either side keep their positions — see `LetterShape`.
+  if (/\s/.test(letter)) return "gap";
   // A capital or a numeral is drawn from the top line to the baseline, which is
   // the tall box — and `letter.toLowerCase() !== letter` is the whole test,
   // rather than a range, so an accented capital is not read as a small letter.
@@ -48,7 +53,7 @@ export function letterShape(letter: string): LetterShape {
   return "small";
 }
 
-/** One word, box by box. Punctuation and spaces count as small — see `LetterShape`. */
+/** One word, box by box. Punctuation counts as small, a space as a gap. */
 export const wordShape = (word: string): WordShape => ({
   word,
   letters: [...word].map(letterShape),
@@ -90,7 +95,14 @@ export const SHAPE_BOX_EMS = 1.3;
 /** The air between one box and the next, in ems. */
 export const SHAPE_BOX_GAP_EMS = 0.1;
 
-/** The top and the bottom of one letter's box, as shares of the row. */
+/**
+ * The top and the bottom of one letter's box, as shares of the row.
+ *
+ * `gap` has no box, so it has no band. It answers with the body one anyway
+ * rather than throwing or widening the return type: the caller that meets a
+ * gap skips drawing before it ever asks, and a total function here is what
+ * keeps that the renderer's one decision instead of two.
+ */
 export function shapeBand(shape: LetterShape): { top: number; bottom: number } {
   if (shape === "tall")
     return { top: BANDS.ascender.top, bottom: BANDS.body.bottom };

--- a/src/engine/sheets/words/spelling.test.ts
+++ b/src/engine/sheets/words/spelling.test.ts
@@ -277,6 +277,24 @@ describe("word shapes", () => {
     expect(letterShape("'")).toBe("small");
   });
 
+  it("draws no box where a space is", () => {
+    // A box is a thing a child writes a letter into, and a space is nothing to
+    // write — so a two-word entry keeps the slot and loses the rectangle,
+    // which is what makes "1 Samuel" read as two words on the paper.
+    expect(letterShape(" ")).toBe("gap");
+    const [samuel] = shapesOf({ words: ["1 Samuel"], count: 1 });
+    expect(samuel.letters).toEqual([
+      "tall",
+      "gap",
+      "tall",
+      "small",
+      "small",
+      "small",
+      "small",
+      "tall",
+    ]);
+  });
+
   it("gives two words the same letters the same outline", () => {
     // The exercise only works because a word has a silhouette: "bed" and "bad"
     // are the same picture, and "big" is not.

--- a/src/games/printshop/Bootstrap.tsx
+++ b/src/games/printshop/Bootstrap.tsx
@@ -18,7 +18,7 @@
 import { useEffect, useState } from "react";
 
 import { Button, Field, Select } from "@/components/ui/kit";
-import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
+import { SHIPPED_LISTS, listWords } from "@/engine/decks/wordlists";
 import { PRACTICE_SEED, wordsSheet } from "@/engine/sheets/practice";
 import type { SheetConfig } from "@/engine/sheets/types";
 import type { CustomDeck } from "@/engine/types";
@@ -61,6 +61,12 @@ type Listed = { id: string; label: string; words: string[] };
  * and are always there, which is the reason this step no longer disappears: the
  * Dolch lists exist whether or not a browser has storage, so the only thing
  * IndexedDB decides is whether a parent's own lists join them.
+ *
+ * Every shipped list, which since PRINT23 means the books of the Bible, the
+ * names, the places and the Bible words as well as Dolch — one control with all
+ * of them in it, exactly as the passage picker has Scripture and the Gettysburg
+ * Address in one list (§12). A parent picking this week's words is not choosing
+ * a subject; they are choosing a list.
  */
 function FromWordList({ onOpen }: { onOpen: Open }) {
   const [decks, setDecks] = useState<CustomDeck[]>([]);
@@ -81,7 +87,7 @@ function FromWordList({ onOpen }: { onOpen: Open }) {
   }, []);
 
   const lists: Listed[] = [
-    ...WORD_LISTS.map((list) => ({
+    ...SHIPPED_LISTS.map((list) => ({
       id: list.id,
       label: `${list.emoji} ${list.name} — ${list.group}`,
       words: listWords(list),

--- a/src/services/analytics.test.ts
+++ b/src/services/analytics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { beaconUrl, deckLabel } from "./analytics";
-import { WORD_LISTS } from "@/engine/decks/wordlists";
+import { SHIPPED_LISTS } from "@/engine/decks/wordlists";
 import { wordMode } from "@/engine/decks/words";
 
 /**
@@ -16,7 +16,9 @@ describe("what a beacon is allowed to say", () => {
   it("names a shipped deck, because a shipped deck is a public list", () => {
     // Knowing that someone practised "dolch-1" says something about the site,
     // not about them: everyone who picks that list produces the same string.
-    for (const list of WORD_LISTS) {
+    // The whole shelf, not Dolch alone — a Bible list is just as public, and
+    // reporting one as "custom" is the mistake this file exists to prevent.
+    for (const list of SHIPPED_LISTS) {
       expect(deckLabel(wordMode(list.id))).toBe(`words:${list.id}`);
     }
     for (const op of ["add", "subtract", "multiply", "divide"]) {

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -40,7 +40,7 @@
 
 import { OPERATION_ORDER } from "@/engine/decks/flashcards";
 import { TYPING_LEVELS, typingMode } from "@/engine/decks/typing";
-import { WORD_LISTS } from "@/engine/decks/wordlists";
+import { SHIPPED_LISTS } from "@/engine/decks/wordlists";
 import { wordMode } from "@/engine/decks/words";
 
 /** Where the beacon lands. Excluded from the service worker — see `public/sw.js`. */
@@ -85,10 +85,16 @@ export type Beacon =
  * written: it listed the six graded Dolch lists and not the nouns list, so a
  * real shipped deck was being reported as somebody's private one. A list that
  * has to be kept in step with another list won't be.
+ *
+ * `SHIPPED_LISTS` and not `WORD_LISTS`, for the same reason: `WORD_LISTS` is
+ * Dolch alone — the typing pools, the age lookup and the spelling shelf all
+ * legitimately mean that — while the shelf a child can actually pick from is
+ * the whole of it, Bible lists included. Reading the narrower one here would
+ * log a public list as somebody's private one all over again.
  */
 const SHIPPED: ReadonlySet<string> = new Set<string>([
   ...OPERATION_ORDER,
-  ...WORD_LISTS.map((list) => wordMode(list.id)),
+  ...SHIPPED_LISTS.map((list) => wordMode(list.id)),
   ...TYPING_LEVELS.map((level) => typingMode(level.id)),
 ]);
 


### PR DESCRIPTION
Closes #67.

## What

Five shipped word lists for memory work — the books of the Old Testament and the New Testament in order, key names, key places, and the vocabulary the stories are told in — authored once in `src/engine/decks/biblelists.ts` as ordinary `WordList`s.

That last part is the whole design. A Bible list is not a new kind of thing: it is picked from the same control as Dolch, printed by the same seven spelling styles and three puzzles from PRINT20/PRINT21, resolved through the same id map, and already deals as a deck for when Word Jungle takes them in PRINT31. A second kind of list would have meant a second picker, a second sanitiser, and a second answer to what a word is.

## Why it is split from `WORD_LISTS`

`WORD_LISTS` stays Dolch alone, because the typing pools, the age lookup and the spelling shelf all legitimately mean *Dolch* when they say word list — a book of the Bible in a "hundred commonest words" typing level would be a proper noun in the wrong pool. The new `SHIPPED_LISTS` is the whole shelf, and it is what the id map, the clue map and the analytics allowlist read.

## Getting the canon right

The risk here is not the code, it is that a child memorises whatever is on the sheet. So the book names and their order are pinned from two directions rather than trusted: they come from eBible's USFM release of the WEBu — the same release `passages/scripture.ts` already quotes — and `biblelists.test.ts` holds them to a second copy of that order name for name. Separately, every book the passage library already references must be spelt the same way here (48 of the 66, counted off `ScriptureEntry.ref` rather than remembered, and asserted as a floor).

Review corrections in the second commit, all of them things a child would have memorised wrong: Nahum announces Nineveh's fall rather than warning it twice; Paul's three years at Ephesus is Acts 20:31, the two years being the length of the teaching in the hall of Tyrannus; Timothy's faith is Lois *and* Eunice's; Martha is busy with the serving. The places list now actually runs Eden to Rome in the order it happens, with Nineveh before Babylon and Athens before Corinth before Ephesus per Acts 17-19.

## Two fixes to the machinery, not the lists

- **`services/analytics.ts`** built its shipped-deck set from `WORD_LISTS`, so the moment these lists reached the picker a public list would have been logged as a household's private one — the exact mistake the doc comment above it records having already made once with the nouns list. It reads the whole shelf now.
- **Word shapes** drew a box per character including spaces, so `1 Samuel` asked a child to write a letter into the gap between the words. A space is now a `gap` in `LetterShape`: the slot is still counted so the boxes either side do not move, but no rectangle is drawn.

`docs/printables.md` §12 promised catechism vocabulary; the code declines it, so §12 now says why rather than losing the reasoning.

## Validation

`type-check`, `lint`, `test:unit` (1146 passing), `build` (static, 141 pages) and the browser smoke test all pass locally.
