### PR TITLE
Actually turn on the access logging

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -292,11 +292,37 @@ export default $config({
           // request lines CloudFront was already generating, kept somewhere we
           // can count them. `includeCookies` stays false because we set none
           // and logging them would be a way to start.
+          //
+          // It has to go through `transform.distribution`, NOT straight onto
+          // `args`. This callback receives the Cdn component's own `CdnArgs`,
+          // which exposes a curated subset of the distribution — `domain`,
+          // `origins`, `customErrorResponses` and friends — and `loggingConfig`
+          // is not among them. An earlier version assigned it directly, which
+          // Pulumi then dropped on the floor: no error, no warning, just a
+          // distribution that never logged and a bucket that stayed empty from
+          // the day analytics shipped. The monthly rollup compounded it by
+          // "succeeding" over zero files, so the alarm built for exactly this
+          // could never fire either.
+          //
+          // TypeScript does catch it — `Property 'loggingConfig' does not
+          // exist on type 'CdnArgs'` — but nothing type-checks this file:
+          // tsconfig.json excludes it (see the note there) and SST bundles it
+          // with esbuild, which strips types without checking them. So the
+          // compiler is not a backstop here; this comment is.
+          //
+          // The `assets` transform below nests the same way for the same
+          // reason. If you add a distribution-level setting and it appears to
+          // do nothing, this is why — check CdnArgs first.
           if (logs) {
-            args.loggingConfig = {
-              bucket: logs.bucketDomainName,
-              prefix: "cf/",
-              includeCookies: false,
+            args.transform = {
+              ...args.transform,
+              distribution: (distributionArgs) => {
+                distributionArgs.loggingConfig = {
+                  bucket: logs.bucketDomainName,
+                  prefix: "cf/",
+                  includeCookies: false,
+                };
+              },
             };
           }
         },


### PR DESCRIPTION
## The problem

The analytics pipeline described in `docs/analytics.md` has never recorded a single request.

- `s3://schoolskills-access-logs-578771850338/` — **0 objects**, since the day it was created
- `analytics/counts.json` — still `{"days": {}}`
- Distribution `E2B47B9IHQSJU0` (schoolskills.app) — `Logging.Enabled: false`

## Why

The `cdn` transform receives the Cdn component's own `CdnArgs`, which exposes a curated subset of the distribution — `domain`, `origins`, `customErrorResponses` and friends. `loggingConfig` is not among them, so assigning it there set a property nobody reads and Pulumi discarded it. No error, no warning, just a distribution that never logged.

The `args.customErrorResponses = []` line right above it worked precisely because that one *is* a `CdnArgs` field — which is what made the whole block look correct.

Distribution-level settings have to nest through `transform.distribution`. The `assets` transform further down this same file already does exactly that, and its `s3:ListBucket` statement is live on the production bucket policy. Same file, same pattern, one of them wrong.

## Why nothing caught it

Both halves of the safety net were out at once:

- **TypeScript does catch this** — `Property 'loggingConfig' does not exist on type 'CdnArgs'` — but nothing type-checks this file. `tsconfig.json` excludes `sst.config.ts`, and SST bundles it with esbuild, which strips types without checking them.
- **The monthly rollup "succeeds" over zero log files**, commits nothing, and so the issue-opening alarm built for exactly this failure could never fire.

Neither is fixed here; both are worth doing separately.

## Validation

Type-checked the config against SST's platform types using a throwaway tsconfig, since the repo's own excludes it:

| | Result |
| --- | --- |
| Code on `develop` | `TS2339: Property 'loggingConfig' does not exist on type 'CdnArgs'` |
| This branch | clean, 0 errors |
| Deliberate typo in the nested callback | caught — confirms the param really is `DistributionArgs`, not `any` |

`npm run lint` and prettier pass.

## After deploy

1. `aws cloudfront get-distribution-config --id E2B47B9IHQSJU0 --profile schoolskills --query DistributionConfig.Logging` → expect `Enabled: true`
2. First objects appear under `cf/` within a few hours
3. `gh workflow run analytics.yml` to backfill `counts.json` without waiting for the 2nd

Until then the only view of traffic is CloudWatch request metrics (~8,100 requests on the apex since Aug 12, no per-URL breakdown).

Refs #9