### PR TITLE
PRINT31: Scripture in Frost Keys and Word Jungle, as one source among several

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -950,6 +950,33 @@ places are nearly free:
 
 Neither is a phase-0 concern; both belong with the passage library in phase 3.
 
+**What shipped (PRINT31).** A fifth typing level — _Verses_, thirty-three of
+the library's verses from Psalms, Proverbs, the Gospels and the letters — and
+the whole shipped shelf in Word Jungle's picker rather than Dolch alone, which
+is a one-word change because PRINT23 authored the Bible lists as ordinary
+`WordList`s. Nothing was renamed and `configKey` is untouched, so every saved
+run still resolves and still races its own ghosts.
+
+Two rules picked the thirty-three, and the second was the surprise: no divine
+name, as above — and nothing but keys a plain keyboard has. The release sets
+quoted speech in curly quotation marks and typing marks **exactly**, so a verse
+carrying one would be unpassable rather than hard. That rules out the narrative
+and every quoted saying, and leaves the sayings themselves, which is the right
+shape for a level anyway.
+
+The verses are written out in `decks/typing.ts` rather than read through
+`passage()`, and that is the one place this epic paid for "authored once".
+Every island imports the deck registry, the print shop uses the whole library,
+and a module is assigned to a chunk whole — so an import of the library from
+that file moved all of it into the chunk the flash cards, the spelling mount
+and the record book load: 46KB of shared chunk became 222KB, measured on the
+way past. `typing.test.ts` pins every line to the library character for
+character instead, which is the arrangement `scripture.ts` already has with its
+release file. `SCRIPTURE_CREDIT` moved to a leaf module (`passages/credit.ts`)
+so a game can carry the credit without carrying the verses, and it is printed
+on all three screens that show the words: the setup that names the level, the
+race, and the results that list every word back.
+
 ---
 
 ## 13 · Phonics — and why it isn't called DISTAR

--- a/src/engine/decks/typing.test.ts
+++ b/src/engine/decks/typing.test.ts
@@ -6,6 +6,7 @@ import {
   buildTypingDeck,
   buildTypingDrill,
   describeTypingConfig,
+  levelCredit,
   passageFor,
   typingConfigKey,
   typingDeckSpec,
@@ -13,6 +14,7 @@ import {
   typingMode,
   wordsPerMinute,
 } from "./typing";
+import { SCRIPTURE_CREDIT, listPassages } from "@/engine/sheets/passages";
 import { buildDeck, configKey, deckSpec, isTyping, modeOf } from "./index";
 import type { TypingConfig } from "@/engine/types";
 
@@ -67,6 +69,79 @@ describe("the levels", () => {
   it("gives every age a level", () => {
     for (const age of [4, 5, 6, 7, 8, 9, 10, 11, 14]) {
       expect(typingLevelForAge(age).pool.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+/**
+ * The Scripture level, held to the licence rather than to a promise.
+ *
+ * eBible.org's one condition on the World English Bible is that a *modified*
+ * text may not carry the name, and `passages/scripture.test.ts` enforces that
+ * for the library by comparing it to the release file it was pulled from. The
+ * typing pool is a second copy of thirty-three of those verses (typing.ts says
+ * why it is a copy), so it gets the same treatment one link further along: the
+ * pool is compared to the library, which is compared to the release. Edit a
+ * verse here and it stops matching; edit both and the release check catches it.
+ */
+describe("the Scripture level", () => {
+  const pool = TYPING_LEVELS_BY_ID.get("scripture")!.pool;
+
+  /** Every verse this build ships, in the translation the pool quotes. */
+  const library = new Map<string, string>(
+    listPassages()
+      .filter((entry) => entry.kind === "scripture")
+      .flatMap((entry) =>
+        entry.lines.map((line): [string, string] => [line, entry.title]),
+      ),
+  );
+
+  it("quotes the library character for character", () => {
+    for (const line of pool) {
+      expect(library.has(line), line).toBe(true);
+    }
+  });
+
+  it("avoids the divine name", () => {
+    // "LORD" and "GOD" render the divine name in small caps. They are a
+    // nuisance to type with the shift key held and read as shouting to a
+    // seven-year-old, so the psalms and proverbs here are the ones without.
+    for (const line of pool) {
+      expect(line, library.get(line)).not.toMatch(/\b(LORD|GOD)\b/);
+    }
+  });
+
+  it("uses only keys a plain keyboard has", () => {
+    // The release sets quoted speech in curly quotation marks, and marking
+    // here is exact — so a verse carrying one would be unpassable rather than
+    // hard. This is the rule that decided which verses could be quoted at all.
+    for (const line of pool) {
+      expect(line, library.get(line)).toMatch(/^[A-Za-z ,.;]+$/);
+    }
+  });
+
+  it("quotes whole sentences, never a fragment of one", () => {
+    // A sentence level splits on spaces and never on meaning, so a verse that
+    // trails off mid-list would arrive as a fragment with a comma hanging off
+    // it — which is unfair to type and worse to read.
+    for (const line of pool) {
+      expect(line[0], library.get(line)).toBe(line[0].toUpperCase());
+      expect(line, library.get(line)).toMatch(/[.!?]$/);
+    }
+  });
+
+  it("carries the credit line wherever its words are shown", () => {
+    // One constant, so the race, the setup screen and the results can't drift
+    // apart from the sheet footer and the catalog page.
+    expect(levelCredit("scripture")).toBe(SCRIPTURE_CREDIT);
+    expect(levelCredit("sentences")).toBeUndefined();
+    expect(levelCredit("no-such-level")).toBeUndefined();
+  });
+
+  it("is chosen and never assigned", () => {
+    // A source, not a step in the progression: no age lands on it.
+    for (const age of [4, 6, 8, 10, 12, 16]) {
+      expect(typingLevelForAge(age).id).not.toBe("scripture");
     }
   });
 });

--- a/src/engine/decks/typing.ts
+++ b/src/engine/decks/typing.ts
@@ -1,6 +1,7 @@
 import type { Card, TypingConfig } from "@/engine/types";
 
 import { mulberry32, shuffled } from "@/engine/random";
+import { SCRIPTURE_CREDIT } from "@/engine/sheets/passages/credit";
 import { WORD_LISTS, listWords } from "./wordlists";
 import type { DeckSpec } from "./spec";
 
@@ -34,6 +35,13 @@ export type TypingLevel = {
   /** Whole sentences, or a bag of words to shuffle. */
   kind: "words" | "sentences";
   pool: string[];
+  /**
+   * The line this level's source asks to be printed under its words, if it
+   * asks for one. The same field `Passage.credit` is, and for the same
+   * reason: attribution travels *with* the text rather than beside it, so a
+   * screen that shows the passage cannot show it uncredited.
+   */
+  credit?: string;
 };
 
 /** Home row only: a s d f g — h j k l ;. Every word below uses nothing else. */
@@ -141,6 +149,113 @@ const SENTENCES = [
   "My brother is learning to play the piano.",
 ];
 
+/**
+ * Scripture, as a typing pool — one source among several, and nothing more
+ * than that (docs/printables.md §12).
+ *
+ * Thirty-three verses from Psalms, Proverbs, the Gospels and the letters, in
+ * the World English Bible Updated. Three rules picked them, and all three are
+ * about the exercise rather than about the text:
+ *
+ *   - **No divine name.** `LORD` in small caps is a nuisance to type and
+ *     reads as shouting to a seven-year-old, so the psalms and proverbs here
+ *     are the ones that don't carry it.
+ *   - **Nothing but keys a child can find.** Typing marks exactly — case and
+ *     punctuation are the whole exercise at this level — and the release sets
+ *     quoted speech in curly quotation marks, which a plain keyboard does not
+ *     produce. A verse containing one would be unpassable rather than hard.
+ *     That rules out most of the narrative and every quoted saying, which is
+ *     why these are sayings and not stories. Only `.`, `,` and `;` survive.
+ *   - **Whole sentences.** A capital at the front and a full stop at the end.
+ *     The sentence levels split on spaces and never on meaning, so a verse
+ *     that trails off mid-list would arrive as a fragment with a comma on it.
+ *
+ * ── Why the words are written out here ──────────────────────────────────────
+ * Because `decks/index.ts` is the front door for every island — the flash
+ * cards, the spelling mount, the record book, the print shop — and a module is
+ * assigned to a chunk whole. An import of the passage library from this file
+ * puts all of it into all of them: the WEBu, the KJV beside it and thirty
+ * other passages, shipped to every game to type thirty-three verses in one of
+ * them. It was measured on the way past — 46KB of shared chunk became 222KB —
+ * which is also why the credit comes from `passages/credit.ts` and not from
+ * the file the verses are in.
+ *
+ * So the text is repeated, and `typing.test.ts` pins every line of it to
+ * `passage()` character for character. That is the arrangement `scripture.ts`
+ * already has with `release/engwebu.vpl.txt`: two files that would have to be
+ * edited identically, in one commit, for the text to drift — which is the
+ * point at which it stops being an accident. The reference above each line is
+ * where it came from, and is what the test reads when one of them fails.
+ */
+const SCRIPTURE_PASSAGES = [
+  // Psalm 23
+  "He makes me lie down in green pastures. He leads me beside still waters.",
+  // Psalm 34:13-14
+  "Keep your tongue from evil, and your lips from speaking lies.",
+  // Psalm 51:10
+  "Create in me a clean heart, O God. Renew a right spirit within me.",
+  // Psalm 56:3
+  "When I am afraid, I will put my trust in you.",
+  // Psalm 90:12
+  "So teach us to count our days, that we may gain a heart of wisdom.",
+  // Psalm 119:9-11
+  "I have hidden your word in my heart, that I might not sin against you.",
+  // Psalm 119:105
+  "Your word is a lamp to my feet, and a light for my path.",
+  // Psalm 121
+  "Behold, he who keeps Israel will neither slumber nor sleep.",
+  // Psalm 147:3
+  "He heals the broken in heart, and binds up their wounds.",
+  // Proverbs 3:5-6
+  "In all your ways acknowledge him, and he will make your paths straight.",
+  // Proverbs 4:23
+  "Keep your heart with all diligence, for out of it is the wellspring of life.",
+  // Proverbs 10:12
+  "Hatred stirs up strife, but love covers all wrongs.",
+  // Proverbs 11:2
+  "When pride comes, then comes shame, but with humility comes wisdom.",
+  // Proverbs 13:20
+  "One who walks with wise men grows wise, but a companion of fools suffers harm.",
+  // Proverbs 15:1
+  "A gentle answer turns away wrath, but a harsh word stirs up anger.",
+  // Proverbs 16:24
+  "Pleasant words are a honeycomb, sweet to the soul, and health to the bones.",
+  // Proverbs 17:17
+  "A friend loves at all times; and a brother is born for adversity.",
+  // Proverbs 17:22
+  "A cheerful heart makes good medicine, but a crushed spirit dries up the bones.",
+  // Proverbs 21:5
+  "The plans of the diligent surely lead to profit; and everyone who is hasty surely rushes to poverty.",
+  // Proverbs 25:11
+  "A word fitly spoken is like apples of gold in settings of silver.",
+  // Matthew 5:3-12
+  "Blessed are the peacemakers, for they shall be called children of God.",
+  // Matthew 6:9-13
+  "Give us today our daily bread.",
+  // Luke 2:52
+  "And Jesus increased in wisdom and stature, and in favor with God and men.",
+  // John 1:1-5
+  "In him was life, and the life was the light of men.",
+  // Romans 12:9-13
+  "Let love be without hypocrisy. Abhor that which is evil. Cling to that which is good.",
+  // 1 Corinthians 16:13-14
+  "Let all that you do be done in love.",
+  // Ephesians 4:32
+  "And be kind to one another, tender hearted, forgiving each other, just as God also in Christ forgave you.",
+  // Philippians 4:13
+  "I can do all things through Christ who strengthens me.",
+  // 1 Thessalonians 5:16-18
+  "In everything give thanks, for this is the will of God in Christ Jesus toward you.",
+  // Hebrews 11:1
+  "Now faith is assurance of things hoped for, proof of things not seen.",
+  // Hebrews 13:8
+  "Jesus Christ is the same yesterday, today, and forever.",
+  // James 1:22
+  "But be doers of the word, and not only hearers, deluding your own selves.",
+  // 1 John 4:19
+  "We love him, because he first loved us.",
+];
+
 export const TYPING_LEVELS: TypingLevel[] = [
   {
     id: "home-row",
@@ -182,17 +297,44 @@ export const TYPING_LEVELS: TypingLevel[] = [
     kind: "sentences",
     pool: SENTENCES,
   },
+  {
+    id: "scripture",
+    name: "Verses",
+    group: "Ages 9+",
+    blurb: "Psalms, Proverbs and the letters, punctuated exactly as written.",
+    emoji: "📖",
+    keys: "shift, comma, semicolon",
+    kind: "sentences",
+    pool: SCRIPTURE_PASSAGES,
+    credit: SCRIPTURE_CREDIT,
+  },
 ];
 
 export const TYPING_LEVELS_BY_ID = new Map(TYPING_LEVELS.map((l) => [l.id, l]));
 
-/** Where a child of this age is likely to be starting. */
+/**
+ * Where a child of this age is likely to be starting.
+ *
+ * The four-level progression, and only that. The Scripture level is a *source*
+ * rather than a step — it is the sentence level's marking rule over somebody
+ * else's words — so nobody is landed on it by an age; it is chosen or it isn't.
+ */
 export function typingLevelForAge(age: number): TypingLevel {
   if (age <= 7) return TYPING_LEVELS[0];
   if (age <= 8) return TYPING_LEVELS[1];
   if (age <= 10) return TYPING_LEVELS[2];
   return TYPING_LEVELS[3];
 }
+
+/**
+ * The credit line to print under this level's words, if its source asks for
+ * one. Every screen that shows the passage asks — the setup that names the
+ * level, the race that shows the words, the results that lists them back —
+ * because a credit that appears on one of the three is a credit that a reader
+ * can be shown the text without.
+ */
+export const levelCredit = (levelId: string): string | undefined =>
+  TYPING_LEVELS_BY_ID.get(levelId)?.credit;
 
 /**
  * The words of a passage, in the order they'll be typed.

--- a/src/engine/sheets/passages/credit.ts
+++ b/src/engine/sheets/passages/credit.ts
@@ -1,0 +1,21 @@
+/**
+ * The Scripture credit line, alone in a module of its own.
+ *
+ * One constant, so the sheet footer, the catalog page and the typing race
+ * can't drift apart — required by nothing (a public-domain text needs no
+ * attribution) and printed anyway, on every sheet and every screen that shows
+ * one (docs/printables.md §12).
+ *
+ * It sits here rather than beside the verses in `scripture.ts` for a bundling
+ * reason that is invisible until it bites. A module is assigned to a chunk
+ * whole: `decks/typing.ts` needs this line for the Scripture level, every
+ * island imports the deck registry, and the print shop uses the whole passage
+ * library — so an import of this string *from the file that holds the verses*
+ * moves the entire library (the WEBu, the KJV beside it and thirty other
+ * passages) into the chunk that the flash cards, the spelling mount and the
+ * record book all load. Measured, not guessed: it took the shared chunk from
+ * 46KB to 222KB. A leaf module with one string in it costs them nothing, and
+ * the constant is still the only copy there is.
+ */
+export const SCRIPTURE_CREDIT =
+  "Scripture: World English Bible Updated (public domain) · worldenglish.bible";

--- a/src/engine/sheets/passages/scripture.ts
+++ b/src/engine/sheets/passages/scripture.ts
@@ -49,12 +49,11 @@
 import type { PassageCollection } from "./types";
 
 /**
- * The credit line. One constant, so the sheet footer and the catalog page can't
- * drift apart — required by nothing (a public-domain text needs no attribution)
- * and printed anyway, on every sheet and every page that shows one.
+ * The credit line, re-exported from the leaf module that holds it so this file
+ * still names its own attribution. It lives in `credit.ts` because the games
+ * need the line without needing the verses — see the note there.
  */
-export const SCRIPTURE_CREDIT =
-  "Scripture: World English Bible Updated (public domain) · worldenglish.bible";
+export { SCRIPTURE_CREDIT } from "./credit";
 
 /**
  * One curated entry: a contiguous run of verses in one chapter.

--- a/src/games/flashcards/setup/WordSettings.tsx
+++ b/src/games/flashcards/setup/WordSettings.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Button, FilePicker } from "@/components/ui/kit";
 import { useHub } from "@/components/state/HubContext";
-import { WORD_LISTS } from "@/engine/decks/wordlists";
+import { SHIPPED_LISTS } from "@/engine/decks/wordlists";
 import { wordsOf } from "@/engine/decks/words";
 import { readDeckFile } from "@/services/decks";
 import { sfx } from "@/services/sound";
@@ -18,6 +18,12 @@ import type { CustomDeck, WordConfig } from "@/engine/types";
  * A parent's own lists sit above the shipped ones, because someone who has
  * typed in this week's spellings is here for those and not for Dolch. They
  * carry an Edit button; the shipped lists don't, and can't be deleted.
+ *
+ * The shipped half is the whole shelf — `SHIPPED_LISTS`, so the books of the
+ * Bible and the other memory-work lists sit here with Dolch rather than being
+ * a printables-only thing a child can't play (docs/printables.md §12). Dolch
+ * leads it, because that is the order the shelf is built in and the graded
+ * lists are what most people came for.
  *
  * A drill arrives with its words already chosen, so it replaces the list
  * exactly as an arithmetic drill replaces the number grids.
@@ -132,7 +138,7 @@ export function WordSettings({
         {decks.map((deck) =>
           row(deck, `Yours · ${deck.words.length} words`, null, deck),
         )}
-        {WORD_LISTS.map((list) =>
+        {SHIPPED_LISTS.map((list) =>
           row(
             list,
             `${list.group} · ${list.entries.length} words`,
@@ -179,7 +185,7 @@ export function WordSettings({
               config.listId === editing.id &&
               !decks.some((d) => d.id === editing.id)
             ) {
-              onChange({ ...config, listId: WORD_LISTS[0].id });
+              onChange({ ...config, listId: SHIPPED_LISTS[0].id });
             }
           }}
         />

--- a/src/games/typing/Passage.tsx
+++ b/src/games/typing/Passage.tsx
@@ -19,20 +19,23 @@ export function Passage({
   deck,
   results,
   entry,
+  credit,
 }: {
   deck: Card[];
   results: CardResult[];
   /** What's been typed of the current word. */
   entry: string;
+  /** What the words are quoted from, where the source asks to be named. */
+  credit?: string;
 }) {
   const at = results.length;
   const from = Math.max(0, at - BEHIND);
-  const window = deck.slice(from, at + AHEAD);
+  const visible = deck.slice(from, at + AHEAD);
 
   return (
     <section className="passage" aria-label="Passage to type">
       <p className="passage__text">
-        {window.map((card, offset) => {
+        {visible.map((card, offset) => {
           const i = from + offset;
           if (i < at) {
             const done = results[i];
@@ -79,6 +82,7 @@ export function Passage({
           );
         })}
       </p>
+      {credit && <p className="passage__credit">{credit}</p>}
     </section>
   );
 }

--- a/src/games/typing/TypingResults.tsx
+++ b/src/games/typing/TypingResults.tsx
@@ -3,7 +3,8 @@ import { usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
 import TopBar from "@/components/TopBar";
 import { Button, Confetti } from "@/components/ui/kit";
-import { wordsPerMinute } from "@/engine/decks/typing";
+import { isTyping } from "@/engine/decks";
+import { levelCredit, wordsPerMinute } from "@/engine/decks/typing";
 import { clock, delta, percent } from "@/engine/format";
 import { cumulativeSplits, raceTimeMs } from "@/engine/records";
 import { randomSeed } from "@/engine/random";
@@ -44,6 +45,11 @@ export default function TypingResults() {
   const { session, ghost, personalRecord, previousBest, newBadges, bonuses } =
     outcome;
   const wpm = wordsPerMinute(session.cards, session.durationMs);
+  // Through the deck registry's own guard rather than reading `kind` here:
+  // narrowing the config union is `decks/index.ts`'s job and nowhere else's.
+  const credit = isTyping(session.config)
+    ? levelCredit(session.config.levelId)
+    : undefined;
   const accuracy =
     session.correct / Math.max(1, session.correct + session.incorrect);
   const previousWpm = previousBest
@@ -169,6 +175,9 @@ export default function TypingResults() {
         mySplits={cumulativeSplits(session)}
         ghostSplits={ghost ? cumulativeSplits(ghost.session) : null}
       />
+      {/* The splits list every word of the passage back, one to a row, so
+          this screen shows the text as surely as the race did. */}
+      {credit && <p className="passage__credit">{credit}</p>}
     </main>
   );
 }

--- a/src/games/typing/TypingSetup.tsx
+++ b/src/games/typing/TypingSetup.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/kit";
 import { configKey, describeConfig } from "@/engine/decks";
 import {
   TYPING_LEVELS,
+  levelCredit,
   typingLevelForAge,
   wordsPerMinute,
 } from "@/engine/decks/typing";
@@ -53,6 +54,7 @@ export default function TypingSetup() {
 
   if (!profile) return <Navigate to="/" replace />;
 
+  const credit = levelCredit(config.levelId);
   const mine = sessionsFor(sessions, profile.id, key);
   const best = bestRun(mine);
   const bestWpm = best ? wordsPerMinute(best.cards, best.durationMs) : null;
@@ -114,6 +116,10 @@ export default function TypingSetup() {
                 </li>
               ))}
             </ul>
+            {/* Under the list rather than in the row that carries it: the
+                credit belongs to the words a player is about to be shown, so
+                it appears when that level is the one chosen. */}
+            {credit && <p className="passage__credit">{credit}</p>}
           </div>
 
           <div className="control">

--- a/src/games/typing/TypingTrack.tsx
+++ b/src/games/typing/TypingTrack.tsx
@@ -3,6 +3,7 @@ import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
 import { buildDeck, configKey, deckSpec, modeOf } from "@/engine/decks";
+import { levelCredit } from "@/engine/decks/typing";
 import { cardXp } from "@/engine/progress";
 import {
   WRONG_ANSWER_PENALTY_MS,
@@ -263,7 +264,12 @@ function Track({
         note="Space moves you on"
       />
 
-      <Passage deck={deck} results={results.current} entry={entry} />
+      <Passage
+        deck={deck}
+        results={results.current}
+        entry={entry}
+        credit={levelCredit(config.levelId)}
+      />
 
       <TypeField
         value={entry}

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1315,6 +1315,18 @@ label.segmented__btn {
   border-radius: 3px;
 }
 
+/* The line a passage's source asks to be printed under it — the setup that
+   names the level, the race that shows the words, and the results that list
+   them back. Quiet and small: it is a credit, not a caption, and it is set
+   the same on all three so it reads as one line rather than three notes. */
+.passage__credit {
+  font-size: var(--step--2);
+  color: var(--chalk-dim);
+  text-align: center;
+  margin-top: 0.7rem;
+  text-wrap: pretty;
+}
+
 .typefield {
   display: grid;
   gap: 0.4rem;


### PR DESCRIPTION
Closes #75. Final story of epic #76 (PRINT31).

## What changed

Scripture turns up in the two games the same way any other passage does — a level you can pick and a word list you can play — rather than as a separate mode.

**Frost Keys gets a fifth level, "Verses."** Thirty-three verses from Psalms, Proverbs, the Gospels and the letters, added to `TYPING_LEVELS` in `src/engine/decks/typing.ts` beside the four that were already there. Two rules picked them:

- **No divine name.** `LORD` in small caps is a nuisance to type and reads as shouting to a seven-year-old, so the psalms and proverbs here are the ones that don't carry it.
- **Nothing but keys a plain keyboard has.** Typing marks case and punctuation exactly, and the release sets quoted speech in curly quotation marks — a verse carrying one would be unpassable rather than hard. That leaves the sayings rather than the narrative, which is the right shape for a level anyway.

The level is a *source*, not a step, so `typingLevelForAge` still returns one of the original four — nobody is landed on Verses by their age; it is chosen or it isn't.

**Word Jungle's picker shows the whole shipped shelf.** `WordSettings.tsx` reads `SHIPPED_LISTS` instead of `WORD_LISTS`, so the books of the Bible and the other memory-work lists PRINT23 authored are playable rather than printables-only. Dolch still leads the list.

**The credit prints on every screen that shows the words** — the setup that names the level, the race itself, and the results that list every word back. A credit that appears on only one of the three is a credit the reader can be shown the text without.

## Why the verses are written out rather than read through `passage()`

Measured on the way past, then undone: importing the passage library from `decks/typing.ts` took the shared chunk from **46KB to 222KB**. Every island imports the deck registry, the print shop uses the whole library, and a module lands in a chunk whole — so one import shipped the WEBu, the KJV beside it and thirty other passages to the flash cards, the spelling mount and the record book, in order to type thirty-three verses in a different game.

So the text is repeated, and `src/engine/decks/typing.test.ts` pins every line to the library character for character — the same arrangement `scripture.ts` already has with its release file. `SCRIPTURE_CREDIT` moved to a leaf module (`src/engine/sheets/passages/credit.ts`) for the same reason, so a game can carry the credit without dragging in the verses.

## Saved runs

Nothing renamed, nothing removed, `configKey` format untouched. Every run saved before this still resolves and still races its ghosts.

## Also

- quick-win: `Passage.tsx`'s window slice no longer shadows the DOM `window` global.

## Validation

`type-check`, `lint`, `test:unit` (1481 passing), `build`, and the browser smoke test (create profile → race → results → reload, plus the print bench) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
