### PR TITLE
Release: the logs start arriving

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -292,11 +292,37 @@ export default $config({
           // request lines CloudFront was already generating, kept somewhere we
           // can count them. `includeCookies` stays false because we set none
           // and logging them would be a way to start.
+          //
+          // It has to go through `transform.distribution`, NOT straight onto
+          // `args`. This callback receives the Cdn component's own `CdnArgs`,
+          // which exposes a curated subset of the distribution — `domain`,
+          // `origins`, `customErrorResponses` and friends — and `loggingConfig`
+          // is not among them. An earlier version assigned it directly, which
+          // Pulumi then dropped on the floor: no error, no warning, just a
+          // distribution that never logged and a bucket that stayed empty from
+          // the day analytics shipped. The monthly rollup compounded it by
+          // "succeeding" over zero files, so the alarm built for exactly this
+          // could never fire either.
+          //
+          // TypeScript does catch it — `Property 'loggingConfig' does not
+          // exist on type 'CdnArgs'` — but nothing type-checks this file:
+          // tsconfig.json excludes it (see the note there) and SST bundles it
+          // with esbuild, which strips types without checking them. So the
+          // compiler is not a backstop here; this comment is.
+          //
+          // The `assets` transform below nests the same way for the same
+          // reason. If you add a distribution-level setting and it appears to
+          // do nothing, this is why — check CdnArgs first.
           if (logs) {
-            args.loggingConfig = {
-              bucket: logs.bucketDomainName,
-              prefix: "cf/",
-              includeCookies: false,
+            args.transform = {
+              ...args.transform,
+              distribution: (distributionArgs) => {
+                distributionArgs.loggingConfig = {
+                  bucket: logs.bucketDomainName,
+                  prefix: "cf/",
+                  includeCookies: false,
+                };
+              },
             };
           }
         },


### PR DESCRIPTION
Ships #110 — the one-line-shaped fix that turns CloudFront access logging on for the first time.

The analytics pipeline in `docs/analytics.md` has been wired up but silent since it was built: the log bucket is empty, `analytics/counts.json` is still `{"days": {}}`, and `Logging.Enabled` is `false` on the live distribution. `loggingConfig` was being assigned to `CdnArgs`, which has no such property, so Pulumi discarded it without an error. It now nests through `transform.distribution`, the way the `assets` transform in the same file already does.

## Verify after deploy

```bash
aws cloudfront get-distribution-config --id E2B47B9IHQSJU0 \
  --profile schoolskills --query DistributionConfig.Logging
```

Expect `Enabled: true`. First objects land under `s3://schoolskills-access-logs-578771850338/cf/` within a few hours, after which `gh workflow run analytics.yml` will backfill `counts.json` without waiting for the 2nd.

No user-facing change; nothing in `dist/` differs.