### PR TITLE
PRINT30: Scripture on the site where it's content, not where it's a credential

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -882,16 +882,24 @@ read as evasive.
 | `/about`, under _Why it exists_              | The one page whose entire job is "who is behind this". One plain sentence, not a statement of faith. A parent who cares finds it where they'd look; nobody else trips over it.                                                         |
 
 **Where it does not go, and this is the part that protects the intent.** Any
-`<title>`, `description` or `jsonLd`, on any page — that surface _is_
-marketing. The home page hero, which is the pitch. The `#limits` columns and
-the "What they see, and what you don't" ledger, which are about scope and
-privacy and would take a verse as a non sequitur. And no badge, emblem,
-"faith-based" label, or statement of faith anywhere.
+`<title>`, `description` or `jsonLd` on a page whose subject is _not_ Scripture
+— that surface is marketing, and a marker there is a credential rather than a
+description. A page whose subject **is** Scripture names it in its metadata the
+way every page names its own subject: the `/printables/bible` shelf and the
+sheets under it (`/printables/bible/1-corinthians-13-copywork` opens its
+description with the verse it prints), the three verse templates, and a grade
+hub that lists Bible among its shelves (`/printables/grade/1st-grade`). Those
+are the search surfaces this section asked for a few paragraphs up, and the
+carve-out is exactly as wide as the subject — no wider. Also out: the home page
+hero, which is the pitch; the `#limits` columns and the "What they see, and
+what you don't" ledger, which are about scope and privacy and would take a
+verse as a non sequitur. And no badge, emblem, "faith-based" label, or
+statement of faith anywhere.
 
 **Which verse, which is most of the decision.** Prefer verses apt to the
 _thesis_ over verses apt to the _audience_:
 
-- Zechariah 4:10 — _"who has despised the day of small things?"_ Directly the
+- Zechariah 4:10 — _"who despises the day of small things?"_ Directly the
   site's argument about ten minutes a day.
 - Proverbs 13:11 — _"…but he who gathers by hand makes it grow."_ Incremental
   accumulation, which is the whole product.
@@ -902,6 +910,26 @@ them diligently to your children"_), which are the two most-used verses in
 homeschool marketing. They're apt, but they're apt to _who is reading_, and a
 reader clocks that instantly. The first set says something about the work. The
 second says something about us.
+
+**What shipped (PRINT30).** Four placements, two verses, and neither of them
+typed into a page. Zechariah 4:10 is the footer signature — the reference
+alone, no text, one quiet line under _"Made for four kids, then shared."_ on
+every page. Proverbs 21:5 is the one quotation, in the "Where it fits in a day"
+band, because that band already argues what the verse argues; it is set the way
+an aside is set, with the reference and `SCRIPTURE_CREDIT` underneath it.
+`/about` gets one sentence under _Why it exists_ — a fact, with a link to
+`/printables/bible`, which is the page a reader checks it against. The Print
+Shop's map card needed nothing: its blurb already listed Scripture copywork
+among times tables, handwriting and spelling lists, so `worlds.ts` is
+unchanged.
+
+Both are read through `passage()` rather than inlined, which puts the licence
+condition in code instead of in a reviewer's memory: the words on the home page
+are the release's own, and the credit travels with them exactly as it travels
+onto a sheet. `passage()` answers `undefined` rather than throwing, so either
+surface renders nothing at all if its id is ever retired — which is silent, so
+`passages/index.test.ts` pins both ids to their references and makes a rename
+fail there instead.
 
 ### The same principle extends to the games
 

--- a/src/components/site/SiteFooter.astro
+++ b/src/components/site/SiteFooter.astro
@@ -2,12 +2,15 @@
 /**
  * The footer, and the site's internal-linking backbone.
  *
- * The twelve times-table pages are the main organic-search surface, and they
- * are listed here rather than only on the home page so every page links to
- * every one of them — which is the cheap half of making a set of pages
- * crawlable from any entry point. As a row of number chips it costs one line
- * of vertical space instead of twelve.
+ * The twelve times-table pages are the site's oldest organic-search surface,
+ * and they are listed here rather than only on the home page so every page
+ * links to every one of them — which is the cheap half of making a set of
+ * pages crawlable from any entry point. As a row of number chips it costs one
+ * line of vertical space instead of twelve. (The Print Shop's catalog is the
+ * larger surface now, and it links its own sheets from its own hubs, so a
+ * single link to its front door in the worlds column is all it wants here.)
  */
+import { passage } from "@/engine/sheets/passages";
 import { WORLDS } from "@/engine/worlds";
 
 const tables = Array.from({ length: 12 }, (_, i) => i + 1);
@@ -16,6 +19,21 @@ const tables = Array.from({ length: 12 }, (_, i) => i + 1);
 // and needs its own, or it's a page nothing points at. Only some worlds have
 // one, so this renders nothing when none do.
 const guides = WORLDS.flatMap((w) => (w.guide ? [w.guide] : []));
+
+/**
+ * The signature under the fine print — a reference, and deliberately not a
+ * verse (docs/printables.md §12).
+ *
+ * This is the author's own voice already ("Made for four kids, then shared"),
+ * which is the whole reason it is the one piece of chrome a reference belongs
+ * in: it reads as a signature rather than a banner, and it is on every page
+ * without being on any one page's pitch. Nothing is quoted, so nothing needs
+ * crediting — but the reference is still read out of the passage library
+ * rather than typed here, so the footer cannot name a passage the site does
+ * not actually hold. `passage()` answers `undefined` rather than throwing, and
+ * a footer that lost its signature is a footer, so this renders nothing.
+ */
+const signature = passage("the-day-of-small-things")?.title;
 ---
 
 <footer class="foot">
@@ -68,5 +86,6 @@ const guides = WORLDS.flatMap((w) => (w.guide ? [w.guide] : []));
     nowhere else &mdash; which also means clearing site data clears it, so
     there&rsquo;s a <strong>Back up progress</strong> button on the player screen
     that writes a file you keep.
+    {signature && <span class="foot__sign">{signature}</span>}
   </p>
 </footer>

--- a/src/engine/sheets/passages/index.test.ts
+++ b/src/engine/sheets/passages/index.test.ts
@@ -148,6 +148,25 @@ describe("the front door", () => {
     expect(passage("the-swing", "kjv")).toEqual(passage("the-swing"));
   });
 
+  it("still holds the two passages the site's own chrome quotes", () => {
+    // The footer's signature (`components/site/SiteFooter.astro`) and the
+    // verse under "Where it fits in a day" (`pages/index.astro`) both read
+    // through this door, and both render nothing when it answers `undefined`
+    // — by design, because a chrome element is not worth a failed build.
+    // Which means renaming either id would quietly drop a reference from
+    // every page on the site, and a verse from the home page, with the types,
+    // the build and the rest of this suite all green. This is what fails
+    // instead, and it names the two surfaces so the reason arrives with it.
+    expect(passage("the-day-of-small-things")?.title).toBe("Zechariah 4:10");
+
+    const band = passage("the-plans-of-the-diligent");
+    expect(band?.title).toBe("Proverbs 21:5");
+    // The home page prints this under the verse. A passage that arrived
+    // without it would be quoted on the front door saying nothing about where
+    // the words came from, which is the one condition §12 accepts.
+    expect(band?.credit).toBe(SCRIPTURE_CREDIT);
+  });
+
   it("groups by collection, and every collection has something in it", () => {
     for (const collection of PASSAGE_COLLECTIONS) {
       expect(passagesIn(collection.id).length, collection.id).toBeGreaterThan(

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,7 +21,7 @@ import Content from "@/layouts/Content.astro";
 const title = "About School Skills — who made it and how to reach us";
 const description =
   "School Skills is a free set of practice games built by a parent for four kids, then shared. No accounts, no tracking, and a real address to write to.";
-const updated = "16 August 2026";
+const updated = "17 August 2026";
 ---
 
 <Content
@@ -72,6 +72,23 @@ const updated = "16 August 2026";
         repetition bearable: a clock, and a version of yourself from last week
         to race. A child who is bored of being told they are improving can
         instead watch a ghost of their own previous run and beat it.
+      </p>
+      {
+        /*
+          One sentence, and a fact rather than a statement of faith
+          (docs/printables.md §12). This is the page whose whole job is "who is
+          behind this", so a parent who wants to know finds it where they would
+          look and nobody else trips over it. What it says is checkable on the
+          page it links to: Scripture is in the same passage picker as the
+          poems and the founding documents, listed first, and is one source
+          among several rather than the point of the place.
+        */
+      }
+      <p>
+        It&rsquo;s run by a Christian family, which is why{" "}
+        <a href="/printables/bible">Scripture copywork</a> is in The Print Shop&rsquo;s
+        passage picker beside the poems and the founding documents &mdash; listed
+        first, and one source among several.
       </p>
 
       <h2>What it is, and what it isn&rsquo;t</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,8 +35,13 @@ const description =
  * saying which team the site is on. That rule puts it here and keeps it out of
  * the hero, the `#limits` columns and the ledger, which are the pitch, the
  * scope and the privacy ledger and would each take a verse as a non sequitur.
- * The title, the description and the jsonLd above are marketing surfaces and
- * carry nothing of the sort, on this page or on any other.
+ * The title, the description and the jsonLd above are marketing surfaces, and
+ * they carry no verse and no reference — which is the rule for every page
+ * whose subject is not Scripture. The pages whose subject *is* Scripture name
+ * it there as any page names its own subject: the Bible shelf and its sheets,
+ * the verse templates, and the grade hubs that list Bible among their
+ * shelves. Naming a subject is a description; a marker on a page about
+ * something else would be the credential.
  *
  * Read out of the passage library rather than typed here: the condition on the
  * translation's name is that the text is not altered, and quoting it through

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import WorldMap from "@/components/site/WorldMap.astro";
+import { passage, passageText } from "@/engine/sheets/passages";
 
 /**
  * The overworld.
@@ -23,6 +24,26 @@ const title =
   "School Skills — free homeschool practice games for times tables, spelling and typing";
 const description =
   "Three free practice games for homeschool and after-school: times tables, sight words and touch typing. No account, no tracking, no personalised ads. A supplement to your lessons, not a curriculum.";
+
+/**
+ * The one verse on this page, and the band it sits in is why it is allowed to
+ * be here at all (docs/printables.md §12).
+ *
+ * "Where it fits in a day" already argues that short and frequent beats long
+ * and rare, and Proverbs 21:5 argues the same thing about the same work — so
+ * it reads as the section's own point stated older, rather than as a badge
+ * saying which team the site is on. That rule puts it here and keeps it out of
+ * the hero, the `#limits` columns and the ledger, which are the pitch, the
+ * scope and the privacy ledger and would each take a verse as a non sequitur.
+ * The title, the description and the jsonLd above are marketing surfaces and
+ * carry nothing of the sort, on this page or on any other.
+ *
+ * Read out of the passage library rather than typed here: the condition on the
+ * translation's name is that the text is not altered, and quoting it through
+ * the same door a copywork sheet quotes it from means the words are the
+ * release's own and the credit line travels with them.
+ */
+const verse = passage("the-plans-of-the-diligent");
 ---
 
 <Content
@@ -185,6 +206,21 @@ const description =
         </p>
       </div>
     </div>
+    {
+      verse && (
+        <figure class="verse">
+          {/* Nothing is added around the text and nothing is re-wrapped: the
+              passage is set as the release has it, the same as it would be on
+              a sheet. The reference and the credit go underneath, where a
+              source line belongs. */}
+          <blockquote class="verse__text">{passageText(verse)}</blockquote>
+          <figcaption class="verse__ref">
+            {verse.title}
+            {verse.credit && <span class="verse__credit">{verse.credit}</span>}
+          </figcaption>
+        </figure>
+      )
+    }
   </section>
 
   <section class="band band--inset">

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -277,3 +277,14 @@
   color: var(--chalk-dim);
   line-height: 1.6;
 }
+
+/* The reference under it, set as a signature: its own line, quieter than the
+   paragraph it follows, and no bigger. A banner would be the other thing
+   (docs/printables.md §12). */
+.foot__sign {
+  display: block;
+  margin-top: var(--gap-2);
+  font-family: var(--font-mono);
+  letter-spacing: 0.1em;
+  color: var(--chalk-soft);
+}

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -373,6 +373,43 @@
   color: var(--chalk-soft);
 }
 
+/* The verse under the band, and the styling is most of what keeps it content
+   rather than a credential (docs/printables.md §12). Set as an aside is set —
+   one rule down the left, the body size, the body's colours — so it reads as
+   another line of the argument. Nothing here centres it, enlarges it or gives
+   it a flourish, because all three would make it an announcement. */
+.verse {
+  max-width: 62ch;
+  margin-top: var(--gap-4);
+  padding-left: var(--gap-3);
+  border-left: 2px solid color-mix(in oklab, var(--accent) 45%, transparent);
+}
+
+.verse__text {
+  font-size: var(--step--1);
+  line-height: 1.65;
+  color: var(--chalk-soft);
+}
+
+.verse__ref {
+  margin-top: 0.55rem;
+  font-family: var(--font-mono);
+  font-size: var(--step--2);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+/* The credit is required by nothing and printed anyway, on every surface that
+   shows a verse — so it is small, and it is never smaller than the sheet's. */
+.verse__credit {
+  display: block;
+  margin-top: 0.3rem;
+  letter-spacing: 0.03em;
+  text-transform: none;
+  color: var(--chalk-dim);
+}
+
 /* ── The facts table ────────────────────────────────────────────────────
    A real <table> because it IS tabular data — that's what makes it legible to
    a screen reader and eligible for a rich result. Styled as a scoreboard: the


### PR DESCRIPTION
Closes #74.

Scripture reaches the front door as **content rather than as a credential** —
`docs/printables.md` §12's rule, in four placements and one prohibition.

## What changed

**A reference in the footer's fine print.** Zechariah 4:10, the reference alone
and deliberately no text, on its own quiet line under *"Made for four kids, then
shared."* That paragraph is already the author's own voice, which is the whole
reason a reference belongs there: it reads as a signature rather than a banner,
and it appears on every page without being on any page's pitch.

**A verse in the "Where it fits in a day" band on `/`.** Proverbs 21:5 is the
one quotation on the site's chrome, and it sits in that band because that band
already argues what the verse argues — short and frequent beats long and rare.
It states the section's own point older, rather than announcing which team the
site is on. Set the way an aside is set: one rule down the left, body size, body
colours, nothing centred or enlarged.

**One plain sentence on `/about` under "Why it exists."** A fact with a link to
the page that proves it, not a statement of faith. `/about`'s "Updated" date
moves with the page it dates.

**The Print Shop's map card needed nothing.** Its blurb already listed Scripture
copywork among times tables, handwriting rules and spelling lists — the "fact
among facts" the story asked for — so `worlds.ts` is unchanged.

## Where it deliberately did not go

Nothing was added to a `<title>`, a `description` or a `jsonLd` on any page
whose subject is not Scripture, and nothing went into the hero, the `#limits`
columns or the "what they see, and what you don't" ledger — those are the pitch,
the scope and the privacy ledger, and a verse in any of them would be exactly
the credential §12 rules out. Verified against `dist/`. No badge, emblem or
"faith-based" label anywhere.

## Two things review caught

**The rule was written down twice, and the two readings disagreed.** §12 said a
marker may not appear in any title, description or jsonLd *"on any page"*, while
its own body argued the Bible shelf exists because "bible verse copywork
printable" is a query — and thirty-five built pages take the second reading, one
of them opening its meta description with the verse it prints. §12 now states
the line the code actually follows: a page whose subject **is** Scripture names
it in its metadata the way every page names its own subject, and the prohibition
is on a page about something else carrying a marker as a credential. It cites
the shipped cases so the carve-out can be measured rather than argued. A "What
shipped (PRINT30)" note records the four placements beside the existing
PRINT18/19 and PRINT23 notes.

**Both new surfaces fail silently by design.** `passage()` answers `undefined`
for an id it has never heard of, and the footer and the home page each render
nothing rather than break a build over a piece of chrome — so renaming either id
would drop the signature from every page and the verse from the home page with
lint, types, tests and the build all green. `passages/index.test.ts` now pins
both ids to their references and the home page's verse to `SCRIPTURE_CREDIT`,
and names the two surfaces so a rename fails with the reason attached.

Also corrected §12's own Zechariah 4:10 quotation, which matched neither release
we ship.

## Why quoted through `passage()`

Both quotations come out of the passage library rather than being typed into a
page. The one condition on the translation's name is that the text is not
altered, so quoting through the same door a copywork sheet quotes through means
the words are the release's own and `SCRIPTURE_CREDIT` travels with them. The
credit is printed under the verse, as it is on a sheet and on the Bible hub.

## Validation

`type-check`, `lint`, `test:unit` (1475 passed), `build` (200 pages) and the
browser smoke test all green, with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
