### PR TITLE
PRINT24: the sounds we've covered, and nothing past them

### DIFF
--- a/src/engine/sheets/phonics/bank.ts
+++ b/src/engine/sheets/phonics/bank.ts
@@ -219,7 +219,10 @@ const SHORT_U: Word[] = [
 /* ── Two letters, one sound ───────────────────────────────────────────────
    The doubles at the end of a short word, and `ck` — a child who has been
    taught `k` has not been taught `duck`, which is why the doubles are their
-   own tick boxes rather than a spelling rule applied quietly.               */
+   own tick boxes rather than a spelling rule applied quietly. The same two
+   letters land in the middle of a longer word for the same reason (`rabbit`
+   keeps its vowel short), so those live here too rather than in a group of
+   their own.                                                                */
 
 const DOUBLED: Word[] = [
   w("duck", "d u ck"),
@@ -251,6 +254,7 @@ const DOUBLED: Word[] = [
   w("buzz", "b u zz"),
   w("fizz", "f i zz"),
   w("egg", "e gg"),
+  w("rabbit", "r a bb i t"),
 ];
 
 /* ── The consonant digraphs ───────────────────────────────────────────────
@@ -574,14 +578,19 @@ const VOWEL_TEAMS: Word[] = [
   w("mouth", "m ou th"),
   w("shout", "sh ou t"),
   w("house", "h ou s e:-"),
-  w("cow", "c ow"),
-  w("how", "h ow"),
-  w("now", "n ow"),
-  w("down", "d ow n"),
-  w("town", "t ow n"),
-  w("brown", "b r ow n"),
-  w("clown", "c l ow n"),
-  w("crown", "c r ow n"),
+  // Both sounds of `ow` are written out in full, here and in the `snow` group
+  // above. The bare shorthand would resolve to whichever row `sounds.ts` lists
+  // first — and `ow` is the one grapheme in the table whose two sounds are both
+  // ordinary, so there is no "commonest" to lean on and no reading of `c ow`
+  // that isn't a guess about the table's order.
+  w("cow", "c ow:ow"),
+  w("how", "h ow:ow"),
+  w("now", "n ow:ow"),
+  w("down", "d ow:ow n"),
+  w("town", "t ow:ow n"),
+  w("brown", "b r ow:ow n"),
+  w("clown", "c l ow:ow n"),
+  w("crown", "c r ow:ow n"),
   w("coin", "c oi n"),
   w("join", "j oi n"),
   w("point", "p oi n t"),
@@ -614,6 +623,11 @@ const VOWEL_TEAMS: Word[] = [
   w("funny", "f u nn y:ee"),
   w("puppy", "p u pp y:ee"),
   w("silly", "s i ll y:ee"),
+  // The doubled `r`, and the one place it can be put without picking an
+  // accent: the vowel of `bed` before it is the same on both sides, where
+  // `sorry` and `carry` are the vowel of `dog` or of `cat` in one place and
+  // something else in the other. See the note at the top of this file.
+  w("cherry", "ch e rr y:ee"),
   w("baby", "b a:ai b y:ee"),
   w("paper", "p a:ai p er"),
   w("hello", "h e ll o:oa"),
@@ -706,9 +720,10 @@ const R_VOWELS: Word[] = [
 ];
 
 /* ── The letters that hide ────────────────────────────────────────────────
-   `kn`, `wr`, `mb`, and the endings that only ever come after a short vowel.
-   All of them are spellings with a rule behind them, so all of them are
-   tickable — the words that follow no rule at all are the next group down.  */
+   `kn`, `gn`, `wr`, `mb`, and the endings that only ever come after a short
+   vowel. All of them are spellings with a rule behind them, so all of them
+   are tickable — the words that follow no rule at all are the next group
+   down.                                                                     */
 
 const QUIET_LETTERS: Word[] = [
   w("knee", "kn ee"),
@@ -716,6 +731,7 @@ const QUIET_LETTERS: Word[] = [
   w("knit", "kn i t"),
   w("knock", "kn o ck"),
   w("knife", "kn i_e f"),
+  w("gnat", "gn a t"),
   w("write", "wr i_e t"),
   w("wrong", "wr o ng"),
   w("wrap", "wr a p"),
@@ -811,7 +827,7 @@ const TRICKY: Word[] = [
   w("two", "t w:- o:oo"),
   w("to", "t o:oo"),
   w("do", "d o:oo"),
-  w("who", "wh o:oo"),
+  w("who", "wh:h o:oo"),
   w("love", "l o:u v e:-"),
   w("come", "c o:u m e:-"),
   w("some", "s o:u m e:-"),

--- a/src/engine/sheets/phonics/bank.ts
+++ b/src/engine/sheets/phonics/bank.ts
@@ -1,0 +1,895 @@
+/**
+ * The words phonics may put on a page, each one cut into the spellings it is
+ * actually made of.
+ *
+ * Hand-segmented, for the reason `words/bank.ts` gives for hand-authoring its
+ * answers and then some: **there is no algorithm that cuts an English word into
+ * graphemes.** `ea` is one spelling in `bread` and two in `react`; the `e` of
+ * `cake` belongs to the `a` four letters earlier; `think` has no /n/ in it. A
+ * generator reaching for a rule would decide that `duck` needs `c` and `k`
+ * separately and hand it to a child who has been taught neither — which is the
+ * exact failure the sound inventory exists to prevent, arriving through the
+ * back door.
+ *
+ * So every word below was cut by hand, and `phonics.test.ts` puts the pieces
+ * back together and checks they spell the word again. That test is what makes
+ * the constraint trustworthy: a mis-cut word is a word that gets offered to the
+ * wrong child, and it is invisible in a diff.
+ *
+ * ── Words that are not here, on purpose ────────────────────────────────────
+ *
+ * A sheet is printed on both sides of the Atlantic, and a word whose sounds
+ * depend on the reader's accent cannot be put on a sound-matching line without
+ * marking somebody's child wrong. Those words are excluded here rather than
+ * guarded against later:
+ *
+ *   - **The `bath` set.** `bath`, `grass`, `class`, `ask`, `after`, `last`,
+ *     `can't`, `half`, `path` — `/a/` in America, `/ah/` in southern England.
+ *     There is no cut that is true in both places.
+ *   - **`with`.** Ends in the sound of `thin` for most Americans and the sound
+ *     of `this` in England, and those are two different tick boxes.
+ *   - **`new`, `tune`, `duke`, `stew`.** After `t`, `d` and `n` the `y` of
+ *     `few` is said in England and dropped in most of America. `few`, `cube`
+ *     and `cute` keep it everywhere, so those are the ones here.
+ *   - **`was` and `water`.** The `a` after a `w` is a different vowel in the
+ *     two places — `was` has the vowel of `cup` for many Americans and of `dog`
+ *     in England, and `water` has the vowel of `saw` in England. `want`,
+ *     `wash` and `watch`, which agree, are here.
+ *
+ * Words whose *vowel* differs while its identity doesn't — everything using
+ * `/o/`, `/aw/` or an r-coloured vowel — are fine and are here, because both
+ * varieties agree about which words share a vowel. `variesByAccent` names them
+ * for the one sheet style that has to care: hearing two sounds apart.
+ */
+import { CORRESPONDENCE_BY_ID, PHONEME_BY_ID, spellingId } from "./sounds";
+
+export type Word = {
+  /** As it is printed. Lower case; a sheet decides its own capitals. */
+  word: string;
+  /**
+   * The spellings it is made of, in reading order, as correspondence ids.
+   * `cake` is `["c:k", "a_e:ai", "k:k"]` — the split vowel owns the final `e`.
+   */
+  parts: string[];
+};
+
+/**
+ * One word, written the way it is read: the spellings, spaced apart.
+ *
+ * A bare grapheme means its commonest sound, so `c a t` is exactly what it
+ * looks like and only the surprises are spelled out — `b r ea:e d` is `bread`,
+ * and the `ea:e` is the whole reason the word is worth having. See
+ * `spellingId` for what a part that names nothing does, which is fail a test
+ * rather than print.
+ */
+const w = (word: string, spelling: string): Word => ({
+  word,
+  parts: spelling.split(" ").map(spellingId),
+});
+
+/* ── The short vowels, three sounds at a time ─────────────────────────────
+   Where every programme starts and where most of a first year is spent. The
+   order inside each vowel is roughly the order the letters are taught in, so
+   a parent who has ticked six letters gets the words at the top of the list
+   rather than a scattering from the bottom.                                */
+
+const SHORT_A: Word[] = [
+  w("at", "a t"),
+  w("sat", "s a t"),
+  w("pat", "p a t"),
+  w("cat", "c a t"),
+  w("hat", "h a t"),
+  w("mat", "m a t"),
+  w("bat", "b a t"),
+  w("rat", "r a t"),
+  w("fat", "f a t"),
+  w("an", "a n"),
+  w("man", "m a n"),
+  w("can", "c a n"),
+  w("pan", "p a n"),
+  w("ran", "r a n"),
+  w("fan", "f a n"),
+  w("van", "v a n"),
+  w("tap", "t a p"),
+  w("map", "m a p"),
+  w("cap", "c a p"),
+  w("lap", "l a p"),
+  w("gap", "g a p"),
+  w("nap", "n a p"),
+  w("bag", "b a g"),
+  w("tag", "t a g"),
+  w("rag", "r a g"),
+  w("wag", "w a g"),
+  w("bad", "b a d"),
+  w("sad", "s a d"),
+  w("mad", "m a d"),
+  w("pad", "p a d"),
+  w("ham", "h a m"),
+  w("jam", "j a m"),
+  w("ram", "r a m"),
+  w("cab", "c a b"),
+  w("lad", "l a d"),
+];
+
+const SHORT_I: Word[] = [
+  w("it", "i t"),
+  w("sit", "s i t"),
+  w("pit", "p i t"),
+  w("hit", "h i t"),
+  w("bit", "b i t"),
+  w("fit", "f i t"),
+  w("in", "i n"),
+  w("pin", "p i n"),
+  w("tin", "t i n"),
+  w("win", "w i n"),
+  w("bin", "b i n"),
+  w("fin", "f i n"),
+  w("pig", "p i g"),
+  w("big", "b i g"),
+  w("dig", "d i g"),
+  w("fig", "f i g"),
+  w("wig", "w i g"),
+  w("lid", "l i d"),
+  w("did", "d i d"),
+  w("hid", "h i d"),
+  w("kid", "k i d"),
+  w("lip", "l i p"),
+  w("tip", "t i p"),
+  w("rip", "r i p"),
+  w("dip", "d i p"),
+  w("hip", "h i p"),
+  w("zip", "z i p"),
+  w("rib", "r i b"),
+  w("six", "s i x"),
+  w("mix", "m i x"),
+  w("fix", "f i x"),
+];
+
+const SHORT_E: Word[] = [
+  w("bed", "b e d"),
+  w("red", "r e d"),
+  w("fed", "f e d"),
+  w("led", "l e d"),
+  w("ten", "t e n"),
+  w("hen", "h e n"),
+  w("pen", "p e n"),
+  w("men", "m e n"),
+  w("den", "d e n"),
+  w("net", "n e t"),
+  w("pet", "p e t"),
+  w("wet", "w e t"),
+  w("get", "g e t"),
+  w("jet", "j e t"),
+  w("let", "l e t"),
+  w("leg", "l e g"),
+  w("peg", "p e g"),
+  w("beg", "b e g"),
+  w("web", "w e b"),
+  w("yes", "y e s"),
+];
+
+const SHORT_O: Word[] = [
+  w("on", "o n"),
+  w("dog", "d o g"),
+  w("log", "l o g"),
+  w("fog", "f o g"),
+  w("hop", "h o p"),
+  w("top", "t o p"),
+  w("mop", "m o p"),
+  w("pop", "p o p"),
+  w("cot", "c o t"),
+  w("dot", "d o t"),
+  w("hot", "h o t"),
+  w("pot", "p o t"),
+  w("not", "n o t"),
+  w("rod", "r o d"),
+  w("nod", "n o d"),
+  w("job", "j o b"),
+  w("sob", "s o b"),
+  w("box", "b o x"),
+  w("fox", "f o x"),
+  w("ox", "o x"),
+];
+
+const SHORT_U: Word[] = [
+  w("up", "u p"),
+  w("us", "u s"),
+  w("bug", "b u g"),
+  w("hug", "h u g"),
+  w("mug", "m u g"),
+  w("rug", "r u g"),
+  w("jug", "j u g"),
+  w("bun", "b u n"),
+  w("fun", "f u n"),
+  w("run", "r u n"),
+  w("sun", "s u n"),
+  w("cup", "c u p"),
+  w("pup", "p u p"),
+  w("cut", "c u t"),
+  w("but", "b u t"),
+  w("hut", "h u t"),
+  w("nut", "n u t"),
+  w("mud", "m u d"),
+  w("bud", "b u d"),
+  w("tub", "t u b"),
+  w("rub", "r u b"),
+  w("cub", "c u b"),
+];
+
+/* ── Two letters, one sound ───────────────────────────────────────────────
+   The doubles at the end of a short word, and `ck` — a child who has been
+   taught `k` has not been taught `duck`, which is why the doubles are their
+   own tick boxes rather than a spelling rule applied quietly.               */
+
+const DOUBLED: Word[] = [
+  w("duck", "d u ck"),
+  w("sock", "s o ck"),
+  w("rock", "r o ck"),
+  w("lock", "l o ck"),
+  w("kick", "k i ck"),
+  w("pick", "p i ck"),
+  w("sick", "s i ck"),
+  w("back", "b a ck"),
+  w("sack", "s a ck"),
+  w("pack", "p a ck"),
+  w("neck", "n e ck"),
+  w("bell", "b e ll"),
+  w("tell", "t e ll"),
+  w("well", "w e ll"),
+  w("fell", "f e ll"),
+  w("hill", "h i ll"),
+  w("will", "w i ll"),
+  w("fill", "f i ll"),
+  w("doll", "d o ll"),
+  w("miss", "m i ss"),
+  w("kiss", "k i ss"),
+  w("mess", "m e ss"),
+  w("less", "l e ss"),
+  w("off", "o ff"),
+  w("puff", "p u ff"),
+  w("cliff", "c l i ff"),
+  w("buzz", "b u zz"),
+  w("fizz", "f i zz"),
+  w("egg", "e gg"),
+];
+
+/* ── The consonant digraphs ───────────────────────────────────────────────
+   `sh`, `ch`, `th` twice over, `ng`, `wh`, `ph` — and the `n` of `think`,
+   which is a /ng/ nobody writes down. The two `th` sets are kept apart
+   deliberately: `this` is not readable to a child who has only met `thin`.  */
+
+const DIGRAPHS: Word[] = [
+  w("ship", "sh i p"),
+  w("shop", "sh o p"),
+  w("shed", "sh e d"),
+  w("shut", "sh u t"),
+  w("shell", "sh e ll"),
+  w("fish", "f i sh"),
+  w("dish", "d i sh"),
+  w("wish", "w i sh"),
+  w("cash", "c a sh"),
+  w("dash", "d a sh"),
+  w("rush", "r u sh"),
+  w("chin", "ch i n"),
+  w("chip", "ch i p"),
+  w("chop", "ch o p"),
+  w("chat", "ch a t"),
+  w("chick", "ch i ck"),
+  w("much", "m u ch"),
+  w("such", "s u ch"),
+  w("rich", "r i ch"),
+  w("thin", "th i n"),
+  w("thick", "th i ck"),
+  w("moth", "m o th"),
+  w("this", "th:dh i s"),
+  w("that", "th:dh a t"),
+  w("then", "th:dh e n"),
+  w("them", "th:dh e m"),
+  w("king", "k i ng"),
+  w("ring", "r i ng"),
+  w("sing", "s i ng"),
+  w("wing", "w i ng"),
+  w("long", "l o ng"),
+  w("song", "s o ng"),
+  w("bang", "b a ng"),
+  w("hang", "h a ng"),
+  w("sung", "s u ng"),
+  w("think", "th i n:ng k"),
+  w("bank", "b a n:ng k"),
+  w("pink", "p i n:ng k"),
+  w("sink", "s i n:ng k"),
+  w("junk", "j u n:ng k"),
+  w("thank", "th a n:ng k"),
+  w("when", "wh e n"),
+  w("whip", "wh i p"),
+  w("which", "wh i ch"),
+  w("quit", "qu i t"),
+  w("quick", "qu i ck"),
+  w("quiz", "qu i z"),
+];
+
+/* ── Blends ───────────────────────────────────────────────────────────────
+   No new spellings at all — two consonants said one after the other, each
+   still saying its own sound. Which is exactly why they belong in the bank
+   rather than in the tick list: a child who has `s` and `t` can read `stop`,
+   and an inventory that made them tick `st` would be teaching a fiction.    */
+
+const BLENDS: Word[] = [
+  w("stop", "s t o p"),
+  w("step", "s t e p"),
+  w("spin", "s p i n"),
+  w("spot", "s p o t"),
+  w("snap", "s n a p"),
+  w("slip", "s l i p"),
+  w("slam", "s l a m"),
+  w("sled", "s l e d"),
+  w("swim", "s w i m"),
+  w("skip", "s k i p"),
+  w("flag", "f l a g"),
+  w("flat", "f l a t"),
+  w("flip", "f l i p"),
+  w("plan", "p l a n"),
+  w("plum", "p l u m"),
+  w("clap", "c l a p"),
+  w("club", "c l u b"),
+  w("glad", "g l a d"),
+  w("grin", "g r i n"),
+  w("grab", "g r a b"),
+  w("crab", "c r a b"),
+  w("crib", "c r i b"),
+  w("drum", "d r u m"),
+  w("drip", "d r i p"),
+  w("trip", "t r i p"),
+  w("frog", "f r o g"),
+  w("from", "f r o m"),
+  w("brick", "b r i ck"),
+  w("black", "b l a ck"),
+  w("stand", "s t a n d"),
+  w("stamp", "s t a m p"),
+  w("string", "s t r i ng"),
+  w("strong", "s t r o ng"),
+  w("spring", "s p r i ng"),
+  w("hand", "h a n d"),
+  w("land", "l a n d"),
+  w("sand", "s a n d"),
+  w("band", "b a n d"),
+  w("bend", "b e n d"),
+  w("send", "s e n d"),
+  w("lend", "l e n d"),
+  w("pond", "p o n d"),
+  w("jump", "j u m p"),
+  w("lamp", "l a m p"),
+  w("camp", "c a m p"),
+  w("damp", "d a m p"),
+  w("tent", "t e n t"),
+  w("went", "w e n t"),
+  w("sent", "s e n t"),
+  w("best", "b e s t"),
+  w("nest", "n e s t"),
+  w("rest", "r e s t"),
+  w("test", "t e s t"),
+  w("must", "m u s t"),
+  w("dust", "d u s t"),
+  w("just", "j u s t"),
+  w("lost", "l o s t"),
+  w("list", "l i s t"),
+  w("fist", "f i s t"),
+  w("milk", "m i l k"),
+  w("silk", "s i l k"),
+  w("help", "h e l p"),
+  w("belt", "b e l t"),
+  w("melt", "m e l t"),
+  w("gift", "g i f t"),
+  w("lift", "l i f t"),
+  w("soft", "s o f t"),
+  w("desk", "d e s k"),
+];
+
+/* ── A vowel that says its own name ───────────────────────────────────────
+   The split vowel first — `a_e` is one spelling with a consonant standing in
+   the middle of it, which is why `graphemeParts` exists — then the letters
+   that go long at the end of a syllable.                                    */
+
+const SPLIT_VOWELS: Word[] = [
+  w("cake", "c a_e k"),
+  w("lake", "l a_e k"),
+  w("make", "m a_e k"),
+  w("take", "t a_e k"),
+  w("name", "n a_e m"),
+  w("game", "g a_e m"),
+  w("came", "c a_e m"),
+  w("gate", "g a_e t"),
+  w("late", "l a_e t"),
+  w("date", "d a_e t"),
+  w("wave", "w a_e v"),
+  w("cave", "c a_e v"),
+  w("save", "s a_e v"),
+  w("snake", "s n a_e k"),
+  w("plate", "p l a_e t"),
+  w("grape", "g r a_e p"),
+  w("shape", "sh a_e p"),
+  w("time", "t i_e m"),
+  w("five", "f i_e v"),
+  w("nine", "n i_e n"),
+  w("line", "l i_e n"),
+  w("bike", "b i_e k"),
+  w("like", "l i_e k"),
+  w("ride", "r i_e d"),
+  w("side", "s i_e d"),
+  w("wide", "w i_e d"),
+  w("hide", "h i_e d"),
+  w("smile", "s m i_e l"),
+  w("white", "wh i_e t"),
+  w("bite", "b i_e t"),
+  w("kite", "k i_e t"),
+  w("home", "h o_e m"),
+  w("hope", "h o_e p"),
+  w("rope", "r o_e p"),
+  w("nose", "n o_e s:z"),
+  w("rose", "r o_e s:z"),
+  w("bone", "b o_e n"),
+  w("stone", "s t o_e n"),
+  w("hole", "h o_e l"),
+  w("note", "n o_e t"),
+  w("those", "th:dh o_e s:z"),
+  w("cube", "c u_e:y-oo b"),
+  w("cute", "c u_e:y-oo t"),
+  w("use", "u_e:y-oo s:z"),
+  w("flute", "f l u_e t"),
+  w("rule", "r u_e l"),
+  w("these", "th:dh e_e s:z"),
+  w("go", "g o:oa"),
+  w("no", "n o:oa"),
+  w("so", "s o:oa"),
+  w("me", "m e:ee"),
+  w("be", "b e:ee"),
+  w("he", "h e:ee"),
+  w("we", "w e:ee"),
+  w("she", "sh e:ee"),
+  w("cold", "c o:oa l d"),
+  w("old", "o:oa l d"),
+  w("gold", "g o:oa l d"),
+  w("told", "t o:oa l d"),
+  w("hold", "h o:oa l d"),
+  w("wild", "w i:ie l d"),
+  w("mild", "m i:ie l d"),
+  w("kind", "k i:ie n d"),
+  w("find", "f i:ie n d"),
+  w("mind", "m i:ie n d"),
+  w("child", "ch i:ie l d"),
+];
+
+/* ── Vowel teams ──────────────────────────────────────────────────────────
+   Two letters that make one vowel, and the place the many-to-many in
+   `sounds.ts` stops being theoretical: `bread` and `eat` are the same two
+   letters and a year apart.                                                 */
+
+const VOWEL_TEAMS: Word[] = [
+  w("rain", "r ai n"),
+  w("train", "t r ai n"),
+  w("wait", "w ai t"),
+  w("paint", "p ai n t"),
+  w("tail", "t ai l"),
+  w("nail", "n ai l"),
+  w("sail", "s ai l"),
+  w("chain", "ch ai n"),
+  w("snail", "s n ai l"),
+  w("day", "d ay"),
+  w("play", "p l ay"),
+  w("say", "s ay"),
+  w("way", "w ay"),
+  w("may", "m ay"),
+  w("stay", "s t ay"),
+  w("tray", "t r ay"),
+  w("away", "a:uh w ay"),
+  w("see", "s ee"),
+  w("tree", "t r ee"),
+  w("feet", "f ee t"),
+  w("feel", "f ee l"),
+  w("week", "w ee k"),
+  w("sleep", "s l ee p"),
+  w("green", "g r ee n"),
+  w("three", "th r ee"),
+  w("deep", "d ee p"),
+  w("keep", "k ee p"),
+  w("sweet", "s w ee t"),
+  w("street", "s t r ee t"),
+  w("eat", "ea t"),
+  w("sea", "s ea"),
+  w("tea", "t ea"),
+  w("leaf", "l ea f"),
+  w("clean", "c l ea n"),
+  w("dream", "d r ea m"),
+  w("teach", "t ea ch"),
+  w("beach", "b ea ch"),
+  w("each", "ea ch"),
+  w("meat", "m ea t"),
+  w("seat", "s ea t"),
+  w("speak", "s p ea k"),
+  w("bread", "b r ea:e d"),
+  w("head", "h ea:e d"),
+  w("boat", "b oa t"),
+  w("coat", "c oa t"),
+  w("road", "r oa d"),
+  w("soap", "s oa p"),
+  w("toast", "t oa s t"),
+  w("goat", "g oa t"),
+  w("snow", "s n ow:oa"),
+  w("blow", "b l ow:oa"),
+  w("grow", "g r ow:oa"),
+  w("slow", "s l ow:oa"),
+  w("throw", "th r ow:oa"),
+  w("yellow", "y e ll ow:oa"),
+  w("toe", "t oe"),
+  w("night", "n igh t"),
+  w("light", "l igh t"),
+  w("right", "r igh t"),
+  w("bright", "b r igh t"),
+  w("fight", "f igh t"),
+  w("high", "h igh"),
+  w("pie", "p ie:ie"),
+  w("tie", "t ie:ie"),
+  w("my", "m y:ie"),
+  w("by", "b y:ie"),
+  w("cry", "c r y:ie"),
+  w("dry", "d r y:ie"),
+  w("fly", "f l y:ie"),
+  w("sky", "s k y:ie"),
+  w("try", "t r y:ie"),
+  w("why", "wh y:ie"),
+  w("moon", "m oo n"),
+  w("soon", "s oo n"),
+  w("food", "f oo d"),
+  w("room", "r oo m"),
+  w("pool", "p oo l"),
+  w("tooth", "t oo th"),
+  w("spoon", "s p oo n"),
+  w("zoo", "z oo"),
+  w("broom", "b r oo m"),
+  w("book", "b oo:uu k"),
+  w("look", "l oo:uu k"),
+  w("took", "t oo:uu k"),
+  w("cook", "c oo:uu k"),
+  w("foot", "f oo:uu t"),
+  w("wood", "w oo:uu d"),
+  w("good", "g oo:uu d"),
+  w("stood", "s t oo:uu d"),
+  w("put", "p u:uu t"),
+  w("blue", "b l ue"),
+  w("glue", "g l ue"),
+  w("true", "t r ue"),
+  w("fruit", "f r ui:oo t"),
+  w("juice", "j ui:oo c:s e:-"),
+  w("flew", "f l ew"),
+  w("grew", "g r ew"),
+  w("chew", "ch ew"),
+  w("screw", "s c r ew"),
+  w("few", "f ew:y-oo"),
+  w("out", "ou t"),
+  w("loud", "l ou d"),
+  w("cloud", "c l ou d"),
+  w("round", "r ou n d"),
+  w("sound", "s ou n d"),
+  w("found", "f ou n d"),
+  w("mouth", "m ou th"),
+  w("shout", "sh ou t"),
+  w("house", "h ou s e:-"),
+  w("cow", "c ow"),
+  w("how", "h ow"),
+  w("now", "n ow"),
+  w("down", "d ow n"),
+  w("town", "t ow n"),
+  w("brown", "b r ow n"),
+  w("clown", "c l ow n"),
+  w("crown", "c r ow n"),
+  w("coin", "c oi n"),
+  w("join", "j oi n"),
+  w("point", "p oi n t"),
+  w("boil", "b oi l"),
+  w("soil", "s oi l"),
+  w("boy", "b oy"),
+  w("toy", "t oy"),
+  w("joy", "j oy"),
+  w("saw", "s aw"),
+  w("paw", "p aw"),
+  w("draw", "d r aw"),
+  w("straw", "s t r aw"),
+  w("claw", "c l aw"),
+  w("lawn", "l aw n"),
+  w("yawn", "y aw n"),
+  w("crawl", "c r aw l"),
+  w("haul", "h au l"),
+  w("sauce", "s au c:s e:-"),
+  w("ball", "b a:aw ll"),
+  w("call", "c a:aw ll"),
+  w("fall", "f a:aw ll"),
+  w("tall", "t a:aw ll"),
+  w("wall", "w a:aw ll"),
+  w("small", "s m a:aw ll"),
+  w("walk", "w al k"),
+  w("talk", "t al k"),
+  w("chalk", "ch al k"),
+  w("happy", "h a pp y:ee"),
+  w("sunny", "s u nn y:ee"),
+  w("funny", "f u nn y:ee"),
+  w("puppy", "p u pp y:ee"),
+  w("silly", "s i ll y:ee"),
+  w("baby", "b a:ai b y:ee"),
+  w("paper", "p a:ai p er"),
+  w("hello", "h e ll o:oa"),
+];
+
+/* ── The r-coloured vowels ────────────────────────────────────────────────
+   Three spellings for the vowel of `her` and three sounds for the letters of
+   `ear`, which between them make the case for the whole model. Rhotic or not,
+   the letters are the same — see the accent note in `sounds.ts`.             */
+
+const R_VOWELS: Word[] = [
+  w("car", "c ar"),
+  w("far", "f ar"),
+  w("star", "s t ar"),
+  w("jar", "j ar"),
+  w("arm", "ar m"),
+  w("farm", "f ar m"),
+  w("card", "c ar d"),
+  w("hard", "h ar d"),
+  w("yard", "y ar d"),
+  w("park", "p ar k"),
+  w("dark", "d ar k"),
+  w("shark", "sh ar k"),
+  w("sharp", "sh ar p"),
+  w("start", "s t ar t"),
+  w("part", "p ar t"),
+  w("smart", "s m ar t"),
+  w("barn", "b ar n"),
+  w("garden", "g ar d e:uh n"),
+  w("for", "f or"),
+  w("fork", "f or k"),
+  w("corn", "c or n"),
+  w("horn", "h or n"),
+  w("born", "b or n"),
+  w("sort", "s or t"),
+  w("short", "sh or t"),
+  w("sport", "s p or t"),
+  w("storm", "s t or m"),
+  w("north", "n or th"),
+  w("more", "m ore"),
+  w("store", "s t ore"),
+  w("score", "s c ore"),
+  w("door", "d oor"),
+  w("floor", "f l oor"),
+  w("four", "f our"),
+  w("your", "y our"),
+  w("her", "h er"),
+  w("herd", "h er d"),
+  w("term", "t er m"),
+  w("father", "f a:ah th:dh er"),
+  w("letter", "l e tt er"),
+  w("summer", "s u mm er"),
+  w("sister", "s i s t er"),
+  w("better", "b e tt er"),
+  w("under", "u n d er"),
+  w("over", "o:oa v er"),
+  w("never", "n e v er"),
+  w("winter", "w i n t er"),
+  w("bird", "b ir d"),
+  w("girl", "g ir l"),
+  w("first", "f ir s t"),
+  w("shirt", "sh ir t"),
+  w("third", "th ir d"),
+  w("dirt", "d ir t"),
+  w("turn", "t ur n"),
+  w("burn", "b ur n"),
+  w("hurt", "h ur t"),
+  w("curl", "c ur l"),
+  w("nurse", "n ur s e:-"),
+  w("church", "ch ur ch"),
+  w("earth", "ear:er th"),
+  w("learn", "l ear:er n"),
+  w("heard", "h ear:er d"),
+  w("hair", "h air"),
+  w("chair", "ch air"),
+  w("care", "c are"),
+  w("share", "sh are"),
+  w("bear", "b ear:air"),
+  w("pear", "p ear:air"),
+  w("wear", "w ear:air"),
+  w("hear", "h ear:eer"),
+  w("near", "n ear:eer"),
+  w("year", "y ear:eer"),
+  w("ear", "ear:eer"),
+  w("dear", "d ear:eer"),
+  w("clear", "c l ear:eer"),
+  w("deer", "d eer"),
+  w("cheer", "ch eer"),
+  w("here", "h ere:eer"),
+];
+
+/* ── The letters that hide ────────────────────────────────────────────────
+   `kn`, `wr`, `mb`, and the endings that only ever come after a short vowel.
+   All of them are spellings with a rule behind them, so all of them are
+   tickable — the words that follow no rule at all are the next group down.  */
+
+const QUIET_LETTERS: Word[] = [
+  w("knee", "kn ee"),
+  w("know", "kn ow:oa"),
+  w("knit", "kn i t"),
+  w("knock", "kn o ck"),
+  w("knife", "kn i_e f"),
+  w("write", "wr i_e t"),
+  w("wrong", "wr o ng"),
+  w("wrap", "wr a p"),
+  w("wrist", "wr i s t"),
+  w("comb", "c o:oa mb"),
+  w("thumb", "th u mb"),
+  w("lamb", "l a mb"),
+  w("climb", "c l i:ie mb"),
+  w("catch", "c a tch"),
+  w("match", "m a tch"),
+  w("watch", "w a:o tch"),
+  w("fetch", "f e tch"),
+  w("ditch", "d i tch"),
+  w("kitchen", "k i tch e:uh n"),
+  w("bridge", "b r i dge"),
+  w("edge", "e dge"),
+  w("badge", "b a dge"),
+  w("judge", "j u dge"),
+  w("fudge", "f u dge"),
+  w("large", "l ar ge"),
+  w("age", "a:ai ge"),
+  w("cage", "c a:ai ge"),
+  w("page", "p a:ai ge"),
+  w("huge", "h u:y-oo ge"),
+  w("stage", "s t a:ai ge"),
+  w("city", "c:s i t y:ee"),
+  w("ice", "i_e c:s"),
+  w("nice", "n i_e c:s"),
+  w("mice", "m i_e c:s"),
+  w("rice", "r i_e c:s"),
+  w("face", "f a_e c:s"),
+  w("race", "r a_e c:s"),
+  w("place", "p l a_e c:s"),
+  w("prince", "p r i n c:s e:-"),
+  w("fence", "f e n c:s e:-"),
+  w("since", "s i n c:s e:-"),
+  w("giant", "g:j i:ie a:uh n t"),
+  w("magic", "m a g:j i c"),
+  w("little", "l i tt le"),
+  w("apple", "a pp le"),
+  w("table", "t a:ai b le"),
+  w("bottle", "b o tt le"),
+  w("middle", "m i dd le"),
+  w("candle", "c a n d le"),
+  w("phone", "ph o_e n"),
+  w("dolphin", "d o l ph i n"),
+  w("elephant", "e l e:uh ph a:uh n t"),
+  w("school", "s ch:k oo l"),
+];
+
+/* ── Spellings that only happen somewhere ─────────────────────────────────
+   A letter can be told what to say by the letter in front of it. `w` is the
+   loudest of them — it turns `a` into the vowel of `wash` and `ar` into the
+   vowel of `warm` — and the silent `e` on the end of `have` is the same kind
+   of fact: not a sound, a position. Each is a tick box of its own, because a
+   child reading `was` as if it rhymed with `gas` has been taught `w`, `a` and
+   `s` and nothing that would tell them otherwise.                           */
+
+const POSITIONS: Word[] = [
+  w("have", "h a v e:-"),
+  w("give", "g i v e:-"),
+  w("live", "l i v e:-"),
+  w("gone", "g o n e:-"),
+  w("because", "b e:uh c au s:z e:-"),
+  w("the", "th:dh e:uh"),
+  w("want", "w a:o n t"),
+  w("wash", "w a:o sh"),
+  w("word", "w or:er d"),
+  w("work", "w or:er k"),
+  w("war", "w ar:or"),
+  w("warm", "w ar:or m"),
+  w("music", "m u:y-oo s:z i c"),
+  w("eight", "eigh t"),
+  w("key", "k ey"),
+  w("chief", "ch ie f"),
+];
+
+/* ── The ones that follow nothing ─────────────────────────────────────────
+   Every word here uses a spelling marked `odd` in `sounds.ts`, which is what
+   makes it unreachable by ticking sounds — the only way one of these reaches
+   a page is a parent putting the word itself on their `tricky` list, which is
+   exactly how a programme teaches them. The cuts are still honest: `ai`
+   really does say /e/ in `said`, and saying so is how a sheet can print the
+   awkward part in a different weight (§13).                                 */
+
+const TRICKY: Word[] = [
+  w("said", "s ai:e d"),
+  w("again", "a:uh g ai:e n"),
+  w("money", "m o:u n ey"),
+  w("any", "a:e n y:ee"),
+  w("many", "m a:e n y:ee"),
+  w("one", "o:w-u n e:-"),
+  w("two", "t w:- o:oo"),
+  w("to", "t o:oo"),
+  w("do", "d o:oo"),
+  w("who", "wh o:oo"),
+  w("love", "l o:u v e:-"),
+  w("come", "c o:u m e:-"),
+  w("some", "s o:u m e:-"),
+  w("done", "d o:u n e:-"),
+  w("month", "m o:u n th"),
+  w("mother", "m o:u th:dh er"),
+  w("other", "o:u th:dh er"),
+  w("brother", "b r o:u th:dh er"),
+  w("touch", "t ou:u ch"),
+  w("young", "y ou:u ng"),
+  w("friend", "f r ie:e n d"),
+  w("build", "b ui:i l d"),
+  w("gym", "g:j y:i m"),
+  w("where", "wh ere:air"),
+  w("there", "th:dh ere:air"),
+  w("were", "w ere:er"),
+  w("great", "g r ea:ai t"),
+  w("listen", "l i s t:- e:uh n"),
+];
+
+/**
+ * Every word this build may print, in teaching order.
+ *
+ * One flat list rather than a map of groups, because the groups above are a
+ * writing aid and not a curriculum: what a word is available for is decided by
+ * the sounds in it and nothing else, and a sheet that drew from "the digraph
+ * group" would hand a child `chick` because of the `ch` and the `ck` they
+ * hadn't been taught.
+ */
+export const WORDS: Word[] = [
+  ...SHORT_A,
+  ...SHORT_I,
+  ...SHORT_E,
+  ...SHORT_O,
+  ...SHORT_U,
+  ...DOUBLED,
+  ...DIGRAPHS,
+  ...BLENDS,
+  ...SPLIT_VOWELS,
+  ...VOWEL_TEAMS,
+  ...R_VOWELS,
+  ...QUIET_LETTERS,
+  ...POSITIONS,
+  ...TRICKY,
+];
+
+export const WORD_BY_SPELLING = new Map(
+  WORDS.map((entry) => [entry.word, entry]),
+);
+
+/** The sounds a word is made of, in order — what a blending line says aloud. */
+export function wordSounds(entry: Word): string[] {
+  return entry.parts.flatMap(
+    (part) => CORRESPONDENCE_BY_ID.get(part)?.phonemes ?? [],
+  );
+}
+
+/**
+ * True when the word can't be reached by ticking sounds.
+ *
+ * Derived rather than authored, so the two can't disagree: a word is tricky
+ * exactly when one of its spellings is one no inventory may hold. Which means
+ * marking a spelling `odd` in `sounds.ts` moves every word that uses it in one
+ * edit, rather than leaving a flag behind on each.
+ */
+export function isTricky(entry: Word): boolean {
+  return entry.parts.some((part) => CORRESPONDENCE_BY_ID.get(part)?.odd);
+}
+
+/**
+ * True when General American and RP disagree about one of the word's sounds.
+ *
+ * Not a defect and not a reason to drop a word — `dog` and `car` are here and
+ * are fine. It matters for exactly one kind of exercise: asking a child to
+ * *tell two sounds apart*, where a merged pair makes the question unanswerable
+ * for half the children who see it. A sheet that asks that can filter on this;
+ * everything else can ignore it.
+ */
+export function variesByAccent(entry: Word): boolean {
+  return wordSounds(entry).some((sound) => PHONEME_BY_ID.get(sound)?.varies);
+}

--- a/src/engine/sheets/phonics/index.ts
+++ b/src/engine/sheets/phonics/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Phonics' front door.
+ *
+ * Three modules behind it, and the split is the one `words/` already uses: the
+ * table of what letters say (`sounds.ts`), the words cut into those spellings
+ * (`bank.ts`), and what a parent has taught plus the generation it constrains
+ * (`inventory.ts`).
+ *
+ * Everything above the engine comes through here — the sheet families in
+ * PRINT25, the tick list that builds an inventory, and the service that saves
+ * one — so that none of them has to know which module a fact lives in, and so
+ * the model can be re-cut without a screen noticing. There is no `SheetSpec`
+ * here yet: a sound inventory is not a sheet, it is what several sheets are
+ * built out of, and the families that consume it are the next story.
+ */
+export {
+  CORRESPONDENCES,
+  CORRESPONDENCES_BY_GRAPHEME,
+  CORRESPONDENCE_BY_ID,
+  PHONEMES,
+  PHONEME_BY_ID,
+  defaultSpelling,
+  graphemeParts,
+  isTeachable,
+  spellingId,
+  type Correspondence,
+  type Phoneme,
+} from "./sounds";
+
+export {
+  WORDS,
+  WORD_BY_SPELLING,
+  isTricky,
+  variesByAccent,
+  wordSounds,
+  type Word,
+} from "./bank";
+
+export {
+  EMPTY_INVENTORY,
+  MAX_TRICKY,
+  allSounds,
+  canRead,
+  decodable,
+  pickWords,
+  readInventory,
+  taughtSounds,
+  type Inventory,
+  type SavedInventory,
+  type WordPick,
+} from "./inventory";

--- a/src/engine/sheets/phonics/inventory.ts
+++ b/src/engine/sheets/phonics/inventory.ts
@@ -1,0 +1,210 @@
+/**
+ * A sound inventory: what this child has been taught, and nothing else.
+ *
+ * The mechanism the whole phonics family is built on, and the reason there is
+ * no sheet in the shop called after anybody's programme (docs/printables.md
+ * §13). A parent following a scheme — Direct Instruction, Orton-Gillingham,
+ * Jolly Phonics, a school's own — is always at some point in a sequence, and
+ * the only thing a worksheet has to know about that sequence is where they have
+ * got to. Ticking the sounds says it, works for every programme, and belongs to
+ * nobody.
+ *
+ * ── Two lists, because English has two kinds of word ────────────────────────
+ *
+ * `sounds` is what has been *taught to decode*, as correspondence ids from
+ * `sounds.ts`. A word is available when every spelling in it is on that list —
+ * not when its letters are, which is the distinction the whole model turns on:
+ * a child who knows `c`, `a`, `t` and `h` can read `cat` and cannot read `chat`.
+ *
+ * `tricky` is the parent's own list of words taught by sight — the "tricky
+ * words", "heart words" or "red words" every programme has, under one name or
+ * another, because `said` and `one` cannot be sounded out on any day of the
+ * course. It is the only door a word with an `odd` spelling in it can come
+ * through, so the rule is never bent to admit one: `said` is not decodable
+ * because a parent ticked `ai`, and never becomes so.
+ *
+ * ── Presets ────────────────────────────────────────────────────────────────
+ *
+ * A saved inventory *is* the preset. There are none in this build and there
+ * will not be: a preset is a name plus a set of sounds, both of which the
+ * parent writes. Shipping "Lesson 47" would be reproducing somebody's
+ * copyrighted sequence by reference, and shipping "Level 3" would be pretending
+ * there is one sequence when the whole point of the model is that there isn't.
+ * `services/phonics.ts` is where a named one is kept.
+ */
+import { mulberry32, shuffled } from "@/engine/random";
+
+import { WORDS, isTricky, variesByAccent, wordSounds, type Word } from "./bank";
+import {
+  CORRESPONDENCES,
+  CORRESPONDENCE_BY_ID,
+  isTeachable,
+  type Correspondence,
+} from "./sounds";
+
+export type Inventory = {
+  /** Correspondence ids, in the order they were taught where that is known. */
+  sounds: string[];
+  /** Whole words taught by sight, lower case. */
+  tricky: string[];
+};
+
+/**
+ * A named inventory a parent kept.
+ *
+ * The same shape as a `SavedSheet` for the same reasons: an id that can't
+ * collide with another store's, a name the parent chose, and two timestamps.
+ * It belongs to the household rather than to a child — one family teaches one
+ * sequence, and a second child arriving at the same point uses the same list.
+ */
+export type SavedInventory = Inventory & {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** Where a parent starts: nothing taught yet, so nothing may be printed. */
+export const EMPTY_INVENTORY: Inventory = { sounds: [], tricky: [] };
+
+/** As many sight words as a parent may put in a deck — `services/decks.ts`. */
+export const MAX_TRICKY = 200;
+
+/** Long enough for `elephant`; anything longer is not an early reader's word. */
+const MAX_TRICKY_LETTERS = 20;
+
+/**
+ * Everything the table can teach — the "no constraint" answer.
+ *
+ * Not a preset, and deliberately unnamed: it is what a sheet uses when a parent
+ * hasn't said where they are, and what "tick them all" produces. The `odd`
+ * spellings stay out, because they are not teachable in the first place, and
+ * every word behind them is reachable through `tricky` anyway.
+ */
+export function allSounds(): Inventory {
+  return {
+    sounds: CORRESPONDENCES.filter(isTeachable).map((entry) => entry.id),
+    tricky: WORDS.filter(isTricky).map((entry) => entry.word),
+  };
+}
+
+/**
+ * Makes an inventory safe to build a sheet from, whatever it arrived as.
+ *
+ * The untrusted door, and there are three of them: a shared `#s=` URL, a saved
+ * sheet from a build ago, and a record read back out of IndexedDB. Everything
+ * that isn't a spelling this build knows about is dropped rather than refused —
+ * a sound retired between two releases must narrow the sheet, not stop it
+ * printing — and an `odd` spelling is dropped for the reason the header gives:
+ * ticking `ai:e` would make `said` decodable, and it isn't.
+ */
+export function readInventory(value: unknown): Inventory {
+  const raw = (value ?? {}) as Partial<Inventory>;
+  const sounds = new Set<string>();
+  for (const id of Array.isArray(raw.sounds) ? raw.sounds : []) {
+    if (typeof id !== "string") continue;
+    const found = CORRESPONDENCE_BY_ID.get(id);
+    if (found && isTeachable(found)) sounds.add(id);
+  }
+
+  const tricky = new Set<string>();
+  for (const word of Array.isArray(raw.tricky) ? raw.tricky : []) {
+    if (typeof word !== "string") continue;
+    const clean = word.trim().toLowerCase().slice(0, MAX_TRICKY_LETTERS);
+    if (clean) tricky.add(clean);
+    if (tricky.size === MAX_TRICKY) break;
+  }
+
+  return { sounds: [...sounds], tricky: [...tricky] };
+}
+
+/** The spellings on the list, in table order — what a wall chart prints. */
+export function taughtSounds(inventory: Inventory): Correspondence[] {
+  const held = new Set(inventory.sounds);
+  return CORRESPONDENCES.filter((entry) => held.has(entry.id));
+}
+
+/**
+ * Can this child read this word?
+ *
+ * Every spelling taught, or the whole word learnt by sight. The `has` is over a
+ * set the caller may hand in, because the question is asked once per word in
+ * the bank per sheet and rebuilding the set three hundred times is the kind of
+ * thing that turns a live preview into a stutter.
+ */
+export function canRead(
+  entry: Word,
+  inventory: Inventory,
+  taught: Set<string> = new Set(inventory.sounds),
+  sight: Set<string> = new Set(inventory.tricky),
+): boolean {
+  if (sight.has(entry.word)) return true;
+  return entry.parts.every((part) => taught.has(part));
+}
+
+/**
+ * Every word in the bank this child can read. The whole point of the model.
+ *
+ * Bank order, which is roughly teaching order — a caller wanting a spread takes
+ * `pickWords` instead, which shuffles from a seed the way every other family in
+ * the shop draws its problems.
+ */
+export function decodable(inventory: Inventory): Word[] {
+  const taught = new Set(inventory.sounds);
+  const sight = new Set(inventory.tricky);
+  return WORDS.filter((entry) => canRead(entry, inventory, taught, sight));
+}
+
+export type WordPick = {
+  /** How many to put on the page. Fewer come back if fewer can be read. */
+  count: number;
+  /**
+   * Only words using this spelling — "this week we're doing `sh`". A sheet
+   * about a sound the parent hasn't ticked comes back empty rather than
+   * quietly ignoring the request, which is the answer that shows up on screen
+   * as an empty sheet instead of a wrong one.
+   */
+  focus?: string;
+  /**
+   * Let sight words in. Off by default: the point of a decodable sheet is that
+   * every word on it can be sounded out, and a dictation line is the one place
+   * `said` belongs.
+   */
+  tricky?: boolean;
+  /** At most this many sounds, for the first sheets a child ever does. */
+  maxSounds?: number;
+  /**
+   * Only words the two varieties in `sounds.ts` agree about. For the one
+   * exercise that needs it — telling two sounds apart — and off elsewhere,
+   * because it would otherwise throw away `dog`.
+   */
+  sameEverywhere?: boolean;
+};
+
+/**
+ * Words for a sheet: readable, matching the options, in an order the seed
+ * decides.
+ *
+ * Deterministic in `(inventory, options, seed)` like every other generator in
+ * the shop, so the same sheet prints the same page and `seed + 1` is "another
+ * one like this". No word twice — a page with `cat` on it twice reads as a
+ * mistake to the parent and as a trick to the child.
+ */
+export function pickWords(
+  inventory: Inventory,
+  options: WordPick,
+  seed: number,
+): Word[] {
+  const taught = new Set(inventory.sounds);
+  const sight = new Set(inventory.tricky);
+  const pool = WORDS.filter((entry) => {
+    if (!canRead(entry, inventory, taught, sight)) return false;
+    if (!options.tricky && isTricky(entry)) return false;
+    if (options.focus && !entry.parts.includes(options.focus)) return false;
+    if (options.sameEverywhere && variesByAccent(entry)) return false;
+    if (options.maxSounds && wordSounds(entry).length > options.maxSounds)
+      return false;
+    return true;
+  });
+  return shuffled(pool, mulberry32(seed)).slice(0, Math.max(0, options.count));
+}

--- a/src/engine/sheets/phonics/phonics.test.ts
+++ b/src/engine/sheets/phonics/phonics.test.ts
@@ -106,10 +106,16 @@ describe("the table of sounds and spellings", () => {
 
   it("says which accents it is describing where they differ", () => {
     // The divergences the header names, spelled out as a test so that a later
-    // edit quietly resolving one in favour of a single accent fails here.
-    for (const id of ["o", "aw", "ah", "ar", "er", "air"]) {
+    // edit quietly resolving one in favour of a single accent fails here. All
+    // eight, including the r-coloured ones the header's rhoticity paragraph
+    // covers as a set rather than one at a time.
+    const varying = ["o", "aw", "ah", "ar", "or", "er", "air", "eer"];
+    for (const id of varying) {
       expect(PHONEME_BY_ID.get(id)?.varies).toBeTruthy();
     }
+    // And no others, so that `Phoneme.varies`' own doc comment cannot drift
+    // away from the count it exists to make visible.
+    expect(PHONEMES.filter((p) => p.varies).map((p) => p.id)).toEqual(varying);
     // And the consonants, which the two varieties agree about completely.
     for (const phoneme of PHONEMES.filter((p) => p.kind === "consonant")) {
       expect(phoneme.varies).toBeUndefined();
@@ -202,6 +208,30 @@ describe("the word bank", () => {
     ]);
     // A silent letter says nothing, and takes up no room in the blend.
     expect(wordSounds(WORD_BY_SPELLING.get("have")!)).toEqual(["h", "a", "v"]);
+    // The same letters, two sounds, and nothing in the spelling to say which.
+    // `respell` cannot see the difference — both cuts put `ow` back — so the
+    // only thing standing between `cow` and a blending line that reads it as
+    // `co` is a case that names the sounds.
+    expect(wordSounds(WORD_BY_SPELLING.get("cow")!)).toEqual(["k", "ow"]);
+    expect(wordSounds(WORD_BY_SPELLING.get("snow")!)).toEqual(["s", "n", "oa"]);
+    expect(wordSounds(WORD_BY_SPELLING.get("who")!)).toEqual(["h", "oo"]);
+    expect(wordSounds(WORD_BY_SPELLING.get("when")!)).toEqual(["w", "e", "n"]);
+  });
+
+  it("has a word behind every spelling a parent can tick", () => {
+    // A tickable correspondence with no word in the bank is a box that can be
+    // ticked and can never produce anything: `pickWords({ focus })` on it comes
+    // back empty, and a wall chart prints a sound the child will never meet.
+    //
+    // It is also the cheapest guard there is against the shorthand resolving to
+    // the wrong row — `cow` was cut as the `ow` of `snow` for exactly as long
+    // as nothing checked that `ow:ow` was used by anything.
+    const used = new Set(WORDS.flatMap((entry) => entry.parts));
+    for (const entry of CORRESPONDENCES.filter(isTeachable)) {
+      expect(used.has(entry.id), `nothing in the bank uses ${entry.id}`).toBe(
+        true,
+      );
+    }
   });
 
   it("marks the words that follow no rule", () => {

--- a/src/engine/sheets/phonics/phonics.test.ts
+++ b/src/engine/sheets/phonics/phonics.test.ts
@@ -1,0 +1,367 @@
+import { describe, expect, it } from "vitest";
+
+import { mulberry32 } from "@/engine/random";
+
+import {
+  WORDS,
+  WORD_BY_SPELLING,
+  isTricky,
+  variesByAccent,
+  wordSounds,
+  type Word,
+} from "./bank";
+import {
+  EMPTY_INVENTORY,
+  MAX_TRICKY,
+  allSounds,
+  canRead,
+  decodable,
+  pickWords,
+  readInventory,
+  taughtSounds,
+  type Inventory,
+} from "./inventory";
+import {
+  CORRESPONDENCES,
+  CORRESPONDENCES_BY_GRAPHEME,
+  CORRESPONDENCE_BY_ID,
+  PHONEMES,
+  PHONEME_BY_ID,
+  defaultSpelling,
+  graphemeParts,
+  isTeachable,
+} from "./sounds";
+
+/**
+ * The sound inventory, held to the one bar that matters.
+ *
+ * **Nothing on the page uses a sound that hasn't been taught.** That is the
+ * only promise this family makes to a parent, it is the reason the model exists
+ * rather than a word list, and it is the promise every case below is a way of
+ * checking. A maths sheet with a wrong answer on it is embarrassing; a phonics
+ * sheet with an untaught spelling on it hands a five-year-old a word they have
+ * been set up to fail, which is worse.
+ *
+ * The bank is checked by an independent path in the same spirit the maths
+ * families check their answer keys: the spellings are put back together *from
+ * the table* and compared with the word as it is printed, so a mis-cut word
+ * fails here rather than on somebody's kitchen table.
+ */
+
+/**
+ * The word rebuilt out of its parts.
+ *
+ * The independent path: it reads the graphemes from `sounds.ts` rather than the
+ * shorthand `bank.ts` was authored in, so a part naming the wrong spelling
+ * shows up as a word that no longer spells itself. A split vowel puts its head
+ * where the vowel goes and its tail at the end, which is what makes `cake` out
+ * of `c` + `a_e` + `k`.
+ */
+function respell(entry: Word): string {
+  let head = "";
+  let tail = "";
+  for (const part of entry.parts) {
+    const grapheme = CORRESPONDENCE_BY_ID.get(part)?.grapheme ?? "?";
+    const [before, after] = graphemeParts(grapheme);
+    head += before;
+    tail += after;
+  }
+  return head + tail;
+}
+
+/** Inventories a parent might really have, at three points in a course. */
+const FIRST_SIX: Inventory = {
+  sounds: ["s:s", "a:a", "t:t", "p:p", "i:i", "n:n"],
+  tricky: [],
+};
+
+const ALL = allSounds();
+
+describe("the table of sounds and spellings", () => {
+  it("gives every correspondence its own id", () => {
+    expect(CORRESPONDENCE_BY_ID.size).toBe(CORRESPONDENCES.length);
+  });
+
+  it("only names sounds that exist", () => {
+    for (const entry of CORRESPONDENCES) {
+      for (const sound of entry.phonemes) {
+        expect(
+          PHONEME_BY_ID.get(sound),
+          `${entry.id} says ${sound}`,
+        ).toBeDefined();
+      }
+    }
+  });
+
+  it("can spell every sound it lists", () => {
+    // A phoneme nothing spells is a sound card with no word behind it, and a
+    // tick list with a box that can never do anything.
+    const spelled = new Set(CORRESPONDENCES.flatMap((entry) => entry.phonemes));
+    for (const phoneme of PHONEMES) {
+      expect(spelled.has(phoneme.id), `nothing spells /${phoneme.id}/`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("says which accents it is describing where they differ", () => {
+    // The divergences the header names, spelled out as a test so that a later
+    // edit quietly resolving one in favour of a single accent fails here.
+    for (const id of ["o", "aw", "ah", "ar", "er", "air"]) {
+      expect(PHONEME_BY_ID.get(id)?.varies).toBeTruthy();
+    }
+    // And the consonants, which the two varieties agree about completely.
+    for (const phoneme of PHONEMES.filter((p) => p.kind === "consonant")) {
+      expect(phoneme.varies).toBeUndefined();
+    }
+  });
+
+  it("keeps a grapheme's commonest sound first", () => {
+    // The shorthand in `bank.ts` reads a bare grapheme as this, so the order is
+    // data rather than presentation: `c` has to be the `c` of `cat`.
+    expect(defaultSpelling("c")?.id).toBe("c:k");
+    expect(defaultSpelling("ea")?.id).toBe("ea:ee");
+    expect(defaultSpelling("th")?.id).toBe("th:th");
+    expect(defaultSpelling("qu")?.id).toBe("qu:k-w");
+    expect(defaultSpelling("nothing")).toBeUndefined();
+  });
+
+  it("never lets a one-off stand in for its letters", () => {
+    // `ui` says /oo/ in `fruit` and /i/ in `build`, and only one of those is a
+    // rule. Listing the exception first would make the shorthand `ui` mean
+    // `build` — a whole grapheme standing for the one word that breaks it.
+    for (const [grapheme, rows] of CORRESPONDENCES_BY_GRAPHEME) {
+      if (!rows.some(isTeachable)) continue;
+      expect(isTeachable(rows[0]), grapheme).toBe(true);
+    }
+  });
+
+  it("holds the same letters saying different things", () => {
+    // The many-to-many the model exists for. Three sounds for `ear` and two for
+    // `th`: flatten either and a child gets a word they can't read.
+    const ear = CORRESPONDENCES.filter((entry) => entry.grapheme === "ear");
+    expect(ear.map((entry) => entry.phonemes.join())).toEqual([
+      "eer",
+      "er",
+      "air",
+    ]);
+    expect(
+      CORRESPONDENCES.filter((entry) => entry.grapheme === "th"),
+    ).toHaveLength(2);
+  });
+});
+
+describe("the word bank", () => {
+  it("names a spelling this build has", () => {
+    // A typo in the shorthand resolves to itself, which would silently retire
+    // the word rather than print it wrong. It still has to fail.
+    for (const entry of WORDS) {
+      for (const part of entry.parts) {
+        expect(
+          CORRESPONDENCE_BY_ID.get(part),
+          `${entry.word}: ${part}`,
+        ).toBeDefined();
+      }
+    }
+  });
+
+  it("puts every word back together out of its parts", () => {
+    for (const entry of WORDS) {
+      expect(respell(entry), entry.word).toBe(entry.word);
+    }
+  });
+
+  it("holds each word once, in letters a child can read", () => {
+    expect(WORD_BY_SPELLING.size).toBe(WORDS.length);
+    for (const entry of WORDS) {
+      expect(entry.word).toMatch(/^[a-z]+$/);
+      expect(entry.parts.length).toBeGreaterThan(0);
+      // One split vowel at most: two would both claim the final `e`, and
+      // `respell` would put the tails in an order nobody meant.
+      const splits = entry.parts.filter((part) =>
+        CORRESPONDENCE_BY_ID.get(part)?.grapheme.includes("_"),
+      );
+      expect(splits.length, entry.word).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("says what a word sounds like, in order", () => {
+    expect(wordSounds(WORD_BY_SPELLING.get("cat")!)).toEqual(["k", "a", "t"]);
+    // One letter, two sounds — and `think` has a sound its letters don't show.
+    expect(wordSounds(WORD_BY_SPELLING.get("box")!)).toEqual([
+      "b",
+      "o",
+      "k",
+      "s",
+    ]);
+    expect(wordSounds(WORD_BY_SPELLING.get("think")!)).toEqual([
+      "th",
+      "i",
+      "ng",
+      "k",
+    ]);
+    // A silent letter says nothing, and takes up no room in the blend.
+    expect(wordSounds(WORD_BY_SPELLING.get("have")!)).toEqual(["h", "a", "v"]);
+  });
+
+  it("marks the words that follow no rule", () => {
+    for (const word of ["said", "one", "two", "come", "friend", "again"]) {
+      expect(isTricky(WORD_BY_SPELLING.get(word)!), word).toBe(true);
+    }
+    for (const word of ["cat", "ship", "night", "because", "want"]) {
+      expect(isTricky(WORD_BY_SPELLING.get(word)!), word).toBe(false);
+    }
+  });
+
+  it("knows which words two accents would say differently", () => {
+    expect(variesByAccent(WORD_BY_SPELLING.get("dog")!)).toBe(true);
+    expect(variesByAccent(WORD_BY_SPELLING.get("car")!)).toBe(true);
+    expect(variesByAccent(WORD_BY_SPELLING.get("cat")!)).toBe(false);
+    expect(variesByAccent(WORD_BY_SPELLING.get("ship")!)).toBe(false);
+  });
+});
+
+describe("what a child may be given", () => {
+  it("prints nothing at all before anything is taught", () => {
+    expect(decodable(EMPTY_INVENTORY)).toEqual([]);
+    expect(pickWords(EMPTY_INVENTORY, { count: 20 }, 1)).toEqual([]);
+  });
+
+  it("reads the letters taught and not the ones beside them", () => {
+    // The premise of the whole model, as one case: `c`, `a`, `t` and `h` are
+    // four sounds a child has, and `chat` is not a word they can read.
+    const four: Inventory = {
+      sounds: ["c:k", "a:a", "t:t", "h:h"],
+      tricky: [],
+    };
+    expect(canRead(WORD_BY_SPELLING.get("cat")!, four)).toBe(true);
+    expect(canRead(WORD_BY_SPELLING.get("hat")!, four)).toBe(true);
+    expect(canRead(WORD_BY_SPELLING.get("chat")!, four)).toBe(false);
+  });
+
+  it("uses no spelling outside the inventory", () => {
+    // The acceptance criterion, over the three inventories a parent is likeliest
+    // to have and fifty they might.
+    const rand = mulberry32(20260816);
+    const teachable = CORRESPONDENCES.filter(isTeachable).map(
+      (entry) => entry.id,
+    );
+    const inventories: Inventory[] = [FIRST_SIX, ALL, EMPTY_INVENTORY];
+    for (let i = 0; i < 50; i++) {
+      inventories.push({
+        sounds: teachable.filter(() => rand() < 0.35),
+        tricky: [],
+      });
+    }
+
+    for (const [index, inventory] of inventories.entries()) {
+      const taught = new Set(inventory.sounds);
+      const sight = new Set(inventory.tricky);
+      const words = [
+        ...decodable(inventory),
+        ...pickWords(inventory, { count: 40, tricky: true }, index),
+      ];
+      for (const entry of words) {
+        const untaught = entry.parts.filter((part) => !taught.has(part));
+        if (untaught.length === 0) continue;
+        // The only other way onto a page: the parent said this whole word is
+        // one their child knows by sight. Nothing else may put an untaught
+        // spelling in front of a child, and `[...]` names the culprit when
+        // something does.
+        expect(
+          sight.has(entry.word),
+          `${entry.word} needs ${untaught.join(", ")}, which was not taught`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("never lets a rule reach a word that follows none", () => {
+    // Ticking every teachable spelling in the table still cannot produce
+    // `said` — the only door it has is the parent's own sight list.
+    const everything: Inventory = { sounds: ALL.sounds, tricky: [] };
+    const said = WORD_BY_SPELLING.get("said")!;
+    expect(canRead(said, everything)).toBe(false);
+    expect(decodable(everything)).not.toContain(said);
+    expect(canRead(said, { sounds: [], tricky: ["said"] })).toBe(true);
+  });
+
+  it("keeps sight words off a decodable sheet unless they're asked for", () => {
+    const taught: Inventory = { ...ALL, tricky: ["said", "come"] };
+    const plain = pickWords(taught, { count: 200 }, 3);
+    expect(plain.some(isTricky)).toBe(false);
+    const dictation = pickWords(taught, { count: 1000, tricky: true }, 3);
+    expect(dictation.map((entry) => entry.word)).toContain("said");
+  });
+
+  it("draws the same page from the same seed, and a different one from the next", () => {
+    const once = pickWords(ALL, { count: 12 }, 7).map((entry) => entry.word);
+    expect(pickWords(ALL, { count: 12 }, 7).map((entry) => entry.word)).toEqual(
+      once,
+    );
+    expect(
+      pickWords(ALL, { count: 12 }, 8).map((entry) => entry.word),
+    ).not.toEqual(once);
+    // And no word twice on one page.
+    expect(new Set(once).size).toBe(once.length);
+  });
+
+  it("gives back what it can when it can't fill the page", () => {
+    const words = pickWords(FIRST_SIX, { count: 500 }, 1);
+    expect(words.length).toBeGreaterThan(3);
+    expect(words.length).toBe(decodable(FIRST_SIX).length);
+    for (const entry of words) expect(entry.word).toMatch(/^[satpin]+$/);
+  });
+
+  it("narrows to the sound the sheet is about", () => {
+    const sh = pickWords(ALL, { count: 30, focus: "sh:sh" }, 2);
+    expect(sh.length).toBeGreaterThan(5);
+    for (const entry of sh) expect(entry.parts).toContain("sh:sh");
+    // A sound the child hasn't met is an empty sheet, not a silent fallback to
+    // whatever else was lying around.
+    expect(pickWords(FIRST_SIX, { count: 30, focus: "sh:sh" }, 2)).toEqual([]);
+  });
+
+  it("keeps the first sheets short, and the listening sheets neutral", () => {
+    for (const entry of pickWords(ALL, { count: 60, maxSounds: 3 }, 4)) {
+      expect(wordSounds(entry).length, entry.word).toBeLessThanOrEqual(3);
+    }
+    for (const entry of pickWords(
+      ALL,
+      { count: 60, sameEverywhere: true },
+      5,
+    )) {
+      expect(variesByAccent(entry), entry.word).toBe(false);
+    }
+  });
+});
+
+describe("an inventory read back from somewhere else", () => {
+  it("keeps what this build still teaches and drops the rest", () => {
+    const read = readInventory({
+      sounds: ["s:s", "a:a", "s:s", "ai:e", "zz:top", 7],
+      tricky: ["  Said ", "said", "one", 12],
+    });
+    // Deduplicated, and `ai:e` is gone: it is recorded in the table so `said`
+    // can be described honestly, never so it can be ticked.
+    expect(read.sounds).toEqual(["s:s", "a:a"]);
+    expect(read.tricky).toEqual(["said", "one"]);
+  });
+
+  it("answers an empty inventory for anything that isn't one", () => {
+    for (const value of [undefined, null, 42, "sounds", { sounds: "a:a" }]) {
+      expect(readInventory(value)).toEqual(EMPTY_INVENTORY);
+    }
+  });
+
+  it("won't take more sight words than a parent could type", () => {
+    const many = Array.from({ length: MAX_TRICKY + 50 }, (_, i) => `word${i}`);
+    expect(readInventory({ tricky: many }).tricky).toHaveLength(MAX_TRICKY);
+  });
+
+  it("lists what has been taught in the order the chart prints it", () => {
+    const chart = taughtSounds({ sounds: ["t:t", "s:s", "a:a"], tricky: [] });
+    expect(chart.map((entry) => entry.id)).toEqual(["s:s", "t:t", "a:a"]);
+    expect(chart[0].example).toBe("sun");
+  });
+});

--- a/src/engine/sheets/phonics/sounds.ts
+++ b/src/engine/sheets/phonics/sounds.ts
@@ -72,9 +72,9 @@ export type Phoneme = {
   /**
    * How the varieties in the header differ over this sound, when they do.
    *
-   * Present on six of the forty-five, absent on the rest — which is the point
-   * of writing it down: it makes the six visible instead of leaving a reader to
-   * wonder about all forty-five.
+   * Present on eight of the forty-five, absent on the rest — which is the
+   * point of writing it down: it makes the eight visible instead of leaving a
+   * reader to wonder about all forty-five.
    */
   varies?: string;
 };
@@ -337,6 +337,10 @@ const CONSONANT_SPELLINGS: Correspondence[] = [
   spells("wh", "w", "when", {
     note: "a few speakers say a puff of air first, as if it were hw",
   }),
+  // `who`, `whose`, `whom`, `whole` — four words, so a rule it is not, but
+  // recording it is what lets `who` be cut honestly instead of being cut as
+  // the `wh` of `when` and printed on a blending line as /w/ /oo/.
+  spells("wh", "h", "who", { odd: true }),
   spells("x", "k s", "box", { note: "two sounds in one letter" }),
   spells("y", "y", "yes", { note: "at the start of a word" }),
   spells("t", "-", "castle", { odd: true }),

--- a/src/engine/sheets/phonics/sounds.ts
+++ b/src/engine/sheets/phonics/sounds.ts
@@ -1,0 +1,509 @@
+/**
+ * The sounds of English, and the letters that spell them.
+ *
+ * The table a sound inventory is ticked out of, and the only place in the
+ * Print Shop where a spelling is claimed to say anything. Everything phonics
+ * generates is constrained by a set of the ids below, so an error here is a
+ * word on a page that a child has not been taught to read yet — which is the
+ * one failure this whole family exists to prevent (docs/printables.md §13).
+ *
+ * ── Which accent this describes ────────────────────────────────────────────
+ *
+ * **The contrasts shared by General American and standard southern British
+ * (RP).** Stated rather than assumed, because a phoneme table always describes
+ * *somebody's* speech, and a table that quietly described only one of the two
+ * would tell half the children using this site that a sound is different from
+ * another sound they say identically — or the same as one they don't.
+ *
+ * A shared table is possible because the two varieties agree about far more
+ * than they disagree about: all twenty-four consonants, and the vowel of every
+ * word below except where marked. Where they genuinely differ, the divergence
+ * is named on the phoneme in `varies` rather than resolved by picking a side:
+ *
+ *   - **cot / caught.** `/o/` and `/aw/` are two sounds in RP and for many
+ *     Americans, and one sound for most of the western and midland United
+ *     States and nearly all of Canada. Both are listed, and a sheet that asks a
+ *     child to *hear the difference* between them can ask `variesByAccent`
+ *     first (see `bank.ts`).
+ *   - **father / bother.** `/ah/` and `/o/` are one sound in General American
+ *     and two in RP. Same treatment.
+ *   - **bath / trap.** The vowel of `bath`, `grass`, `ask` and `after` is `/a/`
+ *     in America and `/ah/` in southern England. There is no honest single
+ *     answer, so those words are simply not in the bank — see the note there.
+ *   - **Rhoticity.** `car`, `her` and `four` end in an r-sound in America and
+ *     in most of Ireland, Scotland and the English south-west, and in a longer
+ *     vowel in RP. It makes no difference to *spelling*, which is what this
+ *     table is for: the letters are the same either way. So the r-coloured
+ *     vowels are one entry each, with the difference recorded on them.
+ *   - **which / witch.** A minority of speakers keep `wh` as a separate sound.
+ *     `wh` is listed as spelling `/w/`, with the note.
+ *
+ * ── One spelling is not one sound ──────────────────────────────────────────
+ *
+ * English is many-to-many in both directions and the table says so rather than
+ * flattening it. `/k/` is spelled six ways; `ea` spells three different vowels
+ * (`eat`, `bread`, `great`) and `ear` three more (`hear`, `earth`, `bear`).
+ * So **the unit a parent ticks is a correspondence — a grapheme _and_ the sound
+ * it makes — not a grapheme.** That is not a modelling nicety: every systematic
+ * programme teaches `ea` as `/ee/` months before it teaches `ea` as `/e/`, and
+ * an inventory that could only hold "we've done ea" would put `bread` on a page
+ * for a child who can only read `eat`.
+ *
+ * ── What is not tickable ───────────────────────────────────────────────────
+ *
+ * A spelling that appears in a handful of words is not a rule, and pretending
+ * otherwise is how a generator ends up printing `said` as if it rhymed with
+ * `paid`. Those correspondences are recorded — truthfully, because `ai` really
+ * does spell `/e/` in `said` — and marked `odd`. An `odd` correspondence can
+ * never be in an inventory, so the only door a word using one comes through is
+ * the parent's own list of words taught by sight (`Inventory.tricky`), which is
+ * exactly how every programme handles them.
+ */
+
+/** A sound. `id` is what a correspondence names and what a sheet prints by. */
+export type Phoneme = {
+  /** Short, readable, and stable: it is written into saved inventories. */
+  id: string;
+  /** IPA, for the parent who wants to know exactly which sound is meant. */
+  ipa: string;
+  /** A word that has it. Chosen so the sound is unmistakable when said aloud. */
+  example: string;
+  kind: "consonant" | "vowel";
+  /**
+   * How the varieties in the header differ over this sound, when they do.
+   *
+   * Present on six of the forty-five, absent on the rest — which is the point
+   * of writing it down: it makes the six visible instead of leaving a reader to
+   * wonder about all forty-five.
+   */
+  varies?: string;
+};
+
+/* ── Consonants ───────────────────────────────────────────────────────────
+   All twenty-four, and the two varieties agree about every one of them. The
+   only footnote in the set is `wh`, and it is a footnote about a *spelling*
+   rather than about a sound — it lives on the correspondence below.        */
+
+const CONSONANT_PHONEMES: Phoneme[] = [
+  { id: "b", ipa: "b", example: "bat", kind: "consonant" },
+  { id: "d", ipa: "d", example: "dog", kind: "consonant" },
+  { id: "f", ipa: "f", example: "fan", kind: "consonant" },
+  { id: "g", ipa: "ɡ", example: "got", kind: "consonant" },
+  { id: "h", ipa: "h", example: "hat", kind: "consonant" },
+  { id: "j", ipa: "dʒ", example: "jam", kind: "consonant" },
+  { id: "k", ipa: "k", example: "cat", kind: "consonant" },
+  { id: "l", ipa: "l", example: "leg", kind: "consonant" },
+  { id: "m", ipa: "m", example: "man", kind: "consonant" },
+  { id: "n", ipa: "n", example: "net", kind: "consonant" },
+  { id: "ng", ipa: "ŋ", example: "ring", kind: "consonant" },
+  { id: "p", ipa: "p", example: "pig", kind: "consonant" },
+  { id: "r", ipa: "ɹ", example: "red", kind: "consonant" },
+  { id: "s", ipa: "s", example: "sun", kind: "consonant" },
+  { id: "sh", ipa: "ʃ", example: "ship", kind: "consonant" },
+  { id: "t", ipa: "t", example: "top", kind: "consonant" },
+  { id: "ch", ipa: "tʃ", example: "chip", kind: "consonant" },
+  // The two `th` sounds, which share a spelling and are told apart by nothing
+  // on the page. A child who can read `thin` cannot necessarily read `this`,
+  // so they are two sounds here and two tick boxes in front of a parent.
+  { id: "th", ipa: "θ", example: "thin", kind: "consonant" },
+  { id: "dh", ipa: "ð", example: "this", kind: "consonant" },
+  { id: "v", ipa: "v", example: "van", kind: "consonant" },
+  { id: "w", ipa: "w", example: "win", kind: "consonant" },
+  { id: "y", ipa: "j", example: "yes", kind: "consonant" },
+  { id: "z", ipa: "z", example: "zip", kind: "consonant" },
+  { id: "zh", ipa: "ʒ", example: "measure", kind: "consonant" },
+];
+
+/* ── Vowels ───────────────────────────────────────────────────────────────
+   Where the two varieties part company, and where the `varies` notes earn
+   their place. Named by their spelling rather than by a lexical set, because
+   the audience is a parent with a tick list rather than a phonetician.      */
+
+const VOWEL_PHONEMES: Phoneme[] = [
+  { id: "a", ipa: "æ", example: "cat", kind: "vowel" },
+  { id: "e", ipa: "ɛ", example: "bed", kind: "vowel" },
+  { id: "i", ipa: "ɪ", example: "sit", kind: "vowel" },
+  {
+    id: "o",
+    ipa: "ɒ / ɑ",
+    example: "dog",
+    kind: "vowel",
+    varies:
+      "Rounded in southern England, unrounded in America — and for most of " +
+      "the western United States and Canada the same vowel as in `saw`.",
+  },
+  { id: "u", ipa: "ʌ", example: "cup", kind: "vowel" },
+  { id: "uu", ipa: "ʊ", example: "book", kind: "vowel" },
+  { id: "ee", ipa: "iː", example: "see", kind: "vowel" },
+  { id: "ai", ipa: "eɪ", example: "rain", kind: "vowel" },
+  { id: "ie", ipa: "aɪ", example: "night", kind: "vowel" },
+  { id: "oa", ipa: "oʊ / əʊ", example: "boat", kind: "vowel" },
+  { id: "oo", ipa: "uː", example: "moon", kind: "vowel" },
+  { id: "ow", ipa: "aʊ", example: "cow", kind: "vowel" },
+  { id: "oy", ipa: "ɔɪ", example: "boy", kind: "vowel" },
+  {
+    id: "aw",
+    ipa: "ɔː",
+    example: "saw",
+    kind: "vowel",
+    varies:
+      "The other half of the cot/caught pair: a sound of its own in southern " +
+      "England and the eastern United States, merged with the vowel of `dog` " +
+      "for most other American and Canadian speakers.",
+  },
+  {
+    id: "ah",
+    ipa: "ɑː",
+    example: "father",
+    kind: "vowel",
+    varies:
+      "The father/bother pair: distinct from the vowel of `dog` in southern " +
+      "England, the same vowel in almost all of North America.",
+  },
+  {
+    id: "ar",
+    ipa: "ɑːr",
+    example: "car",
+    kind: "vowel",
+    varies: "The r is sounded in America, Ireland and Scotland; not in RP.",
+  },
+  {
+    id: "or",
+    ipa: "ɔːr",
+    example: "fork",
+    kind: "vowel",
+    varies: "The r is sounded in America, Ireland and Scotland; not in RP.",
+  },
+  {
+    id: "er",
+    ipa: "ɜːr / ər",
+    example: "her",
+    kind: "vowel",
+    varies:
+      "The r is sounded in America, Ireland and Scotland; not in RP. One " +
+      "entry rather than two, because the vowel of `her` and the ending of " +
+      "`letter` are spelled the same way and differ only in stress.",
+  },
+  {
+    id: "air",
+    ipa: "ɛər",
+    example: "hair",
+    kind: "vowel",
+    varies: "The r is sounded in America, Ireland and Scotland; not in RP.",
+  },
+  {
+    id: "eer",
+    ipa: "ɪər",
+    example: "deer",
+    kind: "vowel",
+    varies: "The r is sounded in America, Ireland and Scotland; not in RP.",
+  },
+  { id: "uh", ipa: "ə", example: "about", kind: "vowel" },
+];
+
+export const PHONEMES: Phoneme[] = [...CONSONANT_PHONEMES, ...VOWEL_PHONEMES];
+
+export const PHONEME_BY_ID = new Map(PHONEMES.map((p) => [p.id, p]));
+
+/**
+ * A spelling, and the sound it makes *in the words this build prints*.
+ *
+ * The unit a parent ticks. See the header for why it is this rather than a
+ * grapheme, and `odd` for the ones that are recorded but never offered.
+ */
+export type Correspondence = {
+  /**
+   * `grapheme:sound`, e.g. `ea:ee`. Built by `spells` and never parsed back
+   * apart — treat it as opaque. It is stable because it is saved: an inventory
+   * a parent ticked out in September is a list of these strings, and renaming
+   * one would silently un-teach a sound.
+   */
+  id: string;
+  /**
+   * The letters, exactly as they appear in the word. A split vowel is written
+   * with the `_` where its consonant goes: `a_e` is the spelling in `cake`.
+   */
+  grapheme: string;
+  /**
+   * Usually one sound; two for the letters that carry a pair (`x` is /k/+/s/,
+   * `qu` is /k/+/w/, `le` is /uh/+/l/); none for a letter that says nothing,
+   * which is a real thing a spelling does and worth being able to state.
+   */
+  phonemes: string[];
+  /** A word spelled that way. What a sound card and a wall chart print. */
+  example: string;
+  /** When the spelling is restricted to a position or a neighbour. */
+  note?: string;
+  /**
+   * Recorded, but never tickable: a spelling with too few words behind it to
+   * be a rule. See the header — this is the flag that keeps `said` out of a
+   * sheet built for a child who has been taught `ai` as in `rain`.
+   */
+  odd?: true;
+};
+
+/**
+ * One row of the table.
+ *
+ * The id is derived rather than typed so that the two halves cannot drift
+ * apart — a hand-written `"ea:ee"` beside `phonemes: ["e"]` would be a lie
+ * that nothing could catch, because an id is opaque to everything that reads
+ * one.
+ */
+const spells = (
+  grapheme: string,
+  // Space-separated, because a letter can carry two sounds: `x` is `k s`. `-`
+  // is "says nothing", which is a dash rather than an empty string so that an
+  // id doesn't end in a bare colon and read like a typo.
+  sounds: string,
+  example: string,
+  extra: Omit<Correspondence, "id" | "grapheme" | "phonemes" | "example"> = {},
+): Correspondence => {
+  const phonemes = sounds === "-" ? [] : sounds.split(" ");
+  return {
+    id: `${grapheme}:${phonemes.join("-") || "-"}`,
+    grapheme,
+    phonemes,
+    example,
+    ...extra,
+  };
+};
+
+/* ── How the consonants are spelled ───────────────────────────────────────
+   Ordered so that the first entry for a grapheme is its commonest sound. That
+   ordering is load-bearing: `bank.ts` writes a word's spelling in shorthand
+   and a bare grapheme means "the first row for those letters", so moving
+   `c:s` above `c:k` would re-spell half the bank.                          */
+
+const CONSONANT_SPELLINGS: Correspondence[] = [
+  spells("b", "b", "bat"),
+  spells("bb", "b", "rabbit"),
+  spells("c", "k", "cat"),
+  spells("c", "s", "city", { note: "before e, i or y" }),
+  spells("k", "k", "kit"),
+  spells("ck", "k", "duck", {
+    note: "after a short vowel, never at the start",
+  }),
+  spells("ch", "ch", "chip"),
+  spells("ch", "k", "school", { note: "mostly in words taken from Greek" }),
+  spells("tch", "ch", "catch", { note: "after a short vowel" }),
+  spells("qu", "k w", "queen"),
+  spells("d", "d", "dog"),
+  spells("dd", "d", "ladder"),
+  spells("f", "f", "fan"),
+  spells("ff", "f", "cliff"),
+  spells("ph", "f", "phone"),
+  spells("gh", "f", "laugh", { odd: true }),
+  spells("g", "g", "got"),
+  spells("gg", "g", "egg"),
+  spells("g", "j", "giant", { note: "before e, i or y" }),
+  spells("ge", "j", "large", { note: "at the end of a word" }),
+  spells("dge", "j", "bridge", { note: "after a short vowel" }),
+  spells("j", "j", "jam"),
+  spells("h", "h", "hat"),
+  spells("l", "l", "leg"),
+  spells("ll", "l", "bell"),
+  spells("le", "uh l", "little", { note: "at the end of a word" }),
+  spells("m", "m", "man"),
+  spells("mm", "m", "hammer"),
+  spells("mb", "m", "comb", { note: "the b says nothing" }),
+  spells("n", "n", "net"),
+  spells("nn", "n", "dinner"),
+  spells("n", "ng", "think", { note: "before k or g" }),
+  spells("kn", "n", "knee", { note: "at the start; the k says nothing" }),
+  spells("gn", "n", "gnat", { note: "at the start; the g says nothing" }),
+  spells("ng", "ng", "ring"),
+  spells("p", "p", "pig"),
+  spells("pp", "p", "happy"),
+  spells("r", "r", "red"),
+  spells("rr", "r", "sorry"),
+  spells("wr", "r", "write", { note: "at the start; the w says nothing" }),
+  spells("s", "s", "sun"),
+  spells("ss", "s", "miss"),
+  spells("s", "z", "has"),
+  spells("s", "zh", "measure", { odd: true }),
+  spells("z", "z", "zip"),
+  spells("zz", "z", "buzz"),
+  spells("sh", "sh", "ship"),
+  spells("t", "t", "top"),
+  spells("tt", "t", "butter"),
+  // One spelling, two sounds, no clue on the page which is which. `thin` and
+  // `this` are the pair that makes the case for correspondences over
+  // graphemes better than any argument could.
+  spells("th", "th", "thin"),
+  spells("th", "dh", "this"),
+  spells("v", "v", "van"),
+  spells("w", "w", "win"),
+  spells("wh", "w", "when", {
+    note: "a few speakers say a puff of air first, as if it were hw",
+  }),
+  spells("x", "k s", "box", { note: "two sounds in one letter" }),
+  spells("y", "y", "yes", { note: "at the start of a word" }),
+  spells("t", "-", "castle", { odd: true }),
+  spells("w", "-", "two", { odd: true }),
+  spells("h", "-", "hour", { odd: true }),
+];
+
+/* ── How the vowels are spelled ───────────────────────────────────────────
+   The long half of the table, and where nearly all the many-to-many lives.
+   `ea` is three rows and `ear` is three more; the same grapheme with a
+   different sound is a different thing to have been taught.                 */
+
+const VOWEL_SPELLINGS: Correspondence[] = [
+  spells("a", "a", "cat"),
+  spells("a", "ai", "baby", { note: "at the end of a syllable" }),
+  spells("a", "o", "wash", { note: "after w or qu" }),
+  spells("a", "aw", "ball", { note: "before ll" }),
+  spells("a", "uh", "about", { note: "in a syllable with no stress on it" }),
+  spells("a", "ah", "father"),
+  spells("a", "e", "any", { odd: true }),
+  spells("al", "aw", "walk", { note: "before k; the l says nothing" }),
+  spells("a_e", "ai", "cake"),
+  spells("ai", "ai", "rain"),
+  spells("ai", "e", "said", { odd: true }),
+  spells("ay", "ai", "day", { note: "at the end of a word" }),
+  spells("eigh", "ai", "eight"),
+  spells("e", "e", "bed"),
+  spells("e", "ee", "me", { note: "at the end of a syllable" }),
+  spells("e", "uh", "garden", { note: "in a syllable with no stress on it" }),
+  spells("e", "-", "have", {
+    note: "at the end of a word, after a consonant",
+  }),
+  spells("e_e", "ee", "these"),
+  spells("ee", "ee", "see"),
+  spells("ea", "ee", "eat"),
+  spells("ea", "e", "bread"),
+  spells("ea", "ai", "great", { odd: true }),
+  spells("ie", "ee", "chief"),
+  spells("ie", "e", "friend", { odd: true }),
+  spells("ey", "ee", "key"),
+  spells("y", "ee", "happy", { note: "at the end of a word of two syllables" }),
+  spells("i", "i", "sit"),
+  spells("i", "ie", "mind", {
+    note: "before ld, nd or mb, and at the end of a syllable",
+  }),
+  spells("i_e", "ie", "bike"),
+  spells("igh", "ie", "night"),
+  spells("ie", "ie", "pie", { note: "at the end of a word" }),
+  spells("y", "ie", "my", { note: "at the end of a short word" }),
+  spells("y", "i", "gym", { odd: true }),
+  spells("o", "o", "dog"),
+  spells("o", "oa", "go", { note: "at the end of a syllable, and before ld" }),
+  spells("o", "u", "love", { odd: true }),
+  spells("o", "oo", "do", { odd: true }),
+  spells("o", "w u", "one", { odd: true }),
+  spells("o_e", "oa", "home"),
+  spells("oa", "oa", "boat"),
+  spells("ow", "oa", "snow"),
+  spells("oe", "oa", "toe"),
+  spells("u", "u", "cup"),
+  spells("u", "uu", "put"),
+  spells("u", "y oo", "music", { note: "at the end of a syllable" }),
+  spells("u_e", "oo", "flute"),
+  spells("u_e", "y oo", "cube"),
+  spells("ue", "oo", "blue"),
+  spells("ui", "oo", "fruit"),
+  spells("ui", "i", "build", { odd: true }),
+  spells("ew", "oo", "flew"),
+  spells("ew", "y oo", "few"),
+  spells("oo", "oo", "moon"),
+  spells("oo", "uu", "book"),
+  spells("ou", "ow", "out"),
+  spells("ou", "u", "touch", { odd: true }),
+  spells("ow", "ow", "cow"),
+  spells("oi", "oy", "coin"),
+  spells("oy", "oy", "boy", { note: "at the end of a word" }),
+  spells("aw", "aw", "saw"),
+  spells("au", "aw", "haul"),
+  spells("ar", "ar", "car"),
+  spells("ar", "or", "war", { note: "after w" }),
+  spells("or", "or", "fork"),
+  spells("or", "er", "word", { note: "after w" }),
+  spells("ore", "or", "more"),
+  spells("oor", "or", "door"),
+  spells("our", "or", "four"),
+  spells("er", "er", "her"),
+  spells("ir", "er", "bird"),
+  spells("ur", "er", "turn"),
+  // All three `ear` rows together, commonest first, so that the trio is
+  // readable as the one fact it is: the same three letters say the vowel of
+  // `hear`, of `earth` and of `bear`, and no rule tells a child which.
+  spells("ear", "eer", "hear"),
+  spells("ear", "er", "earth"),
+  spells("ear", "air", "bear"),
+  spells("ere", "eer", "here"),
+  spells("ere", "air", "where", { odd: true }),
+  spells("ere", "er", "were", { odd: true }),
+  spells("air", "air", "hair"),
+  spells("are", "air", "care"),
+  spells("eer", "eer", "deer"),
+];
+
+export const CORRESPONDENCES: Correspondence[] = [
+  ...CONSONANT_SPELLINGS,
+  ...VOWEL_SPELLINGS,
+];
+
+export const CORRESPONDENCE_BY_ID = new Map(
+  CORRESPONDENCES.map((c) => [c.id, c]),
+);
+
+/**
+ * Every spelling of a grapheme, in the order the table lists them.
+ *
+ * What a tick list is drawn from: a parent looks for the letters they taught
+ * this week, and the sounds those letters make are the boxes under them. Built
+ * here so the screen never has to group the table itself and get a different
+ * answer from the one the shorthand resolver got.
+ */
+export const CORRESPONDENCES_BY_GRAPHEME = CORRESPONDENCES.reduce<
+  Map<string, Correspondence[]>
+>((map, entry) => {
+  const found = map.get(entry.grapheme);
+  if (found) found.push(entry);
+  else map.set(entry.grapheme, [entry]);
+  return map;
+}, new Map());
+
+/**
+ * A grapheme's commonest sound — the first row the table lists for it.
+ *
+ * The shorthand `bank.ts` writes its spellings in, so that `c a t` means what
+ * it looks like it means and only the unexpected sounds have to be spelled out
+ * in full.
+ */
+export function defaultSpelling(grapheme: string): Correspondence | undefined {
+  return CORRESPONDENCES_BY_GRAPHEME.get(grapheme)?.[0];
+}
+
+/**
+ * Resolves one written part of a spelling to a correspondence id.
+ *
+ * `a` is the commonest sound those letters make; `ea:e` says which one when it
+ * matters. Never throws and never guesses: a part that names nothing in the
+ * table comes back as itself, which is an id no inventory can ever hold, so the
+ * word it belongs to is simply never decodable. `phonics.test.ts` asserts the
+ * bank contains none of those — a typo must fail a test rather than quietly
+ * retire a word.
+ */
+export function spellingId(part: string): string {
+  if (CORRESPONDENCE_BY_ID.has(part)) return part;
+  return defaultSpelling(part)?.id ?? part;
+}
+
+/** True for a spelling a parent may tick. See `Correspondence.odd`. */
+export const isTeachable = (entry: Correspondence): boolean => !entry.odd;
+
+/**
+ * The letters of a correspondence as they land in a word.
+ *
+ * A split vowel is two pieces with a consonant between them, so it answers with
+ * the piece that sits where the vowel goes and the piece that trails at the end
+ * of the word. Every other spelling is itself, and no tail.
+ */
+export function graphemeParts(grapheme: string): [head: string, tail: string] {
+  const split = grapheme.indexOf("_");
+  return split < 0
+    ? [grapheme, ""]
+    : [grapheme.slice(0, split), grapheme.slice(split + 1)];
+}

--- a/src/services/phonics.test.ts
+++ b/src/services/phonics.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { InvalidInventory, MAX_NAME, create } from "./phonics";
+
+/**
+ * The pure half of the phonics service — what a parent may save, and what is
+ * refused before anything reaches disk.
+ *
+ * `validate` runs before `create` awaits the store, so every case here is a
+ * rejection that never opens IndexedDB. The half that does — the round trip
+ * through the `inventories` store, and re-ticking a list that has since been
+ * deleted — is covered in `storage/db.test.ts` against a fake one, which is the
+ * same split `sheets.ts` and `decks.ts` are tested along.
+ */
+
+const SOME_SOUNDS = { sounds: ["s:s", "a:a"], tricky: [] };
+
+describe("what may be saved", () => {
+  it("insists the parent names the list", async () => {
+    // Required, unlike a saved sheet's name — which the engine can write for
+    // itself. Nothing but the parent can say what "where we've got to" is
+    // called, so a blank is a refusal rather than a default.
+    await expect(create({ name: " ", inventory: SOME_SOUNDS })).rejects.toThrow(
+      InvalidInventory,
+    );
+    await expect(
+      create({ name: "\t\n", inventory: SOME_SOUNDS }),
+    ).rejects.toThrow(/name/i);
+  });
+
+  it("takes a name as long as a word list's, and not one longer", async () => {
+    // The boundary itself: one character over is the only way anybody ever
+    // meets this message, and it is the branch nothing exercised.
+    await expect(
+      create({ name: "x".repeat(MAX_NAME + 1), inventory: SOME_SOUNDS }),
+    ).rejects.toThrow(new RegExp(`${MAX_NAME} characters or fewer`));
+  });
+
+  it("refuses a list with nothing on it", async () => {
+    await expect(
+      create({ name: "Nothing yet", inventory: { sounds: [], tricky: [] } }),
+    ).rejects.toThrow(/at least one sound/i);
+    // Held to the engine's reading of an inventory: `ai:e` is in the table so
+    // `said` can be described honestly, and is not something a parent can tick.
+    // A list of nothing but untickable spellings is an empty list.
+    await expect(
+      create({
+        name: "Everything",
+        inventory: { sounds: ["ai:e"], tricky: [] },
+      }),
+    ).rejects.toThrow(/at least one sound/i);
+  });
+});

--- a/src/services/phonics.ts
+++ b/src/services/phonics.ts
@@ -1,0 +1,126 @@
+import { readInventory } from "@/engine/sheets/phonics";
+import type { Inventory, SavedInventory } from "@/engine/sheets/phonics";
+
+import * as store from "./storage/db";
+
+/**
+ * Sound inventories a parent ticked out and kept.
+ *
+ * The only writer of the `inventories` store, and the only place the rules for
+ * what may be saved are written down — the bargain `decks.ts` and `sheets.ts`
+ * both strike, for the same reason.
+ *
+ * **This is what a preset is.** A parent working through a phonics programme
+ * re-ticks the same forty boxes every time they make a sheet unless the list
+ * can be kept, and the list outlives any one worksheet: the same "sounds we
+ * know" builds a blending-line sheet on Monday and a dictation sheet on Friday.
+ * So an inventory is a record of its own rather than a field of a saved sheet.
+ * There are no inventories in this build that a parent didn't make, and there
+ * will not be — see the header of `engine/sheets/phonics/inventory.ts` for why
+ * shipping one named after a lesson number would be reproducing somebody's
+ * sequence.
+ *
+ * Nothing is mirrored back into the engine, unlike a custom word list. A deck
+ * has to be mirrored because `deckSpec` names one from the record book without
+ * knowing storage exists; an inventory needs no such favour, because it travels
+ * *as a value* — a sheet config carries the sounds themselves, not an id
+ * pointing at this store. That is what lets a configured sheet survive being
+ * shared with a family who has never heard of this household's list.
+ */
+
+export class InvalidInventory extends Error {}
+
+/** As long as a word list's name, and for the same reason: it's a label. */
+export const MAX_NAME = 40;
+
+/**
+ * `sounds-` for the same reason a saved sheet's id is `sheet-`: three kinds of
+ * record share one origin's IndexedDB and one backup file, and a collision
+ * between them would be a sound inventory overwriting this week's spellings.
+ */
+const nextId = () =>
+  `sounds-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+
+/** What a caller hands over. The record's id and timestamps are ours to make. */
+export type InventoryInput = { name: string; inventory: Inventory };
+
+function validate(input: InventoryInput): InventoryInput {
+  const name = input.name.trim();
+  // Required, unlike a saved sheet's name — which the engine can write for
+  // itself from the config. Nothing can name an inventory but the parent: the
+  // list is "where we've got to", and only they know what they call it.
+  if (!name) throw new InvalidInventory("Give the sounds a name");
+  if (name.length > MAX_NAME)
+    throw new InvalidInventory(`Name must be ${MAX_NAME} characters or fewer`);
+
+  // Held to the engine's own reading of an inventory, so that a record in
+  // storage and a config in a URL have been through exactly one validator.
+  // Unknown and untickable spellings are dropped there rather than refused.
+  const inventory = readInventory(input.inventory);
+  if (!inventory.sounds.length && !inventory.tricky.length)
+    throw new InvalidInventory("Tick at least one sound");
+
+  return { name, inventory };
+}
+
+/**
+ * Every saved inventory, oldest first.
+ *
+ * All of them, with no profile to filter by — a phonics programme belongs to
+ * the household, the same way a worksheet does, and the second child through it
+ * uses the list the first one's parent already ticked.
+ */
+export async function all(): Promise<SavedInventory[]> {
+  return (await store.allInventories()).sort((a, b) =>
+    a.createdAt.localeCompare(b.createdAt),
+  );
+}
+
+export async function create(input: InventoryInput): Promise<SavedInventory> {
+  const { name, inventory } = validate(input);
+  const now = new Date().toISOString();
+  const saved: SavedInventory = {
+    id: nextId(),
+    name,
+    ...inventory,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await store.putInventory(saved);
+  return saved;
+}
+
+/**
+ * Re-ticks a saved list.
+ *
+ * The commonest write there is, and the reason the store exists at all: an
+ * inventory is not finished when it is made — a parent adds to it after every
+ * lesson, which is `update` rather than a second record each week.
+ */
+export async function update(
+  id: string,
+  input: InventoryInput,
+): Promise<SavedInventory> {
+  const existing = (await store.allInventories()).find((one) => one.id === id);
+  if (!existing) throw new InvalidInventory("That list no longer exists");
+  const { name, inventory } = validate(input);
+  const saved: SavedInventory = {
+    ...existing,
+    name,
+    ...inventory,
+    updatedAt: new Date().toISOString(),
+  };
+  await store.putInventory(saved);
+  return saved;
+}
+
+/**
+ * Forgets an inventory.
+ *
+ * Nothing is orphaned by it, the same way removing a sheet orphans nothing: a
+ * config that was built from this list carries the sounds themselves, so a
+ * sheet saved in March still prints after the list it came from is gone.
+ */
+export async function remove(id: string): Promise<void> {
+  await store.removeInventory(id);
+}

--- a/src/services/storage/db.test.ts
+++ b/src/services/storage/db.test.ts
@@ -12,6 +12,7 @@ import { openDB, type IDBPDatabase } from "idb";
 import { describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "@/engine/sheets/paper";
+import type { SavedInventory } from "@/engine/sheets/phonics";
 import type { SavedSheet } from "@/engine/sheets/types";
 import type { CustomDeck, Profile, Session } from "@/engine/types";
 
@@ -21,7 +22,7 @@ import type { CustomDeck, Profile, Session } from "@/engine/types";
  * The one file in the suite that opens a database, and it exists because this
  * layer holds the only copy of a child's record book there is. An upgrade that
  * dropped a store, an index that came back missing, or a backup that restored
- * three of four collections cannot be caught by reading the diff — the failure
+ * four of five collections cannot be caught by reading the diff — the failure
  * is in what the browser did with the data, not in what the code says.
  *
  * `fake-indexeddb` rather than the browser suite: the interesting case is a
@@ -105,6 +106,15 @@ const sheet: SavedSheet = {
   updatedAt: "2026-03-01T09:00:00.000Z",
 };
 
+const inventory: SavedInventory = {
+  id: "sounds-abc",
+  name: "Sounds we know",
+  sounds: ["s:s", "a:a", "t:t"],
+  tricky: ["said"],
+  createdAt: "2026-03-01T09:00:00.000Z",
+  updatedAt: "2026-03-01T09:00:00.000Z",
+};
+
 const EXPORTED_AT = "2026-03-03T09:00:00.000Z";
 
 /**
@@ -159,8 +169,8 @@ async function seedVersion2(): Promise<IDBPDatabase> {
   return old;
 }
 
-describe("upgrading to version 3", () => {
-  it("adds the sheets store and leaves everything else exactly as it was", async () => {
+describe("upgrading from an older version", () => {
+  it("adds the new stores and leaves everything else exactly as it was", async () => {
     freshIndexedDB();
     (await seedVersion2()).close();
 
@@ -172,12 +182,15 @@ describe("upgrading to version 3", () => {
     expect(await db.allSessions()).toEqual([session]);
     expect(await db.allDecks()).toEqual([deck]);
 
-    // The new store is there and has nothing in it.
+    // The new stores are there and have nothing in them. Two of them from a
+    // version 2 database, which is the case a guarded block has to get right:
+    // both run, in order, on the way past.
     expect(await db.allSheets()).toEqual([]);
+    expect(await db.allInventories()).toEqual([]);
 
     // And `sessions` kept its index. Losing it is the quiet failure: every read
     // above still works, and profile deletion and the ghost list stop.
-    const raw = await openDB("schoolskills", 3);
+    const raw = await openDB("schoolskills", 4);
     expect(await raw.getAllFromIndex("sessions", "byProfile", "kid-1")).toEqual(
       [session],
     );
@@ -209,10 +222,12 @@ describe("backing up and restoring", () => {
     await source.putSession(session);
     await source.putDeck(deck);
     await source.putSheet(sheet);
+    await source.putInventory(inventory);
 
     const backup = await source.exportAll();
-    expect(backup.version).toBe(3);
+    expect(backup.version).toBe(4);
     expect(backup.sheets).toEqual([sheet]);
+    expect(backup.inventories).toEqual([inventory]);
 
     // The new laptop: a fresh database, and the file is all it has.
     freshIndexedDB();
@@ -222,11 +237,13 @@ describe("backing up and restoring", () => {
       sessions: 1,
       decks: 1,
       sheets: 1,
+      inventories: 1,
     });
     expect(await moved.allProfiles()).toEqual([profile]);
     expect(await moved.allSessions()).toEqual([session]);
     expect(await moved.allDecks()).toEqual([deck]);
     expect(await moved.allSheets()).toEqual([sheet]);
+    expect(await moved.allInventories()).toEqual([inventory]);
   });
 
   it("restores a file written before decks and before sheets existed", async () => {
@@ -242,7 +259,13 @@ describe("backing up and restoring", () => {
         profiles: [profile],
         sessions: [session],
       }),
-    ).toEqual({ profiles: 1, sessions: 1, decks: 0, sheets: 0 });
+    ).toEqual({
+      profiles: 1,
+      sessions: 1,
+      decks: 0,
+      sheets: 0,
+      inventories: 0,
+    });
     expect(await db.allProfiles()).toEqual([profile]);
     expect(await db.allSheets()).toEqual([]);
 
@@ -254,7 +277,13 @@ describe("backing up and restoring", () => {
         decks: [deck],
         sessions: [session],
       }),
-    ).toEqual({ profiles: 1, sessions: 1, decks: 1, sheets: 0 });
+    ).toEqual({
+      profiles: 1,
+      sessions: 1,
+      decks: 1,
+      sheets: 0,
+      inventories: 0,
+    });
     expect(await db.allDecks()).toEqual([deck]);
   });
 
@@ -263,6 +292,7 @@ describe("backing up and restoring", () => {
     const db = await loadDb();
     await db.putSheet(sheet);
     await db.putDeck(deck);
+    await db.putInventory(inventory);
 
     // "This device is wrong, make it match the file" has to mean every store,
     // or a restore reports that it replaced everything and quietly keeps the
@@ -278,6 +308,7 @@ describe("backing up and restoring", () => {
     );
     expect(await db.allSheets()).toEqual([]);
     expect(await db.allDecks()).toEqual([]);
+    expect(await db.allInventories()).toEqual([]);
     expect(await db.allProfiles()).toEqual([profile]);
   });
 });
@@ -298,5 +329,50 @@ describe("what the sheet service writes", () => {
     });
     expect(saved.id.startsWith("sheet-")).toBe(true);
     expect(await sheets.all()).toEqual([saved]);
+  });
+});
+
+describe("what the phonics service writes", () => {
+  it("keeps a named inventory, and hands it back to be re-ticked", async () => {
+    // "Saved and reusable" is the whole of what the store is for: a parent
+    // ticks the sounds once and adds to the same list after every lesson.
+    freshIndexedDB();
+    await loadDb();
+    const phonics = await import("../phonics");
+
+    const saved = await phonics.create({
+      name: "Sounds we know",
+      inventory: { sounds: ["s:s", "a:a"], tricky: [] },
+    });
+    expect(saved.id.startsWith("sounds-")).toBe(true);
+    expect(await phonics.all()).toEqual([saved]);
+
+    const grown = await phonics.update(saved.id, {
+      name: "Sounds we know",
+      inventory: { sounds: ["s:s", "a:a", "t:t"], tricky: ["said"] },
+    });
+    expect(grown.sounds).toEqual(["s:s", "a:a", "t:t"]);
+    expect(await phonics.all()).toEqual([grown]);
+
+    await phonics.remove(saved.id);
+    expect(await phonics.all()).toEqual([]);
+  });
+
+  it("refuses a list nobody named and one with nothing on it", async () => {
+    freshIndexedDB();
+    await loadDb();
+    const phonics = await import("../phonics");
+
+    await expect(
+      phonics.create({ name: " ", inventory: { sounds: ["s:s"], tricky: [] } }),
+    ).rejects.toThrow(/name/i);
+    // Held to the engine's reading of an inventory: `ai:e` is in the table so
+    // `said` can be described honestly, and is not something a parent can tick.
+    await expect(
+      phonics.create({
+        name: "Everything",
+        inventory: { sounds: ["ai:e"], tricky: [] },
+      }),
+    ).rejects.toThrow(/at least one sound/i);
   });
 });

--- a/src/services/storage/db.test.ts
+++ b/src/services/storage/db.test.ts
@@ -169,6 +169,33 @@ async function seedVersion2(): Promise<IDBPDatabase> {
   return old;
 }
 
+/**
+ * The same, at version 3 — which is what is on production while this ships, so
+ * it is the upgrade every existing parent's browser will actually run. Version
+ * 2 skips two blocks at once and is the harder case in principle; this one is
+ * the only case where `createObjectStore` runs against a database that already
+ * has a store next to the one being added, and a block that forgot its guard
+ * would abort the whole transaction and leave the open rejecting for good.
+ */
+async function seedVersion3(): Promise<IDBPDatabase> {
+  const old = await openDB("schoolskills", 3, {
+    upgrade(database) {
+      database.createObjectStore("profiles", { keyPath: "id" });
+      const sessions = database.createObjectStore("sessions", {
+        keyPath: "id",
+      });
+      sessions.createIndex("byProfile", "profileId");
+      database.createObjectStore("decks", { keyPath: "id" });
+      database.createObjectStore("sheets", { keyPath: "id" });
+    },
+  });
+  await old.put("profiles", profile);
+  await old.put("sessions", session);
+  await old.put("decks", deck);
+  await old.put("sheets", sheet);
+  return old;
+}
+
 describe("upgrading from an older version", () => {
   it("adds the new stores and leaves everything else exactly as it was", async () => {
     freshIndexedDB();
@@ -190,6 +217,30 @@ describe("upgrading from an older version", () => {
 
     // And `sessions` kept its index. Losing it is the quiet failure: every read
     // above still works, and profile deletion and the ghost list stop.
+    const raw = await openDB("schoolskills", 4);
+    expect(await raw.getAllFromIndex("sessions", "byProfile", "kid-1")).toEqual(
+      [session],
+    );
+    raw.close();
+  });
+
+  it("leaves a print shop's saved sheets alone on the way to version 4", async () => {
+    freshIndexedDB();
+    (await seedVersion3()).close();
+
+    const db = await loadDb();
+
+    // The store that already existed comes back untouched. `sheets` is the one
+    // the version 3 block created, so this is the case that proves the guard on
+    // that block is doing its job rather than being skipped by luck.
+    expect(await db.allSheets()).toEqual([sheet]);
+    expect(await db.allProfiles()).toEqual([profile]);
+    expect(await db.allSessions()).toEqual([session]);
+    expect(await db.allDecks()).toEqual([deck]);
+
+    // And the only thing the upgrade added is an empty store.
+    expect(await db.allInventories()).toEqual([]);
+
     const raw = await openDB("schoolskills", 4);
     expect(await raw.getAllFromIndex("sessions", "byProfile", "kid-1")).toEqual(
       [session],
@@ -358,21 +409,29 @@ describe("what the phonics service writes", () => {
     expect(await phonics.all()).toEqual([]);
   });
 
-  it("refuses a list nobody named and one with nothing on it", async () => {
+  it("won't re-tick a list that has been deleted", async () => {
+    // The one refusal that has to read storage to know it is a refusal — the
+    // rest are pure and live in `services/phonics.test.ts`. Two tabs, one of
+    // them holding the edit screen for a list the other just deleted, is the
+    // way a parent reaches it.
     freshIndexedDB();
     await loadDb();
     const phonics = await import("../phonics");
 
+    const saved = await phonics.create({
+      name: "Sounds we know",
+      inventory: { sounds: ["s:s"], tricky: [] },
+    });
+    await phonics.remove(saved.id);
+
     await expect(
-      phonics.create({ name: " ", inventory: { sounds: ["s:s"], tricky: [] } }),
-    ).rejects.toThrow(/name/i);
-    // Held to the engine's reading of an inventory: `ai:e` is in the table so
-    // `said` can be described honestly, and is not something a parent can tick.
-    await expect(
-      phonics.create({
-        name: "Everything",
-        inventory: { sounds: ["ai:e"], tricky: [] },
+      phonics.update(saved.id, {
+        name: "Sounds we know",
+        inventory: { sounds: ["s:s", "a:a"], tricky: [] },
       }),
-    ).rejects.toThrow(/at least one sound/i);
+    ).rejects.toThrow(/no longer exists/i);
+    // And nothing was written on the way out: a failed re-tick must not put
+    // the list back.
+    expect(await phonics.all()).toEqual([]);
   });
 });

--- a/src/services/storage/db.ts
+++ b/src/services/storage/db.ts
@@ -1,6 +1,7 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 
 import { readSession, readSessions } from "@/engine/migrate";
+import type { SavedInventory } from "@/engine/sheets/phonics";
 import type { SavedSheet } from "@/engine/sheets/types";
 import type {
   CustomDeck,
@@ -28,8 +29,9 @@ const DB_NAME = "schoolskills";
 /**
  * 2 added `decks` — parent-authored word lists.
  * 3 added `sheets` — worksheets a parent configured in the print shop.
+ * 4 added `inventories` — the sounds a parent has taught, for phonics sheets.
  */
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 
 /** Oldest sessions past this count are dropped so a profile stays fast to load. */
 export const MAX_SESSIONS_PER_PROFILE = 2000;
@@ -44,6 +46,12 @@ interface HubDB extends DBSchema {
    * for why that is the shape rather than an oversight.
    */
   sheets: { key: string; value: SavedSheet };
+  /**
+   * Keyed by id and nothing else, for the reason `sheets` is: a phonics
+   * programme belongs to the household rather than to a child. See
+   * `services/phonics.ts` for why it is a store rather than a field of a sheet.
+   */
+  inventories: { key: string; value: SavedInventory };
   sessions: {
     key: string;
     /**
@@ -115,6 +123,9 @@ function open(): Promise<IDBPDatabase<HubDB>> {
       }
       if (oldVersion < 3) {
         database.createObjectStore("sheets", { keyPath: "id" });
+      }
+      if (oldVersion < 4) {
+        database.createObjectStore("inventories", { keyPath: "id" });
       }
     },
     // We are the tab asking for the new version and somebody else won't let go.
@@ -198,6 +209,18 @@ export async function removeSheet(id: string): Promise<void> {
   await (await db()).delete("sheets", id);
 }
 
+export async function allInventories(): Promise<SavedInventory[]> {
+  return (await db()).getAll("inventories");
+}
+
+export async function putInventory(saved: SavedInventory): Promise<void> {
+  await (await db()).put("inventories", saved);
+}
+
+export async function removeInventory(id: string): Promise<void> {
+  await (await db()).delete("inventories", id);
+}
+
 export async function putProfile(profile: Profile): Promise<void> {
   await (await db()).put("profiles", profile);
 }
@@ -268,11 +291,20 @@ export async function trimSessions(profileId: string): Promise<number> {
  * can't be missing from the other — which would be a restore that says it
  * replaced everything and quietly kept the old copy of whatever was forgotten.
  */
-const BACKUP_STORES = ["profiles", "sessions", "decks", "sheets"] as const;
+const BACKUP_STORES = [
+  "profiles",
+  "sessions",
+  "decks",
+  "sheets",
+  "inventories",
+] as const;
 
 export type Backup = {
-  /** 2 added `decks`, 3 added `sheets`. Files at any of the three restore. */
-  version: 1 | 2 | 3;
+  /**
+   * 2 added `decks`, 3 added `sheets`, 4 added `inventories`. Files at any of
+   * the four restore.
+   */
+  version: 1 | 2 | 3 | 4;
   exportedAt: string;
   profiles: Profile[];
   decks?: CustomDeck[];
@@ -282,6 +314,8 @@ export type Backup = {
    * the spring must not stop restoring because a later version added a store.
    */
   sheets?: SavedSheet[];
+  /** Optional for the same reason, and for one release longer. */
+  inventories?: SavedInventory[];
   /**
    * Written current, read wide. A file exported today holds widened cards, but
    * one exported last week — or produced by `scripts/convert-legacy-hub.mjs`
@@ -291,18 +325,20 @@ export type Backup = {
 };
 
 export async function exportAll(): Promise<Backup> {
-  const [profiles, sessions, decks, sheets] = await Promise.all([
+  const [profiles, sessions, decks, sheets, inventories] = await Promise.all([
     allProfiles(),
     allSessions(),
     allDecks(),
     allSheets(),
+    allInventories(),
   ]);
   return {
-    version: 3,
+    version: 4,
     exportedAt: new Date().toISOString(),
     profiles,
     decks,
     sheets,
+    inventories,
     sessions,
   };
 }
@@ -323,6 +359,7 @@ export async function importAll(
   sessions: number;
   decks: number;
   sheets: number;
+  inventories: number;
 }> {
   const database = await db();
   const tx = database.transaction(BACKUP_STORES, "readwrite");
@@ -339,6 +376,11 @@ export async function importAll(
     // wrong answer — a file is the only copy there is, so a sheet whose family
     // was retired has to come back rather than be dropped on the way in.
     ...(backup.sheets ?? []).map((s) => tx.objectStore("sheets").put(s)),
+    // Likewise, and likewise not re-validated: a list of sounds a parent spent
+    // a term ticking out is theirs to get back exactly as they left it.
+    ...(backup.inventories ?? []).map((i) =>
+      tx.objectStore("inventories").put(i),
+    ),
     // Widened on the way in, so a restored run is stored in the shape a fresh
     // one would be. Reads migrate anyway; this just stops the file's age from
     // outliving the import.
@@ -352,5 +394,6 @@ export async function importAll(
     sessions: backup.sessions.length,
     decks: backup.decks?.length ?? 0,
     sheets: backup.sheets?.length ?? 0,
+    inventories: backup.inventories?.length ?? 0,
   };
 }


### PR DESCRIPTION
Closes #68. Epic PRINT24.

## What this adds

A parent following a systematic phonics programme can now say which graphemes their child has been taught, and get words back that use only those. The mechanism is a **sound inventory**: a set of grapheme→phoneme correspondences plus the parent's own list of sight ("tricky") words.

Three modules behind one front door at `src/engine/sheets/phonics/`, splitting the way `words/` already does:

- `sounds.ts` — the correspondence table: what each spelling says, which accents differ where they differ, and which spellings are teachable at all.
- `bank.ts` — the word bank, with every word cut into the spellings it is made of rather than into letters.
- `inventory.ts` — what has been taught, and the constrained generation it drives (`decodable`, `pickWords`, `readInventory`).

The distinction the whole model turns on: a word is available when every *spelling* in it has been taught, not when every letter has. A child who knows `c`, `a`, `t` and `h` can read `cat` and cannot read `chat`. Sight words are the only door a word with an irregular spelling can come through, and the rule is never bent to admit one — `said` does not become decodable because a parent ticked `ai`.

## Storage: `DB_VERSION` 4 and the new `inventories` store

`src/services/storage/db.ts` bumps **`DB_VERSION` 3 → 4** and adds an **`inventories`** object store, keyed on `id`, in an `oldVersion < 4` guarded block — additive only, no rewrite of existing data. An inventory is a record of its own rather than a field of a saved sheet, because the list outlives any one worksheet: the same "sounds we know" builds a blending sheet on Monday and a dictation sheet on Friday. Like `sheets`, it is keyed by id alone and belongs to the household rather than to a child.

Backups travel with it: `inventories` joins `BACKUP_STORES`, `Backup.version` widens to `1 | 2 | 3 | 4`, exports are written at version 4, and the field is **optional on read** so a file exported before this release still restores. Restored inventories are not re-validated, for the reason restored sheets aren't — the file is the only copy there is.

`src/services/phonics.ts` is the only writer of the store. Unlike custom word lists it mirrors nothing back into the engine: an inventory travels *as a value* inside a sheet config rather than as an id pointing at this store, which is what lets a configured sheet survive being shared with a household that has never seen this list. Ids are prefixed `sounds-` so three kinds of record can share one IndexedDB and one backup file without colliding.

## Presets, and the trademark question

**A saved inventory is the preset.** Nothing ships pre-labelled. A preset is a name plus a set of sounds, and the parent writes both — shipping "Lesson 47" would reproduce a copyrighted sequence by reference, and shipping "Level 3" would pretend there is one sequence when the point of the model is that there isn't. The inventory mechanism is what every systematic phonics programme is built on and belongs to nobody; DISTAR is an SRA trademark and is not used as a feature name anywhere in this change.

## Tests

`phonics.test.ts` (30 cases) and `services/phonics.test.ts`, plus new `db.test.ts` coverage for the version-4 upgrade and round-tripping inventories through export/import. The acceptance-criteria test is **"uses no spelling outside the inventory"** — it generates against sampled inventories and asserts every spelling of every returned word is on the taught list. Also covered: nothing is printable before anything is taught, sight words stay off a decodable sheet unless asked for, generation is seed-stable, and a rule never reaches a word that follows none.

## Out of scope

Sheet families are PRINT25 — there is no `SheetSpec` here yet. A sound inventory is not a sheet; it is what several sheets will be built out of.

## Validation

`type-check`, `lint`, `test:unit` (1179 passing), `build` (static, 141 pages) and the browser smoke test all pass. The smoke test is load-bearing for the `DB_VERSION` bump and was run against this build: sessions and sheets still write to and read from IndexedDB after the upgrade, with no console errors.
