### PR TITLE
PRINT28: browse printables by grade and subject

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -394,6 +394,23 @@ grade × operation × difficulty is a doorway-page farm, and the `noindex`
 reasoning in `Base.astro` shows this codebase already knows why that's a
 liability. Curate the slugs; generate the sheets.
 
+**What shipped (PRINT28), and the one decision inside it.** Ten year pages,
+Pre-K through 8th, over the nine subject hubs that were already there. The
+decision that made them possible without inventing anything: **a grade is read
+off the sheets, never written onto them.** Every catalog entry already stated
+the ages it was drawn for — `Ages 8–11` on the division worksheet — so a year
+page is the sheets whose stated band reaches the two ages a child is in that
+year, and `_grades.ts` is a parser and an overlap test rather than a second
+table of judgements to keep true. A sheet therefore appears on two or three of
+the ten, which is the honest answer and is what the pages say out loud; the
+alternative, a grade level asserted by a worksheet site, is a guess dressed as
+a standard. `_shelves.ts` is the registry the year pages read, and `hub: false`
+on paper is the only entry whose "all of it" link is the front door: fifteen
+rulings are chosen by reading how one differs from the next, which is what
+`/printables` already sets out. The counts on a hub are computed and its three
+landmarks are routes whose names are read back out of the catalog, so neither a
+number nor a sheet's name exists twice.
+
 ### The sitemap landmine
 
 `astro.config.mjs` filters **every `WORLDS[].href` out of the sitemap**,

--- a/src/pages/printables/_HubLinks.astro
+++ b/src/pages/printables/_HubLinks.astro
@@ -1,0 +1,78 @@
+---
+import { GRADES, gradeHref } from "./_grades";
+import { HUBS, type ShelfId } from "./_shelves";
+
+/**
+ * The two rows every hub in the Print Shop ends with: the other shelves, and
+ * the ten school years.
+ *
+ * Underscored so Astro leaves it out of the routing table — the same trick the
+ * catalogs use, applied to markup rather than to data. It lives beside
+ * `_shelves.ts` and `_grades.ts` rather than in `src/components/` because that
+ * is where the data it reads lives, and a component in the shared directory
+ * would have to import from `src/pages/` to build itself, which is the
+ * dependency direction the layer rules exist to prevent.
+ *
+ * **A page nothing links to is a page nothing ranks**, which is why this is a
+ * component rather than a paragraph typed eleven times. The grade hubs are new
+ * and every one of them is reachable in one click from every other hub here;
+ * the day a shelf is added it appears at the foot of all of them without any
+ * page being edited.
+ *
+ * The current page is marked rather than dropped. A nav that silently omits
+ * where you are is a nav a reader has to count, and `.stone[aria-current]`
+ * already has a look — the same one the neighbouring-sheet rows use.
+ */
+interface Props {
+  /** The shelf this page is, where it is one. */
+  shelf?: ShelfId;
+  /** The year this page is, where it is one. */
+  grade?: string;
+}
+
+const { shelf, grade } = Astro.props;
+---
+
+<section class="band band--tight wrap no-print">
+  <h2 class="h2">The rest of the Print Shop</h2>
+  <p class="h2__sub">
+    Nine shelves and ten school years, over the same sheets. A shelf is what a
+    sheet <em>is</em>; a year is who it was drawn for, which every sheet states
+    on its own page.
+  </p>
+
+  <h3 class="h2 h2--next">By subject</h3>
+  <nav class="stones" aria-label="Printable subjects">
+    {
+      HUBS.map((hub) => (
+        <a
+          class="stone"
+          href={hub.href}
+          aria-current={hub.id === shelf ? "page" : undefined}
+        >
+          {hub.label}
+        </a>
+      ))
+    }
+  </nav>
+
+  <h3 class="h2 h2--next">By grade</h3>
+  <nav class="stones" aria-label="Printables by grade">
+    {
+      GRADES.map((year) => (
+        <a
+          class="stone"
+          href={gradeHref(year)}
+          aria-current={year.slug === grade ? "page" : undefined}
+        >
+          {year.short}
+        </a>
+      ))
+    }
+  </nav>
+  <div class="hero__actions">
+    <a class="cta cta--quiet" href="/printables/grade">
+      What each year is for
+    </a>
+  </div>
+</section>

--- a/src/pages/printables/_grades.test.ts
+++ b/src/pages/printables/_grades.test.ts
@@ -247,6 +247,32 @@ describe("what a year lists", () => {
       "8th-grade",
     ]);
   });
+
+  it("knows which sheet names collide with a year's own name", () => {
+    // The year prose cannot be built out of `grade.label`. One ruling in the
+    // paper catalog is called "Kindergarten writing paper — 1 inch", after the
+    // size it is conventionally sold at, and its own "Ages 4–6" puts it on both
+    // the Pre-K and the kindergarten page — so a sentence reading "No sheet is
+    // labelled Kindergarten" would ship directly above a link disproving it.
+    //
+    // Pinned rather than forbidden: the sheet's name is right and its ages are
+    // right, and nothing should be renamed to make an assertion easier. What
+    // must not happen quietly is a SECOND such name arriving — a "First grade
+    // writing paper", say — under prose that has been reworded back into
+    // naming years. A new entry here fails this test and sends whoever added
+    // it to `grade/[grade].astro` to check the sentence still holds.
+    const collisions = GRADES.flatMap((grade) =>
+      sheetsForGrade(grade)
+        .filter((sheet) =>
+          sheet.name.toLowerCase().includes(grade.label.toLowerCase()),
+        )
+        .map((sheet) => `${grade.slug} → ${sheet.name}`),
+    );
+
+    expect(collisions).toEqual([
+      "kindergarten → Kindergarten writing paper — 1 inch",
+    ]);
+  });
 });
 
 describe("the three sheets a year opens with", () => {

--- a/src/pages/printables/_grades.test.ts
+++ b/src/pages/printables/_grades.test.ts
@@ -1,0 +1,342 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { BIBLE_SHEETS } from "./_bible";
+import { PAPER_SHEETS, STOCKS } from "./_catalog";
+import { CHART_SHEETS } from "./_charts";
+import { CURSIVE_SHEETS } from "./_cursive";
+import {
+  GRADES,
+  ageBand,
+  ageRange,
+  gradeHref,
+  sheetByHref,
+  sheetsForGrade,
+  shelvesForGrade,
+} from "./_grades";
+import { GRAMMAR_SHEETS } from "./_grammar";
+import { HANDWRITING_SHEETS } from "./_handwriting";
+import { MATHS_SHEETS } from "./_maths";
+import { PHONICS_SHEETS } from "./_phonics";
+import { ALL_SHEETS, HUBS, SHELVES } from "./_shelves";
+import { SPELLING_SHEETS } from "./_spelling";
+import { TEMPLATE_SHEETS } from "./_templates";
+
+/**
+ * The two hubs that cut across the shelves, held to the two things a hub can
+ * get wrong without anything failing.
+ *
+ * **A link to a page that isn't there.** A catalog page that lists a sheet
+ * nobody built still renders, still deploys and still looks right; the reader
+ * finds out. So every route these pages emit is checked against `dist/` rather
+ * than against the data that generated it — the same standard the sitemap
+ * checks in the sibling catalogs use, and skipped identically when the build
+ * hasn't run.
+ *
+ * **A claim the page cannot back up.** The counts on a grade hub are computed,
+ * so they cannot drift; the sentences are not, and the two that make a factual
+ * claim are pinned here — the three landmarks a year recommends, and the
+ * eighth-grade page's statement about which shelves stop before it.
+ */
+
+const ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/** Where a route's HTML lands, with `build.format: "directory"`. */
+const built = (href: string): string => `${ROOT}/dist${href}/index.html`;
+
+const bySlug = (slug: string) => {
+  const grade = GRADES.find((entry) => entry.slug === slug);
+  if (!grade) throw new Error(`no grade at ${slug}`);
+  return grade;
+};
+
+describe("the shelf registry", () => {
+  it("holds every sheet in the shop, once", () => {
+    // The registry is a hand-written list of ten catalogs, which is the one
+    // way a shelf gets left off every grade page at once: nothing else in the
+    // codebase would notice, because each catalog's own tests still pass.
+    const catalogued =
+      MATHS_SHEETS.length +
+      HANDWRITING_SHEETS.length +
+      CURSIVE_SHEETS.length +
+      BIBLE_SHEETS.length +
+      SPELLING_SHEETS.length +
+      GRAMMAR_SHEETS.length +
+      PHONICS_SHEETS.length +
+      CHART_SHEETS.length +
+      TEMPLATE_SHEETS.length +
+      PAPER_SHEETS.length;
+
+    expect(ALL_SHEETS).toHaveLength(catalogued);
+    expect(new Set(ALL_SHEETS.map((sheet) => sheet.href)).size).toBe(
+      catalogued,
+    );
+  });
+
+  it("links the paper shelf at the front door and every other at its own hub", () => {
+    // Paper is the exception the `hub` flag exists for: its fifteen rulings are
+    // set out on /printables itself, because a ruling is chosen by reading what
+    // makes it different from the ruling beside it.
+    expect(HUBS.map((shelf) => shelf.id)).not.toContain("paper");
+    expect(HUBS).toHaveLength(SHELVES.length - 1);
+    for (const shelf of HUBS) {
+      expect(shelf.href.startsWith("/printables/"), shelf.id).toBe(true);
+    }
+    const paper = SHELVES.find((shelf) => shelf.id === "paper");
+    expect(paper?.href).toBe("/printables");
+  });
+
+  it("lists paper on the stock the front door lists it on", () => {
+    // Letter, and no `/a4` suffix: each sheet page carries the link to its twin.
+    const paper = SHELVES.find((shelf) => shelf.id === "paper");
+    expect(STOCKS[0].path).toBe("");
+    for (const sheet of paper?.sheets ?? []) {
+      expect(sheet.href, sheet.name).not.toMatch(/\/a4$/);
+    }
+  });
+});
+
+describe("reading a sheet's stated ages", () => {
+  it("reads the two shapes the catalogs write, and refuses a third", () => {
+    expect(ageBand("Ages 6–9")).toEqual([6, 9]);
+    expect(ageBand("Ages 4+")).toEqual([4, Infinity]);
+    // Throwing rather than returning nothing is the point: a silent miss would
+    // drop the sheet off all ten grade pages with every test still green.
+    expect(() => ageBand("Ages 6-9")).toThrow(); // hyphen, not an en dash
+    expect(() => ageBand("Ages 6 to 9")).toThrow();
+    expect(() => ageBand("KS1")).toThrow();
+  });
+
+  it("reads every sheet in the shop", () => {
+    for (const sheet of ALL_SHEETS) {
+      const [from, to] = ageBand(sheet.ages);
+      expect(from, sheet.href).toBeGreaterThanOrEqual(3);
+      expect(to, sheet.href).toBeGreaterThan(from);
+    }
+  });
+});
+
+describe("the ten years", () => {
+  it("runs Pre-K to 8th, a year at a time and with no gap", () => {
+    expect(GRADES).toHaveLength(10);
+    expect(GRADES[0].slug).toBe("pre-k");
+    expect(GRADES[9].slug).toBe("8th-grade");
+
+    for (const grade of GRADES) {
+      expect(grade.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+      // Two ages to a year: six in the autumn, seven by the spring.
+      expect(grade.ages[1], grade.slug).toBe(grade.ages[0] + 1);
+    }
+    for (const [index, grade] of GRADES.slice(1).entries()) {
+      expect(grade.ages[0], grade.slug).toBe(GRADES[index].ages[0] + 1);
+    }
+    expect(new Set(GRADES.map((grade) => grade.slug)).size).toBe(GRADES.length);
+    expect(ageRange(bySlug("3rd-grade"))).toBe("8-9");
+  });
+
+  it("answers a different query on every page", () => {
+    const keywords = GRADES.map((grade) => grade.keyword.toLowerCase());
+    expect(new Set(keywords).size).toBe(keywords.length);
+  });
+
+  it("carries prose on every page rather than a filled-in template", () => {
+    for (const grade of GRADES) {
+      expect(grade.notes.length, grade.slug).toBeGreaterThanOrEqual(2);
+      for (const note of grade.notes)
+        expect(note.length, grade.slug).toBeGreaterThan(200);
+      expect(grade.lead.length, grade.slug).toBeGreaterThan(100);
+    }
+  });
+
+  it("never claims a path a sheet already prints on", () => {
+    // /printables/grade/3rd-grade is two segments where a sheet is one, so the
+    // patterns cannot collide today. Asserted anyway: the day somebody adds a
+    // shelf at /printables/grade/… , Astro has two routes for one URL.
+    const taken = new Set(ALL_SHEETS.map((sheet) => sheet.href));
+    for (const grade of GRADES) {
+      expect(taken.has(gradeHref(grade)), grade.slug).toBe(false);
+    }
+  });
+});
+
+describe("what a year lists", () => {
+  it("lists something from most of the shop, every year", () => {
+    for (const grade of GRADES) {
+      const shelves = shelvesForGrade(grade);
+      expect(shelves.length, grade.slug).toBeGreaterThanOrEqual(4);
+      expect(sheetsForGrade(grade).length, grade.slug).toBeGreaterThan(20);
+      // An empty shelf is dropped rather than printed as a heading with
+      // nothing under it.
+      for (const shelf of shelves)
+        expect(
+          shelf.sheets.length,
+          `${grade.slug}/${shelf.id}`,
+        ).toBeGreaterThan(0);
+    }
+  });
+
+  it("lists Scripture beside everything else, in every year", () => {
+    // §12, and an acceptance criterion of its own: the Scripture sheets are
+    // listed under their own heading among the other shelves rather than
+    // cordoned off — and there is a passage for every age in the catalog.
+    for (const grade of GRADES) {
+      const shelves = shelvesForGrade(grade).map((shelf) => shelf.id);
+      expect(shelves, grade.slug).toContain("bible");
+      // Among the others, not alone: a year with only Scripture on it would
+      // pass the line above and fail what it means.
+      expect(shelves.length, grade.slug).toBeGreaterThan(1);
+    }
+  });
+
+  it("leaves no sheet unreachable from any year", () => {
+    const listed = new Set(
+      GRADES.flatMap((grade) => sheetsForGrade(grade)).map(
+        (sheet) => sheet.href,
+      ),
+    );
+    for (const sheet of ALL_SHEETS) {
+      expect(listed.has(sheet.href), sheet.href).toBe(true);
+    }
+  });
+
+  it("stops the shelves that stop, on the eighth-grade page", () => {
+    // The one claim the eighth-grade prose makes about what is NOT there:
+    // "no handwriting, cursive, phonics, spelling or grammar sheet on this
+    // page, because every one of those states an age range that ends before
+    // thirteen". Re-ageing a single catalog entry would make that a lie.
+    const shelves = shelvesForGrade(bySlug("8th-grade")).map(
+      (shelf) => shelf.id,
+    );
+    for (const absent of [
+      "handwriting",
+      "cursive",
+      "phonics",
+      "spelling",
+      "grammar",
+    ]) {
+      expect(shelves, absent).not.toContain(absent);
+    }
+    expect(shelves).toContain("math");
+    expect(shelves).toContain("paper");
+  });
+
+  it("puts a sheet on every year its own ages reach, and no other", () => {
+    // The mechanism the pages describe in as many words, spot-checked at both
+    // ends: a sheet for 9–12 belongs to the fourth-grader and the seventh, and
+    // an open-ended ruling belongs to everybody old enough for it.
+    const on = (href: string) =>
+      GRADES.filter((grade) =>
+        sheetsForGrade(grade).some((sheet) => sheet.href === href),
+      ).map((grade) => grade.slug);
+
+    expect(on("/printables/long-division-worksheets")).toEqual([
+      "3rd-grade",
+      "4th-grade",
+      "5th-grade",
+      "6th-grade",
+      "7th-grade",
+    ]);
+    expect(on("/printables/templates/blank-flashcards")).toEqual(
+      GRADES.map((grade) => grade.slug),
+    );
+    expect(on("/printables/narrow-ruled-paper")).toEqual([
+      "6th-grade",
+      "7th-grade",
+      "8th-grade",
+    ]);
+  });
+});
+
+describe("the three sheets a year opens with", () => {
+  it("names a sheet that exists", () => {
+    for (const grade of GRADES) {
+      for (const pick of grade.landmarks) {
+        expect(
+          sheetByHref(pick.href),
+          `${grade.slug} → ${pick.href}`,
+        ).toBeTruthy();
+      }
+    }
+  });
+
+  it("names a sheet this year's ages actually reach", () => {
+    // The failure this exists for: a catalog entry re-aged in the file that
+    // owns it, leaving a hand-written recommendation pointing at a sheet the
+    // listing underneath it no longer shows.
+    for (const grade of GRADES) {
+      const listed = new Set(sheetsForGrade(grade).map((sheet) => sheet.href));
+      for (const pick of grade.landmarks) {
+        expect(listed.has(pick.href), `${grade.slug} → ${pick.href}`).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it("gives three of them, each with a reason", () => {
+    for (const grade of GRADES) {
+      expect(grade.landmarks, grade.slug).toHaveLength(3);
+      for (const pick of grade.landmarks)
+        expect(pick.why.length, pick.href).toBeGreaterThan(30);
+    }
+  });
+});
+
+describe("the built site", () => {
+  /*
+   * Against `dist/`, not against the data: the accuracy trap on a hub is a
+   * link to a page that was described but never built, and the only thing that
+   * disproves it is the file. Skipped when there is no `dist/`, exactly as the
+   * catalogs' sitemap checks are; CI builds before it runs the suite.
+   */
+  it("has a page behind every link a hub prints", () => {
+    if (!existsSync(`${ROOT}/dist`)) return; // `npm run build` hasn't run yet.
+
+    for (const sheet of ALL_SHEETS) {
+      expect(existsSync(built(sheet.href)), sheet.href).toBe(true);
+    }
+    for (const shelf of SHELVES) {
+      expect(existsSync(built(shelf.href)), shelf.id).toBe(true);
+    }
+    for (const grade of GRADES) {
+      expect(existsSync(built(gradeHref(grade))), grade.slug).toBe(true);
+    }
+    expect(existsSync(built("/printables/grade"))).toBe(true);
+  });
+
+  it("ships the year pages with no JavaScript on them", () => {
+    if (!existsSync(`${ROOT}/dist`)) return;
+
+    // §2, and the reason a hub is a listing rather than an island: an
+    // `<astro-island>` is how a component's JavaScript reaches a page at all.
+    for (const grade of GRADES) {
+      const html = readFileSync(built(gradeHref(grade)), "utf8");
+      expect(html, grade.slug).not.toContain("astro-island");
+      expect(html, grade.slug).toContain("<h1");
+    }
+  });
+
+  it("puts every year in the sitemap", () => {
+    // A URL missing from the sitemap is the failure nobody notices — nothing
+    // breaks, the page is simply never submitted.
+    const file = `${ROOT}/dist/sitemap-0.xml`;
+    if (!existsSync(file)) return;
+
+    const xml = readFileSync(file, "utf8");
+    const found = new Set(
+      [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) =>
+        new URL(match[1]).pathname.replace(/\/$/, ""),
+      ),
+    );
+
+    expect(found.has("/printables/grade")).toBe(true);
+    for (const grade of GRADES) {
+      expect(found.has(gradeHref(grade)), grade.slug).toBe(true);
+    }
+    for (const shelf of HUBS) {
+      expect(found.has(shelf.href), shelf.id).toBe(true);
+    }
+  });
+});

--- a/src/pages/printables/_grades.ts
+++ b/src/pages/printables/_grades.ts
@@ -309,7 +309,7 @@ export const GRADES: Grade[] = [
     lead: "Twelve and thirteen: the maths shelf keeps its top half — fractions, decimals and the pre-algebra sheets — while most of what actually gets printed is paper to work on rather than questions to answer.",
     notes: [
       "By this age the useful printables are mostly blank. Squared paper at five millimetres, the four-quadrant grid, a lab report form, a weekly planner: the work itself comes out of a textbook or a class, and what a home printer is for is the surface it is done on. The paper shelf keeps everything on this page except the primary rulings, while the worksheet shelves have thinned right out.",
-      "Narrow ruled arrives here, and it is a fair-copy paper rather than a practice one — a quarter of an inch between rules and no margin line at all, because at that size there is not much page left to give away. It is the ruling for lists, indexes and notes meant to be kept, and it is the last one this catalog has.",
+      "Narrow ruled is the paper for this end of the catalog, and it is a fair-copy paper rather than a practice one — a quarter of an inch between rules and no margin line at all, because at that size there is not much page left to give away. It is the ruling for lists, indexes and notes meant to be kept, and it is the tightest one here. It says Ages 12+, so it is already on the sixth-grade page for anyone who turned twelve there.",
     ],
     landmarks: [
       {

--- a/src/pages/printables/_grades.ts
+++ b/src/pages/printables/_grades.ts
@@ -1,0 +1,415 @@
+/**
+ * The school years the Print Shop is browsable by, and how a sheet gets onto
+ * one of them.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data two pages
+ * share — `grade/[grade].astro`, which prerenders one hub per year, and
+ * `grade/index.astro`, which lists them.
+ *
+ * **No sheet on this site is labelled “Grade 3”, and none is going to be.**
+ * Every catalog entry states the ages it was drawn for, on its own page, in the
+ * shape “Ages 8–11” — a judgement made once, beside the sheet, by whoever chose
+ * the numbers that go on it. A grade page collects the sheets whose stated ages
+ * reach the years a child is in that grade, and says so out loud. That is the
+ * whole mechanism, and it is deliberately the weakest claim that is still
+ * useful: a grade-level label invented by a worksheet site is a guess dressed
+ * up as a standard, and the parent reading it can already see their own child.
+ *
+ * The consequence is that the same sheet appears on two or three of these
+ * pages, which is correct rather than sloppy. A sheet for nine to twelve
+ * belongs to the fourth-grader and the seventh-grader both, and pretending
+ * otherwise would mean withholding it from one of them.
+ */
+import { SHELVES, type Shelf, type ShelfSheet } from "./_shelves";
+
+export type Grade = {
+  /** The route under /printables/grade, and the head term it answers. */
+  slug: string;
+  /** How the year is named in a heading, and where a page addresses it. */
+  label: string;
+  /**
+   * The same year inside a sentence, where the capital would be wrong.
+   *
+   * Written out rather than lower-cased from `label`: "pre-k" is not how
+   * anybody writes Pre-K, and it is the one of the ten that would break the
+   * rule the other nine follow.
+   */
+  phrase: string;
+  /** How it is labelled in a row of the ten. A few characters. */
+  short: string;
+  /** The page's `<h1>`. */
+  heading: string;
+  /** The query this page exists to answer, in the words a parent types. */
+  keyword: string;
+  /**
+   * The ages most children are during this year, inclusive at both ends.
+   *
+   * Two of them, not one: a first-grader is six in the autumn and seven by the
+   * spring, and a shelf that only reached one of those would drop half the
+   * sheets a parent needs in the second half of the year.
+   */
+  ages: [number, number];
+  /** The lead paragraph: what changes at this age. */
+  lead: string;
+  /** Two things that are true of this year and not of the one beside it. */
+  notes: string[];
+  /**
+   * Three sheets worth starting with, by route, and why this year.
+   *
+   * A route rather than a name, so the name is read back out of the catalog
+   * that owns it and cannot drift from it. `_grades.test.ts` holds every one of
+   * these to two things: that it is a sheet that exists, and that it is a sheet
+   * this year's ages actually reach — the second being the way a hand-written
+   * recommendation goes quietly wrong when a catalog entry is re-aged.
+   */
+  landmarks: Array<{ href: string; why: string }>;
+};
+
+/**
+ * Pre-K through 8th, at the ages an American school puts them.
+ *
+ * Ten pages, and the bound is the same one §8 puts on every other shelf here:
+ * these are the years a parent types into a search box, and the twelve-way
+ * cross with subject and difficulty that would follow from generating more is
+ * the doorway-page farm that section exists to forbid.
+ */
+export const GRADES: Grade[] = [
+  {
+    slug: "pre-k",
+    label: "Pre-K",
+    phrase: "Pre-K",
+    short: "Pre-K",
+    heading: "Pre-K printable worksheets",
+    keyword: "Free printable Pre-K worksheets",
+    ages: [4, 5],
+    lead: "Four and five, and almost all of it is a shape to fill in: letters and numbers traced an inch high, the first sounds on cards, and the words that have to be known by sight before anything else can be read. Nothing on this page asks a child to read the instructions, because at this age the grown-up reads them.",
+    notes: [
+      "The paper is the biggest ruling in the shop, and that is the point rather than a concession. An inch from one set of lines to the next, with a solid midline through the middle of it, because a four-year-old is aiming at a line rather than reading a hint — and because a child whose fine motor control is still arriving writes large. Paper that asks them to write small teaches them that handwriting is something they are bad at, which is a lesson that takes years to undo.",
+      "The phonics shelf is the one to spend this year on, and it is built the opposite way round from most of them: you tick the sounds that have actually been taught, and the sheet is made out of those and nothing else. A four-year-old handed a page with a spelling on it they have never seen is being asked to guess, and guessing is the habit the whole method exists to prevent.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/phonics/phonics-sound-cards",
+        why: "The sounds you have taught, on cards to cut out, and none you haven’t.",
+      },
+      {
+        href: "/printables/kindergarten-writing-paper",
+        why: "Inch-high lines with a solid midline: the ruling a first letter is written on.",
+      },
+      {
+        href: "/printables/handwriting/letter-tracing-worksheets",
+        why: "The whole alphabet, traced then copied, a letter at a time.",
+      },
+    ],
+  },
+  {
+    slug: "kindergarten",
+    label: "Kindergarten",
+    phrase: "kindergarten",
+    short: "K",
+    heading: "Kindergarten printable worksheets",
+    keyword: "Free printable kindergarten worksheets",
+    ages: [5, 6],
+    lead: "Five and six: small letters after the capitals, the first sight words, sounds blended into whole words, and numbers that start behaving like quantities rather than like shapes. This is the year the ruling comes down a size, from an inch to three quarters of one.",
+    notes: [
+      "Sight words are the odd ones out on the spelling shelf and this is the year they matter most. A hundred or so words make up about half of everything a child reads, and a good many of them — “said”, “one”, “come” — do not say what their letters suggest, so they are learned by the eye rather than worked out. The sheets trace them, write them out and hide them in a grid to find, which is three different ways of looking at the same short list.",
+      "The counting sheets here have nothing on them to answer, and that is what they are for. A hundred chart is ten rows of ten so that moving down it is adding ten; a number line to twenty is a distance a finger can walk. Both are references a child works against rather than work a child hands in, and both stay on the wall long after the worksheets have gone in the recycling.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/handwriting/lowercase-letter-tracing-worksheets",
+        why: "The small letters, which are the ones nearly all writing is actually made of.",
+      },
+      {
+        href: "/printables/spelling/sight-word-worksheets",
+        why: "The words that will not sound out, on the list a school works through first.",
+      },
+      {
+        href: "/printables/charts/hundred-chart",
+        why: "Ten rows of ten, so that going down the chart is adding ten.",
+      },
+    ],
+  },
+  {
+    slug: "1st-grade",
+    label: "First grade",
+    phrase: "first grade",
+    short: "1st",
+    heading: "Printable 1st grade worksheets",
+    keyword: "Free printable 1st grade worksheets",
+    ages: [6, 7],
+    lead: "Six and seven: sums that cross ten, sentences that a child can decode on their own, and the ⅝-inch ruling that most of primary school is written on. The work stops being letters and starts being lines of them.",
+    notes: [
+      "Adding with regrouping is the sheet this year turns on. Carrying is the first piece of arithmetic that is a procedure rather than a fact, and it is where a child who has been counting on their fingers quietly runs out of fingers — so the sheet is set in columns, with the room above the sum where the carried digit goes, rather than written along a line where there is nowhere to put it.",
+      "Decodable sentences are the reading equivalent, and they come off the same ticked list of sounds as the rest of the phonics shelf: every word in every sentence is built from spellings that have already been taught. A first sentence read without a single guess in it is worth more than a page of pictures, and it is only possible if the page knows what has been covered.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/handwriting-paper",
+        why: "⅝ of an inch, dashed midline: the size most of Year 1 is written at.",
+      },
+      {
+        href: "/printables/addition-with-regrouping-worksheets",
+        why: "Carrying, set in columns with room above the sum for the digit.",
+      },
+      {
+        href: "/printables/phonics/decodable-sentences-worksheets",
+        why: "Sentences with nothing untaught in them, so there is nothing to guess.",
+      },
+    ],
+  },
+  {
+    slug: "2nd-grade",
+    label: "Second grade",
+    phrase: "second grade",
+    short: "2nd",
+    heading: "Printable 2nd grade worksheets",
+    keyword: "Free printable 2nd grade worksheets",
+    ages: [7, 8],
+    lead: "Seven and eight: the times tables start, money and clocks arrive, handwriting drops to half an inch, and the first joined letters appear. It is the busiest year in this catalog, which is why nearly every shelf has something on this page.",
+    notes: [
+      "Multiplication is the one to be systematic about, because it is the last piece of arithmetic that is pure recall and everything after it — long division, fractions, ratio — is built on the assumption that it is already automatic. The worksheets and the twelve times-table pages here are the same facts as the flash cards in The Grid, so a table can be practised on paper in the morning and raced on screen in the afternoon.",
+      "Cursive can start this year, and the sheets say what most cursive worksheets leave out: the joins are the skill. A child who can form twenty-six cursive letters and cannot join them writes print with curls on it, so the alphabet, the joins and the words are three separate sheets rather than one.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/multiplication-worksheets",
+        why: "The tables, on paper, and the same facts the flash cards deal.",
+      },
+      {
+        href: "/printables/handwriting-paper-1-2-inch",
+        why: "Half an inch: small enough that a sentence fits on a line.",
+      },
+      {
+        href: "/printables/spelling/spelling-practice-worksheets",
+        why: "This week’s list, written out, or your own list typed in.",
+      },
+    ],
+  },
+  {
+    slug: "3rd-grade",
+    label: "Third grade",
+    phrase: "third grade",
+    short: "3rd",
+    heading: "Printable 3rd grade worksheets",
+    keyword: "Free printable 3rd grade worksheets",
+    ages: [8, 9],
+    lead: "Eight and nine: division, the first fractions, area and the measures that go with it, and the ⅜ ruling that has a top line and a baseline and nothing in between. Grammar becomes a subject of its own rather than something corrected in passing.",
+    notes: [
+      "Division here is the short kind — facts that undo the times tables — and equivalent fractions sit beside it for a reason. Both are the same idea approached twice: that a quantity can be cut into equal parts and named. A child who is fluent with the tables meets neither as a new fact, which is the whole argument for having spent the year before on them.",
+      "The transitional ruling is the quiet event of this year. Three eighths of an inch, top line and baseline, no midline — the sheet stops telling a child how tall a letter is, because by now they know. It is the last ruling before ordinary lined paper, and printing both and writing the same sentence on each is a fair way to see whether someone is ready.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/division-worksheets",
+        why: "The facts that undo the tables, with the key on the page behind.",
+      },
+      {
+        href: "/printables/cursive/cursive-alphabet-worksheets",
+        why: "The joined alphabet, in whichever of the three models you were taught.",
+      },
+      {
+        href: "/printables/grammar/parts-of-speech-worksheets",
+        why: "Nouns, verbs and adjectives, with the answers written down by a person.",
+      },
+    ],
+  },
+  {
+    slug: "4th-grade",
+    label: "Fourth grade",
+    phrase: "fourth grade",
+    short: "4th",
+    heading: "Printable 4th grade worksheets",
+    keyword: "Free printable 4th grade worksheets",
+    ages: [9, 10],
+    lead: "Nine and ten: long division, fractions that are added rather than shaded, decimals, and word problems where the hard part is deciding what to do. The handwriting shelf is down to its last sheet by now, and that sheet is copywork.",
+    notes: [
+      "Long division is the longest procedure in primary maths and the one most often printed badly, so these sheets are set in the bracket with the quotient written along the top and a band of blank paper under each problem to bring the digits down into. The working is the exercise rather than the answer. If the columns drift the answer is wrong for a reason that has nothing to do with division, which is why squared paper is on this page as well.",
+      "Copywork is what handwriting turns into once the letters are formed. The passage is real writing — a psalm, a speech, a poem out of the public domain — and the sheet is a model line above an empty one, so the practice is a sentence worth reading rather than a row of the same letter. It is also the shelf where Scripture sits, in the same picker as everything else.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/long-division-worksheets",
+        why: "Set on the bracket, with room for the subtractions underneath.",
+      },
+      {
+        href: "/printables/fraction-worksheets",
+        why: "Added, subtracted and reduced, with every key in its lowest terms.",
+      },
+      {
+        href: "/printables/bible/psalm-23-copywork",
+        why: "The whole psalm, copied out, in a public-domain translation.",
+      },
+    ],
+  },
+  {
+    slug: "5th-grade",
+    label: "Fifth grade",
+    phrase: "fifth grade",
+    short: "5th",
+    heading: "Printable 5th grade worksheets",
+    keyword: "Free printable 5th grade worksheets",
+    ages: [10, 11],
+    lead: "Ten and eleven: percentages, negative numbers, the order of operations, and the first equations with a letter in them. Wide ruled paper is running out of usefulness and college ruled starts to make sense.",
+    notes: [
+      "This is where arithmetic turns into algebra without announcing it. An equation with a letter in it is a sum with the answer moved, the order of operations is a rule about reading rather than about numbers, and integers are the first quantity a child meets that cannot be counted out on a table. Each of those has a sheet of its own here, and each prints its own key.",
+      "The paper changes with the work. College ruled is nine thirty-seconds of an inch against wide ruled’s eleven, which is about six more lines to the page — the difference between fitting a paragraph and running out of room. If handwriting is still growing into the line, print the wide ruled sheet instead: narrow rules do not make writing neater, they make a child write smaller than they can control.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/percentage-worksheets",
+        why: "Percentages of a quantity, and the fraction each one is.",
+      },
+      {
+        href: "/printables/decimal-worksheets",
+        why: "Added as whole hundredths, so no key ever prints a rounded last place.",
+      },
+      {
+        href: "/printables/college-ruled-paper",
+        why: "Six more lines to the page than wide ruled, and the same margin.",
+      },
+    ],
+  },
+  {
+    slug: "6th-grade",
+    label: "Sixth grade",
+    phrase: "sixth grade",
+    short: "6th",
+    heading: "Printable 6th grade worksheets",
+    keyword: "Free printable 6th grade worksheets",
+    ages: [11, 12],
+    lead: "Eleven and twelve: ratio and proportion, averages, the whole pre-algebra strand, and paperwork that starts to look like a secondary school’s — a lab report, a timeline, a paragraph frame with the shape of an argument printed on it.",
+    notes: [
+      "Ratio and averages are the two topics on this page where a generated worksheet most often prints a confident wrong answer, and both are guarded in the engine rather than by hand: a ratio is reduced with a greatest common divisor so the key is in its lowest terms rather than merely equal to the right answer, and a set of numbers is redrawn until it has a single mode, because a page that asks for “the” mode of a set with two is asking for something that does not exist.",
+      "The writing frames matter more than they look. A paragraph frame is a page with the shape of a paragraph on it and nothing else — a topic sentence, three reasons with a detail attached to each, and a close — and it is the difference between a child who cannot start and a child who has started. It is also scaffolding, which is meant to come down: print it for a fortnight, then hand over lined paper and ask for the same thing.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/order-of-operations-worksheets",
+        why: "A rule about reading a sum, practised until it is not a rule any more.",
+      },
+      {
+        href: "/printables/charts/decimal-place-value-chart",
+        why: "Hundreds to thousandths, with the point ruled between ones and tenths.",
+      },
+      {
+        href: "/printables/templates/lab-report",
+        why: "Question, method, results, conclusion: blank, and better for it.",
+      },
+    ],
+  },
+  {
+    slug: "7th-grade",
+    label: "Seventh grade",
+    phrase: "seventh grade",
+    short: "7th",
+    heading: "Printable 7th grade worksheets",
+    keyword: "Free printable 7th grade worksheets",
+    ages: [12, 13],
+    lead: "Twelve and thirteen: the maths shelf keeps its top half — fractions, decimals and the pre-algebra sheets — while most of what actually gets printed is paper to work on rather than questions to answer.",
+    notes: [
+      "By this age the useful printables are mostly blank. Squared paper at five millimetres, the four-quadrant grid, a lab report form, a weekly planner: the work itself comes out of a textbook or a class, and what a home printer is for is the surface it is done on. The paper shelf keeps everything on this page except the primary rulings, while the worksheet shelves have thinned right out.",
+      "Narrow ruled arrives here, and it is a fair-copy paper rather than a practice one — a quarter of an inch between rules and no margin line at all, because at that size there is not much page left to give away. It is the ruling for lists, indexes and notes meant to be kept, and it is the last one this catalog has.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/one-step-equations-worksheets",
+        why: "Solve for the letter, one operation at a time, key on the second page.",
+      },
+      {
+        href: "/printables/graph-paper-5-mm",
+        why: "The squares a school exercise book is printed at, on both stocks.",
+      },
+      {
+        href: "/printables/narrow-ruled-paper",
+        why: "Quarter-inch rules, no margin: the most words on a page here.",
+      },
+    ],
+  },
+  {
+    slug: "8th-grade",
+    label: "Eighth grade",
+    phrase: "eighth grade",
+    short: "8th",
+    heading: "Printable 8th grade worksheets",
+    keyword: "Free printable 8th grade worksheets",
+    ages: [13, 14],
+    lead: "Thirteen and fourteen, and this is the shortest page of the ten. The pre-algebra worksheets, the reference paper, the paperwork a week needs and the longer copywork are what a catalog built for primary school honestly has at this age.",
+    notes: [
+      "The shelves that stop, stop. There is no handwriting, cursive, phonics, spelling or grammar sheet on this page, because every one of those states an age range that ends before thirteen — and relabelling one “Grade 8” to make this page look fuller is the single thing a catalog like this must not do. A parent who found a tracing sheet listed for a fourteen-year-old would be right to distrust every other page here.",
+      "What is left is genuinely for this age. Integers, ratio, averages, the order of operations and one-step equations are the arithmetic that carries into algebra; the four-quadrant grid and the graph papers are what it is worked on; and the copywork and memory sheets take whole passages rather than a verse at a time. If your child needs something from an earlier year, the page for that year is one link away and nothing here will disagree with you about which to use.",
+    ],
+    landmarks: [
+      {
+        href: "/printables/ratio-and-proportion-worksheets",
+        why: "Ratios reduced properly, and proportions solved rather than guessed.",
+      },
+      {
+        href: "/printables/mean-median-mode-worksheets",
+        why: "Sets drawn so the mode is single and the median is a real value.",
+      },
+      {
+        href: "/printables/bible/1-corinthians-13-copywork",
+        why: "A long passage, copied out over several pages of ruled lines.",
+      },
+    ],
+  },
+];
+
+/**
+ * The band a sheet's own page states, as `[from, to]`.
+ *
+ * Two shapes exist across the ten catalogs and only two: a closed range,
+ * “Ages 6–9”, and an open one, “Ages 4+”, for the sheets that never stop being
+ * useful. Anything else **throws**, deliberately and at build time: the failure
+ * to avoid is a new sheet whose age string is written a third way, silently
+ * matching no grade and appearing on none of these pages while every test still
+ * passes and the page still builds.
+ */
+export function ageBand(ages: string): [number, number] {
+  const closed = /^Ages (\d+)–(\d+)$/.exec(ages);
+  if (closed) return [Number(closed[1]), Number(closed[2])];
+
+  const open = /^Ages (\d+)\+$/.exec(ages);
+  if (open) return [Number(open[1]), Infinity];
+
+  throw new Error(
+    `Unreadable age range ${JSON.stringify(ages)}. A catalog entry states its ages as "Ages 6–9" or "Ages 4+" — the grade hubs are built entirely out of that string, so a third shape would drop the sheet off every one of them.`,
+  );
+}
+
+/** Whether a sheet's stated ages reach any part of this year. */
+const fits = (grade: Grade, sheet: ShelfSheet): boolean => {
+  const [from, to] = ageBand(sheet.ages);
+  return from <= grade.ages[1] && to >= grade.ages[0];
+};
+
+/**
+ * Every shelf, cut down to what this year's ages reach.
+ *
+ * A shelf with nothing left is dropped rather than printed empty. That is the
+ * honest rendering of the eighth-grade page — five of the ten shelves end
+ * before thirteen — and an empty heading would read as a missing link.
+ */
+export function shelvesForGrade(grade: Grade): Shelf[] {
+  return SHELVES.map((shelf) => ({
+    ...shelf,
+    sheets: shelf.sheets.filter((sheet) => fits(grade, sheet)),
+  })).filter((shelf) => shelf.sheets.length > 0);
+}
+
+/** Everything printable for a year, whichever shelf it came off. */
+export const sheetsForGrade = (grade: Grade): ShelfSheet[] =>
+  shelvesForGrade(grade).flatMap((shelf) => shelf.sheets);
+
+/** A sheet by route, for the landmarks — which name a page rather than copy it. */
+export const sheetByHref = (href: string): ShelfSheet | undefined =>
+  SHELVES.flatMap((shelf) => shelf.sheets).find((sheet) => sheet.href === href);
+
+/** The route a year is listed at. */
+export const gradeHref = (grade: Grade): string =>
+  `/printables/grade/${grade.slug}`;
+
+/** The ages, as `typicalAgeRange` wants them and as the page says them. */
+export const ageRange = (grade: Grade): string =>
+  `${grade.ages[0]}-${grade.ages[1]}`;

--- a/src/pages/printables/_shelves.ts
+++ b/src/pages/printables/_shelves.ts
@@ -1,0 +1,242 @@
+/**
+ * Every shelf in the Print Shop, in one list.
+ *
+ * Underscored so Astro leaves it out of the routing table: it is data the hubs
+ * share rather than a route of its own — the same job `_catalog.ts` does for
+ * paper and `_maths.ts` for the worksheets, one level up. Each of those ten
+ * files knows one shelf completely; this one knows only that there are ten of
+ * them, which is all a page listing sheets ACROSS shelves needs.
+ *
+ * **It exists because of the grade hubs.** A page about what a seven-year-old
+ * can print has no shelf of its own — it cuts across all of them — and the
+ * alternative to a registry is ten imports and ten maps in every such page,
+ * which is ten chances to leave one out and no way to notice. Adding a shelf is
+ * an entry here, and the grade pages list it without being edited.
+ *
+ * **The projection is deliberately thin.** A `ShelfSheet` is what a listing
+ * needs — a link, the name it is listed under, a sentence, and the ages the
+ * sheet's own page states — and nothing else. Configs, seeds, leads and notes
+ * stay in the catalog that owns them, so this file cannot quietly become a
+ * second place a sheet is described.
+ */
+import { BIBLE_SHEETS, hrefFor as bibleHref } from "./_bible";
+import { PAPER_SHEETS, STOCKS, stockHref } from "./_catalog";
+import { CHART_SHEETS, pathFor as chartPath } from "./_charts";
+import { CURSIVE_SHEETS, hrefFor as cursiveHref } from "./_cursive";
+import { GRAMMAR_SHEETS, pathFor as grammarPath } from "./_grammar";
+import { HANDWRITING_SHEETS, hrefFor as handwritingHref } from "./_handwriting";
+import { MATHS_SHEETS, pathFor as mathsPath } from "./_maths";
+import { PHONICS_SHEETS, pathFor as phonicsPath } from "./_phonics";
+import { SPELLING_SHEETS, pathFor as spellingPath } from "./_spelling";
+import { TEMPLATE_SHEETS, pathFor as templatePath } from "./_templates";
+
+/** The shelves, in the order the front door sets them out. */
+export type ShelfId =
+  | "math"
+  | "handwriting"
+  | "cursive"
+  | "bible"
+  | "spelling"
+  | "grammar"
+  | "phonics"
+  | "charts"
+  | "templates"
+  | "paper";
+
+/** One sheet, as a page that did not write it lists it. */
+export type ShelfSheet = {
+  /** Where it prints. On the shelves with two stocks, the default one. */
+  href: string;
+  /** How it is listed in a sentence. */
+  name: string;
+  /** How it is labelled in a row of links. A few words. */
+  short: string;
+  /** One sentence of what is on it. */
+  summary: string;
+  /** For the `LearningResource` block. */
+  teaches: string;
+  /**
+   * The ages the sheet's own page states: "Ages 6–9", or "Ages 4+".
+   *
+   * The grade hubs are built entirely out of this string, which is why it is
+   * carried rather than restated — see `_grades.ts` for how it is read, and
+   * why a shape it cannot read fails the build rather than emptying a page.
+   */
+  ages: string;
+};
+
+export type Shelf = {
+  id: ShelfId;
+  /** What it is called in a heading and in a row of links. */
+  label: string;
+  /**
+   * Where all of it is listed.
+   *
+   * A hub of its own for nine of the ten. Paper's is the front door itself:
+   * `/printables` sets out all fifteen rulings with the sentence that tells
+   * one from the next, because a ruling is chosen by reading how it differs
+   * from the ruling beside it rather than by recognising a topic. `hub` is
+   * what says which of the two this is, so a nav of subject hubs can leave the
+   * front door out without hard-coding which shelf is the exception.
+   */
+  href: string;
+  hub: boolean;
+  /**
+   * What the link to `href` is labelled, in that shelf's own words.
+   *
+   * Written out rather than composed from `label`, because "All the Scripture
+   * sheets" and "All the forms, planners and cards" are what those two shelves
+   * call themselves on the front door, and a generated "all the bible sheets"
+   * would be a worse sentence in three of the ten cases.
+   */
+  all: string;
+  /** One line: what the shelf is for, in the words a parent would use. */
+  blurb: string;
+  sheets: ShelfSheet[];
+};
+
+/** Listed on the default stock; each sheet page carries the link to its twin. */
+const letter = STOCKS[0];
+
+/**
+ * The projection every shelf makes onto a listing.
+ *
+ * Generic over the fields it reads rather than over a sheet type: the ten
+ * catalogs agree on these five field names and on nothing else, and this file
+ * has no business knowing what a `PaperSheet` has that a `MathsSheet` doesn't.
+ */
+const listing = <
+  Sheet extends {
+    name: string;
+    short: string;
+    summary: string;
+    teaches: string;
+    ages: string;
+  },
+>(
+  sheets: Sheet[],
+  href: (sheet: Sheet) => string,
+): ShelfSheet[] =>
+  sheets.map((sheet) => ({
+    href: href(sheet),
+    name: sheet.name,
+    short: sheet.short,
+    summary: sheet.summary,
+    teaches: sheet.teaches,
+    ages: sheet.ages,
+  }));
+
+export const SHELVES: Shelf[] = [
+  {
+    id: "math",
+    label: "Maths",
+    href: "/printables/math",
+    hub: true,
+    all: "All the maths sheets",
+    blurb:
+      "Worksheets from adding to twenty through to word problems, each with its answer key on the page behind it.",
+    sheets: listing(MATHS_SHEETS, mathsPath),
+  },
+  {
+    id: "handwriting",
+    label: "Handwriting",
+    href: "/printables/handwriting",
+    hub: true,
+    all: "All the handwriting sheets",
+    blurb:
+      "Letters traced, then copied, then written on an empty line — the same three steps at every size of ruling.",
+    sheets: listing(HANDWRITING_SHEETS, (sheet) =>
+      handwritingHref(sheet, letter),
+    ),
+  },
+  {
+    id: "cursive",
+    label: "Cursive",
+    href: "/printables/cursive",
+    hub: true,
+    all: "All the cursive sheets",
+    blurb:
+      "The same progression again in a joined hand, including the page printing never needed — the joins themselves.",
+    sheets: listing(CURSIVE_SHEETS, (sheet) => cursiveHref(sheet, letter)),
+  },
+  {
+    id: "bible",
+    label: "Bible",
+    href: "/printables/bible",
+    hub: true,
+    all: "All the Scripture sheets",
+    blurb:
+      "Scripture copywork, handwriting and memory work: the sheets above with a passage on them, in a public-domain translation.",
+    sheets: listing(BIBLE_SHEETS, (sheet) => bibleHref(sheet, letter)),
+  },
+  {
+    id: "spelling",
+    label: "Spelling",
+    href: "/printables/spelling",
+    hub: true,
+    all: "All the spelling sheets",
+    blurb:
+      "This week’s list in five shapes, the first sight words, and the pages on how words are put together.",
+    sheets: listing(SPELLING_SHEETS, spellingPath),
+  },
+  {
+    id: "grammar",
+    label: "Grammar",
+    href: "/printables/grammar",
+    hub: true,
+    all: "All the grammar sheets",
+    blurb:
+      "How a sentence is put together — the parts of speech, its two halves, what it is for, and the marks that finish it.",
+    sheets: listing(GRAMMAR_SHEETS, grammarPath),
+  },
+  {
+    id: "phonics",
+    label: "Phonics",
+    href: "/printables/phonics",
+    hub: true,
+    all: "All the phonics sheets",
+    blurb:
+      "Built from the sounds you have ticked, so a sheet never contains a spelling that has not been taught yet.",
+    sheets: listing(PHONICS_SHEETS, phonicsPath),
+  },
+  {
+    id: "charts",
+    label: "Charts and grids",
+    href: "/printables/charts",
+    hub: true,
+    all: "All the charts and grids",
+    blurb:
+      "References with nothing on them to answer: hundred charts, number lines, coordinate grids and place-value columns.",
+    sheets: listing(CHART_SHEETS, chartPath),
+  },
+  {
+    id: "templates",
+    label: "Forms and planners",
+    href: "/printables/templates",
+    hub: true,
+    all: "All the forms, planners and cards",
+    blurb:
+      "The paperwork a week needs — logs, reports, calendars, charts, certificates and cards. Supposed to be empty.",
+    sheets: listing(TEMPLATE_SHEETS, templatePath),
+  },
+  {
+    id: "paper",
+    label: "Paper",
+    href: "/printables",
+    hub: false,
+    all: "All the paper and rulings",
+    blurb:
+      "Ruled paper by the sheet: notebook rules, the five handwriting sizes, and squares, dots and triangles.",
+    sheets: listing(PAPER_SHEETS, (sheet) =>
+      stockHref("/printables", sheet.slug, letter),
+    ),
+  },
+];
+
+/** The nine shelves with a hub of their own — the subject nav, in order. */
+export const HUBS: Shelf[] = SHELVES.filter((shelf) => shelf.hub);
+
+/** Every sheet in the shop, whichever shelf it is on. */
+export const ALL_SHEETS: ShelfSheet[] = SHELVES.flatMap(
+  (shelf) => shelf.sheets,
+);

--- a/src/pages/printables/_shelves.ts
+++ b/src/pages/printables/_shelves.ts
@@ -13,11 +13,12 @@
  * which is ten chances to leave one out and no way to notice. Adding a shelf is
  * an entry here, and the grade pages list it without being edited.
  *
- * **The projection is deliberately thin.** A `ShelfSheet` is what a listing
- * needs — a link, the name it is listed under, a sentence, and the ages the
- * sheet's own page states — and nothing else. Configs, seeds, leads and notes
- * stay in the catalog that owns them, so this file cannot quietly become a
- * second place a sheet is described.
+ * **The projection is deliberately thin.** A `ShelfSheet` is the four things a
+ * cross-shelf listing actually reads — where it prints, what to call it, what
+ * it teaches, and the ages the sheet's own page states — and nothing else.
+ * Configs, seeds, leads, blurbs and notes stay in the catalog that owns them,
+ * so this file cannot quietly become a second place a sheet is described, and a
+ * field nobody reads cannot sit here documenting a contract nothing keeps.
  */
 import { BIBLE_SHEETS, hrefFor as bibleHref } from "./_bible";
 import { PAPER_SHEETS, STOCKS, stockHref } from "./_catalog";
@@ -47,12 +48,17 @@ export type ShelfId =
 export type ShelfSheet = {
   /** Where it prints. On the shelves with two stocks, the default one. */
   href: string;
-  /** How it is listed in a sentence. */
+  /**
+   * The sheet's full name, which is what a cross-shelf page links it by.
+   *
+   * The catalogs also carry a `short` — "Equivalent", "Decimals", "1 inch" —
+   * and a shelf's own hub can use it, because everything around it is from the
+   * same shelf and often the same strand. A grade page has no such context:
+   * one row per shelf, ten shelves deep, where "Chart" is a times-table chart
+   * on the maths shelf and "Decimals" is two different sheets on two of them.
+   * So the projection carries the name and not the label, deliberately.
+   */
   name: string;
-  /** How it is labelled in a row of links. A few words. */
-  short: string;
-  /** One sentence of what is on it. */
-  summary: string;
   /** For the `LearningResource` block. */
   teaches: string;
   /**
@@ -102,26 +108,18 @@ const letter = STOCKS[0];
  * The projection every shelf makes onto a listing.
  *
  * Generic over the fields it reads rather than over a sheet type: the ten
- * catalogs agree on these five field names and on nothing else, and this file
+ * catalogs agree on these three field names and on nothing else, and this file
  * has no business knowing what a `PaperSheet` has that a `MathsSheet` doesn't.
+ * The constraint is exactly `ShelfSheet` minus `href`, so widening one widens
+ * the other and a field can't be required here that no listing goes on to read.
  */
-const listing = <
-  Sheet extends {
-    name: string;
-    short: string;
-    summary: string;
-    teaches: string;
-    ages: string;
-  },
->(
+const listing = <Sheet extends Omit<ShelfSheet, "href">>(
   sheets: Sheet[],
   href: (sheet: Sheet) => string,
 ): ShelfSheet[] =>
   sheets.map((sheet) => ({
     href: href(sheet),
     name: sheet.name,
-    short: sheet.short,
-    summary: sheet.summary,
     teaches: sheet.teaches,
     ages: sheet.ages,
   }));

--- a/src/pages/printables/bible/index.astro
+++ b/src/pages/printables/bible/index.astro
@@ -3,6 +3,7 @@ import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SCRIPTURE_CREDIT } from "@/engine/sheets/passages";
 import { BIBLE_SHEETS, STOCKS, bibleShelf, hrefFor } from "../_bible";
+import HubLinks from "../_HubLinks.astro";
 
 /**
  * The Scripture subject hub — the third of the §8 subject names to exist, and
@@ -172,6 +173,8 @@ const letter = STOCKS[0];
       </div>
     </div>
   </section>
+
+  <HubLinks shelf="bible" />
 
   <section class="band band--tight wrap">
     <h2 class="h2">Your child&rsquo;s name is not in the file</h2>

--- a/src/pages/printables/charts/index.astro
+++ b/src/pages/printables/charts/index.astro
@@ -2,11 +2,14 @@
 import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { CHART_SHEETS, chartShelf, pathFor } from "../_charts";
+import HubLinks from "../_HubLinks.astro";
 
 /**
- * The charts-and-grids hub — a peer of `/printables/math`,
- * `/printables/spelling`, `/printables/grammar`, `/printables/phonics`,
- * `/printables/handwriting`, `/printables/cursive` and `/printables/bible`.
+ * The charts-and-grids hub — a peer of the other eight shelves, which are
+ * listed in `_shelves.ts` and printed at the foot of this page from it. They
+ * were named here one by one until the paperwork shelf landed and this sentence
+ * was quietly wrong about how many there are; a registry cannot go stale that
+ * way, so it is the registry that says who the peers are.
  *
  * A listing rather than a sheet, like the other hubs, and that is the right
  * split: nobody searches for "printable list of maths charts". What it is for
@@ -166,6 +169,8 @@ const groups = chartShelf();
       >
     </div>
   </section>
+
+  <HubLinks shelf="charts" />
 
   <section class="band band--tight wrap">
     <h2 class="h2">Your child&rsquo;s name is not in the file</h2>

--- a/src/pages/printables/cursive/index.astro
+++ b/src/pages/printables/cursive/index.astro
@@ -10,6 +10,7 @@ import {
   cursiveShelf,
   hrefFor,
 } from "../_cursive";
+import HubLinks from "../_HubLinks.astro";
 
 /**
  * The cursive subject hub — the third of the §8 names to exist, beside paper,
@@ -264,4 +265,5 @@ const joins = CURSIVE_SHEETS.find((sheet) => sheet.config.style === "joins")!;
       <a class="cta" href="/printables/make">Open the sheet builder</a>
     </div>
   </section>
+  <HubLinks shelf="cursive" />
 </Content>

--- a/src/pages/printables/grade/[grade].astro
+++ b/src/pages/printables/grade/[grade].astro
@@ -1,0 +1,218 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import HubLinks from "../_HubLinks.astro";
+import {
+  GRADES,
+  ageRange,
+  gradeHref,
+  sheetByHref,
+  sheetsForGrade,
+  shelvesForGrade,
+  type Grade,
+} from "../_grades";
+
+/**
+ * One hub per school year, Pre-K through 8th — the other half of §8's browse,
+ * cutting across the shelves rather than along them.
+ *
+ * A parent who knows their child is in third grade does not know that what they
+ * want is on the maths shelf, the cursive shelf and the paperwork shelf at once.
+ * This page is the answer to the question they actually have, and it is written
+ * for the two jobs a hub does: somewhere to go next, and a crawlable parent for
+ * the sheets underneath it.
+ *
+ * **Nothing on it is written twice.** The listing is `shelvesForGrade`, which
+ * reads each catalog's own `ages` string, so a sheet re-aged in the file that
+ * owns it moves between these pages by itself and a sheet added to a shelf
+ * appears on the years it says it is for. The only hand-written parts are the
+ * year's prose and its three landmarks — and a landmark is a *route*, whose
+ * name is read back out of the catalog, so the one thing a person types here
+ * cannot disagree with the sheet it points at.
+ *
+ * **A listing rather than a sheet**, like every other hub in this corner:
+ * nobody prints a list of worksheets. It ships no JavaScript, which is the
+ * whole SEO argument (§2), and it needs none — there is nothing on it but
+ * links.
+ *
+ * On the grade labels themselves, see the header of `_grades.ts`: no sheet here
+ * is labelled "Grade 3", these pages collect what the sheets' own stated ages
+ * reach, and the page says so in as many words rather than leaving a parent to
+ * assume a standard was consulted.
+ */
+
+type Props = { grade: Grade };
+
+export function getStaticPaths() {
+  return GRADES.map((grade) => ({
+    params: { grade: grade.slug },
+    props: { grade },
+  }));
+}
+
+const { grade } = Astro.props;
+
+const shelves = shelvesForGrade(grade);
+const sheets = sheetsForGrade(grade);
+const [younger, older] = grade.ages;
+
+/* The names beside the three landmarks come from the catalogs, so this page
+   holds no second copy of a sheet's name to fall out of step with the first.
+   A route that stopped resolving would be dropped here and caught in
+   `_grades.test.ts`, which is the half of it that must not fail quietly.    */
+const landmarks = grade.landmarks.flatMap((pick) => {
+  const sheet = sheetByHref(pick.href);
+  return sheet ? [{ ...pick, name: sheet.name }] : [];
+});
+
+const title = `${grade.keyword} | School Skills`;
+const description = `${grade.heading} for ages ${younger} and ${older}: ${shelves
+  .map((shelf) => shelf.label)
+  .join(
+    ", ",
+  )}. Every one prints straight from the page — free, no account, and nothing to download.`;
+const url = `https://schoolskills.app${gradeHref(grade)}`;
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: grade.heading,
+    description,
+    url,
+    typicalAgeRange: ageRange(grade),
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    hasPart: sheets.map((sheet) => ({
+      "@type": "LearningResource",
+      name: sheet.name,
+      url: `https://schoolskills.app${sheet.href}`,
+      learningResourceType: "Worksheet",
+      teaches: sheet.teaches,
+      typicalAgeRange: sheet.ages,
+      isAccessibleForFree: true,
+    })),
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      {grade.label}
+    </p>
+    <h1 class="hero__title">{grade.heading}</h1>
+    <p class="hero__lead">{grade.lead}</p>
+    <p class="hero__note">
+      Ages {younger} and {older} &middot; {sheets.length} sheets &middot; no account
+    </p>
+  </header>
+
+  {
+    /*
+      Three sheets before the whole shelf. A page that opens with ninety links
+      has answered nothing; the point of a year having prose written for it is
+      that somebody chose what to print first.
+    */
+  }
+  <section class="band band--tight wrap">
+    <h2 class="h2">Where to start</h2>
+    <p class="h2__sub">
+      Three worth printing this week, out of everything below.
+    </p>
+    <div class="prose">
+      <ul>
+        {
+          landmarks.map((sheet) => (
+            <li>
+              <a href={sheet.href}>{sheet.name}</a> &mdash; {sheet.why}
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  </section>
+
+  <div class="wrap"><AdSlot name="article" /></div>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Everything for ages {younger} and {older}</h2>
+    <p class="h2__sub">
+      {sheets.length} sheets across {shelves.length} shelves, and each of them is
+      a page that is itself the sheet &mdash; open it, press print, and that is the
+      whole of it.
+    </p>
+    {
+      shelves.map((shelf) => (
+        <>
+          <h3 class="h2 h2--next">{shelf.label}</h3>
+          <p class="h2__sub">{shelf.blurb}</p>
+          <nav class="stones" aria-label={`${shelf.label} for ${grade.label}`}>
+            {shelf.sheets.map((sheet) => (
+              <a class="stone" href={sheet.href}>
+                {sheet.name}
+              </a>
+            ))}
+          </nav>
+          <div class="hero__actions">
+            <a class="cta cta--quiet" href={shelf.href}>
+              {shelf.all}
+            </a>
+          </div>
+        </>
+      ))
+    }
+  </section>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">What {grade.phrase} means on this page</h2>
+      <p class="h2__sub">
+        The ages come off each sheet, not off a standard we do not have.
+      </p>
+      <div class="prose">
+        {grade.notes.map((note) => <p>{note}</p>)}
+        <p>
+          No sheet on this site is labelled <em>{grade.label}</em>. Each one
+          states the ages it was drawn for on its own page &mdash; <em
+            >Ages 8&ndash;11</em
+          > on the division worksheet, because that is who those numbers suit &mdash;
+          and this page collects the sheets whose stated ages reach {younger} or {
+            older
+          }, which is where most children are in {grade.phrase}. So the same
+          sheet appears on two or three of these pages, and that is the honest
+          answer rather than a lapse: a sheet for nine to twelve belongs to the
+          fourth-grader and the seventh-grader both.
+        </p>
+        <p>
+          If your child is working a year either side of their class, the
+          neighbouring page is the one to use and nothing here will disagree
+          with you about it. Curriculum and grade levels differ by state, by
+          country and by family, and a worksheet site that told you otherwise
+          would be inventing a standard to sound authoritative.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <HubLinks grade={grade.slug} />
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Your child&rsquo;s name is not in the file</h2>
+    <div class="prose">
+      <p>
+        Where a sheet has a <em>Name:</em> line at all, it is printed blank and filled
+        in with a pencil. Nothing is uploaded to make one, no account is needed to
+        print one, and a sheet you send to another family carries the settings you
+        chose and nothing else &mdash; see <a href="/privacy"
+          >what we don&rsquo;t collect</a
+        >.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/grade/[grade].astro
+++ b/src/pages/printables/grade/[grade].astro
@@ -36,9 +36,17 @@ import {
  * links.
  *
  * On the grade labels themselves, see the header of `_grades.ts`: no sheet here
- * is labelled "Grade 3", these pages collect what the sheets' own stated ages
- * reach, and the page says so in as many words rather than leaving a parent to
- * assume a standard was consulted.
+ * is assigned to a school year, these pages collect what the sheets' own stated
+ * ages reach, and the page says so in as many words rather than leaving a
+ * parent to assume a standard was consulted.
+ *
+ * That sentence says "assigned", not "labelled", and it names no year — which
+ * is deliberate. A ruling in the paper catalog is called "Kindergarten writing
+ * paper", after the size it is conventionally sold at, and it is listed here on
+ * the two years its own "Ages 4–6" reaches. A sentence built out of
+ * `grade.label` would therefore have shipped "No sheet is labelled Kindergarten"
+ * directly above a link that says otherwise. What is true of every sheet is
+ * that none of them is *filed* by year; the filing is `ages`, and only `ages`.
  */
 
 type Props = { grade: Grade };
@@ -175,8 +183,8 @@ const url = `https://schoolskills.app${gradeHref(grade)}`;
       <div class="prose">
         {grade.notes.map((note) => <p>{note}</p>)}
         <p>
-          No sheet on this site is labelled <em>{grade.label}</em>. Each one
-          states the ages it was drawn for on its own page &mdash; <em
+          No sheet on this site is assigned to a school year. Each one states
+          the ages it was drawn for on its own page &mdash; <em
             >Ages 8&ndash;11</em
           > on the division worksheet, because that is who those numbers suit &mdash;
           and this page collects the sheets whose stated ages reach {younger} or {

--- a/src/pages/printables/grade/index.astro
+++ b/src/pages/printables/grade/index.astro
@@ -1,0 +1,157 @@
+---
+import Content from "@/layouts/Content.astro";
+import AdSlot from "@/components/site/AdSlot.astro";
+import HubLinks from "../_HubLinks.astro";
+import { GRADES, gradeHref, sheetsForGrade } from "../_grades";
+
+/**
+ * The parent of the ten year pages — the second axis the Print Shop is
+ * browsable on, and the page that explains what a grade means here.
+ *
+ * It exists for two reasons and neither is decorative. A crawler that finds
+ * `/printables/grade/3rd-grade` will ask for `/printables/grade`, and a
+ * directory that 404s on a static host is a dead end rather than a redirect.
+ * And the ten pages each carry two sentences about how their ages were arrived
+ * at; this is where the argument is made once, at length, so those two
+ * sentences are a summary of something rather than the whole of it.
+ *
+ * The counts on it are computed, never typed. A hub whose prose says "twelve
+ * sheets" is one catalog edit away from lying to a reader who can see the list
+ * underneath, and this whole section is meant to survive shelves being added
+ * to it.
+ */
+const years = GRADES.map((grade) => ({
+  grade,
+  sheets: sheetsForGrade(grade).length,
+}));
+
+const title = "Printable worksheets by grade, Pre-K to 8th | School Skills";
+const description =
+  "Ten pages, one per school year: what a child that age can print, drawn from every shelf in the Print Shop at once. Free, no account, and nothing to download — and the ages come off each sheet rather than off a standard.";
+---
+
+<Content
+  title={title}
+  description={description}
+  world="paper"
+  jsonLd={{
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Printable worksheets by grade",
+    description,
+    url: "https://schoolskills.app/printables/grade",
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    hasPart: GRADES.map((grade) => ({
+      "@type": "CollectionPage",
+      name: grade.heading,
+      url: `https://schoolskills.app${gradeHref(grade)}`,
+      isAccessibleForFree: true,
+    })),
+  }}
+>
+  <header class="hero wrap">
+    <p class="hero__eyebrow">
+      <span class="hero__world">The Print Shop</span>
+      By grade
+    </p>
+    <h1 class="hero__title">Printables by school year</h1>
+    <p class="hero__lead">
+      Pre-K through eighth grade, a page each. A shelf answers &ldquo;what kind
+      of sheet is this&rdquo;; a year answers the question a parent actually
+      arrives with, which is what a six-year-old can be handed on a wet
+      Wednesday.
+    </p>
+    <p class="hero__note">Free &middot; no account &middot; no download</p>
+  </header>
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">The ten years</h2>
+    <p class="h2__sub">
+      Each one lists every sheet in the shop whose own stated ages reach it
+      &mdash; maths, handwriting, cursive, spelling, grammar, phonics, Scripture
+      copywork, the blank references, the paperwork and the paper.
+    </p>
+    {
+      years.map(({ grade, sheets }) => (
+        <>
+          <h3 class="h2 h2--next">
+            <a href={gradeHref(grade)}>{grade.heading}</a>
+          </h3>
+          <p class="h2__sub">
+            Ages {grade.ages[0]} and {grade.ages[1]} &middot; {sheets} sheets
+          </p>
+          <div class="prose">
+            <p>{grade.lead}</p>
+          </div>
+        </>
+      ))
+    }
+  </section>
+
+  <div class="wrap"><AdSlot name="article" /></div>
+
+  <section class="band band--inset">
+    <div class="wrap">
+      <h2 class="h2">Where the grade comes from</h2>
+      <p class="h2__sub">
+        Off the sheet, and nowhere else. There is no standard behind these pages
+        and none is implied.
+      </p>
+      <div class="prose">
+        <p>
+          Every sheet in the Print Shop states the ages it was drawn for, on its
+          own page &mdash; <em>Ages 8&ndash;11</em> on the division worksheet, <em
+            >Ages 4&ndash;6</em
+          > on the sound cards. That judgement is made once, beside the sheet, by
+          whoever chose the numbers that go on it. A year page here collects the sheets
+          whose stated ages reach the ages most children are in that year, and that
+          is the whole of the mechanism.
+        </p>
+        <p>
+          It is deliberately the weakest claim that is still useful. A
+          grade-level label invented by a worksheet site is a guess dressed up
+          as a standard: curriculum differs by state, by country and by family,
+          and the parent reading it can already see their own child. So a sheet
+          for nine to twelve is listed on the fourth-grade page and on the
+          seventh-grade page both, because a nine-year-old and a twelve-year-old
+          are each in one of them, and withholding it from either to make the
+          categories look tidy would help nobody.
+        </p>
+        <p>
+          Two years to a page, rather than one age. A first-grader is six in the
+          autumn and seven by the spring, and a page that only reached the
+          younger of those would drop half of what a parent needs by February.
+          If your child is working a year either side of their class, print from
+          the neighbouring page &mdash; nothing here will disagree with you
+          about which one that is.
+        </p>
+        <p>
+          Every shelf is listed the same way, Scripture included. A copywork
+          sheet with a psalm on it is a copywork sheet: it appears under its own
+          heading in the year its ages say, beside the maths and the reading
+          logs, rather than in a section off to one side.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <HubLinks />
+
+  <section class="band band--tight wrap">
+    <h2 class="h2">Your child&rsquo;s name is not in the file</h2>
+    <div class="prose">
+      <p>
+        Nothing on these pages knows anything about your child &mdash; not their
+        age, not their year, and certainly not their name, which is printed as a
+        blank line and filled in with a pencil. Choosing a year here is choosing
+        which list to look at, and it is not recorded anywhere &mdash; see <a
+          href="/privacy">what we don&rsquo;t collect</a
+        >.
+      </p>
+    </div>
+    <div class="hero__actions">
+      <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
+    </div>
+  </section>
+</Content>

--- a/src/pages/printables/grammar/index.astro
+++ b/src/pages/printables/grammar/index.astro
@@ -2,6 +2,7 @@
 import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { GRAMMAR_SHEETS, grammarShelf, pathFor } from "../_grammar";
+import HubLinks from "../_HubLinks.astro";
 
 /**
  * The grammar subject hub — a peer of `/printables/spelling`,
@@ -160,6 +161,8 @@ const groups = grammarShelf();
       >
     </div>
   </section>
+
+  <HubLinks shelf="grammar" />
 
   <section class="band band--tight wrap">
     <h2 class="h2">Your child&rsquo;s name is not in the file</h2>

--- a/src/pages/printables/handwriting/index.astro
+++ b/src/pages/printables/handwriting/index.astro
@@ -7,6 +7,7 @@ import {
   handwritingShelf,
   hrefFor,
 } from "../_handwriting";
+import HubLinks from "../_HubLinks.astro";
 
 /**
  * The handwriting subject hub — the second of the three §8 names to exist.
@@ -236,4 +237,5 @@ const letter = STOCKS[0];
       <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
     </div>
   </section>
+  <HubLinks shelf="handwriting" />
 </Content>

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -34,6 +34,7 @@ import {
   pathFor as templatePath,
   templateShelf,
 } from "./_templates";
+import HubLinks from "./_HubLinks.astro";
 
 /**
  * The Print Shop's front door.
@@ -381,7 +382,9 @@ const paperwork = templateShelf();
         exists rather than what is planned. Paper, maths, handwriting, cursive,
         copywork, spelling, grammar, phonics, the blank references and the
         paperwork &mdash; logs, planners, certificates and cards &mdash; are all
-        open. The grade and subject hubs, and a search across the lot, are next.
+        open, and so are the two ways of browsing them: a shelf per subject, and
+        a page per school year from Pre-K to eighth grade. A search across the
+        lot is next.
       </p>
       <div class="prose">
         <p>
@@ -407,6 +410,8 @@ const paperwork = templateShelf();
       </div>
     </div>
   </section>
+
+  <HubLinks />
 
   <section class="band band--tight wrap">
     <h2 class="h2">Your child&rsquo;s name is not in the file</h2>

--- a/src/pages/printables/math.astro
+++ b/src/pages/printables/math.astro
@@ -2,6 +2,7 @@
 import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { MATHS_SHEETS, mathsShelf, pathFor } from "./_maths";
+import HubLinks from "./_HubLinks.astro";
 
 /**
  * The maths subject hub — one of the three §8 names, and the first to exist.
@@ -179,4 +180,5 @@ const strands = mathsShelf();
       <a class="cta cta--quiet" href="/printables">Back to The Print Shop</a>
     </div>
   </section>
+  <HubLinks shelf="math" />
 </Content>

--- a/src/pages/printables/phonics/index.astro
+++ b/src/pages/printables/phonics/index.astro
@@ -2,6 +2,7 @@
 import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { PHONICS_SHEETS, pathFor, phonicsShelf } from "../_phonics";
+import HubLinks from "../_HubLinks.astro";
 
 /**
  * The phonics subject hub — a peer of `/printables/spelling`,
@@ -165,6 +166,8 @@ const groups = phonicsShelf();
       >
     </div>
   </section>
+
+  <HubLinks shelf="phonics" />
 
   <section class="band band--tight wrap">
     <h2 class="h2">Your child&rsquo;s name is not in the file</h2>

--- a/src/pages/printables/spelling/index.astro
+++ b/src/pages/printables/spelling/index.astro
@@ -2,6 +2,7 @@
 import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SPELLING_SHEETS, pathFor, spellingShelf } from "../_spelling";
+import HubLinks from "../_HubLinks.astro";
 
 /**
  * The spelling subject hub — a peer of `/printables/math`,
@@ -177,6 +178,8 @@ const groups = spellingShelf();
       </a>
     </div>
   </section>
+
+  <HubLinks shelf="spelling" />
 
   <section class="band band--tight wrap">
     <h2 class="h2">Your child&rsquo;s name is not in the file</h2>

--- a/src/pages/printables/templates/index.astro
+++ b/src/pages/printables/templates/index.astro
@@ -2,6 +2,7 @@
 import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { TEMPLATE_SHEETS, pathFor, templateShelf } from "../_templates";
+import HubLinks from "../_HubLinks.astro";
 
 /**
  * The forms-and-templates hub — a peer of `/printables/math`,
@@ -185,6 +186,8 @@ const groups = templateShelf();
       <a class="cta cta--quiet" href="/printables/lined-paper">Lined paper</a>
     </div>
   </section>
+
+  <HubLinks shelf="templates" />
 
   <section class="band band--tight wrap no-print">
     <h2 class="h2">Your child&rsquo;s name is not in the file</h2>


### PR DESCRIPTION
Closes #72. Epic **PRINT28** — design in `docs/printables.md`.

## What this adds

**Ten grade hubs.** `/printables/grade/pre-k` through `/printables/grade/8th-grade`, plus `/printables/grade` as their parent. Each page opens with three landmark sheets for that year, then lists everything on the site drawn for that age, grouped by shelf.

**A cross-link row on every hub.** `_HubLinks.astro` prints every shelf and every school year at the foot of all eleven subject and front-door hubs, so no new page is something only the sitemap knows about. `/printables/bible` sits in that row as a peer of the other shelves, not as a special case.

## Why it is built this way

**A grade is read off the sheets, never written onto them.** All 119 catalog entries already state the ages they were drawn for — "Ages 8–11" on the division worksheet — a judgement made once, beside the sheet, by whoever chose the numbers that go on it. A year page is therefore the sheets whose stated band overlaps the two ages a child is in that year, which makes `_grades.ts` a parser and an overlap test rather than a second table of judgements to keep in sync. Nothing here is labelled "Grade 3" by us, and each page says so in as many words: a grade level invented by a worksheet site is a guess dressed as a standard, and the parent reading it can already see their own child.

Two consequences are stated on the page rather than hidden:

- A sheet for nine to twelve is listed on both the fourth-grade and seventh-grade pages, because a nine-year-old and a twelve-year-old are each in one of those years.
- The shelves that stop, stop. There is no handwriting, cursive, phonics, spelling or grammar sheet on the eighth-grade page, because every one of those families ends before thirteen. A test pins this, since relabelling a sheet to make that page look fuller is the one thing a catalog like this must not do.

**Nothing a hub claims is typed twice.** Counts are computed from the listing beneath them, the landmark sheets are routes whose names are read back out of the catalog that owns them, and the ages come from the catalogs rather than a copy here. `ageBand` throws on an age string written a third way rather than silently matching no year — the failure worth avoiding is a sheet that vanishes from all ten pages with every test still green.

`_shelves.ts` is the registry the year pages read, and the one place that knows there are ten shelves rather than nine.

**Scripture is listed like everything else**, under its own heading in each of the ten years — §12's "woven through" applied to the second axis. Nothing about it reaches a title, description or JSON-LD beyond the shelf's name in a list of what is on the page.

## Review fixes in the second commit

Three places where prose or a docblock asserted something the data underneath did not support:

- **The kindergarten page contradicted itself.** Year prose built from `grade.label` shipped "No sheet on this site is labelled Kindergarten" directly above a link reading "Kindergarten writing paper — 1 inch". The paper is named after the size it is conventionally sold at, and its "Ages 4–6" correctly puts it on both the Pre-K and kindergarten pages — the sentence was the wrong half. It now says no sheet is *assigned* to a school year and names no year at all, which is true of all ten pages. The test pins the collision rather than forbidding it, so a new colliding name fails and sends whoever added it to the sentence.
- **"Narrow ruled arrives here" arrived a year early.** The sheet states "Ages 12+" and sixth grade is eleven and twelve, so it was already listed on `/printables/grade/6th-grade`. The seventh-grade note now makes no arrival claim and says where the sheet first reaches instead. Ages were not touched.
- **Two of `ShelfSheet`'s six fields were dead.** `short` and `summary` were projected out of all ten catalogs and read by nothing, while their docblocks described a contract the only consumer broke by rendering `name`. Rendering `name` is the right call and is now the documented one. Both fields are gone from the type, from `listing()` and from its generic constraint — now `ShelfSheet` minus `href`, so the projection cannot again require a field no listing reads.

Also a quick win: the charts hub named its eight peers one by one and had been wrong since the paperwork shelf landed. It reads the registry now.

## Acceptance criteria

- [x] `/printables/grade/[grade]` for Pre-K through 8th — ten pages, plus a parent index.
- [x] `/printables/[subject]` for each subject, including `/printables/bible` as a peer.
- [x] Every hub lists real sheets that exist, cross-links to siblings, and carries genuine prose.
- [x] Grade hubs list Scripture sheets alongside everything else for that age.
- [x] All hubs indexable, in the sitemap, shipping zero JavaScript.

## Validation

`type-check`, `lint`, `test:unit` (1439 passing), `build` and the browser smoke test all pass locally. Twenty new tests, and the ones that matter run against `dist/` rather than the data that generated it: every link a hub prints has a file behind it, all eleven grade routes are in the sitemap, and no year page ships an `astro-island`. Build is 200 static pages, 195 sitemap URLs, no console errors in the smoke run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
