### PR TITLE
PRINT25: phonics sheets, out of the sounds a parent has taught

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -830,10 +830,13 @@ list: sound cards, the "sounds we know" wall chart, blending lines, word
 families, sound-to-word matching, dictation lines and decodable sentence strips.
 
 The promise is that nothing on any of those pages uses a spelling that has not
-been ticked, and it is checked the way the word search's key is: `sheets.test.ts`
-reads the words back off the finished page, looks each one up in the bank, and
-compares its spellings with the inventory the config carried. A generator
-asserting its own output would agree with itself whatever it did.
+been ticked — with one deliberate exception, the example word printed under a
+sound card, which is the table's own mnemonic ("`sh` as in `ship`") rather than
+a word to decode, and stays put as the inventory grows. Both suites say so where
+they check it. Otherwise it is checked the way the word search's key is:
+`sheets.test.ts` reads the words back off the finished page, looks each one up in
+the bank, and compares its spellings with the inventory the config carried. A
+generator asserting its own output would agree with itself whatever it did.
 
 Two things had to be authored rather than derived. **Sentences** —
 `phonics/sentences.ts` — because a list of readable words is not a sentence and

--- a/docs/printables.md
+++ b/docs/printables.md
@@ -70,7 +70,8 @@ src/engine/sheets/
   maths/*.ts       arithmetic, fractions, geometry, pre-algebra …
   writing/*.ts     tracing, copywork, cursive joins
   words/*.ts       spelling sheets, word search, ABC order, scrambles
-  phonics/*.ts     sound inventories, constrained word generation
+  phonics/*.ts     sound inventories, constrained word generation, the seven
+                   sheets built out of them, and the orthography marking pass
   passages/*.ts    the public-domain text library, Scripture included
   templates/*.ts   lined paper, graph paper, charts, certificates
 
@@ -817,6 +818,45 @@ that is somebody's copyrighted alphabet.
 
 The copy can say, truthfully, that it works alongside DI-style programs. It
 shouldn't use the trademark as a feature name.
+
+**What shipped (PRINT24, PRINT25).** All of it, in that order and in two
+halves. `engine/sheets/phonics/` is the model: a table of correspondences —
+a spelling _and_ the sound it makes there, because `ea` spells three vowels and
+an inventory that could only hold "we've done ea" would put `bread` in front of
+a child who can read `eat` — a hand-cut word bank, and `Inventory`, which is the
+set of correspondences a parent has ticked plus their own list of words taught
+by sight. `phonics/sheets.ts` is the family, and it is seven views of that one
+list: sound cards, the "sounds we know" wall chart, blending lines, word
+families, sound-to-word matching, dictation lines and decodable sentence strips.
+
+The promise is that nothing on any of those pages uses a spelling that has not
+been ticked, and it is checked the way the word search's key is: `sheets.test.ts`
+reads the words back off the finished page, looks each one up in the bank, and
+compares its spellings with the inventory the config carried. A generator
+asserting its own output would agree with itself whatever it did.
+
+Two things had to be authored rather than derived. **Sentences** —
+`phonics/sentences.ts` — because a list of readable words is not a sentence and
+no rule turns one into the other; each is written as the words it is made of, so
+a sentence is available exactly when every word in it is. And the **word bank's
+cuts**, which is PRINT24's argument. Word families are then derived from those
+cuts rather than authored, and grouped by the rime's _spellings_ rather than its
+letters: `be` and `the` end in the same letter and not in the same sound.
+
+The three marks are `macron`, `silent` and `joined` on `PhonicsMarking`, each a
+boolean of its own, all three off by default, and every one of them derived from
+the table — there is nowhere in the code for a programme's own spelling of a
+rule to be written down. They apply to the cards, the chart and the strips, and
+deliberately not to the blending lines or the matching sheet: **marking is for a
+word a child reads, not for a word a child is working out**, and a joined `sh`
+inside `shop` on a matching sheet would print the answer beside the question.
+
+Seven catalog pages at `/printables/phonics`, one per kind of sheet — not per
+sound, which is where this shelf would have become a doorway farm fastest. "sh
+worksheets", "short a worksheets" and forty more are all real queries and all of
+them are one of these sheets with one spelling ticked. Each page states the
+spellings its own sheet uses, and says plainly that yours will be different.
+There is no level, stage or lesson number anywhere on the shelf.
 
 ---
 

--- a/src/components/sheet/blocks/Cards.tsx
+++ b/src/components/sheet/blocks/Cards.tsx
@@ -1,0 +1,110 @@
+import { Fragment, type CSSProperties } from "react";
+
+import {
+  CARD_BIG_LEADING,
+  CARD_PAD_EMS,
+  CARD_SMALL_EMS,
+  CARD_SMALL_LEADING,
+} from "@/engine/sheets/phonics/cards";
+import type { MarkedWord } from "@/engine/sheets/types";
+
+import type { BlockProps } from "./block";
+
+/**
+ * Cards: a spelling over the word it is in, or a sentence on a strip.
+ *
+ * Real text in a real list, not a drawing — the half of §2 the SVG blocks
+ * cannot do. A sound card is a `<li>` a search engine reads, a screen reader
+ * announces and a parent can select and copy, which is exactly what a page
+ * whose whole content is "the letters `sh` say /sh/" needs to be.
+ *
+ * **Nothing here decides a size.** Every proportion comes out of
+ * `phonics/cards.ts` — the big line's size travels on the block, because a
+ * flash card and a sentence strip are this block at two very different sizes,
+ * and the leading and the small line are the constants the family reserved the
+ * page against. A second set of numbers in this file would be a card
+ * overhanging the one beneath it, and the failure is silent on screen.
+ *
+ * The border is a real border rather than a tint, for the reason every other
+ * block gives (§5): background paint is what a browser drops when printing, so
+ * a page of cards to cut out would come out as words floating on nothing.
+ */
+export function Cards({ block }: BlockProps<"cards">) {
+  const columns = Math.max(1, Math.floor(block.columns));
+
+  return (
+    <ol
+      className={`sheet__cards${block.boxed ? " sheet__cards--boxed" : ""}`}
+      style={{ "--sheet-columns": columns } as CSSProperties}
+    >
+      {block.cards.map((card, index) => (
+        <li
+          className="sheet__card"
+          key={index}
+          style={{ padding: `${CARD_PAD_EMS}em` }}
+        >
+          <span
+            className="sheet__card-big"
+            style={{
+              fontSize: `${block.bigEms}em`,
+              lineHeight: CARD_BIG_LEADING,
+            }}
+          >
+            <Marked word={card.big} />
+          </span>
+          {card.small && (
+            <span
+              className="sheet__card-small"
+              style={{
+                fontSize: `${CARD_SMALL_EMS}em`,
+                lineHeight: CARD_SMALL_LEADING,
+              }}
+            >
+              <Marked word={card.small} />
+            </span>
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * A word, in the pieces it is spelled with.
+ *
+ * An unmarked piece is written out as plain text rather than wrapped in a span
+ * of its own, and that is the point: with all three switches off — which is the
+ * default — a card is one run of text with no markup inside it at all, so it
+ * selects, copies and reads aloud as the word it is. Marking a word is
+ * something a parent turns on, and only then does it cost the page any
+ * structure.
+ */
+function Marked({ word }: { word: MarkedWord }) {
+  // Consecutive unmarked pieces are joined back into one run of text. A word is
+  // handed over cut into its spellings whether or not anything is being marked,
+  // and rendering each piece as its own node would leave `sun` on the paper as
+  // three text nodes with React's separators between them — which is worse for
+  // the three things this block is real text *for*: what a search engine
+  // indexes, what a screen reader announces, and what a reader copies.
+  const runs: MarkedWord = [];
+  for (const part of word) {
+    const last = runs.at(-1);
+    if (!part.mark && last && !last.mark)
+      runs[runs.length - 1] = { text: last.text + part.text };
+    else runs.push(part);
+  }
+
+  return (
+    <>
+      {runs.map((part, at) =>
+        part.mark ? (
+          <span className={`sheet__part sheet__part--${part.mark}`} key={at}>
+            {part.text}
+          </span>
+        ) : (
+          <Fragment key={at}>{part.text}</Fragment>
+        ),
+      )}
+    </>
+  );
+}

--- a/src/components/sheet/blocks/index.tsx
+++ b/src/components/sheet/blocks/index.tsx
@@ -15,6 +15,7 @@ import type { Block } from "@/engine/sheets/types";
 
 import type { SheetMetrics } from "../metrics";
 import { Blanks } from "./Blanks";
+import { Cards } from "./Cards";
 import { Choice } from "./Choice";
 import { Clock } from "./Clock";
 import { Copywork } from "./Copywork";
@@ -60,6 +61,8 @@ export function BlockView({
       return <Choice block={block} metrics={metrics} />;
     case "wordshapes":
       return <WordShapes block={block} metrics={metrics} />;
+    case "cards":
+      return <Cards block={block} metrics={metrics} />;
     case "clock":
       return <Clock block={block} metrics={metrics} />;
     case "shapes":

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -30,6 +30,7 @@ import { RATIO_SHEET } from "./maths/ratio";
 import { STATISTICS_SHEET } from "./maths/statistics";
 import { TIME_SHEET } from "./maths/time";
 import { WORD_PROBLEMS_SHEET } from "./maths/wordproblems";
+import { PHONICS_SHEET } from "./phonics/sheets";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
 import { PAPER_SHEET } from "./templates/paper";
 import { HANDWRITING_SHEET } from "./writing/handwriting";
@@ -58,6 +59,7 @@ const SHEETS: Record<string, SheetSpec> = {
   [WORD_STUDY_SHEET.id]: WORD_STUDY_SHEET,
   [PUZZLE_SHEET.id]: PUZZLE_SHEET,
   [GRAMMAR_SHEET.id]: GRAMMAR_SHEET,
+  [PHONICS_SHEET.id]: PHONICS_SHEET,
   [HANDWRITING_SHEET.id]: HANDWRITING_SHEET,
   [MEMORY_SHEET.id]: MEMORY_SHEET,
 };
@@ -83,9 +85,9 @@ export function listSheets(): SheetSpec[] {
 /**
  * The presentation half of `SheetOptions`, copied onto what a family built.
  *
- * Here rather than in fifteen `build` functions for the reason `chrome.ts`
+ * Here rather than in every `build` function for the reason `chrome.ts`
  * gives for living on its own: every family would otherwise write the same
- * three lines, and the sixteenth one added would be the one that forgot. It is
+ * three lines, and the next one added would be the one that forgot. It is
  * safe to do it after the fact because none of the three changes a length —
  * the face is set in points, a bordered slot is the same line box as a ruled
  * one, and the cut guides are drawn over the paper rather than in the flow —

--- a/src/engine/sheets/phonics/cards.ts
+++ b/src/engine/sheets/phonics/cards.ts
@@ -1,0 +1,231 @@
+/**
+ * A word as it is *printed*: cut into its spellings, and marked.
+ *
+ * Two jobs that are one idea, which is why they are one module. The marking
+ * pass turns a word into the pieces a sheet sets it in — a macron over a vowel
+ * that says its own name, a letter that says nothing set pale, two letters
+ * saying one sound joined underneath — and the proportions below are how tall
+ * that lands on the page. A family reserves the page against them and
+ * `Cards.tsx` draws against them, so a second copy in either place would be a
+ * card overhanging the one beneath it.
+ *
+ * ── Why marking is a switch and never a preset ─────────────────────────────
+ *
+ * The three conventions are shared across phonics traditions — every scheme
+ * that marks a long vowel marks it with a bar, and every scheme that shows a
+ * silent letter shows it faintly — but the *combination*, the letterforms and
+ * the sequence they are introduced in are somebody's copyrighted alphabet
+ * (docs/printables.md §13). So they ship as three independent switches with no
+ * shipped combination of them named after anything, and the marks themselves
+ * are derived from `sounds.ts` rather than authored, which means there is
+ * nowhere here for a programme's own spelling of a rule to be written down.
+ *
+ * ── Where marking applies, and where it deliberately does not ──────────────
+ *
+ * **Marking is for a word a child reads, not for a word a child is working
+ * out.** A sound card, a wall chart and a sentence strip are things to be read,
+ * and marking them is the whole point. A blending line has already been cut
+ * into its sounds — the segmentation *is* the marking — and a sound-to-word
+ * matching sheet asks which word contains a spelling, so joining that spelling
+ * in the word would print the answer next to the question. Those styles carry
+ * plain text on purpose, and `sheets.ts` says so where it builds them.
+ *
+ * ── One mark to a piece ────────────────────────────────────────────────────
+ *
+ * The three cannot collide, and it is worth seeing why rather than trusting it:
+ * a silent piece is one the table gives no sounds at all, a macron goes on a
+ * single letter that says one of the five long vowels, and a join needs two
+ * letters or more. No spelling can satisfy two of those at once. So a piece
+ * carries at most one mark and the renderer has one case to draw.
+ */
+import type { MarkedPart, MarkedWord, PhonicsMarking } from "../types";
+
+import { WORD_BY_SPELLING, type Word } from "./bank";
+import { sentenceText, type Sentence } from "./sentences";
+import {
+  CORRESPONDENCE_BY_ID,
+  graphemeParts,
+  type Correspondence,
+} from "./sounds";
+
+/* ── How big a card is ────────────────────────────────────────────────────
+   Declared, not measured (§4). Everything is in ems of the body size, so a
+   parent who wants cards twice the size raises the type size and the whole
+   card grows with it — which is also how the same block prints a flash card an
+   inch high and a sentence strip a child reads across a room.               */
+
+/** The spelling on a sound card, and on the wall chart. */
+export const CARD_BIG_EMS = 3.2;
+
+/** A sentence strip: a whole sentence, so a great deal smaller than a card. */
+export const STRIP_BIG_EMS = 1.6;
+
+/** The example word under the spelling. */
+export const CARD_SMALL_EMS = 0.95;
+
+/** The leading each of the two lines is set on. */
+export const CARD_BIG_LEADING = 1.1;
+export const CARD_SMALL_LEADING = 1.35;
+
+/** The air inside a card's box, top and bottom each. */
+export const CARD_PAD_EMS = 0.42;
+
+/**
+ * How tall one card stands, in ems of the body size.
+ *
+ * Written here and read by both the family that reserves the page and the
+ * renderer that draws the box, for the reason `answerLine` gives: the failure
+ * is silent on screen and is the last row of cards on a second sheet of paper.
+ *
+ * `rows` is how many lines the big line wraps onto — one for a spelling, and
+ * however many the longest sentence needs for a strip.
+ */
+export function cardRowEms(big: number, rows: number, small: boolean): number {
+  return (
+    rows * big * CARD_BIG_LEADING +
+    (small ? CARD_SMALL_EMS * CARD_SMALL_LEADING : 0) +
+    CARD_PAD_EMS * 2
+  );
+}
+
+/* ── The marks ──────────────────────────────────────────────────────────── */
+
+/**
+ * The sound each single vowel letter makes when it says its own name.
+ *
+ * The whole of what "long vowel" means for a marking pass, and it is a fact
+ * about the five letters rather than about any programme: the letter `a` says
+ * /ai/ in `baby` and in `cake`, and the bar is what tells a child that from the
+ * `a` of `cat`. A vowel *team* is not marked — `ea` and `oa` say the same
+ * sounds and carry no bar in any tradition, because the second letter is
+ * already the signal.
+ */
+const SAYS_ITS_NAME = new Map<string, string>([
+  ["a", "ai"],
+  ["e", "ee"],
+  ["i", "ie"],
+  ["o", "oa"],
+  ["u", "oo"],
+]);
+
+/**
+ * One piece of a spelling, marked — or not, if the switch for it is off.
+ *
+ * `letters` is what is printed, which is not always the whole grapheme: a split
+ * vowel is drawn whole on a sound card (`a_e`) and in two places inside a word
+ * (`c a k e`), and both go through here.
+ */
+function markOf(
+  letters: string,
+  entry: Correspondence,
+  marking: PhonicsMarking,
+): MarkedPart {
+  if (marking.silent && entry.phonemes.length === 0)
+    return { text: letters, mark: "silent" };
+  if (
+    marking.macron &&
+    letters.length === 1 &&
+    entry.phonemes.includes(SAYS_ITS_NAME.get(letters) ?? "")
+  )
+    return { text: letters, mark: "macron" };
+  if (marking.joined && letters.length > 1)
+    return { text: letters, mark: "joined" };
+  return { text: letters };
+}
+
+/**
+ * A spelling as a card prints it: the letters as the table writes them, with
+ * the `_` of a split vowel left in.
+ *
+ * Whole rather than cut in two, because on a card the spelling is the *thing*
+ * — `a_e` is what a parent ticked and what the child is being shown — and a
+ * card reading "a" beside a card reading "e" would be two cards that are not
+ * the spelling. A macron here does real work: it is what tells the `a` of
+ * `baby` from the `a` of `cat` when the two are next to each other on the wall.
+ */
+export const markGrapheme = (
+  entry: Correspondence,
+  marking: PhonicsMarking,
+): MarkedWord => [markOf(entry.grapheme, entry, marking)];
+
+/**
+ * A word, cut into the spellings it is made of and marked.
+ *
+ * A split vowel puts its head where the vowel goes and its tail at the end of
+ * the word — the same reassembly `phonics.test.ts` checks the bank with — which
+ * is what makes `cake` out of `c` + `a_e` + `k`, and what makes the final `e`
+ * the piece the silent switch dims. A part naming a spelling this build has
+ * never heard of is printed as itself and marked with nothing: a word that
+ * cannot be cut is still a word, and refusing to print it would be a blank
+ * space on a page where a child is expecting one.
+ */
+export function markWord(entry: Word, marking: PhonicsMarking): MarkedWord {
+  const head: MarkedWord = [];
+  const tail: MarkedWord = [];
+  for (const part of entry.parts) {
+    const found = CORRESPONDENCE_BY_ID.get(part);
+    if (!found) {
+      head.push({ text: part });
+      continue;
+    }
+    const [letters, trailing] = graphemeParts(found.grapheme);
+    head.push(markOf(letters, found, marking));
+    // The trailing half of a split vowel is silent by construction rather than
+    // by anything the table says: the sound belongs to the pair, and the `e` on
+    // the end of `cake` is carrying none of it. It is also the commonest silent
+    // letter in English by a distance, which is why the switch is worth having.
+    if (trailing)
+      tail.push(
+        marking.silent
+          ? { text: trailing, mark: "silent" }
+          : { text: trailing },
+      );
+  }
+  return [...head, ...tail];
+}
+
+/** The same, from the word as it is spelled. Plain if the bank has no cut. */
+export const markSpelling = (
+  word: string,
+  marking: PhonicsMarking,
+): MarkedWord => {
+  const found = WORD_BY_SPELLING.get(word);
+  return found ? markWord(found, marking) : [{ text: word }];
+};
+
+/**
+ * A whole sentence, marked word by word, with its capital and its full stop.
+ *
+ * The spaces are pieces of their own rather than padding on the words either
+ * side, because a marked piece is drawn as a box with a rule under it: a space
+ * inside a joined `sh` would draw the join across it. The capital goes on the
+ * first piece and the mark on the end is a piece with nothing on it — neither
+ * is part of a spelling, and neither is ever marked.
+ */
+export function markSentence(
+  sentence: Sentence,
+  marking: PhonicsMarking,
+): MarkedWord {
+  const out: MarkedWord = [];
+  sentence.words.forEach((word, at) => {
+    if (at > 0) out.push({ text: " " });
+    out.push(...markSpelling(word, marking));
+  });
+  const first = out[0];
+  if (first) {
+    out[0] = {
+      ...first,
+      text: `${first.text.charAt(0).toUpperCase()}${first.text.slice(1)}`,
+    };
+  }
+  out.push({ text: sentence.end });
+  return out;
+}
+
+/** What a marked word says, with the marks taken off — for a test, and a key. */
+export const markedText = (word: MarkedWord): string =>
+  word.map((part) => part.text).join("");
+
+/** How long a sentence prints, before anything is marked. */
+export const sentenceLength = (sentence: Sentence): number =>
+  sentenceText(sentence).length;

--- a/src/engine/sheets/phonics/cards.ts
+++ b/src/engine/sheets/phonics/cards.ts
@@ -45,6 +45,7 @@ import { sentenceText, type Sentence } from "./sentences";
 import {
   CORRESPONDENCE_BY_ID,
   graphemeParts,
+  graphemeText,
   type Correspondence,
 } from "./sounds";
 
@@ -112,7 +113,7 @@ const SAYS_ITS_NAME = new Map<string, string>([
  * One piece of a spelling, marked — or not, if the switch for it is off.
  *
  * `letters` is what is printed, which is not always the whole grapheme: a split
- * vowel is drawn whole on a sound card (`a_e`) and in two places inside a word
+ * vowel is drawn whole on a sound card (`a-e`) and in two places inside a word
  * (`c a k e`), and both go through here.
  */
 function markOf(
@@ -134,19 +135,25 @@ function markOf(
 }
 
 /**
- * A spelling as a card prints it: the letters as the table writes them, with
- * the `_` of a split vowel left in.
+ * A spelling as a card prints it: the letters as the table writes them, with a
+ * split vowel written the way a page writes one — `a-e`, never `a_e`.
  *
  * Whole rather than cut in two, because on a card the spelling is the *thing*
- * — `a_e` is what a parent ticked and what the child is being shown — and a
+ * — `a-e` is what a parent ticked and what the child is being shown — and a
  * card reading "a" beside a card reading "e" would be two cards that are not
  * the spelling. A macron here does real work: it is what tells the `a` of
  * `baby` from the `a` of `cat` when the two are next to each other on the wall.
+ *
+ * The `graphemeText` is not cosmetic and not the family's job to do afterwards:
+ * a card's big line is the last thing between the table's own notation and a
+ * dashed guide a parent cuts along, and an underscore an inch high reads as a
+ * blank to fill in. Every other place a grapheme is printed goes through the
+ * same call, so there is one answer to "how is a split vowel written down".
  */
 export const markGrapheme = (
   entry: Correspondence,
   marking: PhonicsMarking,
-): MarkedWord => [markOf(entry.grapheme, entry, marking)];
+): MarkedWord => [markOf(graphemeText(entry.grapheme), entry, marking)];
 
 /**
  * A word, cut into the spellings it is made of and marked.

--- a/src/engine/sheets/phonics/index.ts
+++ b/src/engine/sheets/phonics/index.ts
@@ -6,12 +6,18 @@
  * (`bank.ts`), and what a parent has taught plus the generation it constrains
  * (`inventory.ts`).
  *
- * Everything above the engine comes through here — the sheet families in
- * PRINT25, the tick list that builds an inventory, and the service that saves
- * one — so that none of them has to know which module a fact lives in, and so
- * the model can be re-cut without a screen noticing. There is no `SheetSpec`
- * here yet: a sound inventory is not a sheet, it is what several sheets are
- * built out of, and the families that consume it are the next story.
+ * Everything above the engine comes through here — the sheet family, the tick
+ * list that builds an inventory, and the service that saves one — so that none
+ * of them has to know which module a fact lives in, and so the model can be
+ * re-cut without a screen noticing.
+ *
+ * Two modules joined the three when the sheets arrived, and both are about
+ * *printing* rather than about the model: `sentences.ts`, the connected text a
+ * child can read, which is the one thing the bank and an inventory could not
+ * between them derive; and `cards.ts`, which cuts a word into the pieces a
+ * sheet sets it in and states how tall they stand. `sheets.ts` is the family
+ * itself and is reached through `engine/sheets/index.ts` like every other one,
+ * not through here.
  */
 export {
   CORRESPONDENCES,
@@ -35,6 +41,30 @@ export {
   wordSounds,
   type Word,
 } from "./bank";
+
+export {
+  CARD_BIG_EMS,
+  CARD_BIG_LEADING,
+  CARD_PAD_EMS,
+  CARD_SMALL_EMS,
+  CARD_SMALL_LEADING,
+  STRIP_BIG_EMS,
+  cardRowEms,
+  markGrapheme,
+  markSentence,
+  markSpelling,
+  markWord,
+  markedText,
+} from "./cards";
+
+export {
+  SENTENCES,
+  canReadSentence,
+  pickSentences,
+  sentenceText,
+  sentenceWords,
+  type Sentence,
+} from "./sentences";
 
 export {
   EMPTY_INVENTORY,

--- a/src/engine/sheets/phonics/index.ts
+++ b/src/engine/sheets/phonics/index.ts
@@ -27,6 +27,7 @@ export {
   PHONEME_BY_ID,
   defaultSpelling,
   graphemeParts,
+  graphemeText,
   isTeachable,
   spellingId,
   type Correspondence,

--- a/src/engine/sheets/phonics/sentences.ts
+++ b/src/engine/sheets/phonics/sentences.ts
@@ -1,0 +1,236 @@
+/**
+ * Sentences a child can read, made only of words this bank already holds.
+ *
+ * A decodable sentence is the one thing in the phonics family that could not be
+ * derived from `bank.ts` and an inventory: a list of readable words is not a
+ * sentence, and there is no rule that turns one into the other. English word
+ * order is learnable by a generator only in the sense that a generator can
+ * produce grammatical nonsense — "the mat sat on the cat" is decodable, is
+ * correct English, and is not a sentence anybody would put in front of a
+ * five-year-old who is still deciding whether reading is worth it.
+ *
+ * So they are written down, the way `grammar/bank.ts` writes its sentences down
+ * and for the same reason: the judgement is a person's.
+ *
+ * ── A sentence is a list of words, not a string ────────────────────────────
+ *
+ * Each one is authored as the words it is made of, and the capital letter and
+ * the mark on the end are put on when it is printed. That is not a storage
+ * trick — it is what makes the constraint checkable. Every word here is looked
+ * up in the bank, so a sentence is available to a child exactly when *each of
+ * its words* is, by the same `canRead` that decides a single word. A sentence
+ * authored as `"The cat sat on the mat."` would have to be cut apart again by
+ * something that knew about capitals and full stops, and that something would
+ * be a second answer to "which words is this made of".
+ *
+ * `sheets.test.ts` holds every word here to the bank, so a typo is a failing
+ * test rather than a sentence that silently never prints.
+ *
+ * ── What is not here ───────────────────────────────────────────────────────
+ *
+ * `and`, `is`, `a`, `was` and `his` are not in the bank, so no sentence below
+ * uses them, and that shows: these are short and a little clipped. That is the
+ * honest cost of the promise, and the alternative — quietly adding words to the
+ * bank so the prose reads better — is how a sheet ends up with a word on it
+ * that nobody cut by hand. `was` in particular stays out for the reason
+ * `bank.ts` gives: the two varieties disagree about its vowel.
+ *
+ * `the` is in nearly all of them, and it costs a child two spellings — `th` as
+ * in `this` and the unstressed `e` of `garden`. Every programme teaches it long
+ * before either, which is exactly what `Inventory.tricky` is for: a parent who
+ * has taught `the` by sight puts it on that list and these sentences open up.
+ */
+import { mulberry32, shuffled } from "@/engine/random";
+
+import { WORD_BY_SPELLING, type Word } from "./bank";
+import { canRead, type Inventory } from "./inventory";
+
+export type Sentence = {
+  /** The words, lower case, in order. Every one of them is in the bank. */
+  words: string[];
+  /**
+   * The mark it ends on.
+   *
+   * Two of them, for the reason the grammar family's punctuation sheet gives:
+   * a full stop and a question mark are decided by how the sentence is built,
+   * and an exclamation mark is decided by how loudly you imagined it.
+   */
+  end: "." | "?";
+};
+
+const s = (words: string, end: Sentence["end"] = "."): Sentence => ({
+  words: words.split(" "),
+  end,
+});
+
+/* ── Short vowels, and nothing else ───────────────────────────────────────
+   What a first reader is: three-letter words, one function word, and a full
+   stop. Every sentence here is readable by a child who has the five short
+   vowels, the single-letter consonants and `the`.                          */
+
+const FIRST: Sentence[] = [
+  s("the cat sat on the mat"),
+  s("the fat pig can dig"),
+  s("the hen ran up the hill"),
+  s("the bug hid in the mud"),
+  s("the pup can jump on the rug"),
+  s("the man let the cat in"),
+  s("the kid hid in the tent"),
+  s("the red hat fell in the mud"),
+  s("the fox ran in the fog"),
+  s("the cup fell on the rug"),
+  s("the pig will not sit"),
+  s("the cat will nap on the bed"),
+  s("the man must run up the hill"),
+  s("can the cat jump", "?"),
+  s("will the dog dig", "?"),
+];
+
+/* ── Doubled letters, ck, and the blends ──────────────────────────────────
+   The same sentences with more than one consonant at an end of a word, which
+   is the step a child takes long before any new vowel.                      */
+
+const BLENDED: Sentence[] = [
+  s("the duck sat on the rock"),
+  s("the frog can hop"),
+  s("the dog will dig in the sand"),
+  s("the lamp fell off the desk"),
+  s("the big black crab went in the sand"),
+  s("stand on the step"),
+  s("put the gift in the box"),
+  s("the best nest fell down"),
+];
+
+/* ── The consonant digraphs ─────────────────────────────────────────────── */
+
+const DIGRAPHED: Sentence[] = [
+  s("the fish will swim"),
+  s("the chick sat in the shed"),
+  s("the king will sing the long song"),
+  s("this fish will not swim"),
+  s("the shop shut at ten"),
+  s("the thin man went in the shop"),
+  s("the fish went in the dish"),
+  s("the duck will swim in the pond"),
+  s("how did the bird get in", "?"),
+];
+
+/* ── A vowel that says its own name ─────────────────────────────────────── */
+
+const SPLIT: Sentence[] = [
+  s("the snake will hide in the cave"),
+  s("the white kite went up"),
+  s("make the cake at nine"),
+  s("take the note home"),
+  s("the mice hid in the hole"),
+  s("the stone fell in the lake"),
+  s("five white mice came home"),
+];
+
+/* ── Vowel teams ────────────────────────────────────────────────────────── */
+
+const TEAMS: Sentence[] = [
+  s("the rain fell on the road"),
+  s("the goat sat on the boat"),
+  s("we can play in the rain"),
+  s("she can see the moon"),
+  s("the train went down the road"),
+  s("keep the food in the room"),
+  s("the boy will play by the pool"),
+  s("the cow went down the street"),
+  s("the green tree grew tall"),
+  s("we will eat the sweet fruit"),
+];
+
+/* ── The r-coloured vowels ──────────────────────────────────────────────── */
+
+const R_COLOURED: Sentence[] = [
+  s("the car went far"),
+  s("the bird sat on the chair"),
+  s("the girl sat in the dark"),
+  s("park the car by the barn"),
+  s("the corn grew in the dirt"),
+];
+
+/**
+ * Every sentence this build may print, roughly in the order a child could
+ * first read one.
+ *
+ * One flat list, exactly as `WORDS` is and for the same reason: what a sentence
+ * is available for is decided by the words in it and by nothing else. A sheet
+ * drawing from "the digraph group" would hand a child a sentence because of the
+ * group it was filed under rather than because they can read it.
+ */
+export const SENTENCES: Sentence[] = [
+  ...FIRST,
+  ...BLENDED,
+  ...DIGRAPHED,
+  ...SPLIT,
+  ...TEAMS,
+  ...R_COLOURED,
+];
+
+/**
+ * The bank entries a sentence is made of, or nothing if one of them is missing.
+ *
+ * All or nothing on purpose. A word the bank has never heard of cannot be
+ * checked against an inventory, so a sentence containing one is not "mostly
+ * decodable" — it is a sentence this build cannot make a promise about, and the
+ * only safe thing to do with it is not print it. The test above is what stops
+ * that ever being the answer in a shipped build.
+ */
+export function sentenceWords(sentence: Sentence): Word[] | undefined {
+  const out: Word[] = [];
+  for (const word of sentence.words) {
+    const found = WORD_BY_SPELLING.get(word);
+    if (!found) return undefined;
+    out.push(found);
+  }
+  return out;
+}
+
+/** How it reads on the paper: a capital at the front, the mark on the end. */
+export function sentenceText(sentence: Sentence): string {
+  const line = sentence.words.join(" ");
+  return `${line.charAt(0).toUpperCase()}${line.slice(1)}${sentence.end}`;
+}
+
+/**
+ * Can this child read this sentence? Every word in it, by the same rule that
+ * decides a single word.
+ *
+ * The sets are the caller's for the reason `canRead`'s are: the question is
+ * asked once per sentence per sheet, and rebuilding two sets each time is what
+ * turns a live preview into a stutter.
+ */
+export function canReadSentence(
+  sentence: Sentence,
+  inventory: Inventory,
+  taught: Set<string> = new Set(inventory.sounds),
+  sight: Set<string> = new Set(inventory.tricky),
+): boolean {
+  const words = sentenceWords(sentence);
+  if (!words) return false;
+  return words.every((word) => canRead(word, inventory, taught, sight));
+}
+
+/**
+ * Sentences for a sheet: readable, in an order the seed decides.
+ *
+ * The same bargain `pickWords` makes, and deliberately the same shape — the
+ * count is a request, fewer come back when fewer can be read, and the page is
+ * deterministic in `(inventory, count, seed)` so that `seed + 1` is "another
+ * one like this" here as it is everywhere else in the shop (§7).
+ */
+export function pickSentences(
+  inventory: Inventory,
+  count: number,
+  seed: number,
+): Sentence[] {
+  const taught = new Set(inventory.sounds);
+  const sight = new Set(inventory.tricky);
+  const pool = SENTENCES.filter((sentence) =>
+    canReadSentence(sentence, inventory, taught, sight),
+  );
+  return shuffled(pool, mulberry32(seed)).slice(0, Math.max(0, count));
+}

--- a/src/engine/sheets/phonics/sheets.test.ts
+++ b/src/engine/sheets/phonics/sheets.test.ts
@@ -18,7 +18,6 @@ import { SENTENCES, sentenceText, sentenceWords } from "./sentences";
 import {
   PHONICS_STYLES,
   familiesOf,
-  graphemeText,
   phonicsColumns,
   phonicsLayout,
   phonicsSupply,
@@ -27,6 +26,7 @@ import {
   CORRESPONDENCES,
   CORRESPONDENCE_BY_ID,
   PHONEME_BY_ID,
+  graphemeText,
   isTeachable,
 } from "./sounds";
 
@@ -301,6 +301,32 @@ describe("an answer that can be checked without the generator", () => {
     }
   });
 
+  it("puts a different ending on every line while endings are left", () => {
+    // The shape the sheet is set in: one word from each family before a second
+    // from any. A page of twenty over three rimes is a spelling list — eleven
+    // of its rows were `-ip` before the draw went round by round — and it is
+    // not what somebody who printed "word families" asked for.
+    for (const [name, inventory] of INVENTORIES) {
+      // Never more lines than there are families, which is the condition the
+      // rule can be stated under: past that a rime has to come round twice.
+      const wanted = Math.min(12, familiesOf(inventory).size);
+      for (let seed = 0; seed < 4; seed++) {
+        const block = only(
+          buildSheet(config("families", inventory, { count: wanted }), seed),
+        );
+        if (block.kind !== "problems") return;
+        // Read off the paper: the ending is the second half of the sum.
+        const rimes = block.items.map(
+          (item) => item.prompt.replace(" =", "").split(" + ")[1],
+        );
+        expect(rimes.length, `${name} · seed ${seed}`).toBeGreaterThan(0);
+        expect(new Set(rimes).size, `${name} · seed ${seed}`).toBe(
+          rimes.length,
+        );
+      }
+    }
+  });
+
   it("never groups two rimes that only look alike", () => {
     // `be` and `the` end in the same letter and not in the same sound. A
     // family keyed on letters would put them together and teach a rhyme that
@@ -360,6 +386,40 @@ describe("an answer that can be checked without the generator", () => {
       // And the same letters never appear twice down the left, which would be
       // two identical rows a child could not tell apart.
       expect(new Set(block.left).size).toBe(block.left.length);
+    }
+  });
+
+  it("leaves no second line a child could defensibly draw", () => {
+    // The same exclusivity, asked the way the child holding the pencil asks it:
+    // over the letters *printed* on the two columns, with no table consulted.
+    // A `n` on the left and `strong` on the right is a line somebody can draw
+    // and be marked wrong for, however certain the generator is that the `ng`
+    // in it is one sound. A split vowel prints with its halves apart — `a-e` —
+    // so there is nothing to search a word for, and it is the one row this
+    // reads by the cut instead.
+    for (const [name, inventory] of INVENTORIES) {
+      for (let seed = 0; seed < 8; seed++) {
+        const block = only(buildSheet(config("matching", inventory), seed));
+        if (block.kind !== "matching") return;
+        expect(block.left.length, `${name} · seed ${seed}`).toBeGreaterThan(0);
+
+        block.left.forEach((letters, at) => {
+          const [head, tail] = letters.split("-");
+          block.right.forEach((word, other) => {
+            if (other === block.answer[at]) return;
+            const shows = tail
+              ? (WORD_BY_SPELLING.get(word)?.parts ?? []).some(
+                  (part) =>
+                    CORRESPONDENCE_BY_ID.get(part)?.grapheme ===
+                    `${head}_${tail}`,
+                )
+              : word.includes(head);
+            expect(shows, `${name} · seed ${seed} · ${letters} → ${word}`).toBe(
+              false,
+            );
+          });
+        });
+      }
     }
   });
 
@@ -584,6 +644,29 @@ describe("the sheet as a whole", () => {
     const block = only(buildSheet(config("blending", EVERYTHING), 9));
     if (block.kind !== "problems") return;
     for (const item of block.items) expect(item.prompt).not.toContain("_");
+  });
+
+  it("shows one on a card and on the chart too, an inch high", () => {
+    // The two styles that print a grapheme *as the thing on the paper* rather
+    // than inside a prompt — which is where the underscore would be an inch
+    // tall and a dashed guide would be cut round it.
+    //
+    // Ticked directly rather than drawn out of everything, because both styles
+    // take the table in its own order and the vowels are the end of it: a page
+    // built from the whole table is as many consonants as the paper holds, and
+    // would pass this without a split vowel ever being on it.
+    const split: Inventory = {
+      sounds: ["a_e:ai", "i_e:ie", "o_e:oa", "s:s", "t:t"],
+      tricky: [],
+    };
+    for (const style of ["cards", "chart"] as const) {
+      const block = only(buildSheet(config(style, split, { count: 5 }), 3));
+      if (block.kind !== "cards") return;
+      const printed = block.cards.map((card) => markedText(card.big));
+      expect(printed, style).toHaveLength(5);
+      for (const letters of printed) expect(letters, style).not.toContain("_");
+      expect(printed, style).toContain("a-e");
+    }
   });
 
   it("cuts every card out of a spelling this build still teaches", () => {

--- a/src/engine/sheets/phonics/sheets.test.ts
+++ b/src/engine/sheets/phonics/sheets.test.ts
@@ -1,0 +1,626 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet } from "@/engine/sheets";
+import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "@/engine/sheets/paper";
+import type {
+  Block,
+  MarkedWord,
+  PhonicsConfig,
+  PhonicsMarking,
+  PhonicsStyle,
+  Sheet,
+} from "@/engine/sheets/types";
+
+import { WORD_BY_SPELLING } from "./bank";
+import { markWord, markedText } from "./cards";
+import { allSounds, readInventory, type Inventory } from "./inventory";
+import { SENTENCES, sentenceText, sentenceWords } from "./sentences";
+import {
+  PHONICS_STYLES,
+  familiesOf,
+  graphemeText,
+  phonicsColumns,
+  phonicsLayout,
+  phonicsSupply,
+} from "./sheets";
+import {
+  CORRESPONDENCES,
+  CORRESPONDENCE_BY_ID,
+  PHONEME_BY_ID,
+  isTeachable,
+} from "./sounds";
+
+/**
+ * The phonics sheets, held to the one promise the family makes.
+ *
+ * **Nothing on the page uses a spelling that has not been taught.** Every case
+ * below is a way of checking that, and the check is deliberately made from the
+ * *finished sheet* rather than from the generator: the words are read back off
+ * the blocks, looked up in the bank, and their spellings compared with the
+ * inventory the config carried. A generator asserting its own output would
+ * agree with itself whatever it did — the same reason a word search's key is
+ * found by searching its grid (§11).
+ *
+ * The answer keys are re-derived the same way. A blending prompt is put back
+ * together into the word it segments, a family's sum is added up, and a
+ * matching pair is checked against the letters in the word rather than against
+ * the index the placer remembered writing.
+ */
+
+/* ── Inventories to print from ─────────────────────────────────────────────
+   Written out as ids rather than derived, because a test whose inventory came
+   out of a filter over the same table the family reads would pass on a table
+   that had quietly changed underneath both. `keeps` asserts every id below is
+   still a spelling this build teaches, so a renamed correspondence fails here
+   rather than silently narrowing every case that follows.                    */
+
+const FIRST_SOUNDS = [
+  "s:s",
+  "a:a",
+  "t:t",
+  "p:p",
+  "i:i",
+  "n:n",
+  "m:m",
+  "d:d",
+  "g:g",
+  "o:o",
+  "c:k",
+  "k:k",
+  "e:e",
+  "u:u",
+  "r:r",
+  "h:h",
+  "b:b",
+  "f:f",
+  "l:l",
+  "j:j",
+  "v:v",
+  "w:w",
+  "y:y",
+  "z:z",
+  "x:k-s",
+];
+
+const DIGRAPH_SOUNDS = [
+  "sh:sh",
+  "ch:ch",
+  "th:th",
+  "th:dh",
+  "ck:k",
+  "ng:ng",
+  "ll:l",
+  "ss:s",
+  "ff:f",
+  "zz:z",
+  "e:uh",
+];
+
+/** The first letters, plus `the` taught by sight the way every scheme does. */
+const FIRST: Inventory = { sounds: FIRST_SOUNDS, tricky: ["the"] };
+
+const DIGRAPHS: Inventory = {
+  sounds: [...FIRST_SOUNDS, ...DIGRAPH_SOUNDS],
+  tricky: ["the", "said"],
+};
+
+const EVERYTHING = allSounds();
+
+const INVENTORIES: Array<[name: string, inventory: Inventory]> = [
+  ["the first letters", FIRST],
+  ["the digraphs as well", DIGRAPHS],
+  ["everything the table teaches", EVERYTHING],
+];
+
+const config = (
+  style: PhonicsStyle,
+  inventory: Inventory,
+  extra: Partial<PhonicsConfig> = {},
+): PhonicsConfig => ({
+  kind: "phonics",
+  paper: DEFAULT_PAPER,
+  fontPt: DEFAULT_FONT_PT,
+  fields: ["name", "date"],
+  style,
+  inventory,
+  marking: {},
+  count: 16,
+  columns: 2,
+  ...extra,
+});
+
+/* ── Reading the page back ─────────────────────────────────────────────── */
+
+const only = (sheet: Sheet): Block => {
+  expect(sheet.blocks).toHaveLength(1);
+  return sheet.blocks[0];
+};
+
+/**
+ * A blending prompt put back together into the word it cuts up.
+ *
+ * The independent path for that style: it reads the letters off the paper and
+ * reassembles them by the one rule the notation has — a split vowel is printed
+ * `a-e`, its first half sits where the vowel goes and its second half at the
+ * end of the word — without consulting the bank entry the prompt came from.
+ */
+function blended(prompt: string): string {
+  const head: string[] = [];
+  const tail: string[] = [];
+  for (const piece of prompt.split("·").map((part) => part.trim())) {
+    const cut = piece.indexOf("-");
+    if (cut < 0) head.push(piece);
+    else {
+      head.push(piece.slice(0, cut));
+      tail.push(piece.slice(cut + 1));
+    }
+  }
+  return [...head, ...tail].join("");
+}
+
+/** Every whole word this sheet prints, whichever block it printed it in. */
+function wordsOn(sheet: Sheet): string[] {
+  const block = only(sheet);
+  if (block.kind === "problems")
+    return block.items.map((item) => item.answer).filter(Boolean);
+  if (block.kind === "matching") return block.right;
+  if (block.kind === "cards")
+    return block.cards.flatMap((card) =>
+      markedText(card.big)
+        .toLowerCase()
+        .split(/[^a-z]+/)
+        .filter(Boolean),
+    );
+  return [];
+}
+
+/**
+ * Is this word one the inventory really allows?
+ *
+ * Re-derived from the spellings rather than asked of `canRead`, which is the
+ * point: the family calls `canRead`, so a bug inside it would make the family
+ * and its test wrong together. Here the parts are compared with the ticked ids
+ * directly, and a sight word is only allowed where the style says it is.
+ */
+function allowed(word: string, inventory: Inventory, sight: boolean): boolean {
+  const entry = WORD_BY_SPELLING.get(word);
+  if (!entry) return false;
+  if (entry.parts.every((part) => inventory.sounds.includes(part))) return true;
+  return sight && inventory.tricky.includes(word);
+}
+
+/* ── The table these cases are written against ─────────────────────────── */
+
+describe("the inventories these cases print from", () => {
+  it("keeps every spelling they name", () => {
+    for (const [name, inventory] of INVENTORIES) {
+      const read = readInventory(inventory);
+      expect(read.sounds, name).toHaveLength(inventory.sounds.length);
+      expect(read.tricky, name).toEqual(inventory.tricky);
+    }
+  });
+});
+
+/* ── The promise ───────────────────────────────────────────────────────── */
+
+/**
+ * The styles that print whole words, and whether a sight word may be one.
+ *
+ * Two of the five say yes, and each for a reason written down where it is
+ * built: a dictation line is read out rather than sounded out, which is exactly
+ * how `said` is taught, and a sentence needs `the` long before a child could
+ * decode it. Everywhere else a sight word on the page would be a word offered
+ * as though it followed the rules.
+ */
+const WORD_STYLES: Array<[style: PhonicsStyle, sight: boolean]> = [
+  ["blending", false],
+  ["families", false],
+  ["matching", false],
+  ["dictation", true],
+  ["sentences", true],
+];
+
+describe("what may go on the page", () => {
+  it("uses no spelling outside the inventory, on any style or seed", () => {
+    for (const [name, inventory] of INVENTORIES) {
+      for (const [style, sight] of WORD_STYLES) {
+        for (let seed = 0; seed < 8; seed++) {
+          const sheet = buildSheet(config(style, inventory), seed);
+          for (const word of wordsOn(sheet)) {
+            expect(
+              allowed(word, inventory, sight),
+              `${style} · ${name} · seed ${seed} · ${word}`,
+            ).toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  it("prints nothing at all before anything is taught", () => {
+    for (const style of PHONICS_STYLES) {
+      const sheet = buildSheet(config(style, { sounds: [], tricky: [] }), 1);
+      const block = only(sheet);
+      const items =
+        block.kind === "problems"
+          ? block.items.length
+          : block.kind === "cards"
+            ? block.cards.length
+            : block.kind === "matching"
+              ? block.left.length
+              : 0;
+      expect(items, style).toBe(0);
+    }
+  });
+
+  it("keeps sight words off every sheet but the dictation one", () => {
+    // `said` is on the list and can never be sounded out, so a sheet that
+    // asks a child to blend it is the exact failure the `odd` flag exists to
+    // prevent. A dictation line is where it belongs, because it is read out.
+    const spoken = new Set(
+      wordsOn(buildSheet(config("dictation", DIGRAPHS, { count: 60 }), 3)),
+    );
+    expect(spoken.size).toBeGreaterThan(0);
+    for (const style of ["blending", "families", "sentences"] as const) {
+      for (let seed = 0; seed < 5; seed++) {
+        const words = wordsOn(buildSheet(config(style, DIGRAPHS), seed));
+        expect(words).not.toContain("said");
+      }
+    }
+  });
+});
+
+/* ── The answer keys ───────────────────────────────────────────────────── */
+
+describe("an answer that can be checked without the generator", () => {
+  it("blends each prompt back into the word it is the answer to", () => {
+    for (const [name, inventory] of INVENTORIES) {
+      const sheet = buildSheet(config("blending", inventory), 5);
+      const block = only(sheet);
+      expect(block.kind).toBe("problems");
+      if (block.kind !== "problems") return;
+      expect(block.items.length).toBeGreaterThan(0);
+      for (const item of block.items) {
+        expect(blended(item.prompt), `${name} · ${item.prompt}`).toBe(
+          item.answer,
+        );
+      }
+    }
+  });
+
+  it("adds up every word family sum", () => {
+    const sheet = buildSheet(config("families", DIGRAPHS), 2);
+    const block = only(sheet);
+    expect(block.kind).toBe("problems");
+    if (block.kind !== "problems") return;
+    expect(block.items.length).toBeGreaterThan(0);
+    for (const item of block.items) {
+      const [onset, rime] = item.prompt.replace(" =", "").split(" + ");
+      expect(`${onset}${rime}`).toBe(item.answer);
+      expect(WORD_BY_SPELLING.has(item.answer)).toBe(true);
+    }
+  });
+
+  it("never groups two rimes that only look alike", () => {
+    // `be` and `the` end in the same letter and not in the same sound. A
+    // family keyed on letters would put them together and teach a rhyme that
+    // isn't one, so the key is the spellings — and this re-derives them out of
+    // the table rather than reading the key the grouping was made on.
+    const rimeOf = (word: string): string[] => {
+      const parts = WORD_BY_SPELLING.get(word)?.parts ?? [];
+      const at = parts.findIndex((part) => {
+        const sound = CORRESPONDENCE_BY_ID.get(part)?.phonemes[0];
+        return (
+          sound !== undefined && PHONEME_BY_ID.get(sound)?.kind === "vowel"
+        );
+      });
+      return at < 0 ? [] : parts.slice(at);
+    };
+
+    const groups = familiesOf(EVERYTHING);
+    expect(groups.size).toBeGreaterThan(0);
+    for (const words of groups.values()) {
+      const rime = rimeOf(words[0].word);
+      expect(rime.length).toBeGreaterThan(0);
+      // Two words at least, or it is a word rather than a family.
+      expect(words.length).toBeGreaterThan(1);
+      for (const word of words) expect(rimeOf(word.word)).toEqual(rime);
+    }
+  });
+
+  it("pairs each spelling with a word that has it and no other on the sheet", () => {
+    for (let seed = 0; seed < 6; seed++) {
+      const sheet = buildSheet(config("matching", EVERYTHING), seed);
+      const block = only(sheet);
+      expect(block.kind).toBe("matching");
+      if (block.kind !== "matching") return;
+      expect(block.left.length).toBeGreaterThan(0);
+
+      // Every spelling on the left, as the ids a word could carry — read off
+      // the table rather than off what the generator paired them with.
+      const wanted = block.left.map((letters) =>
+        CORRESPONDENCES.filter(
+          (entry) => graphemeText(entry.grapheme) === letters,
+        ).map((entry) => entry.id),
+      );
+
+      block.left.forEach((letters, at) => {
+        const word = WORD_BY_SPELLING.get(block.right[block.answer[at]]);
+        expect(word, letters).toBeDefined();
+        const parts = word?.parts ?? [];
+        // In the word it is paired with…
+        expect(parts.some((part) => wanted[at].includes(part))).toBe(true);
+        // …and in none of the others, which is what makes the key unique.
+        wanted.forEach((ids, other) => {
+          if (other === at) return;
+          expect(parts.some((part) => ids.includes(part))).toBe(false);
+        });
+      });
+      expect(new Set(block.right).size).toBe(block.right.length);
+      // And the same letters never appear twice down the left, which would be
+      // two identical rows a child could not tell apart.
+      expect(new Set(block.left).size).toBe(block.left.length);
+    }
+  });
+
+  it("prints the answers only on the key, from the same build", () => {
+    const asked = config("blending", DIGRAPHS);
+    const sheet = buildSheet(asked, 7);
+    const key = answerKey(asked, 7);
+    expect(sheet.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(key.footer.note).toBe("Answer key");
+    // The blocks are the same blocks: the answers were computed when the sheet
+    // was built and the key only decides to print them.
+    expect(key.blocks).toEqual(sheet.blocks);
+  });
+});
+
+/* ── Sentences ─────────────────────────────────────────────────────────── */
+
+describe("the sentences", () => {
+  it("is made of words the bank has cut", () => {
+    for (const sentence of SENTENCES) {
+      expect(sentenceWords(sentence), sentence.words.join(" ")).toBeDefined();
+    }
+  });
+
+  it("prints as a capital, the words, and one mark", () => {
+    for (const sentence of SENTENCES) {
+      const text = sentenceText(sentence);
+      expect(text.endsWith(sentence.end)).toBe(true);
+      expect(text.slice(0, -1).toLowerCase()).toBe(sentence.words.join(" "));
+    }
+  });
+
+  it("puts nothing on a strip a child cannot read", () => {
+    for (const [name, inventory] of INVENTORIES) {
+      const sheet = buildSheet(config("sentences", inventory), 4);
+      const block = only(sheet);
+      expect(block.kind).toBe("cards");
+      if (block.kind !== "cards") return;
+      for (const card of block.cards) {
+        const printed = markedText(card.big);
+        for (const word of printed
+          .toLowerCase()
+          .split(/[^a-z]+/)
+          .filter(Boolean))
+          // Sight words allowed: `the` is what makes a decodable sentence
+          // possible at all, and it is on the parent's own list.
+          expect(allowed(word, inventory, true), `${name} · ${word}`).toBe(
+            true,
+          );
+      }
+    }
+  });
+
+  it("opens up as soon as `the` is taught by sight", () => {
+    const withoutThe: Inventory = { sounds: FIRST_SOUNDS, tricky: [] };
+    expect(phonicsSupply(config("sentences", withoutThe))).toBe(0);
+    expect(phonicsSupply(config("sentences", FIRST))).toBeGreaterThan(0);
+  });
+});
+
+/* ── The marks ─────────────────────────────────────────────────────────── */
+
+const ALL_MARKS: PhonicsMarking = { macron: true, silent: true, joined: true };
+
+const marked = (word: string, marking: PhonicsMarking): MarkedWord =>
+  markWord(WORD_BY_SPELLING.get(word)!, marking);
+
+describe("marking a word", () => {
+  it("says nothing at all with the switches off", () => {
+    for (const entry of WORD_BY_SPELLING.values()) {
+      const pieces = markWord(entry, {});
+      expect(pieces.every((piece) => piece.mark === undefined)).toBe(true);
+      expect(markedText(pieces)).toBe(entry.word);
+    }
+  });
+
+  it("never changes the letters, whatever is switched on", () => {
+    for (const entry of WORD_BY_SPELLING.values()) {
+      expect(markedText(markWord(entry, ALL_MARKS))).toBe(entry.word);
+    }
+  });
+
+  it("marks each of the three where it belongs, and nowhere else", () => {
+    // A bar over a vowel that says its own name, and not over the same letter
+    // saying its short sound.
+    expect(marked("cake", { macron: true })).toContainEqual({
+      text: "a",
+      mark: "macron",
+    });
+    expect(marked("cat", { macron: true }).every((p) => !p.mark)).toBe(true);
+
+    // The `e` of `cake` says nothing, and it is the piece that dims.
+    expect(marked("cake", { silent: true }).at(-1)).toEqual({
+      text: "e",
+      mark: "silent",
+    });
+    expect(marked("cat", { silent: true }).every((p) => !p.mark)).toBe(true);
+
+    // Two letters, one sound, tied underneath.
+    expect(marked("ship", { joined: true })).toContainEqual({
+      text: "sh",
+      mark: "joined",
+    });
+    expect(marked("sit", { joined: true }).every((p) => !p.mark)).toBe(true);
+  });
+
+  it("never puts two marks on one piece", () => {
+    for (const entry of WORD_BY_SPELLING.values()) {
+      for (const piece of markWord(entry, ALL_MARKS)) {
+        // The type allows one, so what this really checks is the argument in
+        // `cards.ts`: a silent piece has no sounds, a macron goes on a single
+        // letter, and a join needs two — no spelling satisfies two of those.
+        const marks = [
+          piece.mark === "macron",
+          piece.mark === "silent",
+          piece.mark === "joined",
+        ].filter(Boolean);
+        expect(marks.length).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it("is switched independently, all eight ways", () => {
+    const word = WORD_BY_SPELLING.get("white")!;
+    const seen = new Set<string>();
+    for (const macron of [false, true])
+      for (const silent of [false, true])
+        for (const joined of [false, true])
+          seen.add(JSON.stringify(markWord(word, { macron, silent, joined })));
+    // `white` has all three in it — `wh`, the long `i`, and the silent `e` —
+    // so every combination of the switches is a different page.
+    expect(seen.size).toBe(8);
+  });
+});
+
+/* ── The page it lands on ──────────────────────────────────────────────── */
+
+describe("the sheet as a whole", () => {
+  it("draws the same page from the same seed, and a different one from the next", () => {
+    for (const style of PHONICS_STYLES) {
+      const asked = config(style, EVERYTHING);
+      expect(buildSheet(asked, 12)).toEqual(buildSheet(asked, 12));
+      if (style === "chart") continue; // A chart is the table, in table order.
+      expect(buildSheet(asked, 12)).not.toEqual(buildSheet(asked, 13));
+    }
+  });
+
+  it("never puts on more than the paper was measured for", () => {
+    for (const style of PHONICS_STYLES) {
+      const asked = config(style, EVERYTHING, { count: 200 });
+      const { perPage } = phonicsLayout(asked);
+      const block = only(buildSheet(asked, 1));
+      const items =
+        block.kind === "problems"
+          ? block.items.length
+          : block.kind === "cards"
+            ? block.cards.length
+            : block.kind === "matching"
+              ? block.left.length
+              : 0;
+      expect(items, style).toBeGreaterThan(0);
+      expect(items, style).toBeLessThanOrEqual(perPage);
+    }
+  });
+
+  it("marks out of what is on the page, and only where there is an answer", () => {
+    for (const style of PHONICS_STYLES) {
+      const sheet = buildSheet(config(style, EVERYTHING), 1);
+      const block = only(sheet);
+      const answers =
+        block.kind === "problems"
+          ? block.items.length
+          : block.kind === "matching"
+            ? block.left.length
+            : 0;
+      expect(sheet.header.score?.outOf ?? 0, style).toBe(answers);
+    }
+  });
+
+  it("lays a list down the page whatever a saved config asks for", () => {
+    for (const style of PHONICS_STYLES) {
+      const block = only(
+        buildSheet(config(style, EVERYTHING, { columns: 6 }), 1),
+      );
+      const columns =
+        block.kind === "problems" || block.kind === "cards" ? block.columns : 1;
+      expect(columns, style).toBeLessThanOrEqual(phonicsColumns(style));
+    }
+  });
+
+  it("names itself in the words it was chosen by", () => {
+    const line = buildSheet(config("cards", FIRST), 1);
+    expect(line.header.title).toBe("Sound cards");
+    expect(line.footer.url).toContain("schoolskills.app");
+  });
+
+  it("prints the table's own example on a card, marked or not", () => {
+    // The example under a spelling is a mnemonic rather than a word to decode
+    // — "sh as in ship", chosen so the sound is unmistakable said aloud — so it
+    // is the table's own and stays put as the inventory grows. That is the one
+    // deliberate exception to "everything on the page is decodable", and it is
+    // stated here so it cannot become an accident.
+    const block = only(buildSheet(config("cards", FIRST, { count: 60 }), 1));
+    if (block.kind !== "cards") return;
+    const examples = new Set(
+      CORRESPONDENCES.filter(isTeachable).map((entry) => entry.example),
+    );
+    for (const card of block.cards) {
+      expect(card.small).toBeDefined();
+      expect(examples.has(markedText(card.small ?? []))).toBe(true);
+    }
+  });
+
+  it("shows a split vowel as `a-e`, never with the table's underscore", () => {
+    // The underscore reads as a blank to fill in, and a single `_` in a prompt
+    // is where `Problems` draws the ruled slot — so one on a sheet would be a
+    // rule drawn through the middle of a spelling.
+    for (const entry of CORRESPONDENCES) {
+      expect(graphemeText(entry.grapheme)).not.toContain("_");
+    }
+    const block = only(buildSheet(config("blending", EVERYTHING), 9));
+    if (block.kind !== "problems") return;
+    for (const item of block.items) expect(item.prompt).not.toContain("_");
+  });
+
+  it("cuts every card out of a spelling this build still teaches", () => {
+    const block = only(buildSheet(config("chart", EVERYTHING), 1));
+    if (block.kind !== "cards") return;
+    expect(block.boxed).toBe(false);
+    const taught = new Set(
+      CORRESPONDENCES.filter(isTeachable).map((entry) =>
+        graphemeText(entry.grapheme),
+      ),
+    );
+    for (const card of block.cards)
+      expect(taught.has(markedText(card.big))).toBe(true);
+    // And nothing untickable reached it, which is what `odd` is for.
+    for (const card of block.cards) {
+      const letters = markedText(card.big);
+      const rows = CORRESPONDENCES.filter(
+        (entry) => graphemeText(entry.grapheme) === letters,
+      );
+      expect(rows.some(isTeachable)).toBe(true);
+    }
+  });
+
+  it("resolves a style this build has never heard of rather than throwing", () => {
+    const saved = config("cards", FIRST);
+    const sheet = buildSheet({ ...saved, style: "runes" as PhonicsStyle }, 1);
+    expect(sheet.header.title).toBe("Say it slowly, then say it fast");
+  });
+
+  it("keeps a spelling the table has retired out of a saved sheet", () => {
+    const stale: Inventory = {
+      sounds: [...FIRST_SOUNDS, "th:ancient"],
+      tricky: [],
+    };
+    expect(CORRESPONDENCE_BY_ID.has("th:ancient")).toBe(false);
+    const words = wordsOn(buildSheet(config("blending", stale), 2));
+    expect(words.length).toBeGreaterThan(0);
+    for (const word of words) expect(allowed(word, stale, false)).toBe(true);
+  });
+});

--- a/src/engine/sheets/phonics/sheets.ts
+++ b/src/engine/sheets/phonics/sheets.ts
@@ -1,0 +1,751 @@
+/**
+ * Phonics, out of the sounds a parent says their child has been taught.
+ *
+ * Seven sheets over one inventory, and the inventory is the whole of what makes
+ * them different from a word list: **nothing on any of these pages uses a
+ * spelling that has not been ticked.** That promise is the reason the model in
+ * `inventory.ts` exists, it is what every style here is a view of, and it is
+ * what `sheets.test.ts` re-derives from the finished page rather than taking on
+ * trust — the same independence the word search buys by reading its own grid
+ * (§11).
+ *
+ * Nothing here is named after a programme and nothing reproduces one. There is
+ * no lesson number, no level, and no shipped inventory: a parent's own list is
+ * the only one there is (`services/phonics.ts`), and the three typographic
+ * marks are independent switches rather than somebody's modified alphabet
+ * (`cards.ts`, §13).
+ *
+ * ── Accent, and what these sheets do not ask ───────────────────────────────
+ *
+ * `bank.ts` records where General American and RP disagree instead of resolving
+ * it, and leaves out the words that have no honest cut in both places. Nothing
+ * below filters on `variesByAccent`, and that is a decision rather than an
+ * oversight: the one exercise that would need it is asking a child to *hear the
+ * difference* between two sounds, and there is no such style here. Every style
+ * that prints a word asks about its **spelling** — which spellings it is made
+ * of, which spelling is in it, how it is written down when it is read out — and
+ * a spelling is the same on both sides of the Atlantic. A sheet that asked
+ * whether `cot` and `caught` sound alike would mark half the children who saw
+ * it wrong, so it is not one of the seven.
+ *
+ * Everything the other families promise holds: the page comes out of
+ * `(config, seed)` and nothing else, the answers are decided when the sheet is
+ * built and the key only prints them, and no row goes on the page that the
+ * capacity arithmetic did not reserve.
+ */
+import { mulberry32, shuffled } from "@/engine/random";
+
+import type {
+  Block,
+  Mil,
+  PhonicsConfig,
+  PhonicsMarking,
+  PhonicsStyle,
+  Problem,
+  Sheet,
+  SheetOptions,
+  SoundCard,
+} from "../types";
+
+import { declaredWidth, sheetBlockBox } from "../chrome";
+import {
+  LIST_GAP,
+  MATCH_ROW_EMS,
+  PROBLEM_GAP,
+  columnWidth,
+  fitAcross,
+  type Box,
+} from "../layout";
+import { points } from "../paper";
+import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
+
+import { WORDS, WORD_BY_SPELLING, type Word } from "./bank";
+import {
+  CARD_BIG_EMS,
+  STRIP_BIG_EMS,
+  cardRowEms,
+  markGrapheme,
+  markSentence,
+  markWord,
+  sentenceLength,
+} from "./cards";
+import {
+  pickWords,
+  readInventory,
+  taughtSounds,
+  type Inventory,
+} from "./inventory";
+import { SENTENCES, pickSentences, type Sentence } from "./sentences";
+import {
+  CORRESPONDENCE_BY_ID,
+  PHONEME_BY_ID,
+  type Correspondence,
+} from "./sounds";
+
+/* ── What a row takes on the page ─────────────────────────────────────────
+   Declared, not measured (§4). A line of words is a line of body type; a card
+   is the arithmetic in `cards.ts`, which the renderer draws against.        */
+
+/** A prompt and its ruled slot, on one line of body type. */
+const ROW_EMS = 1.7;
+
+/** More than this many columns of cards is a page nobody can cut up. */
+const MAX_COLUMNS = 6;
+
+/** And more than this many columns of words is a page nobody can write on. */
+const MAX_WORD_COLUMNS = 4;
+
+/**
+ * As many pairs as a matching sheet may ask for.
+ *
+ * A cap of its own because the supply is the *spellings* rather than the words,
+ * and thirty lines joined across one page is a tangle rather than an exercise.
+ */
+const MAX_MATCHES = 12;
+
+/**
+ * How many words a family needs before it is a family.
+ *
+ * Two, because a rime with one word behind it is not a pattern — it is a word.
+ * A sheet printing "b + ecause = because" under the heading "word families"
+ * would be teaching the opposite of what the exercise is for.
+ */
+const MIN_FAMILY = 2;
+
+/** What goes between the sounds of a word that is being said slowly. */
+const BLEND_JOIN = " · ";
+
+/**
+ * A split vowel as it is printed: `a-e`, not `a_e`.
+ *
+ * The underscore is the table's own notation for "the consonant goes here", and
+ * it cannot survive onto a sheet for two separate reasons. It reads as a blank
+ * to fill in, which is the opposite of what it means; and `Problem.prompt` uses
+ * a single `_` to mark where the answer goes, so a prompt carrying one would
+ * have a ruled slot drawn through the middle of a spelling.
+ */
+export const graphemeText = (grapheme: string): string =>
+  grapheme.replace("_", "-");
+
+const clamp = (value: number, low: number, high: number): number =>
+  Math.max(low, Math.min(high, Math.floor(value)));
+
+/* ── The inventory ─────────────────────────────────────────────────────── */
+
+/**
+ * The sounds this sheet may use, made safe first.
+ *
+ * Through `readInventory` on every build rather than once at a door, because
+ * there is no door: a config arrives from a saved sheet, from a link, or from
+ * the builder, and only one of those has been anywhere near a validator. It
+ * drops what this build no longer teaches instead of refusing, so a sheet made
+ * before a spelling was retired prints a narrower page rather than none.
+ */
+export const inventoryOf = (config: PhonicsConfig): Inventory =>
+  readInventory(config.inventory);
+
+/** The marks a config asks for, and nothing a saved one may have invented. */
+const markingOf = (config: PhonicsConfig): PhonicsMarking => {
+  const asked = config.marking ?? {};
+  return {
+    macron: asked.macron === true,
+    silent: asked.silent === true,
+    joined: asked.joined === true,
+  };
+};
+
+/* ── Word families ────────────────────────────────────────────────────────
+   Derived from the bank rather than authored, and that is safe here in a way
+   it would not be in `words/bank.ts`: a rime is a fact about the cut, and the
+   cuts were made by hand. `cat` is `c` + `at` because somebody wrote down that
+   `cat` is `c a t`, not because anything here decided where a word divides.  */
+
+type Family = {
+  /** The letters a child adds. */
+  onset: string;
+  /** The letters they are added to. */
+  rime: string;
+  /** What the two make. */
+  word: string;
+  /** The rime as spellings rather than as letters — see `familiesOf`. */
+  key: string;
+};
+
+const isVowel = (part: string): boolean => {
+  const sound = CORRESPONDENCE_BY_ID.get(part)?.phonemes[0];
+  return sound !== undefined && PHONEME_BY_ID.get(sound)?.kind === "vowel";
+};
+
+/**
+ * A word split where its rime begins: every consonant spelling at the front,
+ * and everything from the first vowel onwards.
+ *
+ * Nothing at all for the words that cannot be split that way, and there are
+ * three kinds. A word starting on its vowel (`at`, `up`) has no onset to add.
+ * A word with no vowel spelling in it is not a word this can reason about. And
+ * a word whose rime holds a split vowel (`cake`) has a rime whose letters are
+ * not next to each other, so `a_e` + `k` is not "ake" — printing it as though
+ * it were would be a spelling sum that does not add up.
+ */
+function splitWord(entry: Word): Family | undefined {
+  const at = entry.parts.findIndex(isVowel);
+  if (at < 1) return undefined;
+
+  const letters = (parts: string[]): string | undefined => {
+    const out: string[] = [];
+    for (const part of parts) {
+      const grapheme = CORRESPONDENCE_BY_ID.get(part)?.grapheme;
+      if (grapheme === undefined || grapheme.includes("_")) return undefined;
+      out.push(grapheme);
+    }
+    return out.join("");
+  };
+
+  const onset = letters(entry.parts.slice(0, at));
+  const rime = letters(entry.parts.slice(at));
+  if (onset === undefined || rime === undefined) return undefined;
+  // The two halves have to spell the word back. They do for everything the
+  // guards above let through; checking it anyway is what stops a future cut
+  // from quietly printing a sum whose answer is a different word.
+  if (`${onset}${rime}` !== entry.word) return undefined;
+  return {
+    onset,
+    rime,
+    word: entry.word,
+    key: entry.parts.slice(at).join("|"),
+  };
+}
+
+/**
+ * The families a child can read, each one a rime with the words behind it.
+ *
+ * Grouped by the rime's **spellings** and not by its letters, which is the same
+ * distinction the whole model turns on: `be` and `the` end in the same letter
+ * and not in the same sound, and a family sheet that put them in one group
+ * would be teaching a rhyme that isn't one.
+ *
+ * Sight words never reach here, and that is not the `tricky` list being
+ * overruled: a word is in a family because it can be *built* out of an onset
+ * and a rime, and `said` is readable by a child who was taught it whole while
+ * still not being `s` + `aid`.
+ */
+export function familiesOf(inventory: Inventory): Map<string, Family[]> {
+  const taught = new Set(inventory.sounds);
+  const groups = new Map<string, Family[]>();
+  for (const entry of WORDS) {
+    if (!entry.parts.every((part) => taught.has(part))) continue;
+    const split = splitWord(entry);
+    if (!split) continue;
+    const found = groups.get(split.key);
+    if (found) found.push(split);
+    else groups.set(split.key, [split]);
+  }
+  for (const [key, words] of groups)
+    if (words.length < MIN_FAMILY) groups.delete(key);
+  return groups;
+}
+
+/* ── The page ──────────────────────────────────────────────────────────── */
+
+/** The styles that are a list down the page rather than a grid across it. */
+const DOWN_THE_PAGE = new Set<PhonicsStyle>(["matching", "sentences"]);
+
+/** The styles that print a card rather than a line of type. */
+const CARDED = new Set<PhonicsStyle>(["cards", "chart", "sentences"]);
+
+/** And the ones a sheet is marked out of — the four that withhold an answer. */
+const MARKED = new Set<PhonicsStyle>([
+  "blending",
+  "families",
+  "matching",
+  "dictation",
+]);
+
+/** Whether this style's answer key says anything its sheet doesn't. */
+export const phonicsKeyed = (style: PhonicsStyle): boolean => MARKED.has(style);
+
+/**
+ * How many lines the longest sentence in the bank wraps onto.
+ *
+ * Over the whole bank rather than over the sentences that were drawn, because
+ * the reservation is made before the draw: a strip height that depended on the
+ * seed would be a layout that disagreed with its own arithmetic from one sheet
+ * to the next. It over-reserves on a page whose longest sentence stayed in the
+ * bank, which is the cheap side to be wrong on (`chrome.ts`).
+ */
+function stripRows(config: PhonicsConfig, box: Box): number {
+  if (box.width <= 0) return 1;
+  const longest = SENTENCES.reduce(
+    (most, sentence) => Math.max(most, sentenceLength(sentence)),
+    0,
+  );
+  return Math.max(
+    1,
+    Math.ceil(
+      declaredWidth("x".repeat(longest), config, STRIP_BIG_EMS) / box.width,
+    ),
+  );
+}
+
+/**
+ * How much of the page one item of this style takes, and how many fit.
+ *
+ * Arithmetic rather than measurement, so a unit test, a catalog page built at
+ * build time and the builder's live preview all get the same answer (§4).
+ */
+export function phonicsLayout(config: PhonicsConfig): {
+  box: Box;
+  columns: number;
+  cell: Mil;
+  row: Mil;
+  perPage: number;
+} {
+  // Against the header the sheet will print rather than the one the config
+  // holds, and with the score box where there is one. Reserving for the wrong
+  // header is a last row below the bottom margin — invisible on screen, and a
+  // second sheet out of the printer.
+  const style = styleOf(config);
+  const box = sheetBlockBox(headerOf(config), MARKED.has(style));
+  const columns = DOWN_THE_PAGE.has(style)
+    ? 1
+    : clamp(config.columns ?? 1, 1, phonicsColumns(style));
+  const em = (rows: number): Mil => points(config.fontPt * rows);
+
+  const row =
+    style === "matching"
+      ? em(MATCH_ROW_EMS)
+      : style === "sentences"
+        ? em(cardRowEms(STRIP_BIG_EMS, stripRows(config, box), false))
+        : style === "cards" || style === "chart"
+          ? em(cardRowEms(CARD_BIG_EMS, 1, true))
+          : em(ROW_EMS);
+
+  // A matching block draws its own rows one under another with nothing between
+  // them, so there is no gap to pay for; a strip is a list, and everything else
+  // is the grid every family lays its problems out in.
+  const gap =
+    style === "matching" ? 0 : style === "sentences" ? LIST_GAP : PROBLEM_GAP.y;
+
+  return {
+    box,
+    columns,
+    cell: columnWidth(box, columns, PROBLEM_GAP.x),
+    row,
+    perPage: columns * fitAcross(box.height, row, gap),
+  };
+}
+
+/**
+ * How many items this style has to offer, before the paper is asked.
+ *
+ * Read at seed zero for the two that draw from a shuffled pool, because the
+ * *size* of that pool is what is wanted and a shuffle does not change it. Which
+ * means the count in `describe` and the count on the paper are one number: a
+ * line promising twenty over a page of fourteen would be wrong in the record
+ * book and in the picker at once.
+ */
+export function phonicsSupply(config: PhonicsConfig): number {
+  const inventory = inventoryOf(config);
+  switch (styleOf(config)) {
+    case "cards":
+    case "chart":
+      return taughtSounds(inventory).length;
+    case "matching":
+      // Distinct *letters*, because that is what the left column holds — see
+      // `matchingOf`, where `th` is two sounds and one row.
+      return Math.min(
+        MAX_MATCHES,
+        new Set(taughtSounds(inventory).map((entry) => entry.grapheme)).size,
+      );
+    case "families":
+      return [...familiesOf(inventory).values()].reduce(
+        (total, words) => total + words.length,
+        0,
+      );
+    case "sentences":
+      return pickSentences(inventory, SENTENCES.length, 0).length;
+    default:
+      return wordPool(config, 0).length;
+  }
+}
+
+/** How many items this sheet will hold: what was asked for, or what fits. */
+const wantedOf = (config: PhonicsConfig): number =>
+  clamp(
+    config.count ?? Number.MAX_SAFE_INTEGER,
+    0,
+    Math.min(phonicsLayout(config).perPage, phonicsSupply(config)),
+  );
+
+/* ── What goes on it ───────────────────────────────────────────────────── */
+
+/** A spelling over the word it is in — a card, and a line of the wall chart. */
+function cardOf(entry: Correspondence, marking: PhonicsMarking): SoundCard {
+  // The table's own example, chosen so the sound is unmistakable when it is
+  // said aloud. Marked like everything else where the bank has a cut for it,
+  // and printed plainly where it hasn't — `measure` and `giant` are examples
+  // this build can name and has never cut.
+  const example = WORD_BY_SPELLING.get(entry.example);
+  return {
+    big: markGrapheme(entry, marking),
+    small: example ? markWord(example, marking) : [{ text: entry.example }],
+  };
+}
+
+/**
+ * A word cut into its spellings, to be said slowly and then quickly.
+ *
+ * The prompt is the segmentation, which is why nothing on a blending line is
+ * ever *marked*: cutting the word up carries the same information a join would,
+ * and a sheet that did both would be telling a child twice.
+ */
+const blendingOf = (entry: Word): Problem => ({
+  prompt: entry.parts
+    .map((part) =>
+      graphemeText(CORRESPONDENCE_BY_ID.get(part)?.grapheme ?? part),
+    )
+    .join(BLEND_JOIN),
+  answer: entry.word,
+});
+
+/** A beginning, an ending, and the word they make. */
+const familyOf = (family: Family): Problem => ({
+  prompt: `${family.onset} + ${family.rime} =`,
+  answer: family.word,
+});
+
+/** A ruled line and nothing to read — the word arrives through the ear. */
+const dictationOf = (entry: Word): Problem => ({
+  prompt: "",
+  answer: entry.word,
+});
+
+/** A sentence on a strip, big enough to read across a room. */
+const stripOf = (sentence: Sentence, marking: PhonicsMarking): SoundCard => ({
+  big: markSentence(sentence, marking),
+});
+
+/**
+ * The words a word sheet draws from, in the order the seed put them.
+ *
+ * One place rather than two, because `phonicsSupply` asks how many there are
+ * and `bodyOf` asks which ones — and a second copy of the options would be a
+ * second answer to "does this sheet allow sight words".
+ */
+function wordPool(config: PhonicsConfig, seed: number): Word[] {
+  return pickWords(
+    inventoryOf(config),
+    {
+      count: WORDS.length,
+      ...(config.focus ? { focus: config.focus } : {}),
+      // A dictation line is the one place a sight word belongs — it is read
+      // out rather than sounded out, which is exactly how `said` is taught.
+      ...(styleOf(config) === "dictation" ? { tricky: true } : {}),
+    },
+    seed,
+  );
+}
+
+/**
+ * The spellings on the left and a word each on the right.
+ *
+ * **Every word on the right contains exactly one of the spellings on the
+ * left**, which is what makes the key the only possible answer rather than the
+ * one the generator happened to mean. A sheet with `s` and `sh` down one side
+ * and `shop` down the other has two lines a child could defensibly draw, and
+ * the honest fix is not to print that sheet: a spelling with no word that
+ * avoids the others is dropped rather than paired with an ambiguous one.
+ *
+ * **The left column is letters, not correspondences**, and this is the one
+ * place in the family where that is the right unit. `th` is two tick boxes —
+ * `thin` and `this` are different sounds — but they are one thing on paper, and
+ * a sheet printing `th` twice down the left would be asking a child to tell two
+ * identical lines apart. So the column is deduplicated by its letters and a
+ * word is excluded when it holds *any* sound those letters make.
+ *
+ * Nothing here is marked either, and for the reason a blending line isn't — a
+ * joined `sh` inside `shop` would print the answer beside the question.
+ */
+function matchingOf(
+  inventory: Inventory,
+  count: number,
+  seed: number,
+): { left: string[]; right: string[]; answer: number[] } {
+  const rand = mulberry32(seed);
+  // Fully decodable words only. `decodable` would let a sight word through —
+  // `said` is readable by a child who was taught it whole — and a word on this
+  // sheet is one whose spellings are being pointed at.
+  const taught = new Set(inventory.sounds);
+  const readable = WORDS.filter((entry) =>
+    entry.parts.every((part) => taught.has(part)),
+  );
+
+  const graphemeOf = (part: string): string =>
+    CORRESPONDENCE_BY_ID.get(part)?.grapheme ?? part;
+  const holds = (word: string, letters: string): boolean =>
+    (WORD_BY_SPELLING.get(word)?.parts ?? []).some(
+      (part) => graphemeOf(part) === letters,
+    );
+
+  // Built a row at a time rather than chosen and then filled, because the
+  // exclusivity runs both ways: a spelling can only join the sheet if a word
+  // exists that avoids everything already on it *and* nothing already on it
+  // holds the new spelling. Choosing ten and then looking for words would
+  // print seven rows and throw three away, which is a shorter sheet for no
+  // reason. Every candidate is tried once, so this terminates.
+  const pairs: Array<{ grapheme: string; word: string }> = [];
+  const chosen = new Set<string>();
+  const used = new Set<string>();
+  for (const entry of shuffled(taughtSounds(inventory), rand)) {
+    if (pairs.length === count) break;
+    const grapheme = entry.grapheme;
+    if (chosen.has(grapheme)) continue;
+    if (pairs.some((pair) => holds(pair.word, grapheme))) continue;
+
+    const word = shuffled(readable, rand).find(
+      (candidate) =>
+        !used.has(candidate.word) &&
+        candidate.parts.some((part) => graphemeOf(part) === grapheme) &&
+        // The exclusivity that makes the key unique: no *other* spelling on
+        // this sheet may be in the word as well.
+        candidate.parts.every((part) => {
+          const letters = graphemeOf(part);
+          return letters === grapheme || !chosen.has(letters);
+        }),
+    );
+    if (!word) continue;
+    chosen.add(grapheme);
+    used.add(word.word);
+    pairs.push({ grapheme, word: word.word });
+  }
+
+  // The right column is shuffled and the left is not, exactly as `study.ts`
+  // does it: a matching sheet whose columns line up is a sheet a child can
+  // answer with a ruler.
+  const right = shuffled(
+    pairs.map((pair) => pair.word),
+    rand,
+  );
+  return {
+    left: pairs.map((pair) => graphemeText(pair.grapheme)),
+    right,
+    answer: pairs.map((pair) => right.indexOf(pair.word)),
+  };
+}
+
+function bodyOf(
+  config: PhonicsConfig,
+  seed: number,
+): { blocks: Block[]; outOf: number } {
+  const inventory = inventoryOf(config);
+  const marking = markingOf(config);
+  const { columns } = phonicsLayout(config);
+  const style = styleOf(config);
+  const wanted = wantedOf(config);
+
+  if (CARDED.has(style)) {
+    const cards =
+      style === "sentences"
+        ? pickSentences(inventory, wanted, seed).map((sentence) =>
+            stripOf(sentence, marking),
+          )
+        : // The chart keeps the table's own order, because a chart is read down
+          // a wall and that order is what makes it readable — the consonants,
+          // then the vowels, each grapheme's sounds together. Cards are
+          // shuffled, so a pack of twelve out of forty is a different twelve on
+          // the next seed.
+          (style === "chart"
+            ? taughtSounds(inventory)
+            : shuffled(taughtSounds(inventory), mulberry32(seed))
+          )
+            .slice(0, wanted)
+            .map((entry) => cardOf(entry, marking));
+    return {
+      blocks: [
+        {
+          kind: "cards",
+          columns,
+          cards,
+          bigEms: style === "sentences" ? STRIP_BIG_EMS : CARD_BIG_EMS,
+          boxed: style !== "chart",
+        },
+      ],
+      outOf: 0,
+    };
+  }
+
+  if (style === "matching") {
+    const block = matchingOf(inventory, wanted, seed);
+    return {
+      blocks: [{ kind: "matching", ...block }],
+      outOf: block.left.length,
+    };
+  }
+
+  if (style === "families") {
+    // One word from each family before a second from any, so a page of twelve
+    // is twelve rimes rather than four rimes three times over — which is the
+    // shape a word-family sheet is set in, and the reason the draw is over the
+    // groups rather than over the words.
+    const rand = mulberry32(seed);
+    const families = familiesOf(inventory);
+    const rimes = shuffled([...families.keys()], rand);
+    const pool = rimes.flatMap((key) =>
+      shuffled(families.get(key) ?? [], rand),
+    );
+    const items = pool.slice(0, wanted).map(familyOf);
+    return {
+      blocks: [{ kind: "problems", columns, items }],
+      outOf: items.length,
+    };
+  }
+
+  const items = wordPool(config, seed)
+    .slice(0, wanted)
+    .map(style === "dictation" ? dictationOf : blendingOf);
+  return {
+    blocks: [{ kind: "problems", columns, items }],
+    outOf: items.length,
+  };
+}
+
+/* ── What it is called ─────────────────────────────────────────────────── */
+
+const TITLE: Record<PhonicsStyle, string> = {
+  cards: "Sound cards",
+  chart: "Sounds we know",
+  blending: "Say it slowly, then say it fast",
+  families: "Word families",
+  matching: "Sounds and words",
+  dictation: "Dictation",
+  sentences: "Sentences to read",
+};
+
+const INSTRUCTION: Record<PhonicsStyle, string> = {
+  cards:
+    "Cut out the cards. Say the sound the letters make, then read the word underneath.",
+  chart:
+    "The sounds we know so far. Say each one, and read the word beside it.",
+  blending:
+    "Say each sound on its own, then say them together. Write the word on the line.",
+  families: "Add the beginning to the ending and write the word they make.",
+  matching: "Join each spelling to the word that has it in.",
+  dictation: "Write each word as it is read out.",
+  sentences: "Read each sentence aloud. Cut them out to keep.",
+};
+
+/** What this style is counting, said the way it reads in a sentence. */
+const THINGS: Record<PhonicsStyle, [one: string, many: string]> = {
+  cards: ["card", "cards"],
+  chart: ["sound", "sounds"],
+  blending: ["word", "words"],
+  families: ["word", "words"],
+  matching: ["pair", "pairs"],
+  dictation: ["word", "words"],
+  sentences: ["sentence", "sentences"],
+};
+
+/**
+ * The style this config will print in.
+ *
+ * Never throws, for the reason `sheetSpec` doesn't: the id arrives from a saved
+ * sheet or from a link somebody was sent, and a page that prints something is
+ * worth more than an exception inside a build.
+ */
+const styleOf = (config: PhonicsConfig): PhonicsStyle =>
+  Object.hasOwn(TITLE, config.style) ? config.style : "blending";
+
+/**
+ * The header this sheet will actually print.
+ *
+ * Written once and read by both the layout and the build, so the two cannot
+ * disagree about what is at the top of the page. `config.title` is an override
+ * and is usually absent — a family names its own sheet.
+ */
+function headerOf(config: PhonicsConfig): SheetOptions {
+  const style = styleOf(config);
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? TITLE[style],
+    instructions: config.instructions ?? INSTRUCTION[style],
+  };
+}
+
+/** One line naming what the sheet holds, in the terms it was chosen by. */
+export function describePhonics(config: PhonicsConfig): string {
+  const style = styleOf(config);
+  const [one, many] = THINGS[style];
+  const asked = wantedOf(config);
+  const sounds = inventoryOf(config).sounds.length;
+  return [
+    TITLE[style],
+    `${asked} ${asked === 1 ? one : many}`,
+    `${sounds} ${sounds === 1 ? "sound" : "sounds"} taught`,
+  ].join(" — ");
+}
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+export function buildPhonicsSheet(config: PhonicsConfig, seed: number): Sheet {
+  const head = headerOf(config);
+  const { blocks, outOf } = bodyOf(config, seed);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: head.title ?? "",
+      instructions: head.instructions,
+      fields: head.fields,
+      // Only the four styles that withhold an answer are marked out of
+      // anything. A page of cards to cut out has no score, and "___ / 20" over
+      // a wall chart would be a box nobody can fill in.
+      ...(outOf > 0 ? { score: { outOf } } : {}),
+    },
+    blocks,
+    // The jungle: phonics is the reading half of the word world, and a child
+    // who has just blended twenty words on paper is the one likeliest to run
+    // the race that reads them aloud (§16).
+    footer: { credit: SHEET_CREDIT, url: gameUrl("jungle"), seed },
+    answers: false,
+  };
+}
+
+export const PHONICS_SHEET: SheetSpec<PhonicsConfig> = {
+  id: "phonics",
+  label: "Phonics",
+  world: SHEET_WORLD,
+  build: buildPhonicsSheet,
+  // Every answer was decided when the sheet was built — which words were drawn,
+  // which spelling each was paired with, which column it landed in — so a key
+  // cannot disagree with the sheet it belongs to. On the three styles that
+  // withhold nothing it is the same page twice, which is why `phonicsKeyed`
+  // exists for the pages that have to decide whether to print one.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describePhonics,
+};
+
+/** Every style, for a picker and for the catalog. */
+export const PHONICS_STYLES = Object.keys(TITLE) as PhonicsStyle[];
+
+/** What a style is called, in the words it is chosen by. */
+export const phonicsStyleLabel = (style: PhonicsStyle): string => TITLE[style];
+
+/**
+ * How many columns this style can honestly be laid out in.
+ *
+ * Out of the engine rather than named in the option panel, so a style laid out
+ * down the page cannot get a stepper that moves a number the paper ignores.
+ */
+export const phonicsColumns = (style: PhonicsStyle): number =>
+  DOWN_THE_PAGE.has(style)
+    ? 1
+    : style === "cards" || style === "chart"
+      ? MAX_COLUMNS
+      : MAX_WORD_COLUMNS;

--- a/src/engine/sheets/phonics/sheets.ts
+++ b/src/engine/sheets/phonics/sheets.ts
@@ -79,6 +79,8 @@ import { SENTENCES, pickSentences, type Sentence } from "./sentences";
 import {
   CORRESPONDENCE_BY_ID,
   PHONEME_BY_ID,
+  graphemeParts,
+  graphemeText,
   type Correspondence,
 } from "./sounds";
 
@@ -114,18 +116,6 @@ const MIN_FAMILY = 2;
 
 /** What goes between the sounds of a word that is being said slowly. */
 const BLEND_JOIN = " · ";
-
-/**
- * A split vowel as it is printed: `a-e`, not `a_e`.
- *
- * The underscore is the table's own notation for "the consonant goes here", and
- * it cannot survive onto a sheet for two separate reasons. It reads as a blank
- * to fill in, which is the opposite of what it means; and `Problem.prompt` uses
- * a single `_` to mark where the answer goes, so a prompt carrying one would
- * have a ruled slot drawn through the middle of a spelling.
- */
-export const graphemeText = (grapheme: string): string =>
-  grapheme.replace("_", "-");
 
 const clamp = (value: number, low: number, high: number): number =>
   Math.max(low, Math.min(high, Math.floor(value)));
@@ -338,11 +328,19 @@ export function phonicsLayout(config: PhonicsConfig): {
 /**
  * How many items this style has to offer, before the paper is asked.
  *
- * Read at seed zero for the two that draw from a shuffled pool, because the
+ * Read at seed zero for the three that draw from a shuffled pool, because the
  * *size* of that pool is what is wanted and a shuffle does not change it. Which
  * means the count in `describe` and the count on the paper are one number: a
  * line promising twenty over a page of fourteen would be wrong in the record
  * book and in the picker at once.
+ *
+ * Matching is the one style where a shuffle *can* change the size, because its
+ * rows are paired greedily and a different order knocks out a different
+ * spelling. So its supply is the pairing run rather than the spellings counted:
+ * counting them said twelve over a page of eleven, which is exactly the line
+ * this comment promises does not exist. Seed zero is not the sheet's own seed,
+ * so a row either way is still possible there — what is gone is the style
+ * systematically over-promising by the width of everything it discards.
  */
 export function phonicsSupply(config: PhonicsConfig): number {
   const inventory = inventoryOf(config);
@@ -351,12 +349,9 @@ export function phonicsSupply(config: PhonicsConfig): number {
     case "chart":
       return taughtSounds(inventory).length;
     case "matching":
-      // Distinct *letters*, because that is what the left column holds — see
-      // `matchingOf`, where `th` is two sounds and one row.
-      return Math.min(
-        MAX_MATCHES,
-        new Set(taughtSounds(inventory).map((entry) => entry.grapheme)).size,
-      );
+      // Rows, not spellings — `matchingOf` drops any it cannot pair without
+      // making the key ambiguous, and `th` is two sounds and one row.
+      return matchingOf(inventory, MAX_MATCHES, 0).left.length;
     case "families":
       return [...familiesOf(inventory).values()].reduce(
         (total, words) => total + words.length,
@@ -438,6 +433,11 @@ function wordPool(config: PhonicsConfig, seed: number): Word[] {
     {
       count: WORDS.length,
       ...(config.focus ? { focus: config.focus } : {}),
+      // How short a word has to be, where a sheet says so. A blending page for
+      // a child three weeks in is `hat` and `pet`, not `strong` — and "short"
+      // has to be counted in *sounds* rather than in letters, or `box` would
+      // pass for three and `ship` would fail for four.
+      ...(config.maxSounds ? { maxSounds: config.maxSounds } : {}),
       // A dictation line is the one place a sight word belongs — it is read
       // out rather than sounded out, which is exactly how `said` is taught.
       ...(styleOf(config) === "dictation" ? { tricky: true } : {}),
@@ -449,19 +449,46 @@ function wordPool(config: PhonicsConfig, seed: number): Word[] {
 /**
  * The spellings on the left and a word each on the right.
  *
- * **Every word on the right contains exactly one of the spellings on the
- * left**, which is what makes the key the only possible answer rather than the
- * one the generator happened to mean. A sheet with `s` and `sh` down one side
- * and `shop` down the other has two lines a child could defensibly draw, and
- * the honest fix is not to print that sheet: a spelling with no word that
- * avoids the others is dropped rather than paired with an ambiguous one.
+ * **Every word on the right shows exactly one of the spellings on the left**,
+ * which is what makes the key the only possible answer rather than the one the
+ * generator happened to mean. A sheet with `s` and `sh` down one side and `shop`
+ * down the other has two lines a child could defensibly draw, and the honest fix
+ * is not to print that sheet: a spelling with no word that avoids the others is
+ * dropped rather than paired with an ambiguous one.
+ *
+ * **"Shows" is about letters on paper and not about sounds**, and getting that
+ * wrong is the whole failure this exercise can have. A child holding a pencil
+ * sees `n` on the left and hunts the right-hand column for an `n`; `strong` has
+ * one, whatever the table says the `ng` in it is doing. Excluding by
+ * correspondence rather than by letters would leave `n` → `land` keyed and
+ * `strong` sitting three lines below it, and the child who joined `n` to
+ * `strong` read the page correctly and would be marked wrong. So a word is out
+ * when another chosen spelling's letters appear *anywhere* in it — `much` bars
+ * `h`, `fell` bars `l`, `chief` bars both `c` and `i`.
+ *
+ * A split vowel is the one spelling whose letters are not next to each other, so
+ * there is nothing to search a word for: `a-e` is excluded by the cut instead —
+ * a word is out when the bank says it is spelled with that correspondence. It is
+ * the only case where the two rules differ, and it differs in the safe
+ * direction.
+ *
+ * The pairing itself still goes by the cut and not by the letters, which is the
+ * other half of the same care: `shop` contains the letters of `s` and does not
+ * contain the *sound*, so it can never be the answer to `s` however it is
+ * spelled.
  *
  * **The left column is letters, not correspondences**, and this is the one
  * place in the family where that is the right unit. `th` is two tick boxes —
  * `thin` and `this` are different sounds — but they are one thing on paper, and
  * a sheet printing `th` twice down the left would be asking a child to tell two
  * identical lines apart. So the column is deduplicated by its letters and a
- * word is excluded when it holds *any* sound those letters make.
+ * word is excluded when it shows those letters at all.
+ *
+ * All of that costs rows — the spellings made of the commonest letters knock
+ * each other out — which is why `phonicsSupply` counts this style by running
+ * the pairing rather than by counting the spellings it could draw from. A page
+ * of nine where ten were asked for is the sheet being honest, and the catalog
+ * page says so in as many words.
  *
  * Nothing here is marked either, and for the reason a blending line isn't — a
  * joined `sh` inside `shop` would print the answer beside the question.
@@ -482,15 +509,23 @@ function matchingOf(
 
   const graphemeOf = (part: string): string =>
     CORRESPONDENCE_BY_ID.get(part)?.grapheme ?? part;
-  const holds = (word: string, letters: string): boolean =>
-    (WORD_BY_SPELLING.get(word)?.parts ?? []).some(
-      (part) => graphemeOf(part) === letters,
-    );
+
+  /** Is this word spelled with that grapheme — what makes it the answer. */
+  const uses = (word: Word, grapheme: string): boolean =>
+    word.parts.some((part) => graphemeOf(part) === grapheme);
+
+  /** Could a child find those letters in this word — what makes it ambiguous. */
+  const shows = (word: string, grapheme: string): boolean => {
+    const [head, tail] = graphemeParts(grapheme);
+    if (!tail) return word.includes(head);
+    const entry = WORD_BY_SPELLING.get(word);
+    return entry !== undefined && uses(entry, grapheme);
+  };
 
   // Built a row at a time rather than chosen and then filled, because the
   // exclusivity runs both ways: a spelling can only join the sheet if a word
   // exists that avoids everything already on it *and* nothing already on it
-  // holds the new spelling. Choosing ten and then looking for words would
+  // shows the new spelling. Choosing ten and then looking for words would
   // print seven rows and throw three away, which is a shorter sheet for no
   // reason. Every candidate is tried once, so this terminates.
   const pairs: Array<{ grapheme: string; word: string }> = [];
@@ -500,18 +535,15 @@ function matchingOf(
     if (pairs.length === count) break;
     const grapheme = entry.grapheme;
     if (chosen.has(grapheme)) continue;
-    if (pairs.some((pair) => holds(pair.word, grapheme))) continue;
+    if (pairs.some((pair) => shows(pair.word, grapheme))) continue;
 
     const word = shuffled(readable, rand).find(
       (candidate) =>
         !used.has(candidate.word) &&
-        candidate.parts.some((part) => graphemeOf(part) === grapheme) &&
+        uses(candidate, grapheme) &&
         // The exclusivity that makes the key unique: no *other* spelling on
-        // this sheet may be in the word as well.
-        candidate.parts.every((part) => {
-          const letters = graphemeOf(part);
-          return letters === grapheme || !chosen.has(letters);
-        }),
+        // this sheet may be visible in the word as well.
+        [...chosen].every((letters) => !shows(candidate.word, letters)),
     );
     if (!word) continue;
     chosen.add(grapheme);
@@ -587,12 +619,27 @@ function bodyOf(
     // is twelve rimes rather than four rimes three times over — which is the
     // shape a word-family sheet is set in, and the reason the draw is over the
     // groups rather than over the words.
+    //
+    // A round at a time, not family after family. Concatenating the groups
+    // would put the whole of `-ip` on the page before `-at` was reached: the
+    // draw would still be over the groups and the paper would still be eleven
+    // `-ip` words out of twenty, which is a spelling list rather than a set of
+    // patterns. Both loops are over arrays the seed has already shuffled, so
+    // the page stays deterministic in `(config, seed)`.
     const rand = mulberry32(seed);
     const families = familiesOf(inventory);
     const rimes = shuffled([...families.keys()], rand);
-    const pool = rimes.flatMap((key) =>
-      shuffled(families.get(key) ?? [], rand),
+    const drawn = rimes.map((key) => shuffled(families.get(key) ?? [], rand));
+    const deepest = drawn.reduce(
+      (most, words) => Math.max(most, words.length),
+      0,
     );
+    const pool: Family[] = [];
+    for (let round = 0; round < deepest; round++)
+      for (const words of drawn) {
+        const one = words[round];
+        if (one) pool.push(one);
+      }
     const items = pool.slice(0, wanted).map(familyOf);
     return {
       blocks: [{ kind: "problems", columns, items }],

--- a/src/engine/sheets/phonics/sounds.ts
+++ b/src/engine/sheets/phonics/sounds.ts
@@ -511,3 +511,23 @@ export function graphemeParts(grapheme: string): [head: string, tail: string] {
     ? [grapheme, ""]
     : [grapheme.slice(0, split), grapheme.slice(split + 1)];
 }
+
+/**
+ * A split vowel as it is *printed*: `a-e`, not `a_e`.
+ *
+ * Beside `graphemeParts` because the two are the same fact seen twice — the
+ * underscore is the table's notation for "the consonant goes here", and neither
+ * a page nor a tick box may show it. It cannot survive onto a sheet for two
+ * separate reasons: it reads as a blank to fill in, which is the opposite of
+ * what it means, and `Problem.prompt` uses a single `_` to mark where the answer
+ * goes, so a prompt carrying one would have a ruled slot drawn through the
+ * middle of a spelling.
+ *
+ * Here rather than in `sheets.ts` because a sound card is drawn in `cards.ts`,
+ * which the family imports rather than the other way round: a card's big line
+ * needs this, and reaching up to the family for it would be a cycle. Everything
+ * that prints a grapheme — card, chart, blending prompt, matching column, tick
+ * list — goes through it.
+ */
+export const graphemeText = (grapheme: string): string =>
+  grapheme.replace("_", "-");

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -1941,6 +1941,20 @@ export type PhonicsConfig = SheetOptions & {
    * is where that argument is made.
    */
   focus?: string;
+  /**
+   * At most this many *sounds* in a word — what makes a CVC sheet a CVC sheet.
+   *
+   * Counted in sounds rather than in letters, which is the same distinction the
+   * rest of the model turns on: `box` is three letters and four sounds, `ship`
+   * is four letters and three. A child who has just learned to hold three
+   * sounds in their head meets a fourth and stalls at the thing they were doing
+   * correctly, and "short word" is not a length in characters.
+   *
+   * Absent on most sheets, and that is the honest default — once blending is
+   * working, the length of the word is no longer the exercise. See
+   * `WordPick.maxSounds`, which is where the filter lives.
+   */
+  maxSounds?: number;
   marking: PhonicsMarking;
   /** How many cards, lines, pairs or strips. Capped at what the page holds. */
   count: number;

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -12,6 +12,7 @@
  * answers the build already computed — `answers: true` and nothing else — so
  * however a key is obtained it can't disagree with the sheet it belongs to.
  */
+import type { Inventory } from "./phonics/inventory";
 import type { TranslationId } from "./passages/types";
 
 /* ── Units ────────────────────────────────────────────────────────────────
@@ -474,6 +475,41 @@ export type CrosswordEntry = {
   row: number;
 };
 
+/**
+ * One piece of a word as it is printed, and how it is marked.
+ *
+ * The piece is a *spelling* rather than a letter — `sh` is one piece, and so is
+ * the `a` of `cake` while its `e` is another at the end of the word — because
+ * that is the unit the whole phonics family is built on (`phonics/sounds.ts`).
+ * A piece carries at most one mark, and the three cannot collide: see the note
+ * in `phonics/cards.ts` for why that is provable rather than hoped for.
+ *
+ * `mark` absent is the ordinary case and is what every piece looks like with
+ * all three switches off.
+ */
+export type MarkedPart = {
+  text: string;
+  mark?: "macron" | "silent" | "joined";
+};
+
+/** A word, or a whole sentence, cut into those pieces. */
+export type MarkedWord = MarkedPart[];
+
+/**
+ * One card: a big line, and a smaller one under it.
+ *
+ * Three sheets are made of these and they differ only in what goes on the two
+ * lines — a spelling over the word it is in, the same pair unboxed on a wall
+ * chart, or a whole sentence on a strip with nothing underneath. Which is why
+ * there is no `kind` here: a card is a shape, and the family that filled it is
+ * the one that knows what it means.
+ */
+export type SoundCard = {
+  big: MarkedWord;
+  /** The example word under a spelling. Absent on a sentence strip. */
+  small?: MarkedWord;
+};
+
 export type Block =
   | { kind: "problems"; columns: number; items: Problem[] }
   | { kind: "rules"; rule: Rule; lines: number }
@@ -546,6 +582,29 @@ export type Block =
    * slot on the end of it would be a sheet a child answers twice.
    */
   | { kind: "wordshapes"; columns: number; words: WordShape[] }
+  /**
+   * Cards: a spelling over the word it is in, or a sentence on a strip.
+   *
+   * A block of its own rather than `problems` with a big prompt, for the reason
+   * `wordshapes` is one: there is no answer place on it at all. A card is a
+   * thing to be read — cut out, pinned up, or handed over — and a ruled slot on
+   * the end of one would be a sheet asking a question nobody set.
+   */
+  | {
+      kind: "cards";
+      columns: number;
+      cards: SoundCard[];
+      /**
+       * How big the big line is set, in ems of the body size.
+       *
+       * On the block rather than in the stylesheet because a card and a
+       * sentence strip are the same block at two very different sizes, and the
+       * family reserved the page against this number — see `cardRowEms`.
+       */
+      bigEms: number;
+      /** A border to cut round. Off for a wall chart, which is not cut up. */
+      boxed: boolean;
+    }
   | { kind: "clock"; faces: ClockFace[] }
   | { kind: "shapes"; figures: Figure[] }
   /** Where to cut, for cards and bookmarks. */
@@ -648,8 +707,8 @@ export type Sheet = {
    *
    * No family sets them. They are copied on by `buildSheet` at the front door
    * (index.ts), which is the same bargain `chrome.ts` struck — every family
-   * would otherwise write the same three lines, and the fifteenth one to be
-   * added would be the one that forgot.
+   * would otherwise write the same three lines, and the next one to be added
+   * would be the one that forgot.
    */
   font?: SheetFont;
   /** A box round the answer place rather than a rule under it. */
@@ -1800,6 +1859,95 @@ export type MemoryConfig = SheetOptions & {
   rounds: number;
 };
 
+/* ── Phonics ───────────────────────────────────────────────────────────────
+   The family whose content is decided by something the parent states rather
+   than by a range or a list: a sound inventory, which is the set of spellings
+   their child has been taught (`engine/sheets/phonics/`, §13). Everything on
+   every one of these sheets is spellable from it, which is the one promise the
+   family makes and the reason it exists rather than a word list.
+
+   The inventory travels *in the config*, as a value, rather than as an id
+   pointing at the store `services/phonics.ts` keeps. That is what lets a sheet
+   somebody configured survive being sent to a family who has never heard of
+   this household's list — and it is why a config carrying a two-hundred-word
+   sight list can outgrow the share cap in `share.ts` and simply not decode,
+   which is the same "fall back to defaults rather than throw" §14 asks for. */
+
+/**
+ * What the sheet asks for.
+ *
+ * Seven, and each of them is a thing somebody sets on a Tuesday morning:
+ * `cards` are the spellings to cut out, `chart` is the same set as one page for
+ * the wall, `blending` prints a word cut into its sounds to be said slowly and
+ * then quickly, `families` adds a beginning to an ending, `matching` joins a
+ * spelling to a word it is in, `dictation` is ruled lines for words read aloud,
+ * and `sentences` are strips of connected text with nothing in them a child has
+ * not been taught.
+ *
+ * One family rather than seven, for the reason the spelling family is one: none
+ * of the seven changes what the sheet is *about*. It is about the sounds this
+ * child knows, and a parent who has ticked those gets all seven from the
+ * control beside the list.
+ */
+export type PhonicsStyle =
+  | "cards"
+  | "chart"
+  | "blending"
+  | "families"
+  | "matching"
+  | "dictation"
+  | "sentences";
+
+/**
+ * The three typographic conventions, as three independent switches.
+ *
+ * Switches rather than a named preset, and that is the whole design (§13):
+ * marking a long vowel with a bar, a silent letter with a lighter weight and a
+ * digraph with a join are shared across many phonics traditions and belong to
+ * none of them, but a particular *combination* of them under a programme's name
+ * is that programme's modified alphabet. So there are three booleans, no
+ * shipped set of them is named after anything, and every mark is derived from
+ * the table of spellings rather than authored (`phonics/cards.ts`).
+ *
+ * All three off is the default, and is not a lesser sheet: most schemes print
+ * plain text and mark on the whiteboard.
+ */
+export type PhonicsMarking = {
+  /** A bar over a single vowel letter that says its own name — `cāke`. */
+  macron?: boolean;
+  /** Letters that say nothing, set pale — the `e` of `cake`, the `w` of `two`. */
+  silent?: boolean;
+  /** Two letters saying one sound, joined underneath — `sh`, `ck`, `igh`. */
+  joined?: boolean;
+};
+
+export type PhonicsConfig = SheetOptions & {
+  kind: "phonics";
+  style: PhonicsStyle;
+  /**
+   * What this child has been taught. Everything on the page comes out of it.
+   *
+   * Read through `readInventory` before it is used, exactly as a word list is
+   * read through `wordsOf`: it arrives from a saved sheet, from a link somebody
+   * was sent, or from a record written by a build that taught a spelling this
+   * one has retired.
+   */
+  inventory: Inventory;
+  /**
+   * Only words using this spelling — "this week we're doing `sh`".
+   *
+   * A correspondence id, and a sheet about a spelling the parent has not ticked
+   * comes back empty rather than quietly widening: see `WordPick.focus`, which
+   * is where that argument is made.
+   */
+  focus?: string;
+  marking: PhonicsMarking;
+  /** How many cards, lines, pairs or strips. Capped at what the page holds. */
+  count: number;
+  /** How many across the page. */
+  columns: number;
+};
+
 /**
  * Anything a saved sheet can hold. Narrow on `kind` — and only in index.ts,
  * which is the one module that knows the whole union.
@@ -1825,7 +1973,8 @@ export type SheetConfig =
   | PuzzleConfig
   | GrammarConfig
   | HandwritingConfig
-  | MemoryConfig;
+  | MemoryConfig
+  | PhonicsConfig;
 
 /* ── A sheet somebody kept ─────────────────────────────────────────────── */
 

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -59,6 +59,55 @@ const DENOMINATORS = [2, 3, 4, 5, 6, 8, 10, 12];
 export const STARTER_WORDS = listWords(WORD_LISTS[0]).slice(0, 12);
 
 /**
+ * One sound each for the letters of the alphabet — where a phonics sheet opens.
+ *
+ * **This is not a preset and not a sequence.** `engine/sheets/phonics/
+ * inventory.ts` is explicit that shipping "Lesson 47" would be reproducing
+ * somebody's copyrighted course by reference, and shipping "Level 3" would be
+ * pretending there is one course when the point of the model is that there
+ * isn't. What is below is neither: it is the commonest sound of each of the
+ * twenty-six letters, which every scheme on earth teaches and none of them
+ * owns, and it is here for exactly the reason `STARTER_WORDS` is — the bench's
+ * first job is to show a sheet rather than a form, and a sheet built from an
+ * empty inventory is a blank page.
+ *
+ * A parent ticks their way to their own list in the panel and keeps it under
+ * their own name (`services/phonics.ts`). This one has no name at all.
+ *
+ * Exported because the catalog's phonics pages are meant to be built from the
+ * same starting point (`pages/printables/_phonics.ts`), and two lists of the
+ * letters would be two lists that could quietly stop matching.
+ */
+export const FIRST_LETTERS: string[] = [
+  "b:b",
+  "c:k",
+  "d:d",
+  "f:f",
+  "g:g",
+  "h:h",
+  "j:j",
+  "k:k",
+  "l:l",
+  "m:m",
+  "n:n",
+  "p:p",
+  "qu:k-w",
+  "r:r",
+  "s:s",
+  "t:t",
+  "v:v",
+  "w:w",
+  "x:k-s",
+  "y:y",
+  "z:z",
+  "a:a",
+  "e:e",
+  "i:i",
+  "o:o",
+  "u:u",
+];
+
+/**
  * A passage to open the copywork style on.
  *
  * A pangram first, because a sentence set for handwriting is chosen for the
@@ -296,6 +345,21 @@ const DEFAULTS: Record<string, SheetConfig> = {
     // What the written topics get when a parent switches to one — a circle-one
     // sheet is a list down the page whatever this says (`grammarLayout`).
     columns: 1,
+  },
+  phonics: {
+    ...BASE,
+    kind: "phonics",
+    // Blending, because it is the one of the seven that looks like a worksheet
+    // at a glance and the one a child does most days. Everything else — the
+    // cards to cut out, the wall chart, the dictation lines, the sentence
+    // strips — is one control away.
+    style: "blending",
+    inventory: { sounds: FIRST_LETTERS, tricky: ["the"] },
+    // All three off. A marked sheet is a choice a parent makes; most schemes
+    // print plain text and mark on the whiteboard.
+    marking: {},
+    count: 20,
+    columns: 2,
   },
   handwriting: {
     ...BASE,

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -31,6 +31,7 @@ import { MemoryPanel } from "./memory";
 import { MoneyPanel } from "./money";
 import { MultiplicationPanel } from "./multiplication";
 import { PaperPanel } from "./paper";
+import { PhonicsPanel } from "./phonics";
 import { PreAlgebraPanel } from "./prealgebra";
 import { PuzzlesPanel } from "./puzzles";
 import { RatioPanel } from "./ratio";
@@ -94,6 +95,7 @@ const PANELS: Record<string, FamilyPanel> = {
   "word-study": panel(WordStudyPanel),
   puzzle: panel(PuzzlesPanel),
   grammar: panel(GrammarPanel),
+  phonics: panel(PhonicsPanel),
   handwriting: panel(HandwritingPanel),
   memory: panel(MemoryPanel),
 };

--- a/src/games/printshop/options/phonics.tsx
+++ b/src/games/printshop/options/phonics.tsx
@@ -22,13 +22,13 @@ import { Checkbox, FieldSet } from "@/components/ui/kit";
 import {
   CORRESPONDENCES,
   PHONEME_BY_ID,
+  graphemeText,
   isTeachable,
   type Correspondence,
   type Inventory,
 } from "@/engine/sheets/phonics";
 import {
   PHONICS_STYLES,
-  graphemeText,
   phonicsColumns,
   phonicsStyleLabel,
 } from "@/engine/sheets/phonics/sheets";

--- a/src/games/printshop/options/phonics.tsx
+++ b/src/games/printshop/options/phonics.tsx
@@ -1,0 +1,174 @@
+/**
+ * Which sounds have been taught, and what to make out of them.
+ *
+ * The tick list is the panel. Every other family here asks for a range or a
+ * list of words; this one asks the only question a phonics worksheet has ever
+ * really turned on — how far have you got? — and everything on the page falls
+ * out of the answer (§13). It is long, and it is meant to be: a parent ticks it
+ * once, saves it under their own name, and never sees it again until the next
+ * sound is taught.
+ *
+ * **There are no presets in this control and there will not be.** A named set
+ * of sounds is somebody's course, and the two honest names for one are the ones
+ * a parent writes: their child's, and their own. `services/phonics.ts` is where
+ * a named list is kept.
+ *
+ * The three marking switches are independent for the same reason. Each is a
+ * convention shared across phonics traditions; the combination of them under a
+ * programme's name is that programme's modified alphabet, and nothing here
+ * ships one.
+ */
+import { Checkbox, FieldSet } from "@/components/ui/kit";
+import {
+  CORRESPONDENCES,
+  PHONEME_BY_ID,
+  isTeachable,
+  type Correspondence,
+  type Inventory,
+} from "@/engine/sheets/phonics";
+import {
+  PHONICS_STYLES,
+  graphemeText,
+  phonicsColumns,
+  phonicsStyleLabel,
+} from "@/engine/sheets/phonics/sheets";
+import type { PhonicsConfig } from "@/engine/sheets/types";
+import { parseWords } from "@/services/decks";
+
+import { Choice, Sizing, WordList, opt, type PanelProps } from "./parts";
+
+/** The seven, in the order the engine lists them — roughly by age. */
+const STYLES = PHONICS_STYLES.map((style) =>
+  opt(style, phonicsStyleLabel(style)),
+);
+
+/**
+ * Whether a spelling is filed under the consonants or the vowels.
+ *
+ * By its first sound rather than by its letters, which is the same rule the
+ * table itself is ordered by — `qu` is filed with the consonants because it
+ * starts on /k/, and the `e` of `have`, which says nothing at all, sits with
+ * the vowels where a parent would look for it.
+ */
+const isConsonant = (entry: Correspondence): boolean =>
+  PHONEME_BY_ID.get(entry.phonemes[0] ?? "")?.kind === "consonant";
+
+const TEACHABLE = CORRESPONDENCES.filter(isTeachable);
+
+const GROUPS: Array<{ label: string; hint: string; sounds: Correspondence[] }> =
+  [
+    {
+      label: "Consonants",
+      hint: "A spelling and the sound it makes there — tick the ones you have taught.",
+      sounds: TEACHABLE.filter(isConsonant),
+    },
+    {
+      label: "Vowels",
+      hint: "The same letters can say more than one thing. `ea` is three rows, because `eat` and `bread` are two different lessons.",
+      sounds: TEACHABLE.filter((entry) => !isConsonant(entry)),
+    },
+  ];
+
+export function PhonicsPanel({ config, set }: PanelProps<PhonicsConfig>) {
+  const inventory: Inventory = config.inventory ?? { sounds: [], tricky: [] };
+  const ticked = new Set(inventory.sounds);
+  const marking = config.marking ?? {};
+
+  const setSounds = (sounds: string[]) =>
+    set({ inventory: { ...inventory, sounds } });
+
+  return (
+    <>
+      <Choice
+        label="Sheet"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+        hint="Seven sheets out of one list of sounds. Nothing on any of them uses a spelling that is not ticked below."
+      />
+
+      {GROUPS.map((group) => (
+        <FieldSet
+          key={group.label}
+          legend={`${group.label} — ${group.sounds.filter((entry) => ticked.has(entry.id)).length} of ${group.sounds.length}`}
+          hint={group.hint}
+        >
+          <span className="pool">
+            {group.sounds.map((entry) => (
+              <Checkbox
+                key={entry.id}
+                label={graphemeText(entry.grapheme)}
+                hint={`as in ${entry.example}`}
+                checked={ticked.has(entry.id)}
+                onChange={(on) =>
+                  setSounds(
+                    on
+                      ? // Filtered from the table rather than appended, so the
+                        // list stays in teaching order however it was ticked.
+                        TEACHABLE.filter(
+                          (row) => row.id === entry.id || ticked.has(row.id),
+                        ).map((row) => row.id)
+                      : inventory.sounds.filter((id) => id !== entry.id),
+                  )
+                }
+              />
+            ))}
+          </span>
+        </FieldSet>
+      ))}
+
+      {/* The other half of the model, and the only door a word that follows no
+          rule may come through. `said` is not decodable because `ai` was
+          ticked, and never becomes so — it is here or it is nowhere. */}
+      <WordList
+        label="Words taught by sight"
+        text={inventory.tricky.join("\n")}
+        onChange={(text) =>
+          set({
+            inventory: {
+              ...inventory,
+              tricky: parseWords(text).map((word) => word.toLowerCase()),
+            },
+          })
+        }
+        rows={3}
+        hint="The tricky words, heart words or red words your scheme teaches whole. A dictation line and a sentence strip may use them; nothing else will."
+      />
+
+      <FieldSet
+        legend="Marking"
+        hint="Three conventions many schemes share. Off is the usual, and none of these is anybody's alphabet."
+      >
+        <span className="pool">
+          <Checkbox
+            label="Long vowel bar"
+            hint="cāke"
+            checked={marking.macron === true}
+            onChange={(macron) => set({ marking: { ...marking, macron } })}
+          />
+          <Checkbox
+            label="Silent letters pale"
+            hint="the e of cake"
+            checked={marking.silent === true}
+            onChange={(silent) => set({ marking: { ...marking, silent } })}
+          />
+          <Checkbox
+            label="Joined digraphs"
+            hint="sh, ck, igh"
+            checked={marking.joined === true}
+            onChange={(joined) => set({ marking: { ...marking, joined } })}
+          />
+        </span>
+      </FieldSet>
+
+      <Sizing
+        label="How many"
+        count={config.count}
+        columns={phonicsColumns(config.style) > 1 ? config.columns : undefined}
+        onCount={(count) => set({ count })}
+        onColumns={(columns) => set({ columns })}
+        maxColumns={phonicsColumns(config.style)}
+      />
+    </>
+  );
+}

--- a/src/pages/printables/_phonics.test.ts
+++ b/src/pages/printables/_phonics.test.ts
@@ -1,0 +1,304 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet } from "@/engine/sheets";
+import { WORD_BY_SPELLING, readInventory } from "@/engine/sheets/phonics";
+import { PHONICS_STYLES } from "@/engine/sheets/phonics/sheets";
+import type { Block } from "@/engine/sheets/types";
+
+import { BIBLE_SHEETS, hrefFor as bibleHref } from "./_bible";
+import { PAPER_SHEETS, STOCKS, pathFor as paperPath } from "./_catalog";
+import { CURSIVE_SHEETS, hrefFor as cursiveHref } from "./_cursive";
+import { GRAMMAR_SHEETS, pathFor as grammarPath } from "./_grammar";
+import { HANDWRITING_SHEETS, hrefFor as handwritingHref } from "./_handwriting";
+import { MATHS_SHEETS, pathFor as mathsPath } from "./_maths";
+import {
+  PHONICS_GROUPS,
+  PHONICS_SEED,
+  PHONICS_SHEETS,
+  builderHref,
+  keyed,
+  pathFor,
+  phonicsShelf,
+  type PhonicsSheet,
+} from "./_phonics";
+import { SPELLING_SHEETS, pathFor as spellingPath } from "./_spelling";
+
+/**
+ * The phonics catalog, held to the four things a catalog page has to be — and
+ * to the one promise this shelf exists to make.
+ *
+ * **It has to be a worksheet.** Every entry is prerendered as the page a parent
+ * lands on (§8), so an entry whose config produces an empty page is a URL in
+ * the sitemap with nothing on it.
+ *
+ * **It has to print everything it promised.** The prose says "twenty" in as
+ * many words, and a sheet that quietly dropped four off the bottom would look
+ * exactly like a sheet that didn't.
+ *
+ * **It has to be curated**, and **it has to be reachable** — no two entries
+ * printing the same sheet or answering the same query, every slug in the
+ * sitemap and distinct from the six catalogs sharing the prefix.
+ *
+ * **And nothing on any of these pages may use a spelling its own inventory
+ * does not hold.** That is checked here as well as in the engine, and on
+ * purpose: the engine's suite proves the family keeps the promise for any
+ * inventory, and this one proves the seven inventories somebody wrote by hand
+ * are ones it keeps it for.
+ */
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/** How many things a block puts on the paper, whichever kind it is. */
+function items(block: Block): number {
+  if (block.kind === "problems") return block.items.length;
+  if (block.kind === "cards") return block.cards.length;
+  if (block.kind === "matching") return block.left.length;
+  return 0;
+}
+
+/** Every whole word a block printed, however it printed it. */
+function words(block: Block): string[] {
+  if (block.kind === "problems")
+    return block.items.map((item) => item.answer).filter(Boolean);
+  if (block.kind === "matching") return block.right;
+  if (block.kind === "cards")
+    return block.cards.flatMap((card) =>
+      card.big
+        .map((part) => part.text)
+        .join("")
+        .toLowerCase()
+        .split(/[^a-z]+/)
+        .filter(Boolean),
+    );
+  return [];
+}
+
+/** Everything the prose puts in curly quotes. */
+const QUOTED = /“([^”]+)”/g;
+
+/**
+ * How long a quotation has to be before it is read as a claim about the sheet.
+ *
+ * The same house rule the grammar shelf keeps, and for the same reason: the
+ * page IS the sheet, so a reader can look down it and check. A word or a short
+ * phrase is an example of a kind of thing; five words is a sentence somebody is
+ * pointing at.
+ */
+const CLAIMED = 5;
+
+const same = (text: string): string =>
+  text
+    .trim()
+    .replace(/[.?!]$/, "")
+    .toLowerCase();
+
+const built = (sheet: PhonicsSheet) => buildSheet(sheet.config, PHONICS_SEED);
+
+describe("the phonics catalog", () => {
+  it("is bounded, and every slug is a route somebody could type", () => {
+    for (const sheet of PHONICS_SHEETS) {
+      expect(sheet.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+    expect(new Set(PHONICS_SHEETS.map((sheet) => sheet.slug)).size).toBe(
+      PHONICS_SHEETS.length,
+    );
+  });
+
+  it("never claims a path another shelf already prints on", () => {
+    // Eight route patterns over one prefix. They only coexist because the paths
+    // they emit are disjoint; the day they are not, Astro has two routes for
+    // one URL and picks one of them.
+    const taken = new Set<string>([
+      ...PAPER_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => `/printables/${paperPath(sheet, stock)}`),
+      ),
+      ...MATHS_SHEETS.map((sheet) => mathsPath(sheet)),
+      ...SPELLING_SHEETS.map((sheet) => spellingPath(sheet)),
+      ...GRAMMAR_SHEETS.map((sheet) => grammarPath(sheet)),
+      ...HANDWRITING_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => handwritingHref(sheet, stock)),
+      ),
+      ...CURSIVE_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => cursiveHref(sheet, stock)),
+      ),
+      ...BIBLE_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => bibleHref(sheet, stock)),
+      ),
+    ]);
+    for (const sheet of PHONICS_SHEETS) {
+      expect(taken.has(pathFor(sheet)), sheet.slug).toBe(false);
+    }
+  });
+
+  it("shows every kind of sheet the family can make", () => {
+    // Seven styles, seven pages. A style with no page is a sheet a parent can
+    // only find by opening the builder and reading a dropdown, which is the
+    // opposite of what a catalog is for.
+    expect(new Set(PHONICS_SHEETS.map((sheet) => sheet.config.style))).toEqual(
+      new Set(PHONICS_STYLES),
+    );
+  });
+
+  it("answers a different query on every page", () => {
+    const keywords = PHONICS_SHEETS.map((sheet) => sheet.keyword.toLowerCase());
+    expect(new Set(keywords).size).toBe(keywords.length);
+  });
+
+  it("carries prose on every page rather than a filled-in template", () => {
+    for (const sheet of PHONICS_SHEETS) {
+      expect(sheet.notes.length, sheet.slug).toBeGreaterThanOrEqual(2);
+      for (const note of sheet.notes)
+        expect(note.length, sheet.slug).toBeGreaterThan(200);
+      expect(sheet.lead.length, sheet.slug).toBeGreaterThan(100);
+      expect(sheet.summary.length, sheet.slug).toBeGreaterThan(60);
+    }
+  });
+
+  it("shelves every sheet exactly once", () => {
+    const shelved = phonicsShelf().flatMap((group) => group.sheets);
+    expect(shelved).toHaveLength(PHONICS_SHEETS.length);
+    for (const group of PHONICS_GROUPS)
+      expect(
+        PHONICS_SHEETS.some((sheet) => sheet.group === group.id),
+        group.id,
+      ).toBe(true);
+  });
+});
+
+describe("the sheet on a catalog page", () => {
+  it("prints something on every page", () => {
+    for (const sheet of PHONICS_SHEETS) {
+      const printed = built(sheet);
+      expect(printed.blocks, sheet.slug).toHaveLength(1);
+      expect(items(printed.blocks[0]), sheet.slug).toBeGreaterThan(0);
+    }
+  });
+
+  it("prints everything the config asked for", () => {
+    // The prose counts these out in words — "twenty short words", "eight
+    // sentences" — so a page that quietly fitted fewer would be a page telling
+    // a reader something they can disprove by looking at it.
+    for (const sheet of PHONICS_SHEETS) {
+      expect(items(built(sheet).blocks[0]), sheet.slug).toBe(
+        sheet.config.count,
+      );
+    }
+  });
+
+  it("uses no spelling the page's own inventory does not hold", () => {
+    // The promise, re-derived from the finished sheet: every word read back off
+    // the paper, looked up in the bank, and its spellings compared with the
+    // ticked ids. A card's example word is the table's own mnemonic rather than
+    // something to decode, which is why the cards and the chart are read for
+    // their spellings instead (below).
+    for (const sheet of PHONICS_SHEETS) {
+      if (sheet.config.style === "cards" || sheet.config.style === "chart")
+        continue;
+      const inventory = readInventory(sheet.config.inventory);
+      for (const word of words(built(sheet).blocks[0])) {
+        const entry = WORD_BY_SPELLING.get(word);
+        expect(entry, `${sheet.slug} · ${word}`).toBeDefined();
+        const decodable = (entry?.parts ?? []).every((part) =>
+          inventory.sounds.includes(part),
+        );
+        expect(
+          decodable || inventory.tricky.includes(word),
+          `${sheet.slug} · ${word}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("quotes only what the sheet under the prose really prints", () => {
+    for (const sheet of PHONICS_SHEETS) {
+      const printed = words(built(sheet).blocks[0]).map(same);
+      const prose = [sheet.lead, sheet.summary, ...sheet.notes];
+      for (const [, quote] of prose.join(" ").matchAll(QUOTED)) {
+        if (quote.trim().split(/\s+/).length < CLAIMED) continue;
+        const wanted = same(quote);
+        expect(
+          printed.join(" ").includes(wanted),
+          `${sheet.slug} quotes “${quote}”, which it does not print`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("has a title and an instruction on it, and a score only where marked", () => {
+    for (const sheet of PHONICS_SHEETS) {
+      const printed = built(sheet);
+      expect(printed.header.title, sheet.slug).toBeTruthy();
+      expect(printed.header.instructions, sheet.slug).toBeTruthy();
+      expect(printed.header.score !== undefined, sheet.slug).toBe(keyed(sheet));
+    }
+  });
+
+  it("is the same sheet on every build", () => {
+    for (const sheet of PHONICS_SHEETS) {
+      expect(built(sheet), sheet.slug).toEqual(built(sheet));
+    }
+  });
+
+  it("keys the pages that withhold an answer, and only those", () => {
+    for (const sheet of PHONICS_SHEETS) {
+      const printed = built(sheet);
+      const key = answerKey(sheet.config, PHONICS_SEED);
+      expect(key.blocks, sheet.slug).toEqual(printed.blocks);
+      // A page of cards, a wall chart and a page of sentences withhold nothing,
+      // so printing the same page twice under the word "key" would be noise.
+      expect(keyed(sheet), sheet.slug).toBe(
+        !["cards", "chart", "sentences"].includes(sheet.config.style),
+      );
+    }
+  });
+
+  it("ships no inventory that names a course", () => {
+    // Not a shape a test can check on its own, so what it checks is the thing
+    // that would make one possible: every entry's inventory is one of the two
+    // written down in `_phonics.ts`, both of which are described by what is in
+    // them rather than by where a child is meant to be.
+    const seen = new Set(
+      PHONICS_SHEETS.map((sheet) =>
+        readInventory(sheet.config.inventory).sounds.join(","),
+      ),
+    );
+    expect(seen.size).toBe(2);
+  });
+});
+
+describe("the link into the builder", () => {
+  it("opens the bench on the sheet that was printed", () => {
+    for (const sheet of PHONICS_SHEETS) {
+      const href = builderHref(sheet);
+      expect(href.startsWith("/printables/make#s="), sheet.slug).toBe(true);
+    }
+  });
+});
+
+describe("the sitemap", () => {
+  /*
+   * A URL missing from the sitemap is the failure nobody notices — nothing
+   * breaks, the page is simply never submitted. Skipped when there is no
+   * `dist/`, exactly as the other catalogs' are; CI builds before it runs the
+   * suite.
+   */
+  it("carries every phonics slug and the hub", () => {
+    const file = `${ROOT}/dist/sitemap-0.xml`;
+    if (!existsSync(file)) return; // `npm run build` hasn't run yet.
+
+    const xml = readFileSync(file, "utf8");
+    const found = new Set(
+      [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) =>
+        new URL(match[1]).pathname.replace(/\/$/, ""),
+      ),
+    );
+
+    expect(found.has("/printables/phonics")).toBe(true);
+    for (const sheet of PHONICS_SHEETS) {
+      expect(found.has(pathFor(sheet)), sheet.slug).toBe(true);
+    }
+  });
+});

--- a/src/pages/printables/_phonics.test.ts
+++ b/src/pages/printables/_phonics.test.ts
@@ -4,7 +4,11 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet } from "@/engine/sheets";
-import { WORD_BY_SPELLING, readInventory } from "@/engine/sheets/phonics";
+import {
+  WORD_BY_SPELLING,
+  readInventory,
+  wordSounds,
+} from "@/engine/sheets/phonics";
 import { PHONICS_STYLES } from "@/engine/sheets/phonics/sheets";
 import type { Block } from "@/engine/sheets/types";
 
@@ -208,6 +212,28 @@ describe("the sheet on a catalog page", () => {
           decodable || inventory.tricky.includes(word),
           `${sheet.slug} · ${word}`,
         ).toBe(true);
+      }
+    }
+  });
+
+  it("keeps a page that says how long a word may be to it", () => {
+    // The CVC page is the one entry that names a length, and its prose is a
+    // claim a reader can disprove by looking at the sheet under it — "three
+    // sounds at most" over a page with `camp` and `stop` on it. Counted in
+    // sounds off the bank rather than in letters, which is the rule the copy
+    // states: `box` is three letters and four sounds and is not on the page.
+    for (const sheet of PHONICS_SHEETS) {
+      const cap = sheet.config.maxSounds;
+      if (cap === undefined) continue;
+      const printed = words(built(sheet).blocks[0]);
+      expect(printed.length, sheet.slug).toBeGreaterThan(0);
+      for (const word of printed) {
+        const entry = WORD_BY_SPELLING.get(word);
+        expect(entry, `${sheet.slug} · ${word}`).toBeDefined();
+        expect(
+          wordSounds(entry!).length,
+          `${sheet.slug} · ${word}`,
+        ).toBeLessThanOrEqual(cap);
       }
     }
   });

--- a/src/pages/printables/_phonics.ts
+++ b/src/pages/printables/_phonics.ts
@@ -155,9 +155,9 @@ export const PHONICS_SHEETS: PhonicsSheet[] = [
     keyword: "Free printable phonics sound cards",
     summary:
       "One card for each letter of the alphabet, with the sound it makes and a word it is in, laid out to cut apart along the dashed guides.",
-    lead: "Twenty-six cards to cut out: the letter large enough to read across a table, and underneath it a word that letter starts. Cut once down the guides and once across, and the pack is done.",
+    lead: "Twenty-six cards to cut out: the letter large enough to read across a table, and underneath it a word that letter is in. Cut once down the guides and once across, and the pack is done.",
     notes: [
-      "The word under each letter is a reminder rather than something to decode. A child three days into phonics cannot read “fan”, and is not being asked to — it is there so that whoever is holding the card can say the sound rather than the letter name, which is the single commonest thing to get wrong when teaching this at home. The letter says /f/; it is called “eff”; the card is about the first of those.",
+      "The word under each letter is a reminder rather than something to decode, and it is the word the sound table itself keeps — “cat” sits under the “a” and “box” under the “x” — so it is not always a word the letter starts, and one word can turn up under two cards. A child three days into phonics cannot read “fan”, and is not being asked to: it is there so that whoever is holding the card can say the sound rather than the letter name, which is the single commonest thing to get wrong when teaching this at home. The letter says /f/; it is called “eff”; the card is about the first of those.",
       "Cards for the digraphs are one setting away rather than on this page. Tick “sh”, “ch” and “th” in the builder and they join the pack — and “th” arrives as two cards, because the sound at the front of “thin” and the sound at the front of “this” are two different things a child has to learn separately, however identical they look on paper.",
     ],
     teaches: "Letter sounds",
@@ -173,7 +173,7 @@ export const PHONICS_SHEETS: PhonicsSheet[] = [
     keyword: "Free printable phonics sounds chart",
     summary:
       "Every sound covered so far on one page for the wall — the alphabet and the consonant digraphs, each with a word it is in.",
-    lead: "The same spellings as the card pack, laid out as one page to pin up: the letters first, then the two-letter spellings, each with an example beside it. It is a record of where a child has got to rather than a poster of the whole language.",
+    lead: "The card pack plus the consonant digraphs, laid out as one page to pin up: every spelling in the order the sound table teaches them, each with a word it is in beside it. It is a record of where a child has got to rather than a poster of the whole language.",
     notes: [
       "A chart of what has actually been taught is worth more than a chart of everything, and it is the reason this page exists at all. A wall covered in sounds a child has not met is a wall they learn to stop looking at; a chart that grows by one row a week is one they can point at. Reprint it whenever the list changes — the sounds on it are a setting, and the sheet takes a second.",
       "The two “th” rows are not a mistake. One is the sound at the front of “thin” and the other the sound at the front of “this”, and no rule in English tells a child which of them a “th” is going to be. Every other spelling that says more than one thing is on the chart twice for the same reason, which is what makes it a chart of sounds rather than of letters.",
@@ -198,13 +198,17 @@ export const PHONICS_SHEETS: PhonicsSheet[] = [
       "Twenty short words printed as the sounds they are made of, with a line to write the whole word on — and the answer key on the page behind.",
     lead: "Each line is one word cut into its sounds, spaced apart. A child says each sound on its own, says them again quickly until they hear the word, and writes it on the line. That is the whole of blending, and it is the step everything else in reading waits for.",
     notes: [
-      "Every word here is spellable from the letters of the alphabet and nothing else, which is what makes it a CVC sheet rather than a list of short words. Nothing on the page uses a spelling that has not been taught — no “sh”, no silent “e”, no vowel team — because a child who is still blending three sounds and meets a fourth spelling has been set up to fail at the thing they were doing correctly.",
+      "Every word here is three sounds at most, and every spelling in it is a single letter of the alphabet — no “sh”, no silent “e”, no vowel team. That is what makes it a CVC sheet rather than a list of short words, and both halves of it matter: a child who is still blending three sounds and meets a fourth has been set up to fail at the thing they were doing correctly. The counting is in sounds and not in letters, which is the only way to count it: “box” is three letters and four sounds and is off this page, while “ship” is four letters and three sounds and would be perfectly at home on a page where “sh” had been taught. A two-sound word turns up now and again — “on”, “up” — and it is the same exercise with one sound fewer.",
       "The sounds are printed rather than said, and the separation is the exercise. Reading “sat” as one shape is a thing a child can do by memory long before they can read “sap”; reading it as /s/ /a/ /t/ is a thing that works on every word they will ever meet. Cover the line with a finger, do the sounds twice, and only then write it.",
     ],
     teaches: "Blending sounds into words",
     ages: "Ages 4–6",
     group: "words",
-    config: phonics("blending", LETTERS, 20, 2),
+    // Three sounds at most, which is the whole of what "CVC" names — and the
+    // one page on the shelf that says how long a word may be. `maxSounds`
+    // counts sounds rather than letters, so `box` is out at four and `ship`
+    // would be in at three if the digraph were ever ticked here.
+    config: phonics("blending", LETTERS, 20, 2, { maxSounds: 3 }),
   },
   {
     slug: "word-family-worksheets",

--- a/src/pages/printables/_phonics.ts
+++ b/src/pages/printables/_phonics.ts
@@ -1,0 +1,322 @@
+/**
+ * The phonics sheets the Print Shop has set, and the words that go round them.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data two pages
+ * share — `phonics/[slug].astro`, which prerenders one sheet per kind, and
+ * `phonics/index.astro`, which is the subject hub — rather than a route of its
+ * own. `_catalog.ts` does that job for paper, `_maths.ts` for maths,
+ * `_spelling.ts` for words, `_grammar.ts` for sentences, and
+ * `_handwriting.ts`, `_cursive.ts` and `_bible.ts` for the writing shelves.
+ *
+ * **One page per kind of sheet, and that is the whole shelf.** §8 asks for the
+ * catalog to be bounded, and phonics is where being greedy would be easiest:
+ * "short a worksheets", "sh worksheets", "ai worksheets" and forty more are all
+ * real queries, and every one of them is a sheet on this shelf with one
+ * spelling ticked. Seven pages, seven things a parent sets, and everything else
+ * through the builder — which is where choosing belongs.
+ *
+ * ── The sounds on these pages are not a course ─────────────────────────────
+ *
+ * Every sheet has to be built from *some* inventory, and the two below are the
+ * smallest honest ones: one sound for each letter of the alphabet, and the same
+ * again with the consonant digraphs added. Neither is a stage, a level or a
+ * lesson — `engine/sheets/phonics/inventory.ts` is explicit that shipping one
+ * of those would be reproducing somebody's copyrighted sequence by reference,
+ * and nothing here does. They are a statement about *this sheet*: these are the
+ * spellings it uses, and no others. A parent's own list is ticked in the
+ * builder and kept under their own name.
+ *
+ * **One stock, as with maths, spelling and grammar.** Nothing on a phonics
+ * sheet is a measurement — there is no ⅝ rule to be scaled into a ⅗ rule by a
+ * printer loaded with A4 — so the sheet is correct on either stock and the A4
+ * switch lives in the builder with the other options.
+ */
+import { FIRST_LETTERS } from "@/games/printshop/defaults";
+import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
+import { phonicsKeyed } from "@/engine/sheets/phonics/sheets";
+import type { Inventory } from "@/engine/sheets/phonics";
+import type { PhonicsConfig, PhonicsStyle } from "@/engine/sheets/types";
+
+import { SHEET_FIELDS as FIELDS, benchHref, paperOf, shelve } from "./_catalog";
+
+/** How the hub groups the shelf: the sounds, and then reading with them. */
+export type PhonicsGroup = "sounds" | "words";
+
+export type PhonicsSheet = {
+  /** The route under /printables/phonics, and the head term it answers. */
+  slug: string;
+  /** How it is listed on a hub. */
+  name: string;
+  /** How it is labelled in the row of neighbouring sheets. A few words. */
+  short: string;
+  /** The page's `<h1>`. */
+  heading: string;
+  /** The query this page exists to answer, in the words a parent types. */
+  keyword: string;
+  /** One sentence of what is on the sheet. Used in the description and hubs. */
+  summary: string;
+  /** The lead paragraph: what the sheet asks for, stated plainly. */
+  lead: string;
+  /**
+   * Two things that are true of this sheet and not of the one beside it.
+   *
+   * The sheet is prerendered directly under this prose (§8), which makes a
+   * quoted sentence a claim about the paper rather than an illustration — a
+   * reader can look down the page and check it. `_phonics.test.ts` holds
+   * anything quoted at five words or more to that, exactly as the grammar shelf
+   * is held; a hypothetical the sheet never prints stays shorter than that.
+   */
+  notes: string[];
+  /** For the `LearningResource` block. */
+  teaches: string;
+  ages: string;
+  group: PhonicsGroup;
+  /** The sheet itself. Prerendered at build time — this IS the page (§8). */
+  config: PhonicsConfig;
+};
+
+/**
+ * The seed every sheet on this shelf is built from, and it never moves.
+ *
+ * It decides which words and which sentences land on each page and in what
+ * order, and nothing else — a word's spellings travel with the word. Which is
+ * what §7 promises stays put: the sheet a parent printed in March is the sheet
+ * they print in June, down to the order of the lines.
+ */
+export const PHONICS_SEED = 1;
+
+/**
+ * `the`, taught whole.
+ *
+ * On both inventories below, and it is not a shortcut: nearly every decodable
+ * sentence in English needs it, it cannot be sounded out by a child who has not
+ * met `th` and the unstressed `e`, and every programme there is teaches it by
+ * sight in the first weeks. `Inventory.tricky` is the door for exactly that.
+ */
+const SIGHT = ["the"];
+
+/** One sound for each letter of the alphabet — see the header. */
+const LETTERS: Inventory = { sounds: FIRST_LETTERS, tricky: SIGHT };
+
+/**
+ * The same, plus the consonant digraphs and the doubled letters.
+ *
+ * `th` twice, because `thin` and `this` are two sounds behind one spelling and
+ * a child who can read one cannot necessarily read the other — which is the
+ * distinction the whole model turns on, and the reason a wall chart built from
+ * this list has two `th` cards on it.
+ */
+const WITH_DIGRAPHS: Inventory = {
+  sounds: [
+    ...FIRST_LETTERS,
+    "sh:sh",
+    "ch:ch",
+    "th:th",
+    "th:dh",
+    "wh:w",
+    "ck:k",
+    "ng:ng",
+    "ll:l",
+    "ss:s",
+    "ff:f",
+    "zz:z",
+    "e:uh",
+  ],
+  tricky: SIGHT,
+};
+
+/** A phonics sheet on Letter, with the name and date line printed blank. */
+const phonics = (
+  style: PhonicsStyle,
+  inventory: Inventory,
+  count: number,
+  columns = 1,
+  extra: Partial<PhonicsConfig> = {},
+): PhonicsConfig => ({
+  kind: "phonics",
+  paper: paperOf("letter"),
+  fontPt: DEFAULT_FONT_PT,
+  fields: FIELDS,
+  style,
+  inventory,
+  marking: {},
+  count,
+  columns,
+  ...extra,
+});
+
+export const PHONICS_SHEETS: PhonicsSheet[] = [
+  /* ── The sounds themselves ──────────────────────────────────────────── */
+  {
+    slug: "phonics-sound-cards",
+    name: "Sound cards",
+    short: "Sound cards",
+    heading: "Printable phonics sound cards",
+    keyword: "Free printable phonics sound cards",
+    summary:
+      "One card for each letter of the alphabet, with the sound it makes and a word it is in, laid out to cut apart along the dashed guides.",
+    lead: "Twenty-six cards to cut out: the letter large enough to read across a table, and underneath it a word that letter starts. Cut once down the guides and once across, and the pack is done.",
+    notes: [
+      "The word under each letter is a reminder rather than something to decode. A child three days into phonics cannot read “fan”, and is not being asked to — it is there so that whoever is holding the card can say the sound rather than the letter name, which is the single commonest thing to get wrong when teaching this at home. The letter says /f/; it is called “eff”; the card is about the first of those.",
+      "Cards for the digraphs are one setting away rather than on this page. Tick “sh”, “ch” and “th” in the builder and they join the pack — and “th” arrives as two cards, because the sound at the front of “thin” and the sound at the front of “this” are two different things a child has to learn separately, however identical they look on paper.",
+    ],
+    teaches: "Letter sounds",
+    ages: "Ages 4–6",
+    group: "sounds",
+    config: phonics("cards", LETTERS, 26, 4, { cutLines: true }),
+  },
+  {
+    slug: "phonics-sounds-chart",
+    name: "“Sounds we know” wall chart",
+    short: "Sounds chart",
+    heading: "Printable phonics sounds chart",
+    keyword: "Free printable phonics sounds chart",
+    summary:
+      "Every sound covered so far on one page for the wall — the alphabet and the consonant digraphs, each with a word it is in.",
+    lead: "The same spellings as the card pack, laid out as one page to pin up: the letters first, then the two-letter spellings, each with an example beside it. It is a record of where a child has got to rather than a poster of the whole language.",
+    notes: [
+      "A chart of what has actually been taught is worth more than a chart of everything, and it is the reason this page exists at all. A wall covered in sounds a child has not met is a wall they learn to stop looking at; a chart that grows by one row a week is one they can point at. Reprint it whenever the list changes — the sounds on it are a setting, and the sheet takes a second.",
+      "The two “th” rows are not a mistake. One is the sound at the front of “thin” and the other the sound at the front of “this”, and no rule in English tells a child which of them a “th” is going to be. Every other spelling that says more than one thing is on the chart twice for the same reason, which is what makes it a chart of sounds rather than of letters.",
+    ],
+    teaches: "The letter-sound correspondences taught so far",
+    ages: "Ages 4–7",
+    group: "sounds",
+    // Every sound on the list, which is what a "sounds we know" chart is: the
+    // count is the length of `WITH_DIGRAPHS` rather than a number, so adding a
+    // spelling to that list cannot leave the last row off the wall.
+    config: phonics("chart", WITH_DIGRAPHS, WITH_DIGRAPHS.sounds.length, 6),
+  },
+
+  /* ── Reading and writing with them ──────────────────────────────────── */
+  {
+    slug: "cvc-words-worksheets",
+    name: "CVC words — say it slowly",
+    short: "CVC words",
+    heading: "CVC words worksheets",
+    keyword: "Free printable CVC words worksheets",
+    summary:
+      "Twenty short words printed as the sounds they are made of, with a line to write the whole word on — and the answer key on the page behind.",
+    lead: "Each line is one word cut into its sounds, spaced apart. A child says each sound on its own, says them again quickly until they hear the word, and writes it on the line. That is the whole of blending, and it is the step everything else in reading waits for.",
+    notes: [
+      "Every word here is spellable from the letters of the alphabet and nothing else, which is what makes it a CVC sheet rather than a list of short words. Nothing on the page uses a spelling that has not been taught — no “sh”, no silent “e”, no vowel team — because a child who is still blending three sounds and meets a fourth spelling has been set up to fail at the thing they were doing correctly.",
+      "The sounds are printed rather than said, and the separation is the exercise. Reading “sat” as one shape is a thing a child can do by memory long before they can read “sap”; reading it as /s/ /a/ /t/ is a thing that works on every word they will ever meet. Cover the line with a finger, do the sounds twice, and only then write it.",
+    ],
+    teaches: "Blending sounds into words",
+    ages: "Ages 4–6",
+    group: "words",
+    config: phonics("blending", LETTERS, 20, 2),
+  },
+  {
+    slug: "word-family-worksheets",
+    name: "Word families",
+    short: "Word families",
+    heading: "Word family worksheets",
+    keyword: "Free printable word family worksheets",
+    summary:
+      "Twenty spelling sums — a beginning added to an ending, with the word they make written on the line, and the key on the page behind.",
+    lead: "A beginning, a plus sign and an ending, with a line for the word. Changing one sound at the front of a word a child can already read is the cheapest reading practice there is, and it is where a first reader gets their first hundred words.",
+    notes: [
+      "The endings on this page are not chosen from a list — they are the endings the words a child can read happen to share, which is why a family only appears when there are at least two words behind it. A sheet with one word in a family is not teaching a pattern, it is teaching a word, and there is a better sheet for that.",
+      "Beginnings here include the two- and three-letter clusters as well as single letters, and that is where the page earns its second half. Going from “c + at” to “fl + at” means holding two sounds together before the ending arrives, which is the step a child stalls on for months after single letters have become easy.",
+    ],
+    teaches: "Onset and rime, and building words from a pattern",
+    ages: "Ages 5–7",
+    group: "words",
+    config: phonics("families", WITH_DIGRAPHS, 20, 2),
+  },
+  {
+    slug: "letter-sounds-matching-worksheets",
+    name: "Match the sound to the word",
+    short: "Sound matching",
+    heading: "Letter sounds matching worksheets",
+    keyword: "Free printable letter sounds matching worksheets",
+    summary:
+      "Ten spellings down one side and ten words down the other, to join with a pencil — and the key behind, with the lines drawn in.",
+    lead: "A spelling on the left, a word on the right, and a line to draw between them. Every word on the page contains exactly one of the spellings listed, which is what makes it a question with a single right answer rather than a puzzle with two.",
+    notes: [
+      "That exclusivity took more discarding than choosing. If “s” and “sh” are both on the sheet then “shop” cannot be on it, because a child who joins “s” to “shop” has read the page correctly and would be marked wrong. A spelling with no word that avoids the others is simply left off, which is why some sheets come out with nine lines rather than ten.",
+      "The letters on the left are letters rather than sounds, and that is deliberate on this one sheet. “th” says two different things and is two tick boxes everywhere else in the Print Shop; printing it twice down this column would be two identical lines a child could not choose between. So the column is the spellings, once each, and the words behind them do the rest.",
+    ],
+    teaches: "Finding a taught spelling inside a word",
+    ages: "Ages 5–7",
+    group: "words",
+    config: phonics("matching", WITH_DIGRAPHS, 10),
+  },
+  {
+    slug: "phonics-dictation-worksheets",
+    name: "Dictation",
+    short: "Dictation",
+    heading: "Phonics dictation worksheets",
+    keyword: "Free printable phonics dictation worksheets",
+    summary:
+      "Twenty numbered lines and nothing to read — the words are on the answer key, for whoever is reading them out.",
+    lead: "The page a child gets has numbers and rules on it and nothing else. The words are on the sheet behind, in order, for the person reading them aloud. Writing a word you have only heard is the other half of phonics, and it is the half a worksheet usually skips.",
+    notes: [
+      "Read each word twice, in a normal voice, and then leave it alone. The temptation is to sound it out for them — /c/ /a/ /t/ — and that turns the exercise into copying: the work is the child doing the segmenting themselves, and it is uncomfortable to watch for the first few weeks.",
+      "This is the one sheet on the shelf where a word taught by sight belongs. “Said” cannot be sounded out on any day of any course, so it never appears on a blending line — but it is read out and written down like everything else, which is exactly how every programme handles it. Add your own to the sight-word box in the builder.",
+    ],
+    teaches: "Writing words from the sounds in them",
+    ages: "Ages 5–7",
+    group: "words",
+    config: phonics("dictation", WITH_DIGRAPHS, 20, 2),
+  },
+  {
+    slug: "decodable-sentences-worksheets",
+    name: "Decodable sentences",
+    short: "Decodable sentences",
+    heading: "Decodable sentences worksheets",
+    keyword: "Free printable decodable sentences worksheets",
+    summary:
+      "Eight sentences printed large on strips to cut apart, with nothing in them a child has not been taught to read.",
+    lead: "Connected text, at last — and every word in it spellable from the sounds on the chart. Cut the strips apart and a child reads one a day, or the whole page at once when a week has gone well.",
+    notes: [
+      "These are short and a little plain, and that is the honest cost of the promise. A sentence that reads more naturally is a sentence with a word in it the child has to be told, and being told one word in five is how a child learns that reading means guessing from the picture. Every word here is one they can work out.",
+      "“The” is the exception, and it is on the sheet because English will not make a sentence without it. It is on the sight-word list rather than sounded out, which is where every programme puts it in the first fortnight — and it is the only word on this page that is not built from the spellings above.",
+    ],
+    teaches: "Reading connected text made only of taught spellings",
+    ages: "Ages 5–7",
+    group: "words",
+    config: phonics("sentences", WITH_DIGRAPHS, 8, 1, { cutLines: true }),
+  },
+];
+
+/** What each group is called on a hub, in the order they are listed. */
+export const PHONICS_GROUPS: Array<{
+  id: PhonicsGroup;
+  label: string;
+  blurb: string;
+}> = [
+  {
+    id: "sounds",
+    label: "The sounds themselves",
+    blurb: "Cards to cut out, and a chart of what has been covered so far.",
+  },
+  {
+    id: "words",
+    label: "Reading and writing with them",
+    blurb:
+      "Blending, word families, finding a spelling in a word, dictation, and sentences with nothing untaught in them.",
+  },
+];
+
+/** Whether this sheet's answer key says anything its sheet doesn't. */
+export const keyed = (sheet: PhonicsSheet): boolean =>
+  phonicsKeyed(sheet.config.style);
+
+/** The route a sheet prints at. One stock, so one route — see the note above. */
+export const pathFor = (sheet: PhonicsSheet): string =>
+  `/printables/phonics/${sheet.slug}`;
+
+/** The builder, opened on this sheet. */
+export const builderHref = (sheet: PhonicsSheet): string =>
+  benchHref(sheet.config, PHONICS_SEED);
+
+/** The shelf, grouped — the shape every page lists it in. */
+export function phonicsShelf(): Array<{
+  id: PhonicsGroup;
+  label: string;
+  blurb: string;
+  sheets: PhonicsSheet[];
+}> {
+  return shelve(PHONICS_GROUPS, PHONICS_SHEETS);
+}

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -19,6 +19,11 @@ import {
 } from "./_handwriting";
 import { MATHS_SHEETS, mathsShelf, pathFor as mathsPath } from "./_maths";
 import {
+  PHONICS_SHEETS,
+  pathFor as phonicsPath,
+  phonicsShelf,
+} from "./_phonics";
+import {
   SPELLING_SHEETS,
   pathFor as spellingPath,
   spellingShelf,
@@ -37,14 +42,15 @@ import {
  * It lists what exists and nothing else. A shelf of links to sheets that
  * haven't been built is the thin-content pattern Base.astro's `noindex` block
  * already argues against, and a catalog page here is meant to BE the worksheet
- * — real prerendered HTML a parent can print without touching anything. Seven
+ * — real prerendered HTML a parent can print without touching anything. Eight
  * families fill it: every ruling in §5 on both stocks, the curated maths topics
  * of §8, each of which prints its own answer key, the handwriting and cursive
  * sheets, which come on both stocks for the same reason the paper does, the
  * Scripture shelf, which is those same families with a passage on them, the
  * spelling shelf, which is the one whose content a parent can replace with their
- * own list, and the grammar shelf, which is the one whose answers had to be
- * written down because they cannot be worked out.
+ * own list, the grammar shelf, which is the one whose answers had to be written
+ * down because they cannot be worked out, and the phonics shelf, which is the
+ * one whose content is decided by what a parent says has been taught.
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
@@ -59,6 +65,7 @@ const joined = cursiveShelf();
 const scripture = bibleShelf();
 const words = spellingShelf();
 const sentences = grammarShelf();
+const sounds = phonicsShelf();
 ---
 
 <Content
@@ -101,15 +108,15 @@ const sentences = grammarShelf();
   <section class="band band--tight wrap">
     <h2 class="h2">On the shelf now</h2>
     <p class="h2__sub">
-      Seven families: maths worksheets, each with its answer key on the page
+      Eight families: maths worksheets, each with its answer key on the page
       behind it, handwriting practice that traces before it copies, the same
       progression again in cursive, Scripture copywork and memory work, spelling
       and word study on this week&rsquo;s list or your own, grammar whose
-      answers were written down rather than worked out, and paper in every
-      ruling. Each of these is a page that is itself the sheet &mdash; open it,
-      press print, and that is the whole of it. Everything ruled comes on both
-      stocks, because a ruling shrunk to fit whatever is in the tray is no
-      longer the ruling you chose.
+      answers were written down rather than worked out, phonics built from the
+      sounds you have taught, and paper in every ruling. Each of these is a page
+      that is itself the sheet &mdash; open it, press print, and that is the
+      whole of it. Everything ruled comes on both stocks, because a ruling
+      shrunk to fit whatever is in the tray is no longer the ruling you chose.
     </p>
 
     <h3 class="h2 h2--next">Maths worksheets</h3>
@@ -236,6 +243,27 @@ const sentences = grammarShelf();
       <a class="cta" href="/printables/grammar">All the grammar sheets</a>
     </div>
 
+    <h3 class="h2 h2--next">Phonics</h3>
+    <p class="h2__sub">
+      {PHONICS_SHEETS.length} sheets built from the sounds a child has been taught
+      &mdash; cards, a wall chart, blending, word families, dictation and sentences
+      with nothing untaught in them. Tick the spellings; the words follow.
+    </p>
+    {
+      sounds.map((group) => (
+        <nav class="stones" aria-label={`Phonics — ${group.label}`}>
+          {group.sheets.map((sheet) => (
+            <a class="stone" href={phonicsPath(sheet)}>
+              {sheet.short}
+            </a>
+          ))}
+        </nav>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta" href="/printables/phonics">All the phonics sheets</a>
+    </div>
+
     {
       /*
         Paper keeps its groups and its one-line summaries; every subject shelf
@@ -293,16 +321,17 @@ const sentences = grammarShelf();
       <p class="h2__sub">
         The Print Shop is opening a family at a time, and this page lists what
         exists rather than what is planned. Paper, maths, handwriting, cursive,
-        copywork, spelling and grammar are open. Phonics is next.
+        copywork, spelling, grammar and phonics are open. The charts and forms
+        are next.
       </p>
       <div class="prose">
         <p>
-          The order it opens in: the paper, the maths sheets, the handwriting
+          The order it opened in: the paper, the maths sheets, the handwriting
           and the cursive above, then the copywork &mdash; a few hundred
           passages from the public domain, Scripture among them &mdash; then the
-          spelling and word-study shelf and the grammar sheets beside it, and
-          after that phonics and the charts, certificates and planners that are
-          simply blank forms.
+          spelling and word-study shelf, the grammar sheets beside it, and the
+          phonics shelf after them. What is left is the charts, certificates and
+          planners that are simply blank forms.
         </p>
         <p>
           The one it is really being built for comes with the sheet builder:

--- a/src/pages/printables/phonics/[slug].astro
+++ b/src/pages/printables/phonics/[slug].astro
@@ -1,0 +1,221 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { answerKey, buildSheet } from "@/engine/sheets";
+import {
+  PHONICS_SEED,
+  PHONICS_SHEETS,
+  builderHref,
+  keyed,
+  pathFor,
+  phonicsShelf,
+  type PhonicsSheet,
+} from "../_phonics";
+
+/**
+ * One prerendered phonics sheet per kind — and the page is the sheet.
+ *
+ * The shape §8 describes, on the shelf where what somebody searched for is the
+ * *exercise*: "cvc words worksheets", "word family worksheets" and "decodable
+ * sentences" are queries a parent types, and a page that answers one of them has
+ * prose above the sheet, the sheet itself as HTML under it, and nothing to click
+ * before pressing ⌘P.
+ *
+ * **Not every page here has a key**, unlike the grammar shelf. Three of the
+ * seven withhold nothing — a pack of cards to cut out, a wall chart and a page
+ * of sentences to read — and printing the same page twice under the word "key"
+ * would be noise on a parent's printer. `keyed` is the engine's own answer to
+ * that (`phonicsKeyed`), so the page and the family cannot disagree.
+ *
+ * **One stock, as with maths, spelling and grammar.** Nothing on a phonics
+ * sheet is a measurement, so there is no A4 twin to keep in step — which is also
+ * why this is a single-segment `[slug]` rather than a rest pattern.
+ *
+ * **No client directive on `SheetView`, ever.** `@astrojs/react` renders a
+ * component with no `client:*` to HTML at build time, so these pages ship zero
+ * JavaScript — the whole SEO argument of §2. `Sheet.test.tsx` holds every page
+ * in this directory to it, against the source and against `dist/`.
+ *
+ * **Everything that is not the sheet carries `.no-print`.** `@page` cannot be
+ * scoped to a class, so the zeroed page margin a sheet needs applies to the
+ * prose as well and it would print off the edge.
+ */
+
+type Props = { sheet: PhonicsSheet };
+
+export function getStaticPaths() {
+  return PHONICS_SHEETS.map((sheet) => ({
+    params: { slug: sheet.slug },
+    props: { sheet },
+  }));
+}
+
+const { sheet } = Astro.props;
+
+const printed = buildSheet(sheet.config, PHONICS_SEED);
+const key = keyed(sheet) ? answerKey(sheet.config, PHONICS_SEED) : null;
+
+const title = `${sheet.keyword} | School Skills`;
+const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const url = `https://schoolskills.app${pathFor(sheet)}`;
+
+const groups = phonicsShelf();
+const group = groups.find((entry) => entry.id === sheet.group)!;
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    name: sheet.heading,
+    description,
+    url,
+    learningResourceType: "Worksheet",
+    educationalUse: "Practice",
+    teaches: sheet.teaches,
+    typicalAgeRange: sheet.ages,
+    isAccessibleForFree: true,
+    inLanguage: "en",
+  }}
+>
+  <header class="hero wrap no-print">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Phonics &middot; {group.label}
+    </p>
+    <h1 class="hero__title">{sheet.heading}</h1>
+    <p class="hero__lead">{sheet.lead}</p>
+    <p class="aside">
+      The sheet below <strong>is</strong> the printout{
+        keyed(sheet) ? ", and the page behind it is the answer key" : ""
+      }. Press <strong>&#8984;P</strong> &mdash; <strong>Ctrl+P</strong> on Windows
+      &mdash; and everything but the paper disappears. To keep a copy instead, pick
+      <em>Save as PDF</em> in the print dialog and your browser writes one.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  {
+    /*
+      The sheets, outside `.wrap` deliberately. A wrap adds an inline padding
+      that print.css cannot take back off, and a sheet printed a centimetre in
+      from where it says it is has the wrong geometry everywhere at once. The
+      key is a sibling of the sheet with nothing between them, because
+      print.css breaks pages on `.sheet + .sheet` as well.
+    */
+  }
+  <div class="sheet-frame">
+    <SheetView sheet={printed} />
+    {key && <SheetView sheet={key} />}
+  </div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">What is on this sheet</h2>
+    <div class="prose">
+      {sheet.notes.map((note) => <p>{note}</p>)}
+      <p>
+        Every sheet in this section is built from a list of spellings rather
+        than from a word list, and that is the whole of how it works: the page
+        above uses the sounds named on it and no others, so nothing on it can
+        ask a child to read something they have not been taught. The list is a
+        setting. Open the sheet in the builder, tick the sounds your own child
+        has covered, and the page rebuilds around them &mdash; which is also why
+        there is no level, no stage and no lesson number anywhere here. The
+        number in the footer is the seed the sheet was built from, so the
+        identical sheet can be had again next week.
+      </p>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Change what is on it</h2>
+    <div class="prose">
+      <p>
+        This page is one sheet out of a family that prints seven: cards to cut
+        out, a chart for the wall, words cut into their sounds, word families, a
+        spelling matched to a word it is in, dictation lines, and sentences on
+        strips. The sounds are the same tick list on all seven, so a
+        week&rsquo;s worth of sheets comes out of one list ticked once.
+      </p>
+      <p>
+        Three marking conventions are switches beside it, each on its own: a bar
+        over a vowel that says its own name, silent letters printed faintly, and
+        two letters joined where they make one sound. They are shared across
+        many phonics traditions rather than belonging to any one of them, which
+        is exactly why they are switches here and not a named style.
+      </p>
+      <p class="aside">
+        The settings travel in the link rather than on a server, so a sheet you
+        make can be bookmarked or sent to another family as it stands &mdash;
+        and the <em>Name:</em> line is printed blank, because there is nowhere in
+        a shared link to put a child&rsquo;s name. See{" "}
+        <a href="/privacy">what we don&rsquo;t collect</a>.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href={builderHref(sheet)}>
+        Open this sheet in the builder
+      </a>
+      <a class="cta cta--quiet" href="/printables/phonics">
+        All the phonics sheets
+      </a>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">And when the words are known</h2>
+    <div class="prose">
+      <p>
+        Phonics is how a word is worked out; spelling is what happens once it no
+        longer has to be. The shelf next door prints this week&rsquo;s list in
+        five shapes, the first sight words to trace and find, and ten pages on
+        how words work. Word Jungle then reads the same lists aloud, which is
+        the one thing paper cannot do &mdash; and the record book keeps track of
+        which words a child keeps missing, so the next sheet can be exactly
+        those.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/spelling">Spelling worksheets</a>
+      <a class="cta cta--quiet" href="/spelling">Spelling and sight words</a>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Every phonics sheet</h2>
+    <p class="h2__sub">
+      {PHONICS_SHEETS.length} pages, each one a sheet like this one. Nothing is locked
+      and nothing needs an account.
+    </p>
+    {
+      groups.map((entry) => (
+        <>
+          <h3 class="h2 h2--next">{entry.label}</h3>
+          <p class="h2__sub">{entry.blurb}</p>
+          <nav class="stones" aria-label={entry.label}>
+            {entry.sheets.map((candidate) => (
+              <a
+                class="stone"
+                href={pathFor(candidate)}
+                aria-current={
+                  candidate.slug === sheet.slug ? "page" : undefined
+                }
+              >
+                {candidate.short}
+              </a>
+            ))}
+          </nav>
+        </>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/phonics/index.astro
+++ b/src/pages/printables/phonics/index.astro
@@ -1,0 +1,184 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { PHONICS_SHEETS, pathFor, phonicsShelf } from "../_phonics";
+
+/**
+ * The phonics subject hub — a peer of `/printables/spelling`,
+ * `/printables/grammar`, `/printables/math`, `/printables/handwriting`,
+ * `/printables/cursive` and `/printables/bible`.
+ *
+ * A listing rather than a sheet, like the other hubs, and that is the right
+ * split: nobody searches for "printable list of phonics worksheets". What it is
+ * for is the two jobs a hub does — giving a parent who arrived on
+ * `/printables/phonics/cvc-words-worksheets` somewhere to go next, and giving
+ * the seven pages a crawlable parent that says what they have in common.
+ *
+ * What they have in common is worth a section of its own here, because it is
+ * the argument for the whole shelf: a phonics worksheet is only worth printing
+ * if it is built from the sounds a particular child has been taught, and that
+ * is a thing a parent can state in a minute and no worksheet site has ever
+ * asked them for.
+ */
+const title =
+  "Free printable phonics worksheets — built from the sounds you have taught | School Skills";
+const description =
+  "Printable phonics practice: sound cards, a sounds-we-know wall chart, CVC blending lines, word families, sound-to-word matching, dictation and decodable sentences. Every sheet is built from the spellings you tick, so nothing on it is a sound your child has not met — free, no account, no download.";
+
+const groups = phonicsShelf();
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Printable phonics worksheets",
+    description,
+    url: "https://schoolskills.app/printables/phonics",
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    hasPart: PHONICS_SHEETS.map((sheet) => ({
+      "@type": "LearningResource",
+      name: sheet.heading,
+      url: `https://schoolskills.app${pathFor(sheet)}`,
+      learningResourceType: "Worksheet",
+      teaches: sheet.teaches,
+      typicalAgeRange: sheet.ages,
+      isAccessibleForFree: true,
+    })),
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Phonics
+    </p>
+    <h1 class="hero__title">Printable phonics worksheets</h1>
+    <p class="hero__lead">
+      {PHONICS_SHEETS.length} sheets built from the sounds a child has actually been
+      taught: cards to cut out, a chart for the wall, words cut into their sounds,
+      word families, dictation lines and sentences with nothing untaught in them.
+    </p>
+    <p class="hero__note">Free &middot; answer keys &middot; no download</p>
+  </header>
+
+  {
+    /*
+      What exists, first — before the page explains itself. Somebody who came
+      looking for CVC words should be one link from CVC words, and the argument
+      for how these sheets are built reads better after you have seen one than
+      before.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">On the shelf now</h2>
+    <p class="h2__sub">
+      Each of these is a page that is itself the worksheet &mdash; open it,
+      press print, and that is the whole of it. The four that withhold an answer
+      print their key on the page behind.
+    </p>
+    {
+      groups.map((group) => (
+        <>
+          <h3 class="h2 h2--next">{group.label}</h3>
+          <p class="h2__sub">{group.blurb}</p>
+          <div class="prose">
+            <ul>
+              {group.sheets.map((sheet) => (
+                <li>
+                  <a href={pathFor(sheet)}>{sheet.name}</a> &mdash;{" "}
+                  {sheet.summary}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      ))
+    }
+  </section>
+
+  <div class="wrap"><AdSlot name="article" /></div>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">Built from your sounds, not from a level</h2>
+      <p class="h2__sub">
+        The one thing a phonics worksheet has to know is where a child has got
+        to. Everything on this shelf asks that and nothing else.
+      </p>
+      <div class="prose">
+        <p>
+          A child who has been taught <em>c</em>, <em>a</em>, <em>t</em> and
+          <em>h</em> can read &ldquo;cat&rdquo; and cannot read &ldquo;chat&rdquo;.
+          That is the whole mechanism behind every systematic phonics programme there
+          is, and it is the reason a worksheet full of words a child has not been
+          shown how to work out does harm rather than nothing: it teaches them that
+          reading is guessing.
+        </p>
+        <p>
+          So the sheets here are generated from a list of spellings you tick.
+          Tick <em>sh</em> and words with <em>sh</em> in them appear; leave it and
+          they never do. The same list builds all seven sheets, so a week&rsquo;s
+          practice comes out of one list ticked once, and the list keeps under a name
+          you choose &mdash; on your own device, like everything else here.
+        </p>
+        <p>
+          There are no levels, no stages and no lesson numbers anywhere in this
+          section, and that is deliberate rather than a gap. Numbering the
+          lessons would mean copying somebody&rsquo;s course, and naming a stage
+          would mean pretending there is one course when the whole point is that
+          every programme orders the sounds differently. Whatever scheme you are
+          using &mdash; a boxed curriculum, a school&rsquo;s own, or a book from
+          the library &mdash; the answer to &ldquo;where are you up to&rdquo; is
+          a list of sounds, and that is what these sheets take.
+        </p>
+        <p>
+          Three typographic switches sit beside the list: a bar over a vowel
+          that says its own name, silent letters printed faintly, and two
+          letters joined where they make one sound. Each is on its own, because
+          each is a convention many traditions share &mdash; and no combination
+          of them ships here under anybody&rsquo;s name.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">And the words once they are known</h2>
+    <div class="prose">
+      <p>
+        Phonics is how a word is worked out; spelling is what happens once it no
+        longer has to be. The shelf next door prints this week&rsquo;s list in
+        five shapes, the first sight words to trace and find, and ten pages on
+        how words work &mdash; rhyme, syllables, prefixes and suffixes, plurals,
+        contractions, homophones, synonyms and antonyms.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/spelling">Spelling and word study</a>
+      <a class="cta cta--quiet" href="/printables/make"
+        >Open the sheet builder</a
+      >
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Your child&rsquo;s name is not in the file</h2>
+    <div class="prose">
+      <p>
+        The <em>Name:</em> line is printed blank and filled in with a pencil. The
+        sounds you tick are kept in your own browser and are never uploaded, no account
+        is needed to print anything, and a sheet you send to another family carries
+        the settings you chose and nothing else &mdash; see <a href="/privacy"
+          >what we don&rsquo;t collect</a
+        >.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/phonics/index.astro
+++ b/src/pages/printables/phonics/index.astro
@@ -122,8 +122,9 @@ const groups = phonicsShelf();
           So the sheets here are generated from a list of spellings you tick.
           Tick <em>sh</em> and words with <em>sh</em> in them appear; leave it and
           they never do. The same list builds all seven sheets, so a week&rsquo;s
-          practice comes out of one list ticked once, and the list keeps under a name
-          you choose &mdash; on your own device, like everything else here.
+          practice comes out of one list ticked once &mdash; and the sheet you make
+          carries the sounds inside it, so the link to it opens on the same list for
+          anybody you send it to, with nothing uploaded and nothing to sign into.
         </p>
         <p>
           There are no levels, no stages and no lesson numbers anywhere in this

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -204,6 +204,7 @@
 .sheet__questions,
 .sheet__options,
 .sheet__wordshapes,
+.sheet__cards,
 .sheet__clue-list,
 .sheet__words {
   list-style: none;
@@ -702,6 +703,66 @@
 .sheet__box {
   fill: none;
   stroke: currentcolor;
+}
+
+/* ── Sound cards, wall charts and sentence strips (§13) ─────────────────────
+   The same grid again, and the same bargain: the family decided how many
+   columns fit and how tall a card stands, so the gaps here are the ones
+   `PROBLEM_GAP` names in mil and every type size on a card is set inline from
+   `phonics/cards.ts`. Nothing about a card's size is decided in this file.   */
+
+.sheet__cards {
+  display: grid;
+  grid-template-columns: repeat(var(--sheet-columns, 3), minmax(0, 1fr));
+  gap: 0.2in 0.3in;
+}
+
+.sheet__card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  break-inside: avoid;
+}
+
+/* A real border rather than a tint, for the reason the ink note above gives: a
+   printer with "Background graphics" unticked drops paint and keeps strokes,
+   and a page of cards to cut out whose boxes vanished is a page nobody can cut
+   out. The wall chart has no box at all — it is read, not cut. */
+.sheet__cards--boxed .sheet__card {
+  border: 0.75pt solid currentcolor;
+}
+
+/* A strip is a whole sentence at nearly twice the body size, and the family
+   reserved for it wrapping (`stripRows`). Breaking inside a word rather than
+   overflowing the column is what keeps that reservation honest at the far end,
+   where the type is large and the column is narrow. */
+.sheet__card-big,
+.sheet__card-small {
+  overflow-wrap: break-word;
+}
+
+/* ── The three marks (§13) ──────────────────────────────────────────────────
+   Independent switches, never a preset, and each one a convention shared by
+   many phonics traditions rather than owned by any: a bar over a vowel saying
+   its own name, a letter that says nothing set faintly, and two letters saying
+   one sound tied underneath. All three are foreground ink — an overline, an
+   underline and a lighter weight of the same colour — so all three print. */
+
+.sheet__part--macron {
+  text-decoration: overline;
+  text-decoration-thickness: 0.06em;
+}
+
+.sheet__part--silent {
+  opacity: 40%;
+}
+
+.sheet__part--joined {
+  text-decoration: underline;
+  text-decoration-thickness: 0.06em;
+  text-underline-offset: 0.1em;
 }
 
 .sheet__faces,


### PR DESCRIPTION
Closes #69. Epic PRINT25 — design in `docs/printables.md`.

#68 landed the phonics model: a table of correspondences, a hand-cut word bank, and an inventory that is the set of spellings a parent has ticked. This PR is the seven sheets built on top of it, and the one promise they all make — **nothing on any of these pages uses a spelling that has not been taught.**

## What's here

One `phonics` family, one `PhonicsConfig`, seven views of one list (`PhonicsStyle`):

| Style | Sheet |
| --- | --- |
| `cards` | sound cards |
| `chart` | the "sounds we know" wall chart |
| `blending` | blending lines |
| `families` | word-family sheets |
| `matching` | sound-to-word matching |
| `dictation` | dictation lines |
| `sentences` | decodable sentence strips |

CVC sheets are `blending` with a `maxSounds` cap, so a CVC page prints `hen` and `bad` rather than `camp` and `strong`.

The chart keeps the table's order, because a chart is read down a wall. Everything else is drawn from the seed the way every other sheet family draws.

## Marking is three switches, not a preset

`PhonicsMarking` is three independent booleans — `macron` (a bar over a vowel saying its own name), `silent` (letters that say nothing, set pale), `joined` (two letters saying one sound, joined underneath). All three default off, and every mark is derived from the table of spellings rather than authored.

This is the §13 argument and the reason for the shape: the conventions are shared across many phonics traditions and belong to none of them, but a particular *combination* of them under a programme's name is that programme's modified alphabet. So there are three switches and no shipped set of them is named after anything.

They apply where a word is read and deliberately not where it is worked out — a joined `sh` inside `shop` on a matching sheet would print the answer beside the question, and a blending line's segmentation already *is* the marking. The three cannot collide (a silent piece has no sounds, a macron needs one letter, a join needs two) and a test pins that rather than trusting it.

## The promise is re-derived, not asserted

`sheets.test.ts` reads the words back off the finished page, looks each one up in the bank, and compares its spellings against the ticked ids. A generator agreeing with itself would pass whatever it did. Answer keys go the same way: a blending prompt is blended back into its own answer, a family sum is added up, and a matching pair is checked against the letters in the word rather than the index the placer remembered.

## Two things had to be authored

**Sentences**, because a list of readable words is not a sentence and no rule turns one into the other — each is written as the words it is made of, so it becomes available exactly when every word in it is. And **the cuts**, which were #68's. Word families are derived from those cuts and grouped by the rime's *spellings* rather than its letters: `be` and `the` end in the same letter and not in the same sound.

## Dialect care carried forward

Nothing filters on `variesByAccent`, because the one exercise that would need it — *hear the difference between these two sounds* — is not among the seven. Every style asks about a spelling, and a spelling is the same on both sides of the Atlantic. Sight words stay off every sheet except the two that are read aloud rather than sounded out.

## Catalog

Seven pages at `/printables/phonics`, one per *kind of sheet* rather than one per sound. "sh worksheets" and "short a worksheets" are real queries, and both are one of these sheets with one spelling ticked — the doorway farm §8 argues against. Each page states the spellings its own sheet uses and says yours will differ. No level, no stage, no lesson number anywhere.

## Second commit — what the sheet prints vs. what the page says it prints

Review found six gaps between the paper and the prose, all the same shape: a promise made in a docblock or a lead paragraph that the generated sheet did not keep.

- **The split vowel reached the printed card.** `graphemeText` existed to stop that and was applied to blending prompts and the matching column, but never to a card's big line — so a ticked `a_e` printed the table's own underscore an inch high, which reads as a blank to fill in. It moves to `sounds.ts` beside `graphemeParts` where `cards.ts` can reach it, and `markGrapheme` goes through it.
- **The word-family draw did the opposite of its own comment.** It concatenated each family before starting the next, so the shipped page was twenty rows over three rimes — eleven of them `-ip`. It goes round by round now.
- **The matching sheet printed the exact ambiguity its docblock excludes**, because exclusivity was tested by correspondence rather than by letters: `n` was keyed to `land` with `strong` three lines below. It is a substring test over the letters now.
- Three smaller claims brought back to the sheet under them: a sound card's example is a word the letter is *in* rather than one it starts; the wall chart is the card pack plus the digraphs in table order; the CVC page has a `maxSounds` to be CVC by.
- The hub's claim that a list "keeps under a name you choose" is **removed rather than half-kept** — `services/phonics.ts` has no view-layer consumer, so there is no screen that can save one yet. The copy now says what the config actually does: the sounds travel in the link.

## Validation

`npm run type-check`, `npm run lint`, `npm run test:unit` (1227 passing), `npm run build` (149 pages, static) and the browser smoke test all pass locally, console errors none.
