### PR TITLE
PRINT26: the blank maths references

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -583,6 +583,33 @@ charts · award certificates · name tags and bookmarks · blank flashcards with
 cut lines · dice and spinner nets · memory-verse cards and a verse-of-the-week
 chart.
 
+**What shipped (PRINT26): the blank maths references.** `templates/charts.ts` —
+hundred charts blank and filled over a configurable range, number lines with the
+interval a parent sets, first- and four-quadrant coordinate grids, and
+place-value charts down to thousandths — on eight pages at `/printables/charts`,
+with the metric squares the paper shelf was missing beside them (1 cm and 5 mm
+graph, 1 cm dots, 1 cm isometric). Two things listed above are deliberately not
+in it: a **multiplication grid** is `/printables/multiplication-chart`, which is
+the times-table family with `style: "grid"` on it, and graph paper is the grid
+end of the paper shelf. Both are linked rather than rebuilt, for the reason a
+sight word to trace is a `HandwritingConfig` — a second family that drew a
+times-table square would be a second answer to what goes in square forty-two.
+
+The tier's own argument is what this family had to be held to. A worksheet can
+be marked, so a mistake on one is found; a reference sheet is counted along and
+trusted, and nothing on the page says when it is wrong. So every count is
+verified off the finished blocks and off the rendered markup rather than off the
+arithmetic that made them, and three of the failures were only visible in a
+browser: `chromeHeight` reserves a title row only if the _options_ it is handed
+carry one — a family that prints a title regardless and passes its config
+straight in builds a page an inch too long, and `.sheet` is `min-height`, so
+nothing overflows on screen; `flex: 1 0 100%` means "a line to yourself" inside
+`.sheet__problem` and "take all the height going" inside `.sheet__blocks`, which
+is a number line at six times its declared height; and a spacer between two
+blocks buys the flex column a second gap to pay for. `GridSpec.row` is the one
+new field, set by the one chart whose rows are not squares — everything a child
+measures against leaves it unsaid and gets squares by construction.
+
 ### Not ours to fake
 
 Science content, social studies content, history, and anything with a scope and

--- a/src/components/sheet/NumberLine.tsx
+++ b/src/components/sheet/NumberLine.tsx
@@ -32,6 +32,21 @@ import { RULE, inch } from "./units";
 const AXIS = 120;
 const TICK = 32;
 
+/**
+ * How far a tick with no number under it stands out, as a share of one that
+ * has.
+ *
+ * A line marked every 1 from 0 to 100 cannot carry a hundred and one numerals,
+ * so the engine thins them out (`labelEvery`) — and a tick with nothing under
+ * it has to read as a tick rather than as a shorter version of the same thing.
+ * Two thirds is the ratio a ruler uses, and it is what makes counting between
+ * two labelled ticks possible at all.
+ *
+ * On a line under a sum this never applies: `label` is absent there, every tick
+ * keeps its number, and every tick is full length.
+ */
+const MINOR = 2 / 3;
+
 /** The labels' baseline. */
 const LABEL = 290;
 
@@ -43,6 +58,13 @@ export function NumberLineView({ line }: { line: NumberLine }) {
   const usable = Math.max(0, line.width - LINE_INSET * 2);
   const at = (value: number) =>
     Math.round(LINE_INSET + ((value - line.from) / span) * usable);
+
+  // Which ticks keep their number is the engine's answer as well: every one of
+  // them under a sum, and as many as fit on a reference line. Both of these are
+  // the same for every tick on the line, so they are worked out once rather
+  // than a hundred and one times.
+  const every = Math.max(1, line.label ?? 1);
+  const minor = Math.round(TICK * MINOR);
 
   return (
     <svg
@@ -64,27 +86,33 @@ export function NumberLineView({ line }: { line: NumberLine }) {
         y2={AXIS}
         strokeWidth={RULE}
       />
-      {marks.map((value) => (
-        <g key={value}>
-          <line
-            className="sheet__rule"
-            x1={at(value)}
-            x2={at(value)}
-            y1={AXIS - TICK}
-            y2={AXIS + TICK}
-            strokeWidth={RULE}
-          />
-          <text
-            className="sheet__tick"
-            x={at(value)}
-            y={LABEL}
-            fontSize={LABEL_SIZE}
-            textAnchor="middle"
-          >
-            {value}
-          </text>
-        </g>
-      ))}
+      {marks.map((value, index) => {
+        const numbered = index % every === 0;
+        const out = numbered ? TICK : minor;
+        return (
+          <g key={value}>
+            <line
+              className="sheet__rule"
+              x1={at(value)}
+              x2={at(value)}
+              y1={AXIS - out}
+              y2={AXIS + out}
+              strokeWidth={RULE}
+            />
+            {numbered && (
+              <text
+                className="sheet__tick"
+                x={at(value)}
+                y={LABEL}
+                fontSize={LABEL_SIZE}
+                textAnchor="middle"
+              >
+                {value}
+              </text>
+            )}
+          </g>
+        );
+      })}
     </svg>
   );
 }

--- a/src/components/sheet/Sheet.test.tsx
+++ b/src/components/sheet/Sheet.test.tsx
@@ -13,6 +13,7 @@ import { SCRIPTURE_CREDIT } from "@/engine/sheets/passages";
 import type {
   ArithmeticConfig,
   Block,
+  ChartConfig,
   FractionArt,
   FractionConfig,
   GeometryConfig,
@@ -289,6 +290,12 @@ const EVERY_BLOCK: Block[] = [
         ],
       },
     ],
+  },
+  {
+    // A number line as the sheet rather than as an aid under a sum: the one
+    // shape of it that thins its own labels out, which is what `label` says.
+    kind: "numberline",
+    line: { from: 0, to: 100, step: 5, width: 7500, label: 2 },
   },
   { kind: "cutline" },
   { kind: "spacer", height: 1200 },
@@ -1424,6 +1431,224 @@ describe("a rendered word-shape sheet", () => {
     expect(blank).not.toContain("sheet__cell--answered");
     expect(count(key, "sheet__cell--answered")).toBe(6);
     expect(key).toContain(">b</text>");
+  });
+});
+
+/* ── The blank references, measured off the ink ────────────────────────── */
+
+const chart = (over: Partial<ChartConfig> = {}): ChartConfig => ({
+  kind: "chart",
+  style: "hundred",
+  paper: DEFAULT_PAPER,
+  fontPt: 12,
+  fields: ["name", "date"],
+  ...over,
+});
+
+/** The gridlines of a drawing, split into the two directions they run in. */
+function ruling(html: string): { down: number[]; across: number[] } {
+  const lines = [
+    ...html.matchAll(
+      /<line class="sheet__rule sheet__rule--grid" x1="(\d+)" x2="(\d+)" y1="(\d+)" y2="(\d+)"/g,
+    ),
+  ].map((line) => line.slice(1).map(Number));
+  return {
+    down: lines.filter(([x1, x2]) => x1 === x2).map(([x1]) => x1),
+    across: lines.filter(([x1, x2]) => x1 !== x2).map(([, , y1]) => y1),
+  };
+}
+
+/** The numerals and headings printed inside squares, with where and how big. */
+function inSquares(html: string) {
+  return [
+    ...html.matchAll(
+      /<text class="sheet__cell(?:[^"]*)" x="(-?[\d.]+)" y="(-?[\d.]+)" font-size="(\d+)"[^>]*>([^<]*)<\/text>/g,
+    ),
+  ].map((one) => ({
+    x: Number(one[1]),
+    y: Number(one[2]),
+    size: Number(one[3]),
+    text: one[4],
+  }));
+}
+
+/** The ticks along a number line, and the numbers written under them. */
+function alongTheLine(html: string) {
+  const ticks = [
+    ...html.matchAll(
+      /<line class="sheet__rule" x1="(\d+)" x2="(\d+)" y1="(\d+)" y2="(\d+)"/g,
+    ),
+  ].map((tick) => ({
+    x: Number(tick[1]),
+    out: Number(tick[4]) - Number(tick[3]),
+  }));
+  const labels = [
+    ...html.matchAll(
+      /<text class="sheet__tick" x="(\d+)" y="\d+" font-size="\d+" text-anchor="middle">([^<]*)<\/text>/g,
+    ),
+  ].map((label) => ({ x: Number(label[1]), text: label[2] }));
+  return { ticks, labels };
+}
+
+/** The distance between one of a list of positions and the next. */
+const gaps = (values: number[]): number[] =>
+  values.slice(1).map((value, index) => value - values[index]);
+
+describe("a rendered hundred chart", () => {
+  it("draws a hundred squares that are actually square", () => {
+    // §4, measured rather than reviewed: the eleven rules each way land on a
+    // repeat of one length, and it is the *same* length in both directions.
+    const html = render(buildSheet(chart({ filled: true }), 1));
+    const { down, across } = ruling(html);
+    expect(down).toHaveLength(11);
+    expect(across).toHaveLength(11);
+    expect(new Set(gaps(down)).size).toBe(1);
+    expect(gaps(down)).toEqual(gaps(across));
+  });
+
+  it("numbers them 1 to 100, each in the middle of its own square", () => {
+    const html = render(buildSheet(chart({ filled: true }), 1));
+    const { down, across } = ruling(html);
+    const squares = inSquares(html);
+    expect(squares).toHaveLength(100);
+
+    const cell = gaps(down)[0];
+    for (const [index, square] of squares.entries()) {
+      // Recovered from where the ink is, not from the block: the number in the
+      // square at row 4, column 7 has to be 48 to a child reading the paper.
+      const column = (square.x - cell / 2) / cell;
+      const row = (square.y - cell / 2) / cell;
+      expect(Number(square.text)).toBe(row * 10 + column + 1);
+      expect(square.text).toBe(String(index + 1));
+    }
+    expect(across.at(-1)).toBe(cell * 10);
+  });
+
+  it("prints nothing in the squares until it is a key", () => {
+    expect(inSquares(render(buildSheet(chart(), 1)))).toHaveLength(0);
+    expect(inSquares(render(answerKey(chart(), 1)))).toHaveLength(100);
+  });
+});
+
+describe("a rendered number line", () => {
+  it("spaces its ticks evenly and ends on one", () => {
+    const html = render(
+      buildSheet(
+        chart({ style: "number-line", range: { min: 0, max: 20 }, step: 1 }),
+        1,
+      ),
+    );
+    const { ticks, labels } = alongTheLine(html);
+    expect(ticks).toHaveLength(21);
+    // Rounded, because the axis is divided rather than accumulated: the ticks
+    // land within a thousandth of an inch of one another's spacing, which is
+    // finer than any printer resolves.
+    expect(new Set(gaps(ticks.map((tick) => tick.x)))).toEqual(new Set([361]));
+    expect(labels.map((label) => label.text)).toEqual(
+      Array.from({ length: 21 }, (_, index) => String(index)),
+    );
+  });
+
+  it("is a block of its own without growing to fill the page", () => {
+    // The one rule a number line brought with it from being an aid under a sum.
+    // `.sheet__problem` is a wrapping flex *row*, where `flex: 1 0 100%` means
+    // "a line to yourself"; `.sheet__blocks` is a flex *column*, where the same
+    // declaration means "take all the height that is going". Unscoped, a
+    // reference strip printed at six times the height the family reserved for
+    // it — and it looked deliberate, because the strips spread evenly down the
+    // page. Only a browser can measure that; this is the line that causes it.
+    const css = read(join(ROOT, "src/styles/sheet.css")).replaceAll(
+      /\/\*[\s\S]*?\*\//g,
+      "",
+    );
+    for (const [, selector, body] of css.matchAll(/([^{}]+)\{([^}]*)\}/g)) {
+      if (!selector.includes(".sheet__number-line")) continue;
+      if (selector.includes(".sheet__problem")) continue;
+      expect(body, selector.trim()).not.toContain("flex:");
+    }
+    expect(css).toContain(".sheet__problem > .sheet__number-line");
+  });
+
+  it("thins the numbers out without moving a tick, and keeps the last one", () => {
+    // A line marked every 1 to 100 keeps all hundred and one ticks; what gives
+    // way is the numerals, and the unnumbered ticks are drawn shorter so they
+    // still read as something to count.
+    const html = render(
+      buildSheet(
+        chart({ style: "number-line", range: { min: 0, max: 100 }, step: 1 }),
+        1,
+      ),
+    );
+    const { ticks, labels } = alongTheLine(html);
+    expect(ticks).toHaveLength(101);
+    expect(labels).toHaveLength(21);
+    expect(labels.map((label) => label.text).at(-1)).toBe("100");
+    expect(new Set(ticks.map((tick) => tick.out)).size).toBe(2);
+    // And every numeral sits over a tick rather than between two.
+    const at = new Set(ticks.map((tick) => tick.x));
+    for (const label of labels) expect(at.has(label.x)).toBe(true);
+  });
+});
+
+describe("a rendered place-value chart", () => {
+  const mat = chart({
+    style: "place-value",
+    places: { largest: 2, smallest: -1 },
+    rows: 6,
+  });
+
+  it("prints every heading over the column it names", () => {
+    // The one thing this sheet has to get right. A heading laid out beside the
+    // drawing would be two things to keep aligned; inside the grid it is one.
+    const html = render(buildSheet(mat, 1));
+    const { down } = ruling(html);
+    const headings = inSquares(html);
+    expect(headings.map((heading) => heading.text)).toEqual([
+      "Hundreds",
+      "Tens",
+      "Ones",
+      "Tenths",
+    ]);
+    for (const [index, heading] of headings.entries()) {
+      expect(heading.x).toBe((down[index] + down[index + 1]) / 2);
+    }
+  });
+
+  it("sets a heading small enough to stay inside its column", () => {
+    // "Hundreds" at half the height of a column two inches wide runs four
+    // columns long, and an `<svg>` clips what leaves its viewBox — so what
+    // prints is a chart with most of its headings sliced off.
+    const html = render(buildSheet(mat, 1));
+    const { down } = ruling(html);
+    const column = down[1] - down[0];
+    for (const heading of inSquares(html)) {
+      expect(heading.text.length * heading.size).toBeLessThanOrEqual(
+        column * 2,
+      );
+    }
+  });
+
+  it("rules its rows at the row's height, not at the column's width", () => {
+    const html = render(buildSheet(mat, 1));
+    const { down, across } = ruling(html);
+    expect(down).toHaveLength(5);
+    // Six rows to write in, and the headings above them.
+    expect(across).toHaveLength(8);
+    expect(new Set(gaps(across)).size).toBe(1);
+    expect(gaps(across)[0]).toBeLessThan(gaps(down)[0]);
+  });
+
+  it("draws the decimal point where a decimal point goes", () => {
+    // Immediately right of the ones column — the third gridline in, on a chart
+    // that runs hundreds, tens, ones, tenths.
+    const html = render(buildSheet(mat, 1));
+    const { down } = ruling(html);
+    const axis =
+      /<line x1="(\d+)" x2="(\d+)" y1="0" y2="\d+" class="sheet__rule sheet__rule--axis"/.exec(
+        html,
+      );
+    expect(axis).not.toBeNull();
+    expect(Number(axis?.[1])).toBe(down[3]);
   });
 });
 

--- a/src/components/sheet/blocks/Grid.tsx
+++ b/src/components/sheet/blocks/Grid.tsx
@@ -1,8 +1,31 @@
+import { faceOf, glyphAdvance, type Face } from "@/engine/sheets/faces";
+
 import { HAIRLINE, HEAVY, inch } from "../units";
 import type { BlockProps } from "./block";
 
 /** Numerals inside a square, at about half its height. */
 const CELL_TO_EM = 0.5;
+
+/**
+ * How much of a column a word at the head of one may take.
+ *
+ * Half a square is the right size for the numerals a grid was built for, and
+ * far too big for a word: "Hundred thousands" set at half the height of its own
+ * column runs four columns wide, and an `<svg>` clips to its viewBox, so what
+ * prints is a place-value chart with most of its headings sliced off. So a cell
+ * that cannot hold its text at the shared size is set at the size that fits —
+ * measured the only way there is at build time, off the face's own declared
+ * mean advance (`faces.ts`), which is the same bargain `chrome.ts` strikes for
+ * every other run of text on a sheet. Through `glyphAdvance` rather than off
+ * `advance` directly, because every word here starts with a capital and the
+ * plain mean is taken over `a`–`z`: that is the distinction that put `Mm` a
+ * tenth of an inch into the next cell on a handwriting row.
+ *
+ * It never fires on the grids that were here first: three characters is the
+ * widest thing a hundred chart or a multiplication square puts in a square, and
+ * three of them fit at the shared size on every face in the shop.
+ */
+const CELL_FILL = 0.86;
 
 /** How far from its dot a point's letter is set, in squares. */
 const MARK_TO_EM = 0.42;
@@ -32,9 +55,23 @@ export function Grid({ block, metrics }: BlockProps<"grid">) {
   );
   if (cell <= 0) return null;
 
+  // How tall a row is, which is the square unless the grid says otherwise —
+  // and only one grid in the shop does. See `GridSpec.row`: everything a child
+  // measures against leaves it unsaid and gets squares by construction.
+  const rowHeight = Math.max(1, block.grid.row ?? cell);
+
   const width = columns * cell;
-  const height = rows * cell;
-  const size = Math.round(cell * CELL_TO_EM);
+  const height = rows * rowHeight;
+  // One size for every square, and it is the smallest any of them needs. Per
+  // cell would be arithmetically tidier and would print a header row with a
+  // different type size in each column, which reads as a mistake whether or not
+  // it is one.
+  const size = fits(
+    [...(cells ?? []), ...(answers ?? [])],
+    cell,
+    Math.round(Math.min(cell, rowHeight) * CELL_TO_EM),
+    faceOf(metrics.font),
+  );
 
   // How far off the edge of the drawing a numeral and a point's letter have to
   // stay. An `<svg>` clips to its viewBox and the outermost gridline of a plane
@@ -70,14 +107,14 @@ export function Grid({ block, metrics }: BlockProps<"grid">) {
           strokeWidth={HAIRLINE}
         />
       ))}
-      {count(rows + 1).map((row) => (
+      {count(rows + 1).map((line) => (
         <line
-          key={`r${row}`}
+          key={`r${line}`}
           className="sheet__rule sheet__rule--grid"
           x1={0}
           x2={width}
-          y1={row * cell}
-          y2={row * cell}
+          y1={line * rowHeight}
+          y2={line * rowHeight}
           strokeWidth={HAIRLINE}
         />
       ))}
@@ -95,8 +132,8 @@ export function Grid({ block, metrics }: BlockProps<"grid">) {
           <line
             x1={0}
             x2={width}
-            y1={origin.row * cell}
-            y2={origin.row * cell}
+            y1={origin.row * rowHeight}
+            y2={origin.row * rowHeight}
             className="sheet__rule sheet__rule--axis"
             strokeWidth={HEAVY}
           />
@@ -125,19 +162,19 @@ export function Grid({ block, metrics }: BlockProps<"grid">) {
               <Numbered
                 key={`x${column}`}
                 x={within(column * cell, half, width - half)}
-                y={(origin.row + 0.5) * cell}
+                y={(origin.row + 0.5) * rowHeight}
                 value={column - origin.column}
                 axis={axis}
                 size={size}
               />
             ))}
           {origin.column > 0 &&
-            count(rows + 1).map((row) => (
+            count(rows + 1).map((line) => (
               <Numbered
-                key={`y${row}`}
+                key={`y${line}`}
                 x={(origin.column - 0.5) * cell}
-                y={within(row * cell, half, height - half)}
-                value={origin.row - row}
+                y={within(line * rowHeight, half, height - half)}
+                value={origin.row - line}
                 axis={axis}
                 size={size}
               />
@@ -154,7 +191,7 @@ export function Grid({ block, metrics }: BlockProps<"grid">) {
           <circle
             className="sheet__dot"
             cx={mark.column * cell}
-            cy={mark.row * cell}
+            cy={mark.row * rowHeight}
             r={Math.max(1, Math.round(cell * 0.11))}
           />
           {/* Up and to the right of its dot, and turned inward where that would
@@ -164,7 +201,7 @@ export function Grid({ block, metrics }: BlockProps<"grid">) {
           <text
             className="sheet__cell"
             x={within(mark.column * cell + away, away, width - away)}
-            y={within(mark.row * cell - away, away, height - away)}
+            y={within(mark.row * rowHeight - away, away, height - away)}
             fontSize={Math.round(cell * 0.62)}
             textAnchor="middle"
             dominantBaseline="central"
@@ -180,18 +217,42 @@ export function Grid({ block, metrics }: BlockProps<"grid">) {
           second, so the blank grid and the wall chart are one build with
           `answers` flipped — the same mechanism as every ruled slot. */}
       {written(cells).map(([index, text]) => (
-        <Cell key={`c${index}`} {...{ index, text, columns, cell, size }} />
+        <Cell
+          key={`c${index}`}
+          {...{ index, text, columns, cell, rowHeight, size }}
+        />
       ))}
       {metrics.answers &&
         written(answers).map(([index, text]) => (
           <Cell
             key={`a${index}`}
             answered
-            {...{ index, text, columns, cell, size }}
+            {...{ index, text, columns, cell, rowHeight, size }}
           />
         ))}
     </svg>
   );
+}
+
+/**
+ * The size the squares' text is set at: the shared one, or what the widest of
+ * them will fit at.
+ *
+ * Declared rather than measured, the same way every other run of text on a
+ * sheet is (§4) — there is no DOM at build time to ask instead, and a size a
+ * browser worked out is a size no test can check. The mean advance is the
+ * face's own, so a heading that fits in the print face is not clipped in the
+ * dyslexic one.
+ */
+function fits(texts: string[], cell: number, size: number, face: Face): number {
+  return texts.reduce((smallest, text) => {
+    const advance = glyphAdvance(text, face);
+    if (text.length === 0 || advance <= 0) return smallest;
+    return Math.min(
+      smallest,
+      Math.floor((cell * CELL_FILL) / (text.length * advance)),
+    );
+  }, size);
 }
 
 /** The squares of a list that have something in them, with their positions. */
@@ -201,12 +262,13 @@ function written(cells: string[] | undefined): Array<[number, string]> {
   );
 }
 
-/** One numeral in the middle of its square. */
+/** One numeral — or one heading — in the middle of its square. */
 function Cell({
   index,
   text,
   columns,
   cell,
+  rowHeight,
   size,
   answered = false,
 }: {
@@ -214,6 +276,7 @@ function Cell({
   text: string;
   columns: number;
   cell: number;
+  rowHeight: number;
   size: number;
   answered?: boolean;
 }) {
@@ -221,7 +284,7 @@ function Cell({
     <text
       className={`sheet__cell${answered ? " sheet__cell--answered" : ""}`}
       x={((index % columns) + 0.5) * cell}
-      y={(Math.floor(index / columns) + 0.5) * cell}
+      y={(Math.floor(index / columns) + 0.5) * rowHeight}
       fontSize={size}
       textAnchor="middle"
       dominantBaseline="central"

--- a/src/components/sheet/blocks/Grid.tsx
+++ b/src/components/sheet/blocks/Grid.tsx
@@ -21,9 +21,16 @@ const CELL_TO_EM = 0.5;
  * plain mean is taken over `a`–`z`: that is the distinction that put `Mm` a
  * tenth of an inch into the next cell on a handwriting row.
  *
- * It never fires on the grids that were here first: three characters is the
- * widest thing a hundred chart or a multiplication square puts in a square, and
- * three of them fit at the shared size on every face in the shop.
+ * On the grids that were here first it fires everywhere except the print face.
+ * Three characters is the widest thing a hundred chart or a multiplication
+ * square puts in a square, and only Andika's numerals clear the shared size at
+ * that width: 400 against a shared 375 on the hundred chart's ¾in square, 307
+ * against 288 on the 13×13. The other four faces are all wider per numeral — a
+ * digit is measured at `capAdvance` here, not `advance` — so they are set
+ * smaller, which is the right answer and not a miss: three OpenDyslexic
+ * numerals set at half the square measure 0.89in across a 0.75in square.
+ * Every catalog page is set in the print face, which is why all of them print
+ * at the shared size.
  */
 const CELL_FILL = 0.86;
 

--- a/src/components/sheet/blocks/Line.tsx
+++ b/src/components/sheet/blocks/Line.tsx
@@ -1,0 +1,18 @@
+import { NumberLineView } from "../NumberLine";
+import type { BlockProps } from "./block";
+
+/**
+ * A number line on its own, rather than under a sum.
+ *
+ * The whole of this block is the same drawing a problem carries, which is the
+ * point of it: the strip a child cuts out and sticks on a desk and the line
+ * drawn under `6 + 3 =` are one renderer, so the ticks land in the same places
+ * on both and there is one piece of arithmetic deciding where that is.
+ *
+ * What it is *not* is a `problems` block with one blank item in it. That block
+ * numbers what it holds, and a "1." printed against a wall chart is a question
+ * nobody asked.
+ */
+export function Line({ block }: BlockProps<"numberline">) {
+  return <NumberLineView line={block.line} />;
+}

--- a/src/components/sheet/blocks/index.tsx
+++ b/src/components/sheet/blocks/index.tsx
@@ -22,6 +22,7 @@ import { Copywork } from "./Copywork";
 import { Crossword } from "./Crossword";
 import { Cutline } from "./Cutline";
 import { Grid } from "./Grid";
+import { Line } from "./Line";
 import { Matching } from "./Matching";
 import { Problems } from "./Problems";
 import { Rules } from "./Rules";
@@ -49,6 +50,8 @@ export function BlockView({
       return <Copywork block={block} metrics={metrics} />;
     case "grid":
       return <Grid block={block} metrics={metrics} />;
+    case "numberline":
+      return <Line block={block} metrics={metrics} />;
     case "wordsearch":
       return <WordSearch block={block} metrics={metrics} />;
     case "crossword":

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -32,6 +32,7 @@ import { TIME_SHEET } from "./maths/time";
 import { WORD_PROBLEMS_SHEET } from "./maths/wordproblems";
 import { PHONICS_SHEET } from "./phonics/sheets";
 import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
+import { CHART_SHEET } from "./templates/charts";
 import { PAPER_SHEET } from "./templates/paper";
 import { HANDWRITING_SHEET } from "./writing/handwriting";
 import { MEMORY_SHEET } from "./writing/memory";
@@ -42,6 +43,7 @@ import { WORD_STUDY_SHEET } from "./words/study";
 const SHEETS: Record<string, SheetSpec> = {
   [BLANK_SHEET.id]: BLANK_SHEET,
   [PAPER_SHEET.id]: PAPER_SHEET,
+  [CHART_SHEET.id]: CHART_SHEET,
   [ARITHMETIC_SHEET.id]: ARITHMETIC_SHEET,
   [MULTIPLICATION_SHEET.id]: MULTIPLICATION_SHEET,
   [FRACTIONS_SHEET.id]: FRACTIONS_SHEET,

--- a/src/engine/sheets/numberline.ts
+++ b/src/engine/sheets/numberline.ts
@@ -2,9 +2,12 @@
  * A line to count along.
  *
  * The first thing a child adds with, before they add: 6 + 3 is six hops and
- * then three more. So it is a drawing aid attached to a problem rather than a
- * block of its own — the problem-grid block is the shared primitive every
- * maths family reuses, and a line under a sum is part of the sum.
+ * then three more. It is that twice over — a drawing aid under a sum, where
+ * the problem grid is the shared primitive and a line under a problem is part
+ * of the problem, and a `numberline` block of its own on a reference sheet,
+ * where the line *is* the paper. One set of numbers either way: the strip a
+ * child cuts out and the line under a sum are drawn by one renderer from one
+ * piece of arithmetic, so a tick lands in the same place on both.
  *
  * Where the ticks go is arithmetic, so it lives here and not in the renderer,
  * for the same reason `ruleLines` does: a spacing that a browser worked out is
@@ -129,7 +132,39 @@ export function numberLine(low: number, high: number, width: Mil): NumberLine {
   return lineAt(low, high, width, STEPS[STEPS.length - 1], 1);
 }
 
-/** Every labelled value on a line, left to right. */
+/**
+ * How many ticks apart the numbers under a line have to be to fit.
+ *
+ * One where every tick can keep its number, which is the answer for every line
+ * `numberLine` above chooses — it picks the spacing against the width for
+ * exactly that reason. A *reference* line is the other way round: the interval
+ * is what a parent asked for and cannot be moved, so a line marked every 1 from
+ * 0 to 100 keeps its hundred and one ticks and thins the numerals out until
+ * they stop touching.
+ *
+ * Only ever a multiple a child would count in, and always a divisor of the
+ * whole run where one will do, so the last tick keeps its number: a line to 100
+ * labelled every 3 would end on 99 with nothing under the end of it.
+ */
+export function labelEvery(line: NumberLine): number {
+  const marks = ticks(line);
+  if (marks.length < 2) return 1;
+  const usable = Math.max(0, line.width - LINE_INSET * 2);
+  const gap = usable / (marks.length - 1);
+  const steps = marks.length - 1;
+
+  for (const every of STEPS) {
+    if (steps % every !== 0) continue;
+    const shown = marks.filter((_, index) => index % every === 0);
+    if (gap * every >= labelRoom(shown)) return every;
+  }
+  // Nothing divides the run and still fits, so keep the two ends and the ticks
+  // between them bare. A number under every tick that overlaps its neighbour is
+  // a line nobody can read; two numbers and a scale is still a number line.
+  return steps;
+}
+
+/** Every value a tick stands at, left to right. */
 export function ticks(line: NumberLine): number[] {
   if (line.step <= 0 || line.to <= line.from) return [];
   const count = Math.floor((line.to - line.from) / line.step) + 1;

--- a/src/engine/sheets/plane.ts
+++ b/src/engine/sheets/plane.ts
@@ -29,12 +29,42 @@ const GRID_SHARE = 0.55;
 const QUADRANT_SPAN = 10;
 const FOUR_QUADRANT_SPAN = 8;
 
+/**
+ * How far a caller may move that, either way.
+ *
+ * Four because a plane that runs to three is four squares of paper and a
+ * drawing nobody would print; twenty because past it the squares are finer than
+ * a child can write a coordinate into, whatever the paper. Both are here rather
+ * than in the family that asks, because the plane is what has the opinion.
+ */
+const MIN_SPAN = 4;
+const MAX_SPAN = 20;
+
 export type Plane = {
   /** How far the axes run from nought. */
   span: number;
   /** Whether the plane has negative coordinates on it. */
   negative: boolean;
   grid: GridSpec;
+};
+
+/**
+ * How a plane may be asked for differently from the one under a question.
+ *
+ * Both defaults are what a *problem* sheet needs, because that is what asked
+ * first: a plane no bigger than 0.4in to the square, taking a little over half
+ * the page, with the questions about it underneath. A blank coordinate grid is
+ * the same drawing with neither of those true — it is the whole sheet, and it
+ * is as large as the paper allows — and a second copy of "where do the axes
+ * cross, and how far out do the numerals sit" is the thing worth not having.
+ */
+export type PlaneOptions = {
+  /** How far the axes run from nought, where the caller has an opinion. */
+  span?: number;
+  /** The largest a square may be drawn. */
+  cell?: Mil;
+  /** How much of the block box the plane may take, down the page. */
+  share?: number;
 };
 
 /**
@@ -47,20 +77,29 @@ export type Plane = {
  *
  * `quadrants` is a number rather than a union because it arrives from outside
  * this build — a bookmarked URL, a sheet saved in March — and anything that is
- * not four has to resolve to a plane rather than throw.
+ * not four has to resolve to a plane rather than throw. `span` is guarded the
+ * same way and for the same reason.
  */
-export function planeOf(quadrants: number, box: Box): Plane {
+export function planeOf(
+  quadrants: number,
+  box: Box,
+  options: PlaneOptions = {},
+): Plane {
   const negative = Math.floor(quadrants) === 4;
-  const span = negative ? FOUR_QUADRANT_SPAN : QUADRANT_SPAN;
+  const fallback = negative ? FOUR_QUADRANT_SPAN : QUADRANT_SPAN;
+  const asked = Math.floor(options.span ?? fallback);
+  const span = Number.isFinite(asked)
+    ? Math.max(MIN_SPAN, Math.min(MAX_SPAN, asked))
+    : fallback;
   const pad = negative ? span : 1;
   const columns = span + pad;
   const rows = span + pad;
   const cell = Math.max(
     1,
     Math.min(
-      GRID_CELL,
+      options.cell ?? GRID_CELL,
       Math.floor(box.width / columns),
-      Math.floor((box.height * GRID_SHARE) / rows),
+      Math.floor((box.height * (options.share ?? GRID_SHARE)) / rows),
     ),
   );
   return {

--- a/src/engine/sheets/templates/charts.test.ts
+++ b/src/engine/sheets/templates/charts.test.ts
@@ -1,0 +1,518 @@
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet } from "../index";
+import { chromeHeight, sheetBlockBox } from "../chrome";
+import { blockBox, type Box } from "../layout";
+import { ticks } from "../numberline";
+import { MARGINS, PAPERS, toInches } from "../paper";
+import type {
+  Block,
+  ChartConfig,
+  ChartStyle,
+  GridSpec,
+  MarginSize,
+  PaperSize,
+  Sheet,
+} from "../types";
+
+/**
+ * The family where being one out is the whole of the bug.
+ *
+ * Every sheet here is something a child measures against or counts on, so the
+ * suite is arithmetic rather than judgement: a 1–100 chart has a hundred
+ * squares numbered 1 to 100 in order, a 0–100 line marked every 10 has eleven
+ * ticks and not ten, a first-quadrant plane to 10 has eleven gridlines each
+ * way, and a heading sits over the column it names.
+ *
+ * **Counted off the finished blocks.** Nothing below asks the builder what it
+ * built — every count is recovered from the `Block[]` a page would render, the
+ * way `search.test.ts` reads a word search's key back out of the grid. A
+ * generator asserting its own arithmetic agrees with itself whatever it does.
+ */
+
+const config = (over: Partial<ChartConfig> = {}): ChartConfig => ({
+  kind: "chart",
+  style: "hundred",
+  paper: { size: "letter", orientation: "portrait", margin: "normal" },
+  fontPt: 12,
+  fields: ["name", "date"],
+  ...over,
+});
+
+/** The one grid on a sheet, or a failure that says so. */
+function gridOf(sheet: Sheet): GridSpec {
+  const grids = sheet.blocks.filter((block) => block.kind === "grid");
+  expect(grids).toHaveLength(1);
+  return grids[0].grid;
+}
+
+/** Every number-line strip on a sheet, in the order they print. */
+const linesOf = (sheet: Sheet) =>
+  sheet.blocks
+    .filter((block) => block.kind === "numberline")
+    .map((b) => b.line);
+
+/**
+ * What is left for the blocks, read off the sheet that was built.
+ *
+ * `sheetBlockBox(config)` answers the same question from the *config*, which is
+ * what the family reserved against — so checking a sheet against it cannot fail
+ * however wrong the reservation was. This asks the header and footer that were
+ * actually printed, which is the only version of the question a page can
+ * disagree with.
+ */
+function printedBox(sheet: Sheet): Box {
+  const chrome = chromeHeight(
+    {
+      paper: sheet.paper,
+      fontPt: sheet.fontPt,
+      fields: sheet.header.fields,
+      title: sheet.header.title,
+      instructions: sheet.header.instructions,
+    },
+    sheet.header.score !== undefined,
+    { source: sheet.footer.source, note: sheet.footer.note },
+  );
+  return blockBox(sheet.paper, chrome);
+}
+
+/** How much of the page the blocks take, gaps included. */
+function used(blocks: Block[], grid: GridSpec | null): number {
+  const spacers = blocks
+    .filter((block) => block.kind === "spacer")
+    .reduce((total, block) => total + block.height, 0);
+  const lines = blocks.filter((block) => block.kind === "numberline").length;
+  // The strip's own drawn height (`NUMBER_LINE_HEIGHT`) plus the flex gap the
+  // stylesheet puts between blocks — both declared, per §4.
+  return (
+    spacers +
+    lines * 340 +
+    (blocks.length - 1) * 140 +
+    (grid ? grid.rows * (grid.row ?? grid.cell) : 0)
+  );
+}
+
+/* ── The hundred chart ─────────────────────────────────────────────────── */
+
+describe("a hundred chart", () => {
+  it("holds a hundred squares numbered 1 to 100, in order", () => {
+    // The classic off-by-one, counted rather than trusted: a chart that starts
+    // at nought and calls itself 1–100, or one whose last row is short.
+    const grid = gridOf(buildSheet(config({ filled: true }), 1));
+    expect(grid.columns).toBe(10);
+    expect(grid.rows).toBe(10);
+    expect(grid.cells).toHaveLength(100);
+    expect(grid.cells?.[0]).toBe("1");
+    expect(grid.cells?.[99]).toBe("100");
+    expect(grid.cells).toEqual(
+      Array.from({ length: 100 }, (_, index) => String(index + 1)),
+    );
+  });
+
+  it("starts at nought when that is what was asked for", () => {
+    // The other chart a school prints, and the argument between the two is a
+    // real one: 0–99 puts every multiple of ten at the head of its own row.
+    const grid = gridOf(
+      buildSheet(config({ range: { min: 0, max: 99 }, filled: true }), 1),
+    );
+    expect(grid.cells?.[0]).toBe("0");
+    expect(grid.cells?.[99]).toBe("99");
+    expect(grid.rows).toBe(10);
+  });
+
+  it("completes its last row rather than printing a ragged one", () => {
+    // 1–105 is eleven rows, not ten and a half: the shape is the lesson, and
+    // every number asked for has to be on the paper.
+    const sheet = buildSheet(config({ range: { min: 1, max: 105 } }), 1);
+    const grid = gridOf(sheet);
+    expect(grid.rows).toBe(11);
+    expect(grid.answers).toHaveLength(110);
+    expect(grid.answers?.[104]).toBe("105");
+    expect(sheet.header.title).toBe("Number chart, 1 to 110");
+  });
+
+  it("says a hundred chart only when it is one", () => {
+    expect(buildSheet(config(), 1).header.title).toBe("Hundred chart");
+    expect(
+      buildSheet(config({ range: { min: 0, max: 99 } }), 1).header.title,
+    ).toBe("Hundred chart");
+    expect(
+      buildSheet(config({ range: { min: 1, max: 20 } }), 1).header.title,
+    ).toBe("Number chart, 1 to 20");
+  });
+
+  it("prints squares that are square, inside the paper", () => {
+    const built = config();
+    const grid = gridOf(buildSheet(built, 1));
+    const box = sheetBlockBox(built);
+    // One length for both directions is what makes a square square — the
+    // renderer reads `row ?? cell`, and a chart never sets `row`.
+    expect(grid.row).toBeUndefined();
+    expect(grid.columns * grid.cell).toBeLessThanOrEqual(box.width);
+    expect(grid.rows * grid.cell).toBeLessThanOrEqual(box.height);
+  });
+
+  it("is filled in by its own answer key, and by nothing else", () => {
+    // The key is verified against a list built here rather than against the
+    // one the family built: a generator that agreed with itself would pass a
+    // check written the other way round whatever it printed.
+    const built = config();
+    const blank = buildSheet(built, 1);
+    const key = answerKey(built, 1);
+
+    expect(blank.answers).toBe(false);
+    expect(key.answers).toBe(true);
+    expect(gridOf(blank).cells?.every((cell) => cell === "")).toBe(true);
+
+    const grid = gridOf(key);
+    for (let row = 0; row < grid.rows; row++) {
+      for (let column = 0; column < grid.columns; column++) {
+        // Worked out from where the square *is* on the page, which is the
+        // property a child reads off it: down a column is ten more.
+        expect(grid.answers?.[row * grid.columns + column]).toBe(
+          String(1 + row * 10 + column),
+        );
+      }
+    }
+  });
+
+  it("is the wall chart and the exercise, from one build", () => {
+    // Same numbers, filed under a different key: `cells` when they print on the
+    // sheet and `answers` when they only print on the key.
+    const blank = gridOf(buildSheet(config(), 1));
+    const filled = gridOf(buildSheet(config({ filled: true }), 1));
+    expect(filled.cells).toEqual(blank.answers);
+    expect(filled.answers).toBeUndefined();
+  });
+
+  it("asks for the missing numbers only on the sheet that withholds them", () => {
+    expect(buildSheet(config(), 1).header.instructions).toBe(
+      "Write the numbers in, one to a square.",
+    );
+    expect(
+      buildSheet(config({ filled: true }), 1).header.instructions,
+    ).toBeUndefined();
+  });
+});
+
+/* ── The number line ───────────────────────────────────────────────────── */
+
+describe("a number line", () => {
+  const line = (over: Partial<ChartConfig> = {}) =>
+    config({ style: "number-line", ...over });
+
+  it("has one more tick than it has intervals", () => {
+    // The off-by-one this sheet exists to avoid: 0 to 100 in tens is ten hops
+    // and eleven ticks, and a line with ten of them is missing an end.
+    const [strip] = linesOf(
+      buildSheet(line({ range: { min: 0, max: 100 }, step: 10 }), 1),
+    );
+    expect(ticks(strip)).toHaveLength(11);
+    expect(ticks(strip)[0]).toBe(0);
+    expect(ticks(strip)[10]).toBe(100);
+  });
+
+  it("marks every value the interval says, and nothing between them", () => {
+    const [strip] = linesOf(
+      buildSheet(line({ range: { min: 0, max: 20 }, step: 2 }), 1),
+    );
+    expect(ticks(strip)).toEqual([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
+  });
+
+  it("runs to a whole number of intervals rather than stopping short", () => {
+    // 0 to 25 in tens would otherwise draw its last tick two thirds along and
+    // leave the end of the axis unmarked — a line a child counts wrongly.
+    const [strip] = linesOf(
+      buildSheet(line({ range: { min: 0, max: 25 }, step: 10 }), 1),
+    );
+    expect(strip.to).toBe(30);
+    expect((strip.to - strip.from) % strip.step).toBe(0);
+  });
+
+  it("thins the numbers out, and keeps the number on the last tick", () => {
+    // A hundred and one numerals across seven and a half inches is a smudge, so
+    // the ticks stay and the labels step back to something a child counts in —
+    // and to something that divides the run, or the end of the line loses its
+    // number.
+    const [strip] = linesOf(
+      buildSheet(line({ range: { min: 0, max: 100 }, step: 1 }), 1),
+    );
+    expect(ticks(strip)).toHaveLength(101);
+    expect(strip.label).toBeGreaterThan(1);
+    expect((ticks(strip).length - 1) % (strip.label ?? 1)).toBe(0);
+  });
+
+  it("labels every tick when they fit", () => {
+    const [strip] = linesOf(
+      buildSheet(line({ range: { min: 0, max: 20 }, step: 1 }), 1),
+    );
+    expect(strip.label).toBe(1);
+  });
+
+  it("prints the strips it was asked for, and cuts none of them off", () => {
+    const built = line({ range: { min: 0, max: 20 }, step: 1, strips: 6 });
+    const sheet = buildSheet(built, 1);
+    const strips = linesOf(sheet);
+    expect(strips).toHaveLength(6);
+    // Every strip is the same line: a page of six is six copies to cut apart,
+    // not six different scales to read.
+    for (const strip of strips) expect(strip).toEqual(strips[0]);
+    expect(used(sheet.blocks, null)).toBeLessThanOrEqual(
+      sheetBlockBox(built).height,
+    );
+  });
+
+  it("caps the strips at what the paper holds", () => {
+    const built = line({ strips: 40 });
+    const sheet = buildSheet(built, 1);
+    expect(linesOf(sheet).length).toBeLessThan(40);
+    expect(used(sheet.blocks, null)).toBeLessThanOrEqual(
+      sheetBlockBox(built).height,
+    );
+  });
+});
+
+/* ── The coordinate grid ───────────────────────────────────────────────── */
+
+describe("a coordinate grid", () => {
+  const plane = (over: Partial<ChartConfig> = {}) =>
+    config({ style: "coordinate", ...over });
+
+  it("runs to the number on the axis, with a margin for the numerals", () => {
+    // Eleven squares across for a plane that runs to ten: ten of them are the
+    // plane and the eleventh is where the numbers down the side are printed.
+    const grid = gridOf(buildSheet(plane({ span: 10 }), 1));
+    expect(grid.kind).toBe("coordinate");
+    expect(grid.columns).toBe(11);
+    expect(grid.rows).toBe(11);
+    expect(grid.origin).toEqual({ column: 1, row: 10 });
+    expect(grid.axis).toEqual({ min: 0, max: 10 });
+  });
+
+  it("puts nothing negative on a first-quadrant sheet", () => {
+    // The margin square outside the axes is where the numerals sit, not a
+    // column of −1: `axis` is what tells the renderer the difference.
+    const grid = gridOf(buildSheet(plane({ span: 10 }), 1));
+    expect(grid.axis?.min).toBe(0);
+  });
+
+  it("counts both ways from the middle when all four are asked for", () => {
+    const grid = gridOf(buildSheet(plane({ quadrants: 4, span: 8 }), 1));
+    expect(grid.columns).toBe(16);
+    expect(grid.origin).toEqual({ column: 8, row: 8 });
+    expect(grid.axis).toEqual({ min: -8, max: 8 });
+  });
+
+  it("keeps its squares square and on the paper, at every span", () => {
+    for (const span of [4, 7, 10, 15, 20]) {
+      for (const quadrants of [1, 4]) {
+        const built = plane({ span, quadrants });
+        const grid = gridOf(buildSheet(built, 1));
+        const box = sheetBlockBox(built);
+        expect(grid.row, `${span}/${quadrants}`).toBeUndefined();
+        expect(grid.columns * grid.cell).toBeLessThanOrEqual(box.width);
+        expect(grid.rows * grid.cell).toBeLessThanOrEqual(box.height);
+      }
+    }
+  });
+});
+
+/* ── The place-value chart ─────────────────────────────────────────────── */
+
+describe("a place-value chart", () => {
+  const mat = (over: Partial<ChartConfig> = {}) =>
+    config({ style: "place-value", ...over });
+
+  it("has one column for each power of ten, ends included", () => {
+    // Hundreds to ones is three columns, not two: the off-by-one a chart of
+    // consecutive places invites.
+    const grid = gridOf(
+      buildSheet(mat({ places: { largest: 2, smallest: 0 } }), 1),
+    );
+    expect(grid.columns).toBe(3);
+    expect(grid.cells?.slice(0, 3)).toEqual(["Hundreds", "Tens", "Ones"]);
+  });
+
+  it("names every column, largest first, decimals included", () => {
+    const grid = gridOf(
+      buildSheet(mat({ places: { largest: 3, smallest: -2 } }), 1),
+    );
+    expect(grid.columns).toBe(6);
+    expect(grid.cells?.slice(0, 6)).toEqual([
+      "Thousands",
+      "Hundreds",
+      "Tens",
+      "Ones",
+      "Tenths",
+      "Hundredths",
+    ]);
+  });
+
+  it("puts the heavier upright where the decimal point goes", () => {
+    // Immediately right of the ones column, counted in columns — which is what
+    // makes it land on the ruling rather than near it.
+    expect(
+      gridOf(buildSheet(mat({ places: { largest: 2, smallest: -2 } }), 1))
+        .origin,
+    ).toEqual({ column: 3, row: 1 });
+    // And on a chart with nothing smaller than ones, that is its right edge.
+    expect(
+      gridOf(buildSheet(mat({ places: { largest: 3, smallest: 0 } }), 1))
+        .origin,
+    ).toEqual({ column: 4, row: 1 });
+  });
+
+  it("leaves the rows blank under the headings", () => {
+    const grid = gridOf(buildSheet(mat({ rows: 6 }), 1));
+    expect(grid.rows).toBe(7);
+    expect(grid.cells).toHaveLength(grid.columns * 7);
+    expect(grid.cells?.slice(grid.columns).every((cell) => cell === "")).toBe(
+      true,
+    );
+    expect(grid.answers).toBeUndefined();
+  });
+
+  it("is the one grid whose rows are not squares, and stays on the page", () => {
+    for (const rows of [1, 4, 8, 12, 40]) {
+      const built = mat({ rows });
+      const grid = gridOf(buildSheet(built, 1));
+      const box = sheetBlockBox(built);
+      expect(grid.row, `${rows}`).toBeDefined();
+      expect(grid.columns * grid.cell).toBeLessThanOrEqual(box.width);
+      expect(grid.rows * (grid.row ?? 0)).toBeLessThanOrEqual(box.height);
+    }
+  });
+
+  it("never orders its places the wrong way round", () => {
+    // Both ends arrive from outside the build, and a chart from ones down to
+    // thousands would be a chart with minus two columns.
+    const grid = gridOf(
+      buildSheet(mat({ places: { largest: 0, smallest: 3 } }), 1),
+    );
+    expect(grid.columns).toBeGreaterThan(0);
+    expect(grid.cells?.[0]).toBe("Ones");
+  });
+});
+
+/* ── The bargain every family keeps ────────────────────────────────────── */
+
+const STYLES: ChartStyle[] = [
+  "hundred",
+  "number-line",
+  "coordinate",
+  "place-value",
+];
+
+describe("every reference sheet", () => {
+  it("is the same sheet on every build, and on every seed", () => {
+    // §7. Nothing here is drawn from the seed — a hundred chart is the same
+    // hundred numbers whenever it is printed — so the sheet has to be identical
+    // across seeds as well as across builds, which is the stronger claim.
+    for (const style of STYLES) {
+      const built = config({ style });
+      expect(JSON.stringify(buildSheet(built, 1))).toBe(
+        JSON.stringify(buildSheet(built, 1)),
+      );
+      expect(JSON.stringify(buildSheet(built, 7).blocks)).toBe(
+        JSON.stringify(buildSheet(built, 1).blocks),
+      );
+    }
+  });
+
+  it("fits the paper, on every stock and at every margin", () => {
+    // Measured against the chrome the *finished sheet* carries rather than
+    // against what the family reserved for, because those are the two numbers
+    // that can disagree — and the way they disagree is silent. A family prints
+    // a title whatever its config says; one that reserved no row for it builds
+    // a page an inch and a half too long, `.sheet` is `min-height` so nothing
+    // overflows on screen, and the last inch comes out on a second sheet of
+    // paper. Reserving from the config was exactly that bug.
+    for (const style of STYLES) {
+      for (const size of Object.keys(PAPERS) as PaperSize[]) {
+        for (const margin of Object.keys(MARGINS) as MarginSize[]) {
+          for (const fontPt of [8, 12, 24, 36]) {
+            const built = config({
+              style,
+              fontPt,
+              paper: { size, orientation: "portrait", margin },
+            });
+            // The key as well as the sheet: the two are laid out against one
+            // box, and a key prints a word in the footer that its sheet does
+            // not — so a footer that wraps on one and not the other is a key
+            // whose last row is on a second page.
+            for (const sheet of [buildSheet(built, 1), answerKey(built, 1)]) {
+              const grids = sheet.blocks.filter(
+                (block) => block.kind === "grid",
+              );
+              const box = printedBox(sheet);
+              const where = `${style}/${size}/${margin}/${fontPt}`;
+              expect(sheet.blocks.length, where).toBeGreaterThan(0);
+              expect(
+                used(sheet.blocks, grids[0]?.grid ?? null),
+                where,
+              ).toBeLessThanOrEqual(box.height);
+              for (const grid of grids) {
+                expect(
+                  grid.grid.columns * grid.grid.cell,
+                  where,
+                ).toBeLessThanOrEqual(box.width);
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it("prints something a parent can measure, in inches", () => {
+    // The unit the whole subtree is in (§4). A square that came out as a
+    // fraction of a millimetre would still pass every count above.
+    const grid = gridOf(buildSheet(config(), 1));
+    expect(toInches(grid.cell)).toBeGreaterThan(0.2);
+    expect(toInches(grid.cell)).toBeLessThanOrEqual(0.8);
+  });
+
+  it("says in one line what it is", () => {
+    expect(describeSheet(config())).toBe(
+      "Hundred chart, 1 to 100, blank to fill in",
+    );
+    expect(describeSheet(config({ filled: true }))).toBe(
+      "Hundred chart, 1 to 100, filled in",
+    );
+    expect(
+      describeSheet(
+        config({ style: "number-line", range: { min: 0, max: 20 }, step: 2 }),
+      ),
+    ).toBe("Number line from 0 to 20, a tick every 2 — 11 of them");
+    expect(describeSheet(config({ style: "coordinate", span: 10 }))).toBe(
+      "Coordinate grid, the first quadrant, 0 to 10",
+    );
+    expect(
+      describeSheet(
+        config({ style: "place-value", places: { largest: 2, smallest: 0 } }),
+      ),
+    ).toBe("Place-value chart, hundreds to ones");
+  });
+
+  it("prints a page rather than throwing on a config from outside this build", () => {
+    // Every field here can arrive from a bookmarked link or a sheet saved last
+    // term, and a `NaN` range has to produce paper rather than an exception.
+    const hostile = {
+      ...config(),
+      style: "constructor",
+      range: { min: NaN, max: "lots" },
+      step: -4,
+      strips: 1e9,
+      span: NaN,
+      quadrants: "four",
+      places: { largest: 99, smallest: -99 },
+      rows: -1,
+    } as unknown as ChartConfig;
+    expect(() => buildSheet(hostile, 1)).not.toThrow();
+    const sheet = buildSheet(hostile, 1);
+    expect(sheet.blocks.length).toBeGreaterThan(0);
+    expect(used(sheet.blocks, gridOf(sheet))).toBeLessThanOrEqual(
+      sheetBlockBox(hostile).height,
+    );
+  });
+});

--- a/src/engine/sheets/templates/charts.ts
+++ b/src/engine/sheets/templates/charts.ts
@@ -123,10 +123,11 @@ export const placeName = (power: number): string =>
 /**
  * A number a config asked for, as a whole number inside the bounds.
  *
- * Every field on a `ChartConfig` goes through this, because every one of them
- * can arrive from outside the build — a bookmarked link, a sheet saved last
- * term — and a range of `NaN` to `"lots"` has to produce a chart rather than an
- * exception four modules downstream.
+ * Every `ChartConfig` field resolved in this module goes through it, because
+ * every one of them can arrive from outside the build — a bookmarked link, a
+ * sheet saved last term — and a range of `NaN` to `"lots"` has to produce a
+ * chart rather than an exception four modules downstream. The two that are not
+ * resolved here, `span` and `quadrants`, are guarded the same way by `planeOf`.
  */
 function whole(value: unknown, fallback: number, low: number, high: number) {
   const asked = typeof value === "number" ? Math.round(value) : NaN;

--- a/src/engine/sheets/templates/charts.ts
+++ b/src/engine/sheets/templates/charts.ts
@@ -1,0 +1,565 @@
+/**
+ * The blank maths references: the paper a lesson is done *against*.
+ *
+ * A hundred chart, a number line, a coordinate grid and a place-value chart —
+ * the second family in the "templates" tier of §11, beside the ruled paper, and
+ * the second one that is geometry rather than generation. Nothing on any of
+ * these four sheets is drawn from the seed, which is not an oversight: a
+ * hundred chart is the same hundred numbers in the same order every time it is
+ * printed, and a parent who prints one twice should get the same wall chart.
+ * The seed still rides in the footer, because the sheet is still reproducible
+ * from it.
+ *
+ * **This is the family the counting has to be right in.** Everything here is
+ * something a child measures against or counts on, so an off-by-one is not a
+ * cosmetic bug — it is a sheet that teaches something false and does it in ink:
+ *
+ * - a hundred chart that starts at nought and is still called 1–100,
+ * - a 0–100 number line with a hundred intervals and a hundred ticks,
+ * - a grid one square short at the margin,
+ * - a place-value heading half a column left of the column it names.
+ *
+ * Each of the four is counted rather than assumed below, and `charts.test.ts`
+ * counts them again from the finished blocks rather than from the arithmetic
+ * that made them — the same bargain the word search's key is held to. A
+ * generator asserting its own output would agree with itself whatever it did.
+ *
+ * One sheet here has an answer: a blank hundred chart is filled in, and the
+ * filled chart is its key. The other three withhold nothing — a number line, a
+ * coordinate grid and a place-value chart are supposed to be empty — so
+ * `chartKeyed` is what a page asks before printing a second copy of the same
+ * paper under the word "key".
+ */
+import { sheetBlockBox } from "../chrome";
+import { BLOCK_GAP, answerLine, fitAcross, type Box } from "../layout";
+import { NUMBER_LINE_HEIGHT, labelEvery, ticks } from "../numberline";
+import { inches, own } from "../paper";
+import { planeOf } from "../plane";
+import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
+import type {
+  Block,
+  ChartConfig,
+  ChartStyle,
+  GridSpec,
+  Mil,
+  NumberLine,
+  Sheet,
+  SheetOptions,
+} from "../types";
+
+/* ── What a square may measure ─────────────────────────────────────────────
+   Two bounds rather than one size. The largest is what stops a three-column
+   chart printing squares the size of a fist; the smallest is what stops a
+   thousand-row one printing squares nothing can be written in, and it is what
+   the row and strip counts below are capped against. Between them, a chart is
+   as large as the paper allows — which is the right default for something that
+   goes on a wall.                                                           */
+
+/** The largest square on a chart, and the smallest one worth writing in. */
+const MAX_CELL: Mil = inches(0.8);
+const MIN_CELL: Mil = inches(0.2);
+
+/** And on a coordinate grid, which has no numerals inside its squares. */
+const MAX_PLANE_CELL: Mil = inches(0.75);
+
+/**
+ * A hundred chart is ten to a row, and that is not a setting.
+ *
+ * The whole of what the chart teaches is in the shape: every column is one
+ * digit repeating, every row is a count of ten, and moving down is adding ten.
+ * A chart nine or eleven wide is a rectangle of numbers with none of that in
+ * it, so the range is the option and the width is the chart.
+ */
+const HUNDRED_COLUMNS = 10;
+
+/**
+ * The air left round a number-line strip, so there is room to cut it out.
+ *
+ * An inch and a quarter is scissors and a hand, and it is also the room to draw
+ * the hops a child counts in above the line. Capped rather than simply divided,
+ * because a page of two strips with the page's whole spare height between them
+ * is one strip at the top of the paper and one at the bottom.
+ */
+const MAX_STRIP_GAP: Mil = inches(1.25);
+
+/**
+ * How tall a row of a place-value chart is, at the least and at the most.
+ *
+ * Between them the rows stretch to fill the page, which is what makes the same
+ * block a *mat* at four rows and a chart at twelve: the columns are already as
+ * wide as the paper allows, and a chart three inches down an eleven-inch page
+ * with nothing under it is a mat nobody would put counters on.
+ */
+const MIN_PLACE_ROW: Mil = inches(0.4);
+const MAX_PLACE_ROW: Mil = inches(1.2);
+
+/**
+ * The places a chart can hold, as powers of ten, largest first.
+ *
+ * Millions down to thousandths: the range a school chart is printed over,
+ * either end of which is past what the columns of one page can name. The name
+ * is looked up from the exponent rather than stored beside it, so a chart
+ * cannot be configured with tens next to thousandths.
+ */
+const PLACE_NAMES = [
+  "Millions",
+  "Hundred thousands",
+  "Ten thousands",
+  "Thousands",
+  "Hundreds",
+  "Tens",
+  "Ones",
+  "Tenths",
+  "Hundredths",
+  "Thousandths",
+];
+const LARGEST_PLACE = 6;
+const SMALLEST_PLACE = LARGEST_PLACE - (PLACE_NAMES.length - 1);
+
+/** What the column for 10^power is called at the head of a place-value chart. */
+export const placeName = (power: number): string =>
+  PLACE_NAMES[LARGEST_PLACE - power] ?? "";
+
+/**
+ * A number a config asked for, as a whole number inside the bounds.
+ *
+ * Every field on a `ChartConfig` goes through this, because every one of them
+ * can arrive from outside the build — a bookmarked link, a sheet saved last
+ * term — and a range of `NaN` to `"lots"` has to produce a chart rather than an
+ * exception four modules downstream.
+ */
+function whole(value: unknown, fallback: number, low: number, high: number) {
+  const asked = typeof value === "number" ? Math.round(value) : NaN;
+  const chosen = Number.isFinite(asked) ? asked : fallback;
+  return Math.max(low, Math.min(high, chosen));
+}
+
+/* ── The hundred chart ─────────────────────────────────────────────────── */
+
+/** A hundred chart: where it starts, the shape it runs in, and its square. */
+export type HundredChart = {
+  from: number;
+  /** The last number *printed*, which is the end of a complete row. */
+  to: number;
+  columns: number;
+  rows: number;
+  cell: Mil;
+};
+
+/**
+ * The chart a config asks for, completed to whole rows.
+ *
+ * The range is what a parent sets and the rows are what it rounds to: a chart
+ * asked for 1–105 prints 1–110, because a last row with five squares in it and
+ * five squares missing is a chart a child fills in wrongly — the shape *is* the
+ * lesson, and a ragged one teaches the opposite of it. Rounding up rather than
+ * down, so every number asked for is on the paper.
+ */
+export function hundredChart(config: ChartConfig, box: Box): HundredChart {
+  const from = whole(config.range?.min, 1, 0, 9000);
+  const last = whole(config.range?.max, from + 99, from, from + 999);
+
+  // As many whole rows as the range needs, and never more than the page can
+  // print a legible square for. Capacity is arithmetic here exactly as it is
+  // for problems (§4): the count is a request, and what fits is the answer.
+  const wanted = Math.ceil((last - from + 1) / HUNDRED_COLUMNS);
+  const rows = Math.max(1, Math.min(wanted, Math.floor(box.height / MIN_CELL)));
+  const cell = Math.max(
+    1,
+    Math.min(
+      MAX_CELL,
+      Math.floor(box.width / HUNDRED_COLUMNS),
+      Math.floor(box.height / rows),
+    ),
+  );
+
+  return {
+    from,
+    to: from + rows * HUNDRED_COLUMNS - 1,
+    columns: HUNDRED_COLUMNS,
+    rows,
+    cell,
+  };
+}
+
+/**
+ * The chart as a grid, printed or blank.
+ *
+ * One list of numbers, filed under `cells` when they are printed and under
+ * `answers` when they are not — the same mechanism as the multiplication
+ * square, and the reason the wall chart and the exercise are one build with
+ * `answers` flipped rather than two families that could disagree about what
+ * goes in square forty-seven.
+ */
+function hundredGrid(chart: HundredChart, filled: boolean): GridSpec {
+  const numbers = Array.from({ length: chart.rows * chart.columns }, (_, i) =>
+    String(chart.from + i),
+  );
+  return {
+    kind: "chart",
+    columns: chart.columns,
+    rows: chart.rows,
+    cell: chart.cell,
+    cells: filled ? numbers : numbers.map(() => ""),
+    ...(filled ? {} : { answers: numbers }),
+  };
+}
+
+/* ── The number line ───────────────────────────────────────────────────── */
+
+/**
+ * The line a config asks for, and how many of it fit down the page.
+ *
+ * The range runs to a whole number of steps rather than to whatever was typed:
+ * a line from 0 to 25 marked every 10 would draw its last tick two thirds of
+ * the way along and leave the end of the axis unmarked, which is a line a child
+ * counts wrongly. So the end moves *out* to the next tick — every number asked
+ * for stays on the line — exactly as the hundred chart completes its last row.
+ */
+export function lineStrips(config: ChartConfig, box: Box): NumberLine[] {
+  const from = whole(config.range?.min, 0, -999, 999);
+  const last = whole(config.range?.max, from + 20, from + 1, from + 1000);
+  const step = whole(config.step, 1, 1, last - from);
+  const to = from + Math.ceil((last - from) / step) * step;
+
+  // Every strip is the same line, so which ticks keep their number is worked
+  // out once: a page of six copies to cut apart, rather than six scales to read.
+  const line = { from, to, step, width: box.width };
+  const labelled = { ...line, label: labelEvery(line) };
+  const strips = Math.min(
+    whole(config.strips, 1, 1, 12),
+    Math.max(1, fitAcross(box.height, NUMBER_LINE_HEIGHT, BLOCK_GAP)),
+  );
+  return Array.from({ length: strips }, () => ({ ...labelled }));
+}
+
+/**
+ * The strips, spread down the page with room to cut between them.
+ *
+ * Spacers rather than a margin on the block, because the air between two strips
+ * is the sheet's own arithmetic and not the stylesheet's: what is left over
+ * after the strips have taken their height is what there is, and dividing it is
+ * the last thing this family does with the page. Capped, so that two strips are
+ * two strips near the top of a page rather than one at each end of it.
+ */
+function stripBlocks(lines: NumberLine[], box: Box): Block[] {
+  // Two flex gaps per spacer, not one: a spacer is a block, so putting one
+  // between two strips buys `.sheet__blocks` a second gap to charge for. The
+  // arithmetic that missed that printed a page of six strips an inch and a
+  // half below the bottom margin, which looks perfect on screen.
+  const spare =
+    box.height -
+    lines.length * NUMBER_LINE_HEIGHT -
+    (2 * lines.length - 2) * BLOCK_GAP;
+  const gap =
+    lines.length > 1
+      ? Math.max(
+          0,
+          Math.min(MAX_STRIP_GAP, Math.floor(spare / (lines.length - 1))),
+        )
+      : 0;
+
+  return lines.flatMap((line, index) => [
+    ...(index > 0 && gap > 0 ? [{ kind: "spacer" as const, height: gap }] : []),
+    { kind: "numberline" as const, line },
+  ]);
+}
+
+/* ── The place-value chart ─────────────────────────────────────────────── */
+
+/** A place-value chart: which powers of ten it holds, and the box it draws. */
+export type PlaceChart = {
+  largest: number;
+  smallest: number;
+  rows: number;
+  cell: Mil;
+  row: Mil;
+};
+
+/**
+ * The chart a config asks for.
+ *
+ * The columns are consecutive powers of ten and the arithmetic says so: the
+ * count is `largest − smallest + 1`, which is the off-by-one this sheet would
+ * otherwise make — a chart from hundreds to ones has three columns, not two.
+ *
+ * Its rows are the one place in the shop where a grid is not squares. A column
+ * is as wide as the word at the head of it and a row is one digit tall, so a
+ * square cell would print either a chart a third of the width of the page or
+ * one that ran off the bottom of it. `GridSpec.row` is that, stated.
+ */
+export function placeChart(config: ChartConfig, box: Box): PlaceChart {
+  const largest = whole(
+    config.places?.largest,
+    2,
+    SMALLEST_PLACE + 1,
+    LARGEST_PLACE,
+  );
+  const smallest = whole(config.places?.smallest, 0, SMALLEST_PLACE, largest);
+
+  // A row is a line a child writes a digit on, which is a length the rest of
+  // the shop already has a name for — and never less than the type needs.
+  const least = Math.max(answerLine(config.fontPt), MIN_PLACE_ROW);
+  const rows = Math.max(
+    1,
+    Math.min(
+      whole(config.rows, 8, 1, 40),
+      // Less one, because the headings are the grid's first row.
+      Math.floor(box.height / least) - 1,
+    ),
+  );
+
+  return {
+    largest,
+    smallest,
+    rows,
+    cell: Math.floor(box.width / (largest - smallest + 1)),
+    // The rows stretch to fill what is left, between the two bounds. The count
+    // above was capped against `least`, so the floor here can never overflow
+    // the page even when the type is set as large as a config may ask for.
+    row: Math.max(
+      least,
+      Math.min(MAX_PLACE_ROW, Math.floor(box.height / (rows + 1))),
+    ),
+  };
+}
+
+/**
+ * The chart as a grid: the headings across the top, and blank rows under them.
+ *
+ * The headings are *in* the grid rather than above it, and that is the whole of
+ * how a heading is guaranteed to sit over the column it names. A row of words
+ * laid out beside the drawing would be two things to keep aligned, and the
+ * failure — "Tens" printed over the ones column — is one a child copies into
+ * their arithmetic rather than one anybody notices on screen.
+ */
+function placeGrid(chart: PlaceChart): GridSpec {
+  const columns = chart.largest - chart.smallest + 1;
+  const headings = Array.from({ length: columns }, (_, index) =>
+    placeName(chart.largest - index),
+  );
+
+  return {
+    kind: "chart",
+    columns,
+    rows: chart.rows + 1,
+    cell: chart.cell,
+    row: chart.row,
+    cells: [...headings, ...Array<string>(columns * chart.rows).fill("")],
+    // The rule under the headings, and the decimal point: the heavier upright
+    // goes immediately right of the ones column, which is exactly where a
+    // decimal point is written. On a chart that stops at ones that is the right
+    // edge of the paper's grid, which is the same statement — there is nothing
+    // smaller on it.
+    origin: {
+      column: Math.max(0, Math.min(columns, chart.largest + 1)),
+      row: 1,
+    },
+  };
+}
+
+/* ── The sheet ─────────────────────────────────────────────────────────── */
+
+/** What each reference is called at the head of its own page. */
+const TITLE: Record<ChartStyle, string> = {
+  hundred: "Hundred chart",
+  "number-line": "Number line",
+  coordinate: "Coordinate grid",
+  "place-value": "Place-value chart",
+};
+
+/**
+ * The title, which for one of the four is a question about the range.
+ *
+ * A chart of twenty numbers is not a hundred chart and must not say it is —
+ * ten rows of ten is what the phrase means, and it means it whether the chart
+ * starts at nought or at one. Anything else is a number chart and says which
+ * numbers, because that is the whole of what a parent is looking at.
+ */
+const hundredName = (chart: HundredChart): string =>
+  chart.rows === HUNDRED_COLUMNS ? TITLE.hundred : "Number chart";
+
+function chartTitle(config: ChartConfig, box: Box): string {
+  if (config.style !== "hundred") {
+    // `own` rather than a plain lookup, for the reason `rulingOf` uses it: a
+    // style arrives from a saved sheet, and `"constructor"` is a truthy
+    // function rather than a title.
+    return own(TITLE, config.style, TITLE.hundred);
+  }
+  const chart = hundredChart(config, box);
+  return chart.rows === HUNDRED_COLUMNS
+    ? TITLE.hundred
+    : `${hundredName(chart)}, ${chart.from} to ${chart.to}`;
+}
+
+/**
+ * The one sheet here with something withheld.
+ *
+ * A blank hundred chart is an exercise and its key is the filled chart. The
+ * other three are blank forms: there is nothing on them to be right or wrong
+ * about, and a page printed a second time under the word "Answer key" would be
+ * noise on a parent's printer. `phonicsKeyed` is the same call for the same
+ * reason, and both exist so a catalog page and the family cannot disagree.
+ */
+export const chartKeyed = (config: ChartConfig): boolean =>
+  config.style === "hundred" && config.filled !== true;
+
+/**
+ * The instruction, which only the sheet that withholds something carries.
+ *
+ * "One to a square" rather than "fill in the missing numbers", because on this
+ * sheet they are all missing — and it says nothing about the range, which is
+ * what keeps it a string the chrome can be measured against before the chart
+ * has been worked out. (The range is on the title.)
+ */
+const instructionOf = (config: ChartConfig): string | undefined =>
+  config.instructions ??
+  (chartKeyed(config) ? "Write the numbers in, one to a square." : undefined);
+
+/**
+ * What the chrome will hold, so that the page can be reserved for it.
+ *
+ * The same move every generating family makes, and it is not optional: a family
+ * prints a title whatever the config says, and `chromeHeight` reserves for one
+ * only if the *options* it is handed carry one. Passing the config straight in
+ * under-reserves by the height of a title row — `.sheet` is `min-height`, so
+ * nothing overflows visibly and the page simply grows past eleven inches and
+ * prints its last inch on a second sheet of paper.
+ *
+ * The title here need not be the words that end up on the page: the reservation
+ * is one row whatever it says, and the words are chosen once the box is known
+ * (`chartTitle` reads how many rows a chart came to). The instruction is the
+ * real string, because that one *is* measured — it wraps.
+ */
+function headerOf(config: ChartConfig): SheetOptions {
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    fields: config.fields,
+    title: config.title ?? TITLE.hundred,
+    instructions: instructionOf(config),
+  };
+}
+
+/**
+ * The page the blocks get, once the header and the footer have taken theirs.
+ *
+ * The footer is declared with the note a key prints, per `FootLine.note`: a key
+ * is laid out against the same box as its sheet, so a footer that wraps to two
+ * rows on the key and one on the sheet is a key whose last row is on a second
+ * page.
+ *
+ * Unconditionally, rather than only where `chartKeyed` says there is an answer
+ * to reveal, because `SheetSpec.key` stamps the note on any sheet it is handed
+ * — a parent may print the key of a coordinate grid, and what they get is the
+ * same paper with a word in the footer. It costs one footer row on the seven
+ * sheets that have nothing to reveal, and only at type sizes where that row
+ * wraps at all; at every size a catalog page prints, it costs nothing. That is
+ * the cheap side to be wrong on: a row over-reserved is a rule line, and a row
+ * under-reserved is a second sheet of paper.
+ */
+const chartBox = (config: ChartConfig): Box =>
+  sheetBlockBox(headerOf(config), false, { note: "Answer key" });
+
+export function buildChartSheet(config: ChartConfig, seed: number): Sheet {
+  const box = chartBox(config);
+
+  return {
+    paper: config.paper,
+    fontPt: config.fontPt,
+    header: {
+      title: config.title ?? chartTitle(config, box),
+      instructions: instructionOf(config),
+      fields: config.fields,
+    },
+    blocks: chartBlocks(config, box),
+    footer: { credit: SHEET_CREDIT, url: SHEET_URL, seed },
+    answers: false,
+  };
+}
+
+/** Which drawing this is. The one place `ChartStyle` is narrowed. */
+function chartBlocks(config: ChartConfig, box: Box): Block[] {
+  switch (config.style) {
+    case "number-line":
+      return stripBlocks(lineStrips(config, box), box);
+    case "coordinate":
+      return [
+        {
+          kind: "grid",
+          grid: planeOf(config.quadrants ?? 1, box, {
+            span: config.span,
+            cell: MAX_PLANE_CELL,
+            // The whole page: a blank plane is the sheet, where the one under a
+            // question is half of it and the questions are the rest.
+            share: 1,
+          }).grid,
+        },
+      ];
+    case "place-value":
+      return [{ kind: "grid", grid: placeGrid(placeChart(config, box)) }];
+    case "hundred":
+    default:
+      return [
+        {
+          kind: "grid",
+          grid: hundredGrid(hundredChart(config, box), config.filled === true),
+        },
+      ];
+  }
+}
+
+/**
+ * One line naming the sheet, in the words a teacher says out loud.
+ *
+ * Each says the number that makes it the sheet somebody asked for rather than
+ * one like it: which numbers the chart runs through, what the line counts in,
+ * how far the axes go, and which places the columns hold.
+ */
+export function describeChart(config: ChartConfig): string {
+  const box = chartBox(config);
+  switch (config.style) {
+    case "number-line": {
+      const [line] = lineStrips(config, box);
+      const marks = ticks(line);
+      return `Number line from ${line.from} to ${line.to}, a tick every ${line.step} — ${marks.length} of them`;
+    }
+    case "coordinate": {
+      const plane = planeOf(config.quadrants ?? 1, box, { span: config.span });
+      return plane.negative
+        ? `Coordinate grid, all four quadrants, −${plane.span} to ${plane.span}`
+        : `Coordinate grid, the first quadrant, 0 to ${plane.span}`;
+    }
+    case "place-value": {
+      const chart = placeChart(config, box);
+      return `Place-value chart, ${placeName(chart.largest).toLowerCase()} to ${placeName(chart.smallest).toLowerCase()}`;
+    }
+    case "hundred":
+    default: {
+      const chart = hundredChart(config, box);
+      // The same name the sheet prints at the top of itself, so the line in the
+      // record book and the paper in a parent's hand say the same thing — and
+      // never "hundred chart" over a chart of thirty numbers.
+      const named = `${hundredName(chart)}, ${chart.from} to ${chart.to}`;
+      return config.filled === true
+        ? `${named}, filled in`
+        : `${named}, blank to fill in`;
+    }
+  }
+}
+
+export const CHART_SHEET: SheetSpec<ChartConfig> = {
+  id: "chart",
+  label: "Charts, number lines and grids",
+  world: SHEET_WORLD,
+  build: buildChartSheet,
+  // The filled chart, on the one sheet that has an answer at all. On the other
+  // three `answers` finds nothing to reveal, so a key is the same page again —
+  // which is what `chartKeyed` exists to let a page decide before printing it.
+  key: (sheet) => ({
+    ...sheet,
+    answers: true,
+    footer: { ...sheet.footer, note: "Answer key" },
+  }),
+  describe: describeChart,
+};

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -853,8 +853,12 @@ export type PaperConfig = SheetOptions & { kind: "paper"; rule: Rule };
  *
  * Every style-specific field is optional and every one of them is clamped to
  * what the paper holds, because all four arrive from the same places a saved
- * sheet does — a bookmarked link, a config written last term. `chartPlan` in
- * `templates/charts.ts` is the single place they are resolved.
+ * sheet does — a bookmarked link, a config written last term. They resolve in
+ * two places rather than one: `hundredChart`, `lineStrips` and `placeChart` in
+ * `templates/charts.ts` clamp their own fields through `whole()`, while `span`
+ * and `quadrants` go to `planeOf` in `plane.ts`, which guards them itself so
+ * that every sheet drawn on a plane — blank grid or geometry exercise — gets
+ * the same answer to "how far do the axes run".
  */
 export type ChartStyle =
   "hundred" | "number-line" | "coordinate" | "place-value";

--- a/src/engine/sheets/types.ts
+++ b/src/engine/sheets/types.ts
@@ -102,7 +102,7 @@ export type TraceStyle =
   "solid" | "dim" | "hollow" | "dotted" | "dashed" | "none";
 
 /**
- * A line to count along, under a problem.
+ * A line to count along, under a problem — or, on its own, the whole sheet.
  *
  * Two numbers and a tick spacing, which is all a number line is. The width is
  * declared here rather than measured by the renderer, for the same reason a
@@ -113,10 +113,23 @@ export type TraceStyle =
 export type NumberLine = {
   from: number;
   to: number;
-  /** A tick every `step`, each one labelled. */
+  /** A tick every `step`. */
   step: number;
   /** How wide it is drawn. */
   width: Mil;
+  /**
+   * A number under every `label`th tick, the rest left as bare ticks. Absent
+   * means every tick is labelled, which is what a line under a problem does.
+   *
+   * The one thing a *reference* number line needs that a counting aid under a
+   * sum does not. A line marked every 1 from 0 to 100 is the sheet a Year 2
+   * teacher asks for, and a hundred and one numerals across seven and a half
+   * inches is a smudge — so the ticks stay where the interval says and the
+   * numbers thin out to what will fit. Which ticks keep their number is
+   * arithmetic (`labelEvery` in numberline.ts), not a guess made in a browser,
+   * because a spacing a browser worked out is a spacing no test can check.
+   */
+  label?: number;
 };
 
 /**
@@ -320,8 +333,25 @@ export type GridSpec = {
   kind: "graph" | "chart" | "coordinate";
   columns: number;
   rows: number;
-  /** The square. */
+  /** The square: how wide a column is, and how tall a row is. */
   cell: Mil;
+  /**
+   * How tall a row is, where a row is not a square.
+   *
+   * Absent on every grid a child measures against — graph paper, a hundred
+   * chart, a coordinate plane — because a square that is not square is a grid
+   * that lies about its own geometry, and §4 is about nothing else. It is here
+   * for the one chart whose columns are a *heading* rather than a unit: a
+   * place-value chart's columns are as wide as the word "Hundreds" and its rows
+   * are one digit tall, and squaring them would either print a chart three
+   * inches wide on a page eight inches wide or one eight rows long that runs
+   * off the bottom.
+   *
+   * So: stated, and stated only by the family that means it. A renderer reads
+   * `row ?? cell`, which is what keeps every other grid square by construction
+   * rather than by remembering.
+   */
+  row?: Mil;
   /** What's printed in the squares, row-major. Empty for a blank grid. */
   cells?: string[];
   /**
@@ -607,6 +637,18 @@ export type Block =
     }
   | { kind: "clock"; faces: ClockFace[] }
   | { kind: "shapes"; figures: Figure[] }
+  /**
+   * A number line on its own, rather than under a sum.
+   *
+   * A block of its own for the reason `wordshapes` is one: there is no problem
+   * here. A `problems` block numbers what is in it — "1." against a strip a
+   * child is going to cut out and stick on a desk is a question nobody asked —
+   * and a reference line is the sheet rather than an aid beside something else.
+   * The line itself is the same `NumberLine` a problem carries, drawn by the
+   * same renderer, so the ticks on a wall strip land exactly where the ticks
+   * under a sum do.
+   */
+  | { kind: "numberline"; line: NumberLine }
   /** Where to cut, for cards and bookmarks. */
   | { kind: "cutline" }
   | { kind: "spacer"; height: Mil };
@@ -798,6 +840,75 @@ export type BlankConfig = SheetOptions & { kind: "blank" };
  * which midline, whether there is room for a `g`.
  */
 export type PaperConfig = SheetOptions & { kind: "paper"; rule: Rule };
+
+/**
+ * The blank maths references: a hundred chart, a number line, a coordinate
+ * grid, a place-value chart.
+ *
+ * The second family in the "templates" tier (§11) and the second one that is
+ * geometry rather than generation — which is why it sits beside `PaperConfig`
+ * rather than in `maths/`. Nothing here is drawn from a seed and nothing here
+ * has a right answer to check, save the one that does: a hundred chart printed
+ * blank is filled in, and the filled chart is its key.
+ *
+ * Every style-specific field is optional and every one of them is clamped to
+ * what the paper holds, because all four arrive from the same places a saved
+ * sheet does — a bookmarked link, a config written last term. `chartPlan` in
+ * `templates/charts.ts` is the single place they are resolved.
+ */
+export type ChartStyle =
+  "hundred" | "number-line" | "coordinate" | "place-value";
+
+export type ChartConfig = SheetOptions & {
+  kind: "chart";
+  style: ChartStyle;
+  /**
+   * The hundred chart's numbers, ends included.
+   *
+   * Both ends, rather than a count from one, because the two charts a parent
+   * asks for are 1–100 and 0–99 and the argument between them is a real one:
+   * a chart that starts at nought puts every multiple of ten at the end of its
+   * own row, and a chart that starts at one puts them under each other in the
+   * last column. Neither is wrong and a child is usually taught one of them.
+   */
+  range?: { min: number; max: number };
+  /**
+   * Whether the numbers are printed, or left for the child to write in.
+   *
+   * One switch and two sheets: the wall chart, and the exercise whose answer
+   * key is the wall chart. The numbers are computed either way — which is what
+   * makes the pair one build with `answers` flipped rather than two families.
+   */
+  filled?: boolean;
+  /** The number line: how far apart one tick is from the next. */
+  step?: number;
+  /**
+   * The number line: how many strips down the page, to cut apart.
+   *
+   * `strips` rather than the `count` every generating family carries, because
+   * it is not the same question. A count is how many *problems* were asked for
+   * and is the number a sheet is marked out of; this is how many copies of one
+   * line are printed, and there is nothing on any of them to mark.
+   */
+  strips?: number;
+  /** The coordinate grid: how far the axes run from nought. */
+  span?: number;
+  /** And whether it has negative numbers on it: four quadrants, or one. */
+  quadrants?: number;
+  /**
+   * The place-value chart's columns, as powers of ten: 2 is hundreds, 0 is
+   * ones, −2 is hundredths.
+   *
+   * The exponent rather than the name, because the exponent is what the chart
+   * *is*: the columns are consecutive powers of ten, the decimal point goes
+   * between 0 and −1 wherever both are present, and every name printed at the
+   * head of a column is looked up from it. A pair of names would let a chart be
+   * configured with tens beside thousandths.
+   */
+  places?: { largest: number; smallest: number };
+  /** The place-value chart: how many rows there are to write numbers in. */
+  rows?: number;
+};
 
 /* ── Arithmetic ────────────────────────────────────────────────────────────
    The first *generated* family: the one where a sheet is not a shape to write
@@ -1969,6 +2080,7 @@ export type PhonicsConfig = SheetOptions & {
 export type SheetConfig =
   | BlankConfig
   | PaperConfig
+  | ChartConfig
   | ArithmeticConfig
   | MultiplicationConfig
   | FractionConfig

--- a/src/games/printshop/defaults.ts
+++ b/src/games/printshop/defaults.ts
@@ -161,6 +161,17 @@ const MEMORY_TEXT = "A verse is learnt by saying it, not by reading it again.";
 const DEFAULTS: Record<string, SheetConfig> = {
   blank: { ...BASE, kind: "blank", title: "Blank sheet" },
   paper: { ...BASE, kind: "paper", rule: { style: "wide" } },
+  chart: {
+    ...BASE,
+    kind: "chart",
+    // The hundred chart, blank, 1 to 100. The reference a parent recognises
+    // from across the room, and the only one of the four that is an exercise as
+    // well as a wall chart — so the bench opens on a sheet with something to do
+    // on it and a key behind it. The other three are one control away.
+    style: "hundred",
+    range: { min: 1, max: 100 },
+    filled: false,
+  },
   arithmetic: {
     ...BASE,
     kind: "arithmetic",

--- a/src/games/printshop/options/charts.tsx
+++ b/src/games/printshop/options/charts.tsx
@@ -1,0 +1,180 @@
+/**
+ * The blank references, and the four questions they are chosen by.
+ *
+ * The one panel in the directory where the four styles share almost nothing:
+ * a hundred chart is a range, a number line is a range and an interval, a
+ * coordinate grid is how far the axes run, and a place-value chart is which
+ * powers of ten it holds. So the controls under the style are the style's own,
+ * rather than a wall of settings three quarters of which do nothing to the
+ * sheet in the preview.
+ *
+ * Every number here is a request the engine clamps: `charts.ts` completes a
+ * chart to whole rows, moves a line's end out to the next tick, and caps the
+ * rows and strips at what the paper holds. The hints say so where the number a
+ * parent types is one that visibly moves.
+ */
+import { Checkbox, FieldSet, NumberStepper } from "@/components/ui/kit";
+import { placeName } from "@/engine/sheets/templates/charts";
+import type { ChartConfig, ChartStyle } from "@/engine/sheets/types";
+
+import { Choice, Span, opt, type PanelProps } from "./parts";
+
+const STYLES = [
+  opt<ChartStyle>("hundred", "Hundred chart"),
+  opt<ChartStyle>("number-line", "Number line"),
+  opt<ChartStyle>("coordinate", "Coordinate grid"),
+  opt<ChartStyle>("place-value", "Place value"),
+];
+
+const QUADRANTS = [
+  opt("1", "One", "no negatives"),
+  opt("4", "Four", "all four"),
+];
+
+/**
+ * The places, offered as the words rather than as the exponents they are.
+ *
+ * A config holds the power of ten because that is what a place *is* and it is
+ * what keeps the columns consecutive (see `ChartConfig.places`). Nobody chooses
+ * a column called "10²", so the control names them and converts.
+ */
+const POWERS = [6, 5, 4, 3, 2, 1, 0, -1, -2, -3];
+const PLACES = POWERS.map((power) => opt(String(power), placeName(power)));
+
+export function ChartsPanel({ config, set }: PanelProps<ChartConfig>) {
+  const places = config.places ?? { largest: 2, smallest: 0 };
+
+  return (
+    <>
+      <Choice
+        label="Which reference"
+        value={config.style}
+        onChange={(style) => set({ style })}
+        options={STYLES}
+      />
+
+      {(config.style === "hundred" || config.style === "number-line") && (
+        <Span
+          label={config.style === "hundred" ? "Numbers" : "From and to"}
+          value={config.range ?? rangeFor(config.style)}
+          onChange={(range) => set({ range })}
+          min={config.style === "hundred" ? 0 : -999}
+          max={999}
+          hint={
+            config.style === "hundred"
+              ? "Rounded up to a whole row of ten."
+              : "Rounded up to a whole number of intervals."
+          }
+        />
+      )}
+
+      {config.style === "hundred" && (
+        <Checkbox
+          label="Print the numbers in"
+          checked={config.filled === true}
+          onChange={(filled) => set({ filled })}
+        />
+      )}
+
+      {config.style === "number-line" && (
+        <>
+          <FieldSet
+            legend="Interval"
+            hint="A tick this far apart. The numbers under them thin out to what fits."
+          >
+            <NumberStepper
+              label="Interval"
+              value={config.step ?? 1}
+              min={1}
+              max={100}
+              onChange={(step) => set({ step })}
+            />
+          </FieldSet>
+          <FieldSet legend="Strips" hint="Capped at what fits on the page.">
+            <NumberStepper
+              label="Strips"
+              value={config.strips ?? 1}
+              min={1}
+              max={12}
+              onChange={(strips) => set({ strips })}
+            />
+          </FieldSet>
+        </>
+      )}
+
+      {config.style === "coordinate" && (
+        <>
+          <Choice
+            label="Quadrants"
+            value={String(config.quadrants ?? 1)}
+            onChange={(quadrants) => set({ quadrants: Number(quadrants) })}
+            options={QUADRANTS}
+          />
+          <FieldSet
+            legend="Axes run to"
+            hint="How far out the numbers go, in both directions."
+          >
+            <NumberStepper
+              label="Axes run to"
+              value={config.span ?? 10}
+              min={4}
+              max={20}
+              onChange={(span) => set({ span })}
+            />
+          </FieldSet>
+        </>
+      )}
+
+      {config.style === "place-value" && (
+        <>
+          <Choice
+            label="Largest place"
+            value={String(places.largest)}
+            onChange={(power) =>
+              set({ places: withLargest(places, Number(power)) })
+            }
+            options={PLACES}
+          />
+          <Choice
+            label="Smallest place"
+            value={String(places.smallest)}
+            onChange={(power) =>
+              set({ places: withSmallest(places, Number(power)) })
+            }
+            options={PLACES}
+          />
+          <FieldSet legend="Rows" hint="Capped at what fits on the page.">
+            <NumberStepper
+              label="Rows"
+              value={config.rows ?? 8}
+              min={1}
+              max={20}
+              onChange={(rows) => set({ rows })}
+            />
+          </FieldSet>
+        </>
+      )}
+    </>
+  );
+}
+
+/** What the two range styles open on when a config has not said. */
+const rangeFor = (style: ChartStyle) =>
+  style === "hundred" ? { min: 1, max: 100 } : { min: 0, max: 20 };
+
+/**
+ * The two ends of a place-value chart, each dragging the other where it must.
+ *
+ * The same move `Span` makes with a low and a high: picking a largest place
+ * below the smallest one would be a chart with no columns, so the other end
+ * follows rather than the control refusing.
+ */
+const withLargest = (
+  places: { largest: number; smallest: number },
+  largest: number,
+) => ({ largest, smallest: Math.min(largest, places.smallest) });
+
+const withSmallest = (
+  places: { largest: number; smallest: number },
+  smallest: number,
+) => ({ largest: Math.max(smallest, places.largest), smallest });

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -20,6 +20,7 @@ import type { ReactNode } from "react";
 import type { SheetConfig } from "@/engine/sheets/types";
 
 import { ArithmeticPanel } from "./arithmetic";
+import { ChartsPanel } from "./charts";
 import { DecimalsPanel } from "./decimals";
 import { FractionsPanel } from "./fractions";
 import { GeometryPanel } from "./geometry";
@@ -78,6 +79,7 @@ const NO_OPTIONS: FamilyPanel = () => null;
 const PANELS: Record<string, FamilyPanel> = {
   blank: NO_OPTIONS,
   paper: panel(PaperPanel),
+  chart: panel(ChartsPanel),
   arithmetic: panel(ArithmeticPanel),
   multiplication: panel(MultiplicationPanel),
   fractions: panel(FractionsPanel),

--- a/src/pages/printables/_catalog.ts
+++ b/src/pages/printables/_catalog.ts
@@ -9,16 +9,22 @@
  * why: twelve times-table pages work because there are twelve of them and each
  * has something true on it, and five thousand permutations of a config is a
  * doorway-page farm. So the engine can rule paper any way §5 describes, and
- * this file names the eleven a parent actually searches for, each with a note
+ * this file names the fifteen a parent actually searches for, each with a note
  * that is true of that ruling and no other. The rest arrive with the builder,
  * which is where choosing belongs.
+ *
+ * The line that sorts a page from a permutation is whether it is *different
+ * paper*. A quarter-inch square and a centimetre square are two different
+ * things to count on, and both are searched for by name; five millimetres and a
+ * fifth of an inch are the same square to within three thousandths of an inch,
+ * so one of them is a page and the other is a sentence on it.
  *
  * Every entry is printed on both stocks. A sheet is only correct on the paper
  * it was measured for — a Letter sheet sent to an A4 printer is scaled to fit,
  * and a scaled ⅝ rule is not a ⅝ rule — and `@page` is a document rule, so the
  * two cannot share a page. Hence a route each.
  */
-import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
+import { DEFAULT_FONT_PT, GRID_PITCHES } from "@/engine/sheets/paper";
 import { encodeSharedSheet } from "@/engine/sheets/share";
 import type {
   HeaderField,
@@ -271,6 +277,82 @@ export const PAPER_SHEETS: PaperSheet[] = [
     ages: "Ages 9+",
     group: "grid",
     rule: { style: "isometric" },
+  },
+  /* The metric squares. Everything above this point is a quarter of an inch,
+     which is the paper an American classroom is stocked with and no use at all
+     for work in centimetres: a rectangle 7cm by 4cm drawn on quarter-inch
+     squares has to be measured with a ruler rather than counted, which is most
+     of what squared paper is for. `GRID_PITCHES` already held these three; what
+     was missing was a page a parent could find them on.                      */
+  {
+    slug: "graph-paper-1-cm",
+    name: "Graph paper — 1 cm",
+    short: "1 cm",
+    heading: "Graph paper, 1 cm",
+    keyword: "Free printable 1 cm graph paper",
+    summary: "Centimetre squared paper, ruled edge to edge.",
+    lead: "One centimetre to a square, in both directions. The squared paper a metric classroom works in, where a length in centimetres is a number of squares rather than something to measure.",
+    notes: [
+      "A centimetre square is big enough to write a whole two-digit number into, which makes this the right squared paper for column arithmetic as well as for area. A child who puts one digit in each square keeps the columns lined up without being told to, and a column that drifts is most of what goes wrong in a long sum.",
+      "It is also the paper for area and perimeter the first time either is taught. A rectangle drawn 7 squares by 4 squares has an area a child can count and a perimeter they can walk round with a finger, and both of those are lost the moment the squares are a quarter of an inch and the label says centimetres.",
+    ],
+    teaches: "Area, perimeter and metric measurement",
+    ages: "Ages 7+",
+    group: "grid",
+    rule: { style: "graph", pitch: GRID_PITCHES.centimetre },
+  },
+  {
+    slug: "graph-paper-5-mm",
+    name: "Graph paper — 5 mm",
+    short: "5 mm",
+    heading: "Graph paper, 5 mm",
+    keyword: "Free printable 5 mm graph paper",
+    summary:
+      "Five-millimetre squares — the ruling a school exercise book is printed at.",
+    lead: "Half a centimetre to a square: the squares in a school maths book, and the finest ruling here that is still comfortable to write a digit into.",
+    notes: [
+      "This is what “squared paper” means in most of the world, and a page of it sits beside a torn-out exercise book page without looking like a different thing. Two squares to the centimetre also makes halves obvious, which is worth more than it sounds when a child is first asked to draw a line 3.5 cm long.",
+      "Five millimetres is a hair under a fifth of an inch — three thousandths of an inch smaller, which is finer than a printer resolves — so a sheet of this does duty as the American quad pad as well. If the work is in inches, though, the quarter-inch sheet is the one to print: the squares there are a unit rather than nearly one.",
+    ],
+    teaches: "Graphing and metric measurement",
+    ages: "Ages 9+",
+    group: "grid",
+    rule: { style: "graph", pitch: GRID_PITCHES["half-centimetre"] },
+  },
+  {
+    slug: "dot-grid-paper-1-cm",
+    name: "Dot grid paper — 1 cm",
+    short: "1 cm dots",
+    heading: "Dot grid paper, 1 cm",
+    keyword: "Free printable 1 cm dot grid paper",
+    summary: "Centimetre dot grid — the squares implied rather than drawn.",
+    lead: "A centimetre grid with only the corners printed. Everything the squared sheet gives you to measure against, and nothing crossing what has been drawn on top of it.",
+    notes: [
+      "Dots are the right paper for drawing shapes on. A quadrilateral drawn corner to corner on a centimetre grid has sides a child can count and an area they can work out by cutting it into rectangles — and none of the pencil lines are competing with a printed grid for attention.",
+      "It is also the paper for arrays. Six dots by four dots is a picture of 6 × 4 that a child can circle in rows or in columns, which is commutativity drawn rather than asserted, and it is much harder to see when the dots are a quarter of an inch apart.",
+    ],
+    teaches: "Shapes, arrays and area",
+    ages: "Ages 7+",
+    group: "grid",
+    rule: { style: "dot", pitch: GRID_PITCHES.centimetre },
+  },
+  {
+    slug: "isometric-graph-paper-1-cm",
+    name: "Isometric paper — 1 cm",
+    short: "1 cm triangles",
+    heading: "Isometric graph paper, 1 cm",
+    keyword: "Free printable 1 cm isometric graph paper",
+    summary:
+      "A centimetre triangular grid at 30° — the same paper as the quarter-inch sheet, at a size a whole cube fits on.",
+    lead: "Triangles a centimetre to a side rather than a quarter of an inch. The same three families of lines at sixty degrees to each other, drawn large enough that a solid a few units across takes up a usable part of the page.",
+    notes: [
+      "The larger triangle is the one to print for a first attempt at drawing a cube. Small isometric paper is unforgiving — a line drawn one row out is a corner that does not meet — and a child who has just been shown the trick needs the room before they need the detail.",
+      "The rows are spaced by the height of the triangle rather than by its side, here as on the quarter-inch sheet, which is what makes the grid genuinely thirty degrees rather than a squashed approximation of it. A centimetre triangle is therefore about 8.7 mm from one row to the next, and that number is the whole reason the drawing looks right.",
+    ],
+    teaches: "Three-dimensional shapes and nets",
+    ages: "Ages 9+",
+    group: "grid",
+    rule: { style: "isometric", pitch: GRID_PITCHES.centimetre },
   },
 ];
 

--- a/src/pages/printables/_charts.test.ts
+++ b/src/pages/printables/_charts.test.ts
@@ -1,0 +1,296 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet } from "@/engine/sheets";
+import { ticks } from "@/engine/sheets/numberline";
+import { toInches } from "@/engine/sheets/paper";
+import type { GridSpec, NumberLine, Sheet } from "@/engine/sheets/types";
+
+import { BIBLE_SHEETS, hrefFor as bibleHref } from "./_bible";
+import { PAPER_SHEETS, STOCKS, pathFor as paperPath } from "./_catalog";
+import {
+  CHART_GROUPS,
+  CHART_SEED,
+  CHART_SHEETS,
+  builderHref,
+  chartShelf,
+  keyed,
+  pathFor,
+  type ChartSheet,
+} from "./_charts";
+import { CURSIVE_SHEETS, hrefFor as cursiveHref } from "./_cursive";
+import { GRAMMAR_SHEETS, pathFor as grammarPath } from "./_grammar";
+import { HANDWRITING_SHEETS, hrefFor as handwritingHref } from "./_handwriting";
+import { MATHS_SHEETS, pathFor as mathsPath } from "./_maths";
+import { PHONICS_SHEETS, pathFor as phonicsPath } from "./_phonics";
+import { SPELLING_SHEETS, pathFor as spellingPath } from "./_spelling";
+
+/**
+ * The charts catalog, held to what a catalog page has to be — and to the one
+ * thing this shelf exists to get right.
+ *
+ * A worksheet can be marked, so a mistake on one is found. A reference sheet
+ * cannot: a child counts along it and trusts it. So the numbers the prose says
+ * out loud — twenty-one ticks, ten rows of ten, a numeral every five, four
+ * columns — are checked here against the sheet the page prints under them,
+ * because the page *is* the sheet (§8) and a reader could otherwise disprove it
+ * by looking.
+ */
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+const built = (sheet: ChartSheet): Sheet =>
+  buildSheet(sheet.config, CHART_SEED);
+
+/** The one grid a sheet prints, where it prints one. */
+const gridOf = (sheet: Sheet): GridSpec | undefined =>
+  sheet.blocks.find((block) => block.kind === "grid")?.grid;
+
+/** Every number-line strip a sheet prints. */
+const linesOf = (sheet: Sheet): NumberLine[] =>
+  sheet.blocks
+    .filter((block) => block.kind === "numberline")
+    .map((b) => b.line);
+
+const bySlug = (slug: string): ChartSheet => {
+  const sheet = CHART_SHEETS.find((entry) => entry.slug === slug);
+  if (!sheet) throw new Error(`no sheet at ${slug}`);
+  return sheet;
+};
+
+describe("the charts catalog", () => {
+  it("is bounded, and every slug is a route somebody could type", () => {
+    for (const sheet of CHART_SHEETS) {
+      expect(sheet.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+    expect(new Set(CHART_SHEETS.map((sheet) => sheet.slug)).size).toBe(
+      CHART_SHEETS.length,
+    );
+  });
+
+  it("never claims a path another shelf already prints on", () => {
+    // Nine route patterns over one prefix. They only coexist because the paths
+    // they emit are disjoint; the day they are not, Astro has two routes for
+    // one URL and picks one of them.
+    const taken = new Set<string>([
+      ...PAPER_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => `/printables/${paperPath(sheet, stock)}`),
+      ),
+      ...MATHS_SHEETS.map((sheet) => mathsPath(sheet)),
+      ...SPELLING_SHEETS.map((sheet) => spellingPath(sheet)),
+      ...GRAMMAR_SHEETS.map((sheet) => grammarPath(sheet)),
+      ...PHONICS_SHEETS.map((sheet) => phonicsPath(sheet)),
+      ...HANDWRITING_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => handwritingHref(sheet, stock)),
+      ),
+      ...CURSIVE_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => cursiveHref(sheet, stock)),
+      ),
+      ...BIBLE_SHEETS.flatMap((sheet) =>
+        STOCKS.map((stock) => bibleHref(sheet, stock)),
+      ),
+    ]);
+    for (const sheet of CHART_SHEETS) {
+      expect(taken.has(pathFor(sheet)), sheet.slug).toBe(false);
+    }
+  });
+
+  it("shows every kind of reference the family can make", () => {
+    // Four styles, and a style with no page is a sheet a parent can only find
+    // by opening the builder and reading a dropdown.
+    expect(new Set(CHART_SHEETS.map((sheet) => sheet.config.style))).toEqual(
+      new Set(["hundred", "number-line", "coordinate", "place-value"]),
+    );
+  });
+
+  it("answers a different query on every page", () => {
+    const keywords = CHART_SHEETS.map((sheet) => sheet.keyword.toLowerCase());
+    expect(new Set(keywords).size).toBe(keywords.length);
+  });
+
+  it("carries prose on every page rather than a filled-in template", () => {
+    for (const sheet of CHART_SHEETS) {
+      expect(sheet.notes.length, sheet.slug).toBeGreaterThanOrEqual(2);
+      for (const note of sheet.notes)
+        expect(note.length, sheet.slug).toBeGreaterThan(200);
+      expect(sheet.lead.length, sheet.slug).toBeGreaterThan(100);
+      expect(sheet.summary.length, sheet.slug).toBeGreaterThan(60);
+    }
+  });
+
+  it("shelves every sheet exactly once", () => {
+    const shelved = chartShelf().flatMap((group) => group.sheets);
+    expect(shelved).toHaveLength(CHART_SHEETS.length);
+    for (const group of CHART_GROUPS)
+      expect(
+        CHART_SHEETS.some((sheet) => sheet.group === group.id),
+        group.id,
+      ).toBe(true);
+  });
+});
+
+describe("the sheet on a catalog page", () => {
+  it("prints something on every page", () => {
+    for (const sheet of CHART_SHEETS) {
+      const printed = built(sheet);
+      expect(printed.blocks.length, sheet.slug).toBeGreaterThan(0);
+      expect(printed.header.title, sheet.slug).toBeTruthy();
+    }
+  });
+
+  it("is the same sheet on every build", () => {
+    // §7, and the reason these pages can be prerendered at all: a crawler that
+    // comes back next month has to read the page it indexed.
+    for (const sheet of CHART_SHEETS) {
+      expect(built(sheet), sheet.slug).toEqual(built(sheet));
+    }
+  });
+
+  it("keys the one page that withholds an answer, and only that one", () => {
+    for (const sheet of CHART_SHEETS) {
+      const key = answerKey(sheet.config, CHART_SEED);
+      expect(key.blocks, sheet.slug).toEqual(built(sheet).blocks);
+      expect(keyed(sheet), sheet.slug).toBe(
+        sheet.slug === "blank-hundred-chart",
+      );
+    }
+  });
+
+  it("prints a name line where a child works on the sheet, and not on a wall chart", () => {
+    // The one editorial judgement on this shelf that shows up on the paper: a
+    // chart to pin up and a strip about to be cut into six have nothing to
+    // write a name on. Blank either way, always (§1).
+    for (const sheet of CHART_SHEETS) {
+      const worked = ["blank-hundred-chart", "place-value-chart"];
+      if (worked.includes(sheet.slug))
+        expect(sheet.config.fields, sheet.slug).toContain("name");
+      if (sheet.slug === "hundred-chart" || sheet.slug === "number-line")
+        expect(sheet.config.fields, sheet.slug).toEqual([]);
+    }
+  });
+});
+
+/* ── The numbers the prose says out loud ───────────────────────────────── */
+
+describe("what the pages claim", () => {
+  it("prints a hundred squares numbered 1 to 100, on both hundred charts", () => {
+    for (const slug of ["hundred-chart", "blank-hundred-chart"]) {
+      const grid = gridOf(built(bySlug(slug)));
+      expect(grid?.columns, slug).toBe(10);
+      expect(grid?.rows, slug).toBe(10);
+      const numbers =
+        (grid?.cells?.[0] === "" ? grid?.answers : grid?.cells) ?? [];
+      expect(numbers, slug).toHaveLength(100);
+      expect(numbers[0], slug).toBe("1");
+      expect(numbers[99], slug).toBe("100");
+    }
+  });
+
+  it("prints them at the three quarters of an inch the page says", () => {
+    // The one measurement quoted in the prose, and the sort of claim that goes
+    // quietly wrong when the chrome above the grid changes height.
+    for (const slug of ["hundred-chart", "blank-hundred-chart"]) {
+      expect(toInches(gridOf(built(bySlug(slug)))?.cell ?? 0), slug).toBe(0.75);
+    }
+  });
+
+  it("prints six strips of twenty-one ticks on the 0 to 20 line", () => {
+    const strips = linesOf(built(bySlug("number-line")));
+    expect(strips).toHaveLength(6);
+    expect(ticks(strips[0])).toHaveLength(21);
+    expect(strips[0].label).toBe(1);
+    for (const strip of strips) expect(strip).toEqual(strips[0]);
+  });
+
+  it("keeps every tick and numbers every fifth on the line to 100", () => {
+    const strips = linesOf(built(bySlug("number-line-to-100")));
+    expect(strips).toHaveLength(3);
+    expect(ticks(strips[0])).toHaveLength(101);
+    // "numbered every five", in as many words on the page above it.
+    expect(strips[0].label).toBe(5);
+  });
+
+  it("heads the place-value charts with the columns their prose names", () => {
+    expect(
+      gridOf(built(bySlug("place-value-chart")))?.cells?.slice(0, 4),
+    ).toEqual(["Thousands", "Hundreds", "Tens", "Ones"]);
+    expect(
+      gridOf(built(bySlug("decimal-place-value-chart")))?.cells?.slice(0, 6),
+    ).toEqual([
+      "Hundreds",
+      "Tens",
+      "Ones",
+      "Tenths",
+      "Hundredths",
+      "Thousandths",
+    ]);
+  });
+
+  it("rules the decimal point between the ones and the tenths", () => {
+    // The claim the decimal page is built on, counted in columns: hundreds,
+    // tens, ones is three, so the heavier upright is the third gridline in.
+    expect(gridOf(built(bySlug("decimal-place-value-chart")))?.origin).toEqual({
+      column: 3,
+      row: 1,
+    });
+  });
+
+  it("numbers the coordinate grids the way each page promises", () => {
+    // Eleven squares for a plane that runs to ten — ten of them the plane, and
+    // one the margin the numerals are printed in.
+    const first = gridOf(built(bySlug("coordinate-grid")));
+    expect(first?.columns).toBe(11);
+    expect(first?.axis).toEqual({ min: 0, max: 10 });
+
+    const four = gridOf(built(bySlug("four-quadrant-graph-paper")));
+    expect(four?.columns).toBe(20);
+    expect(four?.axis).toEqual({ min: -10, max: 10 });
+  });
+});
+
+describe("the link into the builder", () => {
+  it("opens the bench on the sheet that was printed", () => {
+    for (const sheet of CHART_SHEETS) {
+      expect(
+        builderHref(sheet).startsWith("/printables/make#s="),
+        sheet.slug,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("the sitemap", () => {
+  /*
+   * A URL missing from the sitemap is the failure nobody notices — nothing
+   * breaks, the page is simply never submitted. Skipped when there is no
+   * `dist/`, exactly as the other catalogs' are; CI builds before it runs the
+   * suite.
+   */
+  it("carries every chart slug and the hub", () => {
+    const file = `${ROOT}/dist/sitemap-0.xml`;
+    if (!existsSync(file)) return; // `npm run build` hasn't run yet.
+
+    const xml = readFileSync(file, "utf8");
+    const found = new Set(
+      [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) =>
+        new URL(match[1]).pathname.replace(/\/$/, ""),
+      ),
+    );
+
+    expect(found.has("/printables/charts")).toBe(true);
+    for (const sheet of CHART_SHEETS) {
+      expect(found.has(pathFor(sheet)), sheet.slug).toBe(true);
+    }
+    // And the metric squares that arrived on the paper shelf with them.
+    for (const slug of [
+      "graph-paper-1-cm",
+      "graph-paper-5-mm",
+      "dot-grid-paper-1-cm",
+      "isometric-graph-paper-1-cm",
+    ]) {
+      expect(found.has(`/printables/${slug}`), slug).toBe(true);
+    }
+  });
+});

--- a/src/pages/printables/_charts.ts
+++ b/src/pages/printables/_charts.ts
@@ -1,0 +1,337 @@
+/**
+ * The reference sheets the Print Shop has set, and the words that go round them.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data two pages
+ * share — `charts/[slug].astro`, which prerenders one reference per entry, and
+ * `charts/index.astro`, which is the hub — rather than a route of its own.
+ * `_catalog.ts` does that job for paper, `_maths.ts` for the worksheets,
+ * `_phonics.ts` for the sounds, and so on down the shelf.
+ *
+ * **Eight pages, and eight is the point rather than a start.** §8 asks the
+ * catalog to be bounded, and this is a shelf where being greedy would be easy:
+ * "number line to 30", "number line to 50", "hundred chart to 120" and forty
+ * more are all real queries, and every one of them is a sheet on this shelf
+ * with one number changed. What is here is the eight a parent actually asks
+ * for; everything else is a stepper in the builder, which is where choosing
+ * belongs.
+ *
+ * **Two of them are already next door.** A multiplication grid, blank and
+ * filled, is `/printables/multiplication-chart` — the multiplication family
+ * with `style: "grid"` on it — and graph, dot and isometric paper are the grid
+ * end of the paper shelf. Neither is rebuilt here. A second family that drew a
+ * times-table square would be a second answer to what goes in square forty-two,
+ * and the hub links to both rather than pretending they are missing.
+ *
+ * **One stock, as with maths, spelling and grammar.** Nothing on these sheets
+ * is a *stated* measurement — there is no ⅝ rule to be scaled into a ⅗ rule by
+ * a printer loaded with A4, and a hundred chart four per cent smaller is still
+ * a hundred chart with a hundred squares in it. The squares on graph paper are
+ * the case where that is not true, and graph paper is on the shelf that prints
+ * both stocks for exactly that reason.
+ */
+import { DEFAULT_FONT_PT } from "@/engine/sheets/paper";
+import { chartKeyed } from "@/engine/sheets/templates/charts";
+import type { ChartConfig, HeaderField } from "@/engine/sheets/types";
+
+import { benchHref, paperOf, shelve } from "./_catalog";
+
+/** How the hub groups the shelf: what a child is counting, and where. */
+export type ChartGroup = "counting" | "places" | "plotting";
+
+export type ChartSheet = {
+  /** The route under /printables/charts, and the head term it answers. */
+  slug: string;
+  /** How it is listed on a hub. */
+  name: string;
+  /** How it is labelled in the row of neighbouring sheets. A few words. */
+  short: string;
+  /** The page's `<h1>`. */
+  heading: string;
+  /** The query this page exists to answer, in the words a parent types. */
+  keyword: string;
+  /** One sentence of what is on the sheet. Used in the description and hubs. */
+  summary: string;
+  /** The lead paragraph: what the sheet is, stated plainly. */
+  lead: string;
+  /**
+   * Two things that are true of this sheet and not of the one beside it.
+   *
+   * The sheet is prerendered directly under this prose (§8), which makes a
+   * number quoted in it a claim about the paper rather than a description of
+   * it — a reader can look down the page and count. `_charts.test.ts` holds
+   * every number written in words to what the sheet under it actually draws.
+   */
+  notes: string[];
+  /** For the `LearningResource` block. */
+  teaches: string;
+  ages: string;
+  group: ChartGroup;
+  /** The sheet itself. Prerendered at build time — this IS the page (§8). */
+  config: ChartConfig;
+};
+
+/**
+ * The seed every sheet on this shelf is built from, and it never moves.
+ *
+ * It decides nothing at all here, which is the honest thing to say about it:
+ * not one of these four sheets draws from it, because a hundred chart is the
+ * same hundred numbers in the same order every time anybody prints one. It is
+ * still printed in the footer, because a sheet is reproducible from its seed
+ * and a reader has no way of knowing which sheets ignore theirs (§7).
+ */
+export const CHART_SEED = 1;
+
+/**
+ * Printed blank, always — on the sheets that carry one at all.
+ *
+ * A worksheet asks for a name because a teacher has thirty of them to hand
+ * back. Nothing here holds one (§1): these are two ruled lines on paper and
+ * there is nowhere in a config to put a value for either. What varies is
+ * whether they are drawn: a chart a child works on has them, and a wall chart
+ * and a strip of paper about to be cut into six do not.
+ */
+const WORKED: HeaderField[] = ["name", "date"];
+const PINNED: HeaderField[] = [];
+
+/** A reference sheet on Letter, portrait. */
+const reference = (
+  fields: HeaderField[],
+  extra: Partial<ChartConfig>,
+): ChartConfig => ({
+  kind: "chart",
+  paper: paperOf("letter"),
+  fontPt: DEFAULT_FONT_PT,
+  fields,
+  style: "hundred",
+  ...extra,
+});
+
+export const CHART_SHEETS: ChartSheet[] = [
+  /* ── Counting ───────────────────────────────────────────────────────── */
+  {
+    slug: "hundred-chart",
+    name: "Hundred chart",
+    short: "Hundred chart",
+    heading: "Printable hundred chart",
+    keyword: "Free printable hundred chart",
+    summary:
+      "The numbers 1 to 100 in ten rows of ten, printed at three quarters of an inch to a square — the wall chart, filled in.",
+    lead: "One hundred squares, ten to a row, numbered 1 to 100. Every column is one digit repeating, every row is a count of ten, and moving down the chart is adding ten — which is the whole of what it teaches and the reason it is never nine or eleven squares wide.",
+    notes: [
+      "The chart is worth having on a wall before it is worth being a worksheet. A child who is asked “what is 34 and 10?” and can put a finger on 34 and move it straight down has been shown something a right answer would not have given them: that the tens digit is the row and the units digit is the column, and that adding ten is a move rather than a sum.",
+      "Print the blank one beside it and the pair does most of Year 1. Counting in twos, fives and tens are three patterns a child can colour in; the multiples of nine come out as a diagonal; and the numbers that will not make a rectangle of counters — the primes — are the ones with nothing shaded around them.",
+    ],
+    teaches: "Counting, place value and number patterns to 100",
+    ages: "Ages 5–8",
+    group: "counting",
+    config: reference(PINNED, {
+      style: "hundred",
+      range: { min: 1, max: 100 },
+      filled: true,
+    }),
+  },
+  {
+    slug: "blank-hundred-chart",
+    name: "Blank hundred chart",
+    short: "Blank chart",
+    heading: "Printable blank hundred chart",
+    keyword: "Free printable blank hundred chart",
+    summary:
+      "The same hundred squares with the numbers left out, to be filled in — and the completed chart on the page behind it.",
+    lead: "A hundred empty squares in ten rows of ten. Filling one in is a lesson rather than a copying exercise: a child who has to write 39 and then 40 finds out where the tens turn over, and finds it out in the one place on the chart where the pattern of the row breaks.",
+    notes: [
+      "The completed chart is the second page, so one print gives both. Mark it by looking down the columns rather than along the rows — every column should be the same digit all the way down, and a column that goes 7, 17, 27, 38 has a mistake in it that is visible from across the room.",
+      "It is also the fastest diagnostic there is for where counting has actually got to. A child fills the first two rows quickly, slows at 29, and stops somewhere in the forties; where they stop is the number the week is about, and no worksheet of sums would have told you which one it was.",
+    ],
+    teaches: "Writing the numbers to 100 in order",
+    ages: "Ages 5–7",
+    group: "counting",
+    config: reference(WORKED, {
+      style: "hundred",
+      range: { min: 1, max: 100 },
+      filled: false,
+    }),
+  },
+  {
+    slug: "number-line",
+    name: "Number line, 0 to 20",
+    short: "0 to 20",
+    heading: "Printable number line, 0 to 20",
+    keyword: "Free printable number line 0 to 20",
+    summary:
+      "Six identical strips numbered 0 to 20, a tick every 1, spaced to cut apart with scissors.",
+    lead: "The line a child adds on before they add: six and three is six hops and then three more. Six copies of it down the page, every one the same scale, so a strip can be cut out for a desk and another for a pencil case without the two disagreeing about how far apart the numbers are.",
+    notes: [
+      "Twenty-one ticks, not twenty. It sounds like pedantry and it is the difference between a line a child can count on and one they cannot: the numbers are on the ticks, the spaces between them are the hops, and a line to 20 has twenty hops and twenty-one places to stand. Every strip on this page is drawn from that arithmetic rather than from a spacing that looked right.",
+      "There is room above each strip to draw the hops in. That is what turns the line from a lookup table into a piece of working: a child who draws two arcs of five for 5 + 5 and lands on 10 has recorded how they got there, and the arcs are what you look at when the answer is wrong.",
+    ],
+    teaches: "Counting on and back within 20",
+    ages: "Ages 4–7",
+    group: "counting",
+    config: reference(PINNED, {
+      style: "number-line",
+      range: { min: 0, max: 20 },
+      step: 1,
+      strips: 6,
+    }),
+  },
+  {
+    slug: "number-line-to-100",
+    name: "Number line to 100",
+    short: "To 100",
+    heading: "Printable number line to 100",
+    keyword: "Free printable number line to 100",
+    summary:
+      "Three strips running 0 to 100 with a tick at every number and a printed numeral every five.",
+    lead: "A hundred and one ticks across seven and a half inches, numbered every five. Every whole number keeps its tick — the counting is what the line is for — and only the numerals thin out, because a hundred and one of them across a sheet of Letter is a smudge rather than a scale.",
+    notes: [
+      "The unnumbered ticks are drawn shorter, exactly as they are on a ruler, so counting between two printed numbers is possible rather than guesswork. That is the skill this line is actually for: finding 68 on a line marked at 65 and 70 is reading a scale, and it is the same thing a child will later do with a measuring jug and a thermometer.",
+      "Three strips rather than six, because a line to 100 is a reference to keep rather than something to cut up for a table of children. If a different interval is wanted — every 2 for even numbers, every 10 for rounding — the sheet is one control away in the builder, and the ticks move with it.",
+    ],
+    teaches: "Reading a scale, and counting to 100",
+    ages: "Ages 6–9",
+    group: "counting",
+    config: reference(PINNED, {
+      style: "number-line",
+      range: { min: 0, max: 100 },
+      step: 1,
+      strips: 3,
+    }),
+  },
+
+  /* ── Place value ────────────────────────────────────────────────────── */
+  {
+    slug: "place-value-chart",
+    name: "Place value chart",
+    short: "Place value",
+    heading: "Printable place value chart",
+    keyword: "Free printable place value chart",
+    summary:
+      "Four columns — thousands, hundreds, tens and ones — with eight rows to write numbers into, one digit to a box.",
+    lead: "Thousands, hundreds, tens and ones, headed and ruled, with eight rows underneath. One digit to a box is the whole rule, and it is the rule that makes a number readable: 407 written into the columns has an empty tens box, which is what the nought in it is for.",
+    notes: [
+      "The headings are printed inside the grid rather than above it, which is not a design decision so much as a correctness one. A row of words laid out beside the drawing is two things that have to stay lined up, and a chart with “Tens” sitting half a column left of the tens is a mistake a child copies into their arithmetic rather than one anybody notices.",
+      "It does the work of base-ten blocks on paper. Write 342 into one row and 138 into the next, add each column, and the moment ten ones have to become one ten is a thing that happens in a box rather than a rule to be remembered — which is the same exchange the blocks make, without there being any blocks.",
+    ],
+    teaches: "Place value to thousands",
+    ages: "Ages 6–10",
+    group: "places",
+    config: reference(WORKED, {
+      style: "place-value",
+      places: { largest: 3, smallest: 0 },
+      rows: 8,
+    }),
+  },
+  {
+    slug: "decimal-place-value-chart",
+    name: "Decimal place value chart",
+    short: "Decimals",
+    heading: "Printable decimal place value chart",
+    keyword: "Free printable decimal place value chart",
+    summary:
+      "Six columns from hundreds down to thousandths, with the decimal point ruled where it belongs and eight rows to write in.",
+    lead: "Hundreds, tens, ones, tenths, hundredths and thousandths, with a heavier rule between the ones and the tenths. That rule is the decimal point, drawn where the point is actually written, and it is the thing the whole chart exists to make obvious.",
+    notes: [
+      "The symmetry is the lesson and it is easy to state wrongly. Tenths sit beside ones, not beside tens — the mirror is about the point rather than about the ones column — and a chart that lines the columns up under their headings is a chart on which that can be seen rather than asserted.",
+      "It is the sheet to reach for the first time a child writes 0.7 and 0.70 and is told they are the same number. Written into the columns, the second one has a nought in the hundredths box and nothing else changes, which is a more convincing argument than any sentence about trailing zeros.",
+    ],
+    teaches: "Decimal place value to thousandths",
+    ages: "Ages 8–12",
+    group: "places",
+    config: reference(WORKED, {
+      style: "place-value",
+      places: { largest: 2, smallest: -3 },
+      rows: 8,
+    }),
+  },
+
+  /* ── Plotting ───────────────────────────────────────────────────────── */
+  {
+    slug: "coordinate-grid",
+    name: "Coordinate grid, first quadrant",
+    short: "First quadrant",
+    heading: "Printable coordinate grid",
+    keyword: "Free printable coordinate grid",
+    summary:
+      "A first-quadrant grid with both axes numbered 1 to 10, and nothing negative anywhere on it.",
+    lead: "Two axes running from nought to ten, numbered along both, with the numerals printed in a margin square outside the grid rather than on top of the ruling. Every point on it has two positive whole numbers for coordinates, which is the whole of what makes it the first grid to hand a child.",
+    notes: [
+      "Nothing on this sheet is negative, and that is a choice rather than a limitation. A plane with four quadrants is not a harder version of this one — it is the week negative numbers arrive — and giving it to a child who has not met them is setting an impossible question rather than a stretching one.",
+      "The numbers count the lines, not the squares. A point is a crossing of two rules and not the middle of a box, which is the single commonest thing to get wrong when this is taught at home, and it is why the numerals here sit against the gridlines they name.",
+    ],
+    teaches: "Plotting and reading coordinates",
+    ages: "Ages 7–11",
+    group: "plotting",
+    config: reference(WORKED, {
+      style: "coordinate",
+      quadrants: 1,
+      span: 10,
+    }),
+  },
+  {
+    slug: "four-quadrant-graph-paper",
+    name: "Four quadrant grid",
+    short: "Four quadrants",
+    heading: "Printable four quadrant graph paper",
+    keyword: "Free printable four quadrant graph paper",
+    summary:
+      "Both axes running −10 to 10, crossing in the middle of the page, with every gridline numbered.",
+    lead: "The full plane: two axes crossing at the origin with ten squares out in each of the four directions, and the numbers running −10 to 10 along both. Nought is left unwritten, because the place where the two heavy rules cross is not something anybody needs telling.",
+    notes: [
+      "This is the paper for reflecting and translating shapes as much as for plotting points. A triangle drawn in the first quadrant and reflected in the y axis is a thing a child can check by counting squares, and counting squares is exactly what the grid is there to make possible.",
+      "It is also where a straight-line graph starts to be worth drawing. Plot y = 2x − 3 on this and the line leaves the first quadrant at the bottom, which is the fact that makes the negative half of the paper feel necessary rather than decorative.",
+    ],
+    teaches: "The coordinate plane, and negative coordinates",
+    ages: "Ages 9–13",
+    group: "plotting",
+    config: reference(WORKED, {
+      style: "coordinate",
+      quadrants: 4,
+      span: 10,
+    }),
+  },
+];
+
+/** What each group is called on a hub, in the order they are listed. */
+export const CHART_GROUPS: Array<{
+  id: ChartGroup;
+  label: string;
+  blurb: string;
+}> = [
+  {
+    id: "counting",
+    label: "Counting",
+    blurb: "The two references a child counts on: a chart, and a line.",
+  },
+  {
+    id: "places",
+    label: "Place value",
+    blurb: "Columns to write a number into, one digit to a box.",
+  },
+  {
+    id: "plotting",
+    label: "Plotting",
+    blurb: "Axes to find a point on, with and without negative numbers.",
+  },
+];
+
+/** Whether this sheet's answer key says anything its sheet doesn't. */
+export const keyed = (sheet: ChartSheet): boolean => chartKeyed(sheet.config);
+
+/** The route a sheet prints at. One stock, so one route — see the note above. */
+export const pathFor = (sheet: ChartSheet): string =>
+  `/printables/charts/${sheet.slug}`;
+
+/** The builder, opened on this sheet. */
+export const builderHref = (sheet: ChartSheet): string =>
+  benchHref(sheet.config, CHART_SEED);
+
+/** The shelf, grouped — the shape every page lists it in. */
+export function chartShelf(): Array<{
+  id: ChartGroup;
+  label: string;
+  blurb: string;
+  sheets: ChartSheet[];
+}> {
+  return shelve(CHART_GROUPS, CHART_SHEETS);
+}

--- a/src/pages/printables/charts/[slug].astro
+++ b/src/pages/printables/charts/[slug].astro
@@ -1,0 +1,219 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { answerKey, buildSheet } from "@/engine/sheets";
+import {
+  CHART_SEED,
+  CHART_SHEETS,
+  builderHref,
+  chartShelf,
+  keyed,
+  pathFor,
+  type ChartSheet,
+} from "../_charts";
+
+/**
+ * One prerendered reference sheet per entry — and the page is the sheet.
+ *
+ * The shape §8 describes, on the shelf where what somebody searched for is a
+ * piece of paper rather than an exercise: "printable hundred chart", "number
+ * line to 100" and "place value chart" are queries where the whole of the
+ * answer is the sheet, so there is prose above it, the paper itself under that,
+ * and nothing to click before pressing ⌘P.
+ *
+ * **Only one page here has a key.** Seven of the eight withhold nothing — a
+ * chart, a line and a grid are supposed to be blank — and printing the same
+ * page twice under the word "key" would be noise on a parent's printer. `keyed`
+ * is the engine's own answer to that (`chartKeyed`), so the page and the family
+ * cannot disagree about which is which.
+ *
+ * **One stock.** Nothing here is a stated measurement, so there is no A4 twin
+ * to keep in step — which is also why this is a single-segment `[slug]` rather
+ * than a rest pattern. Graph paper is the case where that is not true, and it
+ * is on the shelf that prints both.
+ *
+ * **No client directive on `SheetView`, ever.** `@astrojs/react` renders a
+ * component with no `client:*` to HTML at build time, so these pages ship zero
+ * JavaScript — the whole SEO argument of §2. `Sheet.test.tsx` holds every page
+ * in this directory to it, against the source and against `dist/`.
+ *
+ * **Everything that is not the sheet carries `.no-print`.** `@page` cannot be
+ * scoped to a class, so the zeroed page margin a sheet needs applies to the
+ * prose as well and it would print off the edge.
+ */
+
+type Props = { sheet: ChartSheet };
+
+export function getStaticPaths() {
+  return CHART_SHEETS.map((sheet) => ({
+    params: { slug: sheet.slug },
+    props: { sheet },
+  }));
+}
+
+const { sheet } = Astro.props;
+
+const printed = buildSheet(sheet.config, CHART_SEED);
+const key = keyed(sheet) ? answerKey(sheet.config, CHART_SEED) : null;
+
+const title = `${sheet.keyword} | School Skills`;
+const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const url = `https://schoolskills.app${pathFor(sheet)}`;
+
+const groups = chartShelf();
+const group = groups.find((entry) => entry.id === sheet.group)!;
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    name: sheet.heading,
+    description,
+    url,
+    learningResourceType: "Reference sheet",
+    educationalUse: "Practice",
+    teaches: sheet.teaches,
+    typicalAgeRange: sheet.ages,
+    isAccessibleForFree: true,
+    inLanguage: "en",
+  }}
+>
+  <header class="hero wrap no-print">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Charts and grids &middot; {group.label}
+    </p>
+    <h1 class="hero__title">{sheet.heading}</h1>
+    <p class="hero__lead">{sheet.lead}</p>
+    <p class="aside">
+      The sheet below <strong>is</strong> the printout{
+        keyed(sheet) ? ", and the page behind it is the completed chart" : ""
+      }. Press <strong>&#8984;P</strong> &mdash; <strong>Ctrl+P</strong> on Windows
+      &mdash; and everything but the paper disappears. To keep a copy instead, pick
+      <em>Save as PDF</em> in the print dialog and your browser writes one.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  {
+    /*
+      The sheets, outside `.wrap` deliberately. A wrap adds an inline padding
+      that print.css cannot take back off, and a sheet printed a centimetre in
+      from where it says it is has the wrong geometry everywhere at once. The
+      key is a sibling of the sheet with nothing between them, because
+      print.css breaks pages on `.sheet + .sheet` as well.
+    */
+  }
+  <div class="sheet-frame">
+    <SheetView sheet={printed} />
+    {key && <SheetView sheet={key} />}
+  </div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">What is on this sheet</h2>
+    <div class="prose">
+      {sheet.notes.map((note) => <p>{note}</p>)}
+      <p>
+        Every line on the page above is drawn as ink rather than as a
+        background, which is why it comes out of the printer looking like it
+        does on screen: browsers throw background colour away unless somebody
+        has ticked <em>Background graphics</em>, and a chart printed as a set of
+        empty boxes is worse than no chart. The lengths are in inches for the
+        same sort of reason &mdash; a square that says it is three quarters of
+        an inch is three quarters of an inch, because a child measuring against
+        it will find out if it isn&rsquo;t. The number in the footer is the seed
+        the sheet was built from, so the identical sheet can be had again next
+        week.
+      </p>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Change what is on it</h2>
+    <div class="prose">
+      <p>
+        This page is one sheet out of a family that prints four: a hundred
+        chart, a number line, a coordinate grid and a place-value chart. The
+        range, the interval, how far the axes run and which places the columns
+        hold are all settings &mdash; so a number line every 2 to 30, or a chart
+        from 101 to 200, is the same sheet with one control moved rather than a
+        page somebody has to have written first.
+      </p>
+      <p class="aside">
+        The settings travel in the link rather than on a server, so a sheet you
+        make can be bookmarked or sent to another family as it stands &mdash;
+        and the <em>Name:</em> line, where a sheet has one, is printed blank, because
+        there is nowhere in a shared link to put a child&rsquo;s name. See{" "}
+        <a href="/privacy">what we don&rsquo;t collect</a>.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href={builderHref(sheet)}>
+        Open this sheet in the builder
+      </a>
+      <a class="cta cta--quiet" href="/printables/charts">
+        All the charts and grids
+      </a>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">The two references that live next door</h2>
+    <div class="prose">
+      <p>
+        A multiplication grid &mdash; blank to fill in, with the completed
+        twelve-by-twelve square on the page behind it &mdash; is on the maths
+        shelf, because it is the times-table family with the grid switched on
+        rather than a chart of its own. Squared, dotted and isometric paper is
+        on the paper shelf, where everything comes on both Letter and A4: a
+        quarter-inch square scaled to fit whatever was in the tray is no longer
+        a quarter-inch square.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/multiplication-chart">
+        Multiplication chart
+      </a>
+      <a class="cta cta--quiet" href="/printables/graph-paper">Graph paper</a>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap no-print">
+    <h2 class="h2">Every chart and grid</h2>
+    <p class="h2__sub">
+      {CHART_SHEETS.length} pages, each one a sheet like this one. Nothing is locked
+      and nothing needs an account.
+    </p>
+    {
+      groups.map((entry) => (
+        <>
+          <h3 class="h2 h2--next">{entry.label}</h3>
+          <p class="h2__sub">{entry.blurb}</p>
+          <nav class="stones" aria-label={entry.label}>
+            {entry.sheets.map((candidate) => (
+              <a
+                class="stone"
+                href={pathFor(candidate)}
+                aria-current={
+                  candidate.slug === sheet.slug ? "page" : undefined
+                }
+              >
+                {candidate.short}
+              </a>
+            ))}
+          </nav>
+        </>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/charts/index.astro
+++ b/src/pages/printables/charts/index.astro
@@ -1,0 +1,186 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import { CHART_SHEETS, chartShelf, pathFor } from "../_charts";
+
+/**
+ * The charts-and-grids hub — a peer of `/printables/math`,
+ * `/printables/spelling`, `/printables/grammar`, `/printables/phonics`,
+ * `/printables/handwriting`, `/printables/cursive` and `/printables/bible`.
+ *
+ * A listing rather than a sheet, like the other hubs, and that is the right
+ * split: nobody searches for "printable list of maths charts". What it is for
+ * is the two jobs a hub does — giving a parent who arrived on
+ * `/printables/charts/hundred-chart` somewhere to go next, and giving the eight
+ * pages a crawlable parent that says what they have in common.
+ *
+ * What they have in common is worth a section of its own here, because it is
+ * the argument for the whole shelf: a reference sheet is the one kind of
+ * printable whose only job is to be *right*. There are no problems on it to get
+ * wrong and no answer key to check — so the hundred squares have to be a
+ * hundred, the ticks have to be evenly spaced, and the heading has to sit over
+ * the column it names.
+ */
+const title =
+  "Free printable maths charts, number lines and grids | School Skills";
+const description =
+  "Printable reference sheets: hundred charts blank and filled, number lines with the interval you choose, first-quadrant and four-quadrant coordinate grids, and place-value charts down to thousandths. Real inches, drawn as ink so they print — free, no account, no download.";
+
+const groups = chartShelf();
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Printable maths charts and grids",
+    description,
+    url: "https://schoolskills.app/printables/charts",
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    hasPart: CHART_SHEETS.map((sheet) => ({
+      "@type": "LearningResource",
+      name: sheet.heading,
+      url: `https://schoolskills.app${pathFor(sheet)}`,
+      learningResourceType: "Reference sheet",
+      teaches: sheet.teaches,
+      typicalAgeRange: sheet.ages,
+      isAccessibleForFree: true,
+    })),
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      Charts and grids
+    </p>
+    <h1 class="hero__title">The references a lesson is done against</h1>
+    <p class="hero__lead">
+      {CHART_SHEETS.length} sheets with no problems on them: hundred charts blank
+      and filled, number lines at the interval you choose, coordinate grids with and
+      without negative numbers, and place-value columns down to thousandths.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  {
+    /*
+      What exists, first — before the page explains itself. Somebody who came
+      looking for a hundred chart should be one link from a hundred chart, and
+      the argument about geometry reads better after you have seen one.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">On the shelf now</h2>
+    <p class="h2__sub">
+      Each of these is a page that is itself the sheet &mdash; open it, press
+      print, and that is the whole of it. Only the blank hundred chart has a
+      second page, because it is the only one of the eight that withholds
+      anything.
+    </p>
+    {
+      groups.map((group) => (
+        <>
+          <h3 class="h2 h2--next">{group.label}</h3>
+          <p class="h2__sub">{group.blurb}</p>
+          <div class="prose">
+            <ul>
+              {group.sheets.map((sheet) => (
+                <li>
+                  <a href={pathFor(sheet)}>{sheet.name}</a> &mdash;{" "}
+                  {sheet.summary}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      ))
+    }
+  </section>
+
+  <div class="wrap"><AdSlot name="article" /></div>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">A reference sheet only has to be right</h2>
+      <p class="h2__sub">
+        There is nothing on any of these pages to answer, which means there is
+        nowhere for a mistake in one to hide.
+      </p>
+      <div class="prose">
+        <p>
+          A worksheet can be marked. A chart cannot: a child measures against
+          it, counts along it and trusts it, and if a number line has a hundred
+          intervals and a hundred ticks then the sheet is wrong and nothing on
+          the page will say so. So the counting here is arithmetic rather than
+          appearance &mdash; a line to 20 has twenty-one ticks, a hundred chart
+          has ten rows of ten with nothing missing off the end, a grid that runs
+          to 10 has eleven gridlines each way, and a heading is printed inside
+          the column it names rather than laid out beside it.
+        </p>
+        <p>
+          The lengths are in real units for the same reason. Everything else on
+          this site scales with the age of the child using it; a sheet of paper
+          must not, because three quarters of an inch is three quarters of an
+          inch or it is nothing. And every rule is drawn as ink rather than as a
+          background colour, because browsers throw background colour away when
+          printing unless somebody has ticked a box in the print dialog &mdash;
+          which is how a perfectly good chart comes out of the printer as a page
+          of empty squares.
+        </p>
+        <p>
+          What is a setting is the sheet itself. The range on a chart, the
+          interval on a line, how far the axes run, which places the columns
+          hold: all four are controls in the builder, so a number line every 2
+          to 30 or a chart from 101 to 200 is the same page with one number
+          moved. There are eight pages here rather than eighty because eight is
+          what a parent actually asks for, and the rest is a stepper.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">And the two that live next door</h2>
+    <div class="prose">
+      <p>
+        A <a href="/printables/multiplication-chart">multiplication chart</a> is on
+        the maths shelf, blank with the completed twelve-by-twelve square on the page
+        behind it &mdash; it is the times-table family with the grid switched on rather
+        than a chart of its own.{" "}
+        <a href="/printables/graph-paper">Squared</a>,{" "}
+        <a href="/printables/dot-grid-paper">dotted</a> and{" "}
+        <a href="/printables/isometric-graph-paper">isometric</a> paper is on the
+        paper shelf, where everything comes on both Letter and A4: a quarter-inch
+        square scaled to fit whatever was in the tray is no longer a quarter-inch
+        square.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta" href="/printables/math">Maths worksheets</a>
+      <a class="cta cta--quiet" href="/printables/make"
+        >Open the sheet builder</a
+      >
+    </div>
+  </section>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Your child&rsquo;s name is not in the file</h2>
+    <div class="prose">
+      <p>
+        Where a sheet here has a <em>Name:</em> line at all, it is printed blank and
+        filled in with a pencil. No account is needed to print anything, nothing is
+        uploaded, and a sheet you send to another family carries the settings you
+        chose and nothing else &mdash; see <a href="/privacy"
+          >what we don&rsquo;t collect</a
+        >.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -2,6 +2,7 @@
 import Content from "@/layouts/Content.astro";
 import { BIBLE_SHEETS, bibleShelf, hrefFor as bibleHref } from "./_bible";
 import { STOCKS, pathFor, shelf } from "./_catalog";
+import { CHART_SHEETS, chartShelf, pathFor as chartPath } from "./_charts";
 import {
   CURSIVE_SHEETS,
   cursiveShelf,
@@ -42,15 +43,16 @@ import {
  * It lists what exists and nothing else. A shelf of links to sheets that
  * haven't been built is the thin-content pattern Base.astro's `noindex` block
  * already argues against, and a catalog page here is meant to BE the worksheet
- * — real prerendered HTML a parent can print without touching anything. Eight
+ * — real prerendered HTML a parent can print without touching anything. Nine
  * families fill it: every ruling in §5 on both stocks, the curated maths topics
  * of §8, each of which prints its own answer key, the handwriting and cursive
  * sheets, which come on both stocks for the same reason the paper does, the
  * Scripture shelf, which is those same families with a passage on them, the
  * spelling shelf, which is the one whose content a parent can replace with their
  * own list, the grammar shelf, which is the one whose answers had to be written
- * down because they cannot be worked out, and the phonics shelf, which is the
- * one whose content is decided by what a parent says has been taught.
+ * down because they cannot be worked out, the phonics shelf, which is the one
+ * whose content is decided by what a parent says has been taught, and the charts
+ * shelf, which is the one with no questions on it at all.
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
@@ -66,6 +68,7 @@ const scripture = bibleShelf();
 const words = spellingShelf();
 const sentences = grammarShelf();
 const sounds = phonicsShelf();
+const references = chartShelf();
 ---
 
 <Content
@@ -108,15 +111,16 @@ const sounds = phonicsShelf();
   <section class="band band--tight wrap">
     <h2 class="h2">On the shelf now</h2>
     <p class="h2__sub">
-      Eight families: maths worksheets, each with its answer key on the page
+      Nine families: maths worksheets, each with its answer key on the page
       behind it, handwriting practice that traces before it copies, the same
       progression again in cursive, Scripture copywork and memory work, spelling
       and word study on this week&rsquo;s list or your own, grammar whose
       answers were written down rather than worked out, phonics built from the
-      sounds you have taught, and paper in every ruling. Each of these is a page
-      that is itself the sheet &mdash; open it, press print, and that is the
-      whole of it. Everything ruled comes on both stocks, because a ruling
-      shrunk to fit whatever is in the tray is no longer the ruling you chose.
+      sounds you have taught, charts and grids with nothing to answer on them,
+      and paper in every ruling. Each of these is a page that is itself the
+      sheet &mdash; open it, press print, and that is the whole of it.
+      Everything ruled comes on both stocks, because a ruling shrunk to fit
+      whatever is in the tray is no longer the ruling you chose.
     </p>
 
     <h3 class="h2 h2--next">Maths worksheets</h3>
@@ -264,6 +268,27 @@ const sounds = phonicsShelf();
       <a class="cta" href="/printables/phonics">All the phonics sheets</a>
     </div>
 
+    <h3 class="h2 h2--next">Charts and grids</h3>
+    <p class="h2__sub">
+      {CHART_SHEETS.length} references with no problems on them &mdash; hundred charts
+      blank and filled, number lines at the interval you choose, coordinate grids
+      with and without negative numbers, and place-value columns down to thousandths.
+    </p>
+    {
+      references.map((group) => (
+        <nav class="stones" aria-label={`Charts — ${group.label}`}>
+          {group.sheets.map((sheet) => (
+            <a class="stone" href={chartPath(sheet)}>
+              {sheet.short}
+            </a>
+          ))}
+        </nav>
+      ))
+    }
+    <div class="hero__actions">
+      <a class="cta" href="/printables/charts">All the charts and grids</a>
+    </div>
+
     {
       /*
         Paper keeps its groups and its one-line summaries; every subject shelf
@@ -321,17 +346,18 @@ const sounds = phonicsShelf();
       <p class="h2__sub">
         The Print Shop is opening a family at a time, and this page lists what
         exists rather than what is planned. Paper, maths, handwriting, cursive,
-        copywork, spelling, grammar and phonics are open. The charts and forms
-        are next.
+        copywork, spelling, grammar, phonics and the blank references are open.
+        The certificates, logs and planners are next.
       </p>
       <div class="prose">
         <p>
           The order it opened in: the paper, the maths sheets, the handwriting
           and the cursive above, then the copywork &mdash; a few hundred
           passages from the public domain, Scripture among them &mdash; then the
-          spelling and word-study shelf, the grammar sheets beside it, and the
-          phonics shelf after them. What is left is the charts, certificates and
-          planners that are simply blank forms.
+          spelling and word-study shelf, the grammar sheets beside it, the
+          phonics shelf after them, and then the charts and grids &mdash; the
+          first family here with nothing on it to answer. What is left is the
+          certificates, reading logs and planners that are simply blank forms.
         </p>
         <p>
           The one it is really being built for comes with the sheet builder:

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -563,10 +563,22 @@
 }
 
 /* A number line and a workspace are both a full row of their own under the
-   problem they belong to, rather than something beside it. */
+   problem they belong to, rather than something beside it.
+
+   The growth is scoped to that problem row, and the scoping is load-bearing.
+   `.sheet__problem` is a wrapping flex *row*, where `flex: 1 0 100%` means "a
+   line to yourself"; `.sheet__blocks` is a flex *column*, where the same
+   declaration means "take all the height that is going". A number line is now
+   both — an aid under a sum, and a block of its own on a reference sheet — and
+   unscoped, the reference strips stretched to fill the page and printed at six
+   times the height the layout arithmetic had reserved for them. */
 .sheet__workspace,
 .sheet__number-line {
   display: block;
+}
+
+.sheet__problem > .sheet__workspace,
+.sheet__problem > .sheet__number-line {
   flex: 1 0 100%;
 }
 


### PR DESCRIPTION
Closes #70.

## What this is

The second family in the "templates" tier of `docs/printables.md`, and the first
with no questions on it at all: paper a lesson is done *against* rather than on.
`src/engine/sheets/templates/charts.ts` is four views of one idea —

- **Hundred charts**, blank and filled, over a configurable range.
- **Number lines**, with the range and interval a parent sets.
- **Coordinate grids**, first-quadrant and four-quadrant.
- **Place-value charts**, whole numbers through thousandths.

They reach parents two ways. Eight prerendered catalog pages at
`/printables/charts` (hundred chart, blank hundred chart, number line, number
line to 100, place-value chart, decimal place-value chart, coordinate grid,
four-quadrant graph paper) — each directly printable with nothing to click — and
a `charts` option panel on the bench for anything off the shelf. The paper shelf
also picks up the four metric squares it was missing: 1 cm and 5 mm graph, 1 cm
dots, 1 cm isometric.

## What is deliberately not here

**A multiplication grid is not rebuilt.** It is `/printables/multiplication-chart`
— the times-table family with `style: "grid"` on it, blank with the completed
square on the page behind. **Graph paper is the grid end of the paper shelf**,
which prints both stocks because a quarter-inch square scaled to fit is no longer
a quarter-inch square. Both are *linked* from the charts catalog rather than
duplicated: a second family that drew a times-table square would be a second
answer to what goes in square forty-two.

## Why the tests look the way they do

A worksheet can be marked, so a mistake on one is found. A reference sheet is
counted along and trusted, and nothing on the page says when it is wrong — so
being one out *is* the bug. Every count is verified off the finished blocks and
off the rendered markup, never off the arithmetic that produced them: a 1–100
chart has ten rows of ten numbered 1 to 100; a chart asked for 1–105 prints
1–110, because a ragged last row teaches the opposite of what the shape is for;
a 0–100 line marked every 1 carries a hundred and one ticks, and what thins out
is the numerals (`labelEvery` steps back to a stride a child counts in *and*
that divides the run, so the end of the line keeps its number); a first-quadrant
plane to ten has eleven gridlines each way and nothing negative on it. Measured
in a browser, the hundred chart's square is 72px at 96dpi — three quarters of an
inch, exactly.

Three failures only a browser could find, all fixed here:

- **The title nobody reserved for.** `chromeHeight` reserves a title row only if
  the *options* it is handed carry one, and this family prints a title whatever
  its config says. Passing the config straight in under-reserved by a row, and
  `.sheet` is `min-height`, so nothing overflowed on screen — the place-value
  chart just came out 11.36in long. `headerOf` is the fix, and the suite now
  measures the chrome the finished sheet carries rather than what the family
  reserved.
- **`flex: 1 0 100%` means two things.** In `.sheet__problem`, a wrapping flex
  row, it means "a line to yourself"; in `.sheet__blocks`, a flex column, it
  means "take all the height going". A number line is now both, and unscoped the
  reference strips printed at six times their declared height while looking
  deliberate, because they spread evenly down the page.
- **Two flex gaps per spacer, not one.** A spacer is a block, so one between two
  strips buys the column a second gap to charge for.

## Shape

`GridSpec.row` is the one new field, and one chart in the shop sets it: a
place-value column is as wide as the word "Hundreds" and its rows are one digit
tall, so squaring them prints either a chart a third of the page wide or one
that runs off the bottom. Everything a child measures against leaves it unsaid
and gets squares by construction. Headings are drawn *inside* the grid rather
than laid out beside it — that is the whole of how "Tens" is guaranteed to sit
over the tens.

Also hoists the per-tick label stride and minor-tick length out of
`NumberLineView`'s map: worked out once rather than a hundred and one times.

## Validation

`npm run type-check`, `npm run lint`, `npm run test:unit` (1286 tests, 60 files),
`npm run build` (166 static pages) and the browser smoke test all pass locally,
with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
