### PR TITLE
Count what a page view actually is, and give it two front doors

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,8 +1,17 @@
 # How to count things
 
-There is no analytics dashboard. There is no analytics service. What there is:
-CloudFront writes an access log line for every request, those lines land in an
-S3 bucket, and you run SQL over them when you want a number.
+There is no analytics service. Nothing is embedded in a page, no third party
+sees a request, and no identifier follows anyone. What there is: CloudFront
+writes an access log line for every request, those lines land in an S3 bucket,
+and you count them when you want a number.
+
+Three ways to look, in the order you'll want them:
+
+| Want                         | Use                      |
+| ---------------------------- | ------------------------ |
+| Which pages, how many people | `npm run analytics`      |
+| Did traffic move at all      | the CloudWatch dashboard |
+| A one-off question           | Athena                   |
 
 This is the whole of it, and it exists in this shape for a reason —
 `/privacy` promises parents that nothing is stored on their child's device and
@@ -72,12 +81,37 @@ Bots are excluded, assets and beacons don't count as page views, and re-running
 overwrites per-day rather than accumulating — so a day whose logs arrived late is
 corrected rather than doubled.
 
-To run it by hand (or after fixing something):
+To run it by hand — after a fix, or just to see today before the 2nd:
+
+```bash
+npm run analytics                # sync, count, and print a summary
+npm run analytics -- --days 7    # narrow the table
+npm run analytics -- --no-sync   # re-summarise without re-downloading
+```
+
+That writes `analytics/counts.json`, the same file the job commits, so a local
+run leaves a diff. `git checkout analytics/counts.json` if you only wanted to
+look. The long way round still works and is what the workflow runs:
 
 ```bash
 aws s3 sync s3://schoolskills-access-logs-<account>/cf/ /tmp/cflogs --profile schoolskills
 node scripts/rollup-analytics.mjs /tmp/cflogs analytics/counts.json
 ```
+
+## The dashboard, for "is anything happening"
+
+`schoolskills-traffic` in CloudWatch (us-west-1 console, metrics from
+us-east-1) — requests, error rate and bytes, defined in `sst.config.ts` and
+deployed with everything else.
+
+It is a pulse, not analytics. `Requests` counts every HTTP request — assets,
+fonts, beacons, bots, the deploy's own smoke checks — so it runs roughly an
+order of magnitude above page views and can never be split by URL. Use it to
+see whether traffic moved or errors appeared; use the rollup for who and what.
+
+Its one real advantage: CloudWatch keeps these metrics for 15 months and does
+it whether or not logging is configured, so it is also the only record of any
+period when the log pipeline was broken.
 
 ## Athena, for questions the rollup doesn't answer
 
@@ -140,18 +174,39 @@ TBLPROPERTIES ('skip.header.line.count'='2');
 
 ## The queries
 
+**What counts as a page view.** Both queries below start from the same CTE,
+because getting this predicate wrong is how the pipeline's first day of data
+managed to record two bots as visitors and miss the only human. It mirrors
+`isPageView()` in `scripts/rollup-analytics.mjs` — **if you change one, change
+the other**, and the reasoning for each clause is commented there.
+
+```sql
+WITH pages AS (
+  SELECT *
+  FROM cf_logs
+  WHERE (
+          -- Served: the content-type settles it.
+          (status = 200 AND sc_content_type LIKE 'text/html%')
+          -- Revalidated: HTML is `must-revalidate`, so a returning visitor
+          -- gets a 304 — which carries no content-type at all. The path is
+          -- the only thing left to judge it by: a filename with an extension
+          -- is an asset, anything else is a document.
+       OR (status = 304
+           AND (NOT regexp_like(uri, '\.[^/.]+$') OR regexp_like(uri, '\.html?$')))
+        )
+    -- NOT `status < 400`: the http→https redirect is text/html with status
+    -- 301, so that counted every http arrival twice and promoted scanners
+    -- that only ever got a redirect into visitors.
+    AND NOT regexp_like(lower(user_agent), 'bot|crawler|spider|slurp|curl|wget')
+)
+```
+
 **Unique visitors per day.** Approximate by design — see `/privacy`. A
 household behind one router counts once; a phone changing network counts twice.
-Only real page requests count, so assets and beacons don't inflate it:
 
 ```sql
 SELECT "date", COUNT(DISTINCT request_ip) AS people
-FROM cf_logs
-WHERE status < 400
-  AND uri NOT LIKE '/_astro/%'
-  AND uri NOT LIKE '/_e/%'
-  AND uri NOT LIKE '/fonts/%'
-  AND sc_content_type LIKE 'text/html%'
+FROM pages
 GROUP BY "date"
 ORDER BY "date" DESC;
 ```
@@ -160,8 +215,7 @@ ORDER BY "date" DESC;
 
 ```sql
 SELECT uri, COUNT(*) AS hits, COUNT(DISTINCT request_ip) AS people
-FROM cf_logs
-WHERE status < 400 AND sc_content_type LIKE 'text/html%'
+FROM pages
 GROUP BY uri
 ORDER BY hits DESC;
 ```
@@ -221,6 +275,16 @@ ORDER BY "date" DESC;
 - **Page requests are a floor too**, for the opposite reason: a returning
   visitor whose HTML is still in the service worker's cache never reaches
   CloudFront.
+- **A returning visitor who does reach CloudFront arrives as a 304.** HTML is
+  `must-revalidate`, so the second visit revalidates rather than re-downloads,
+  and a 304 carries no content-type. Any query that identifies pages by
+  content-type alone therefore counts first visits only. The `pages` CTE above
+  handles it; a query written from scratch will not.
+- **An undeclared bot is a visitor.** Filtering is on the user-agent, so
+  anything that says it is a crawler is excluded and anything that lies is
+  counted as a person. On this pipeline's first day, a datacentre IP wearing a
+  desktop Chrome user-agent was one of the two recorded "visitors". Treat small
+  visitor counts as an upper bound.
 - **Bots are in there.** Filter `user_agent` if a number looks implausible;
   the times-table pages exist to be crawled and are crawled accordingly.
 - **Logs are delivered late** — usually minutes, occasionally hours. An empty

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:e2e": "playwright test",
     "prepare": "husky",
     "test:smoke": "node e2e/smoke.mjs",
-    "scripture:pull": "node scripts/pull-scripture.mjs"
+    "scripture:pull": "node scripts/pull-scripture.mjs",
+    "analytics": "node scripts/analytics.mjs"
   },
   "dependencies": {
     "@astrojs/react": "^6.0.2",

--- a/scripts/analytics.mjs
+++ b/scripts/analytics.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * `npm run analytics` — the two-step from docs/analytics.md, as one command.
+ *
+ * Sync the access logs out of S3, reduce them with the same rollup the monthly
+ * job runs, and print what happened. The counting itself lives in
+ * scripts/rollup-analytics.mjs and is deliberately NOT duplicated here: this
+ * file is a front door, and a second implementation of `isPageView` is exactly
+ * the kind of thing that drifts and then disagrees with the committed history.
+ *
+ * This writes `analytics/counts.json`, the same file the job commits. That is
+ * intentional — running it by hand after a fix is how a miscounted day gets
+ * corrected — but it does mean a local run leaves a diff. `git checkout
+ * analytics/counts.json` if you only wanted to look.
+ *
+ * Usage:
+ *   npm run analytics              sync, count, summarise
+ *   npm run analytics -- --no-sync re-summarise what's already downloaded
+ *   npm run analytics -- --days 7  narrow the table (default 30)
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const OUT = "analytics/counts.json";
+const ROLLUP = "scripts/rollup-analytics.mjs";
+// Stable rather than a fresh mkdtemp: `aws s3 sync` is incremental, so keeping
+// the directory between runs turns the second run into a no-op download.
+const LOGS = join(tmpdir(), "schoolskills-cflogs");
+const PROFILE = process.env.AWS_PROFILE ?? "schoolskills";
+
+const argv = process.argv.slice(2);
+const flag = (name) => argv.includes(`--${name}`);
+const option = (name, fallback) => {
+  const at = argv.indexOf(`--${name}`);
+  return at === -1 ? fallback : Number(argv[at + 1]);
+};
+
+const run = (cmd, args) =>
+  execFileSync(cmd, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+/** Ask AWS who we are, which is also the bucket name. */
+function bucket() {
+  try {
+    const account = run("aws", [
+      "sts",
+      "get-caller-identity",
+      "--query",
+      "Account",
+      "--output",
+      "text",
+      "--profile",
+      PROFILE,
+    ]).trim();
+    return `schoolskills-access-logs-${account}`;
+  } catch (error) {
+    const detail = String(error.stderr ?? error.message).trim();
+    throw new Error(
+      `Could not reach AWS as profile "${PROFILE}".\n${detail}\n\n` +
+        `If the session has expired: aws sso login --profile ${PROFILE}`,
+      { cause: error },
+    );
+  }
+}
+
+function sync() {
+  const name = bucket();
+  mkdirSync(LOGS, { recursive: true });
+  process.stderr.write(`syncing s3://${name}/cf/ → ${LOGS}\n`);
+  run("aws", [
+    "s3",
+    "sync",
+    `s3://${name}/cf/`,
+    LOGS,
+    "--profile",
+    PROFILE,
+    "--no-progress",
+    "--only-show-errors",
+  ]);
+}
+
+/** The widest value in a column, so the table doesn't wobble. */
+const width = (rows, pick, header) =>
+  Math.max(header.length, ...rows.map((row) => String(pick(row)).length));
+
+function summarise(days, limit) {
+  const dates = Object.keys(days).sort();
+  if (dates.length === 0) {
+    console.log(
+      "\nNo days on record yet.\n\n" +
+        "CloudFront delivers logs minutes to hours after the request, so an\n" +
+        "empty result shortly after a deploy is normal. If it stays empty,\n" +
+        "check that logging is on:\n" +
+        "  aws cloudfront get-distribution-config --id <id> --query DistributionConfig.Logging\n",
+    );
+    return;
+  }
+
+  const shown = dates.slice(-limit);
+  const rows = shown.map((date) => {
+    const day = days[date];
+    const top = Object.entries(day.pages ?? {}).sort((a, b) => b[1] - a[1])[0];
+    return {
+      date,
+      visitors: day.visitors ?? 0,
+      pageViews: day.pageViews ?? 0,
+      top: top ? `${top[0]} (${top[1]})` : "—",
+      events: Object.values(day.events ?? {}).reduce((a, b) => a + b, 0),
+    };
+  });
+
+  const w = {
+    date: width(rows, (r) => r.date, "DATE"),
+    visitors: width(rows, (r) => r.visitors, "VISITORS"),
+    views: width(rows, (r) => r.pageViews, "VIEWS"),
+    events: width(rows, (r) => r.events, "EVENTS"),
+  };
+
+  console.log(
+    `\n${dates.length} day(s) on record (${dates[0]} → ${dates[dates.length - 1]})` +
+      (shown.length < dates.length ? `, showing last ${shown.length}` : "") +
+      "\n",
+  );
+  console.log(
+    [
+      "DATE".padEnd(w.date),
+      "VISITORS".padStart(w.visitors),
+      "VIEWS".padStart(w.views),
+      "EVENTS".padStart(w.events),
+      "TOP PAGE",
+    ].join("  "),
+  );
+  for (const r of rows) {
+    console.log(
+      [
+        r.date.padEnd(w.date),
+        String(r.visitors).padStart(w.visitors),
+        String(r.pageViews).padStart(w.views),
+        String(r.events).padStart(w.events),
+        r.top,
+      ].join("  "),
+    );
+  }
+
+  // Pages and decks across the whole window, which is the question the per-day
+  // table can't answer: what is actually being used.
+  const merge = (key) => {
+    const total = {};
+    for (const date of shown)
+      for (const [k, n] of Object.entries(days[date][key] ?? {}))
+        total[k] = (total[k] ?? 0) + n;
+    return Object.entries(total).sort((a, b) => b[1] - a[1]);
+  };
+
+  const pages = merge("pages");
+  if (pages.length) {
+    console.log("\nTOP PAGES");
+    for (const [path, n] of pages.slice(0, 10))
+      console.log(`  ${String(n).padStart(6)}  ${path}`);
+  }
+
+  const events = merge("events");
+  if (events.length) {
+    console.log("\nEVENTS");
+    for (const [name, n] of events)
+      console.log(`  ${String(n).padStart(6)}  ${name}`);
+  }
+
+  const decks = merge("decks");
+  if (decks.length) {
+    console.log("\nDECKS RACED");
+    for (const [name, n] of decks.slice(0, 10))
+      console.log(`  ${String(n).padStart(6)}  ${name}`);
+  }
+
+  // Said every time rather than in a doc, because the number most likely to be
+  // quoted out of context is the one at the top of a table.
+  console.log(
+    "\nvisitors = distinct IPs that day, and is NOT additive across days —\n" +
+      "the same person on three days is three visitor-days, not three people.\n" +
+      "Undeclared bots count as people; see docs/analytics.md.\n",
+  );
+}
+
+try {
+  if (!flag("no-sync")) sync();
+  else process.stderr.write(`using logs already in ${LOGS}\n`);
+
+  execFileSync("node", [ROLLUP, LOGS, OUT], { stdio: "inherit" });
+
+  if (existsSync(OUT)) {
+    summarise(
+      JSON.parse(readFileSync(OUT, "utf8")).days ?? {},
+      option("days", 30),
+    );
+  }
+} catch (error) {
+  console.error(`\n${error.message}`);
+  process.exit(1);
+}

--- a/scripts/rollup-analytics.mjs
+++ b/scripts/rollup-analytics.mjs
@@ -25,13 +25,7 @@ import { readFile, readdir, writeFile } from "node:fs/promises";
 import { createGunzip } from "node:zlib";
 import { createInterface } from "node:readline";
 import { join } from "node:path";
-
-const [, , LOG_DIR, OUT = "analytics/counts.json"] = process.argv;
-
-if (!LOG_DIR) {
-  console.error("usage: rollup-analytics.mjs <dir-of-gz-logs> [counts.json]");
-  process.exit(2);
-}
+import { pathToFileURL } from "node:url";
 
 /**
  * CloudFront's standard log format, by position.
@@ -51,10 +45,51 @@ const WANTED = [
   "sc-content-type",
 ];
 
-/** Requests that are a person arriving at a page, rather than an asset fetch. */
-const isPageView = (row) =>
-  Number(row["sc-status"]) < 400 &&
-  (row["sc-content-type"] ?? "").startsWith("text/html");
+/**
+ * Does this path name a document rather than an asset?
+ *
+ * Only consulted for 304s, which is the one case where the content-type can't
+ * answer it (see `isPageView`). The rule is the filename: anything with an
+ * extension is an asset, except `.html` itself. `/`, `/spelling/` and
+ * `/printables/templates/chore-chart` are documents; `/sw.js`,
+ * `/icon-192.png`, `/fonts/nunito-latin-var.woff2`, `/robots.txt` and
+ * `/_astro/index.abc123.js` are not.
+ */
+export const isDocumentPath = (path) => {
+  const file = path.slice(path.lastIndexOf("/") + 1);
+  return file === "" || !file.includes(".") || /\.html?$/i.test(file);
+};
+
+/**
+ * Requests that are a person arriving at a page, rather than an asset fetch.
+ *
+ * The two status codes are here for opposite reasons, and an earlier version
+ * of this function — `status < 400 && content-type is text/html` — got both
+ * of them wrong in the same line.
+ *
+ * **200 is the ordinary case** and the content-type settles it.
+ *
+ * **304 is the returning visitor.** HTML ships as
+ * `max-age=3600, must-revalidate` (see `fileOptions` in sst.config.ts), so a
+ * browser that has been here before revalidates and CloudFront answers 304 —
+ * which carries NO content-type at all. The old test therefore threw away
+ * every repeat visit, on top of the service-worker blind spot that
+ * docs/analytics.md already warns about. Since there is no content-type to
+ * read, the path has to decide it.
+ *
+ * **3xx redirects are not page views**, and `< 400` quietly counted them. The
+ * http→https redirect is served as `text/html` with status 301, so every
+ * visitor arriving over http counted twice, and a scanner probing
+ * `/wp-admin/install.php` — which never got a page, only a redirect and then
+ * a 404 — was recorded as a visitor on this pipeline's first day of data.
+ */
+export const isPageView = (row) => {
+  const status = Number(row["sc-status"]);
+  if (status === 200)
+    return (row["sc-content-type"] ?? "").startsWith("text/html");
+  if (status === 304) return isDocumentPath(row["cs-uri-stem"] ?? "");
+  return false;
+};
 
 /**
  * Obvious crawlers.
@@ -86,7 +121,7 @@ async function* lines(file) {
   }
 }
 
-async function tally(dir) {
+export async function tally(dir) {
   const days = new Map();
   const files = (await readdir(dir, { recursive: true })).filter((f) =>
     f.endsWith(".gz"),
@@ -154,7 +189,7 @@ async function tally(dir) {
 const sortObject = (o) =>
   Object.fromEntries(Object.entries(o).sort(([a], [b]) => a.localeCompare(b)));
 
-async function main() {
+async function main(LOG_DIR, OUT) {
   const days = await tally(LOG_DIR);
 
   const existing = existsSync(OUT)
@@ -190,4 +225,24 @@ async function main() {
   );
 }
 
-await main();
+/**
+ * Only bootstrap when run as a script.
+ *
+ * scripts/rollup-analytics.test.mjs imports `tally` and `isPageView` directly,
+ * and a bare `await main()` at module scope would make that import parse argv
+ * and exit(2). The counting logic is the part worth testing, so it has to be
+ * reachable without running the CLI around it.
+ */
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const [, , LOG_DIR, OUT = "analytics/counts.json"] = process.argv;
+
+  if (!LOG_DIR) {
+    console.error("usage: rollup-analytics.mjs <dir-of-gz-logs> [counts.json]");
+    process.exit(2);
+  }
+
+  await main(LOG_DIR, OUT);
+}

--- a/scripts/rollup-analytics.test.mjs
+++ b/scripts/rollup-analytics.test.mjs
@@ -1,0 +1,182 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
+import { describe, expect, it } from "vitest";
+
+import { isDocumentPath, isPageView, tally } from "./rollup-analytics.mjs";
+
+/**
+ * The rollup is the only record of the site's history that outlives the logs,
+ * so a miscount here is permanent in a way a bug in a dashboard would not be —
+ * by the time anyone notices, the raw lines it was derived from have expired.
+ *
+ * These cases are not invented. They are the first hour of real traffic after
+ * access logging was switched on, which happened to contain every shape that
+ * matters: a returning visitor served 304s, a scanner that only ever got a
+ * redirect and a 404, a crawler that says it is one, and one undeclared bot
+ * with a browser's user-agent. The old `status < 400 && text/html` test scored
+ * that hour as "2 visitors, 2 page views" — and both of the things it counted
+ * were bots, while the one human was invisible.
+ */
+
+/** CloudFront writes tab-separated rows under a `#Fields:` header. */
+const FIELDS =
+  "date time c-ip cs-uri-stem cs-uri-query sc-status cs(User-Agent) sc-content-type";
+
+const HUMAN = "Mozilla/5.0%20(Macintosh;%20Intel%20Mac%20OS%20X%2010_15_7)";
+const GOOGLEBOT =
+  "Mozilla/5.0%20(Linux;%20Android%206.0.1)%20(compatible;%20Googlebot/2.1)";
+
+const row = ({
+  date = "2026-08-18",
+  ip,
+  uri,
+  query = "-",
+  status,
+  ua = HUMAN,
+  type = "-",
+}) => [date, "22:30:00", ip, uri, query, String(status), ua, type].join("\t");
+
+/** Write one gzipped log file and count it, the way the real job would. */
+const count = async (rows) => {
+  const dir = mkdtempSync(join(tmpdir(), "rollup-"));
+  const body = ["#Version: 1.0", `#Fields: ${FIELDS}`, ...rows, ""].join("\n");
+  writeFileSync(
+    join(dir, "E2B47B9IHQSJU0.2026-08-18-22.abc.gz"),
+    gzipSync(body),
+  );
+  const days = await tally(dir);
+  return days.get("2026-08-18");
+};
+
+describe("isDocumentPath", () => {
+  it.each([
+    "/",
+    "/spelling/",
+    "/printables/templates/chore-chart",
+    "/404.html",
+  ])("treats %s as a document", (path) =>
+    expect(isDocumentPath(path)).toBe(true),
+  );
+
+  it.each([
+    "/sw.js",
+    "/icon-192.png",
+    "/fonts/nunito-latin-var.woff2",
+    "/robots.txt",
+    "/manifest.webmanifest",
+    "/_astro/index.abc123.js",
+  ])("treats %s as an asset", (path) =>
+    expect(isDocumentPath(path)).toBe(false),
+  );
+});
+
+describe("isPageView", () => {
+  const at = (status, type, uri = "/") => ({
+    "sc-status": String(status),
+    "sc-content-type": type,
+    "cs-uri-stem": uri,
+  });
+
+  it("counts a served page", () =>
+    expect(isPageView(at(200, "text/html;charset=UTF-8"))).toBe(true));
+
+  it("counts a revalidated page, which carries no content-type", () =>
+    expect(isPageView(at(304, "-"))).toBe(true));
+
+  it("does not count a revalidated asset", () =>
+    expect(isPageView(at(304, "-", "/sw.js"))).toBe(false));
+
+  // The http→https redirect is text/html with status 301. Counting it made
+  // every visitor arriving over http count twice, and promoted a scanner that
+  // never received a page into a visitor.
+  it("does not count a redirect", () =>
+    expect(isPageView(at(301, "text/html"))).toBe(false));
+
+  it("does not count a 404", () =>
+    expect(isPageView(at(404, "application/xml"))).toBe(false));
+
+  it("does not count an image", () =>
+    expect(isPageView(at(200, "image/png", "/icon-192.png"))).toBe(false));
+});
+
+describe("tally, over the first real hour of logs", () => {
+  const FIRST_HOUR = [
+    // A person, back for a second visit: three revalidated page loads and the
+    // assets that come with them. Invisible to the old test, every one.
+    row({ ip: "98.168.10.1", uri: "/", status: 304 }),
+    row({ ip: "98.168.10.1", uri: "/", status: 304 }),
+    row({ ip: "98.168.10.1", uri: "/", status: 304 }),
+    row({ ip: "98.168.10.1", uri: "/sw.js", status: 304 }),
+    row({
+      ip: "98.168.10.1",
+      uri: "/icon-192.png",
+      status: 200,
+      type: "image/png",
+    }),
+    // A WordPress scanner. Never got a page — a redirect, then a 404.
+    row({
+      ip: "104.23.221.1",
+      uri: "/wp-admin/install.php",
+      status: 301,
+      type: "text/html",
+    }),
+    row({
+      ip: "104.23.221.1",
+      uri: "/wp-admin/install.php",
+      status: 404,
+      type: "application/xml",
+    }),
+    // Googlebot, which says so and is filtered on its word.
+    row({
+      ip: "192.178.4.1",
+      uri: "/printables/graph-paper-5-mm/a4/",
+      status: 200,
+      ua: GOOGLEBOT,
+      type: "text/html;charset=UTF-8",
+    }),
+    // An undeclared bot from a datacentre, wearing a browser's user-agent.
+    // Nothing here can catch this one; it is counted as a person by design.
+    row({
+      ip: "34.171.68.1",
+      uri: "/multiplication/10-times-table/",
+      status: 200,
+      type: "text/html;charset=UTF-8",
+    }),
+    // A beacon, which is neither a page nor an asset.
+    row({
+      ip: "98.168.10.1",
+      uri: "/_e/px.gif",
+      query: "e=race_start&deck=multiply&input=type",
+      status: 200,
+      type: "image/gif",
+    }),
+  ];
+
+  it("counts the person and the undeclared bot, and nothing else", async () => {
+    const day = await count(FIRST_HOUR);
+    expect(day.visitors.size).toBe(2);
+  });
+
+  it("sees all three of the returning visitor's page loads", async () => {
+    const day = await count(FIRST_HOUR);
+    expect(day.pageViews).toBe(4);
+    expect(day.pages).toEqual({
+      "/": 3,
+      "/multiplication/10-times-table/": 1,
+    });
+  });
+
+  it("keeps the scanner out of the record entirely", async () => {
+    const day = await count(FIRST_HOUR);
+    expect(day.pages["/wp-admin/install.php"]).toBeUndefined();
+  });
+
+  it("still records beacons, which are exempt from the page-view test", async () => {
+    const day = await count(FIRST_HOUR);
+    expect(day.events).toEqual({ race_start: 1 });
+    expect(day.decks).toEqual({ multiply: 1 });
+  });
+});

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -352,12 +352,117 @@ export default $config({
       },
     });
 
+    /**
+     * A traffic pulse, for the questions that shouldn't need a log query.
+     *
+     * CloudFront publishes these metrics to CloudWatch for free and whether or
+     * not anyone looks, so this dashboard costs nothing to feed — it is three
+     * widgets over data AWS is already keeping. Retention is 15 months, which
+     * is longer than the raw logs live (90 days) and shorter than
+     * analytics/counts.json, which is forever.
+     *
+     * It deliberately does NOT try to be the analytics. `Requests` counts every
+     * HTTP request — assets, fonts, beacons, bots, the deploy's own smoke
+     * checks — so it is roughly an order of magnitude above page views and can
+     * never be broken down by URL. What it is good for is the shape of things:
+     * whether traffic moved, whether errors appeared, whether the site went
+     * quiet. For "which pages, how many people", the rollup is the only answer.
+     *
+     * Production only, because the metrics are per-distribution and a dev stage
+     * has nobody on it.
+     *
+     * ⚠️ CloudFront metrics live in **us-east-1** regardless of where anything
+     * else is, and they carry a `Region: Global` dimension. Both are stated per
+     * widget below; get either wrong and the graph renders empty rather than
+     * failing, which is the worst way for a dashboard to be broken.
+     */
+    if (production) {
+      const distributionId = site.nodes.cdn!.nodes.distribution.id;
+
+      const widget = (
+        x: number,
+        y: number,
+        title: string,
+        metrics: unknown[],
+      ) => ({
+        type: "metric",
+        x,
+        y,
+        width: 12,
+        height: 6,
+        properties: {
+          title,
+          view: "timeSeries",
+          stacked: false,
+          region: "us-east-1",
+          period: 3600,
+          metrics,
+        },
+      });
+
+      new aws.cloudwatch.Dashboard("TrafficDashboard", {
+        // Fixed name so a bookmark keeps working across deploys.
+        dashboardName: "schoolskills-traffic",
+        dashboardBody: distributionId.apply((id) =>
+          JSON.stringify({
+            widgets: [
+              widget(0, 0, "Requests (all HTTP, not page views)", [
+                [
+                  "AWS/CloudFront",
+                  "Requests",
+                  "Region",
+                  "Global",
+                  "DistributionId",
+                  id,
+                  { stat: "Sum", label: "requests" },
+                ],
+              ]),
+              widget(12, 0, "Error rate (%)", [
+                [
+                  "AWS/CloudFront",
+                  "4xxErrorRate",
+                  "Region",
+                  "Global",
+                  "DistributionId",
+                  id,
+                  { stat: "Average", label: "4xx" },
+                ],
+                [
+                  "AWS/CloudFront",
+                  "5xxErrorRate",
+                  "Region",
+                  "Global",
+                  "DistributionId",
+                  id,
+                  { stat: "Average", label: "5xx" },
+                ],
+              ]),
+              widget(0, 6, "Bytes downloaded", [
+                [
+                  "AWS/CloudFront",
+                  "BytesDownloaded",
+                  "Region",
+                  "Global",
+                  "DistributionId",
+                  id,
+                  { stat: "Sum", label: "bytes" },
+                ],
+              ]),
+            ],
+          }),
+        ),
+      });
+    }
+
     return {
       url: site.url,
       stage: $app.stage,
       // Named in the outputs so docs/analytics.md doesn't have to hardcode a
       // generated bucket name that changes if the stack is ever rebuilt.
       logs: logs?.bucket ?? "none (production only)",
+      dashboard: production
+        ? "https://us-west-1.console.aws.amazon.com/cloudwatch/home#dashboards/dashboard/schoolskills-traffic"
+        : "none (production only)",
     };
   },
 });


### PR DESCRIPTION
Three things, from reading the first hour of real logs after #110 turned logging on.

## 1. The page-view test was wrong in both directions

That hour scored as **"2 visitors, 2 page views"**. Both counted were bots; the one human was invisible.

| IP | Path | Status | Old | New |
| --- | --- | --- | --- | --- |
| `98.168.10.x` | `/` ×3 + assets | **304** | ❌ missed | ✅ counted — the only plausible human |
| `104.23.221.x` | `/wp-admin/install.php` | **301** → 404 | ✅ counted | ❌ excluded — WordPress scanner |
| `34.171.68.x` | `/multiplication/10-times-table/` | 200 | ✅ counted | ✅ counted — undeclared bot, uncatchable |
| `192.178.4.x` | 4 printables pages | 200 | ❌ filtered | ❌ filtered — Googlebot, correctly |

`status < 400 && sc_content_type LIKE 'text/html%'` caused both faults:

- **3xx counted.** The http→https redirect is `text/html` with status 301, so every visitor arriving over http counted twice, and a scanner that only ever got a redirect became a visitor.
- **304 didn't.** HTML ships `must-revalidate`, so returning visitors revalidate and get a 304 — which carries **no content-type at all**. Every repeat visit was discarded. This compounds the service-worker blind spot the docs already warn about, and is much larger.

Since a 304 has no content-type, the path decides it: a filename with an extension is an asset, anything else is a document.

Same result on the real data:

```
before: visitors 2, pageViews 2, pages { "/multiplication/10-times-table/": 1, "/wp-admin/install.php": 1 }
after:  visitors 2, pageViews 4, pages { "/": 3, "/multiplication/10-times-table/": 1 }
```

The Athena queries had the identical flaw, so both now start from one documented `pages` CTE that mirrors `isPageView()`, each carrying a note that changing one means changing the other.

**Tests.** `rollup-analytics.mjs` now exports its counting logic and only bootstraps when run as a script, so the predicate is reachable. The suite is built from that first real hour and **fails on four counts against the old logic** rather than passing vacuously.

## 2. `npm run analytics`

Replaces the documented two-step with sync + count + summary:

```
DATE        VISITORS  VIEWS  EVENTS  TOP PAGE
2026-08-18         3      5       0  / (3)

TOP PAGES
       3  /
       1  /multiplication/10-times-table/
       1  /printables/templates/book-report/
```

Flags: `--days N`, `--no-sync`. It shells out to the rollup rather than reimplementing it — a second copy of `isPageView` is exactly the thing that would drift. It prints the "visitors is not additive across days" caveat every run, because that's the number most likely to be quoted out of context.

## 3. A CloudWatch dashboard

`schoolskills-traffic` — requests, error rate, bytes. Free, since CloudFront publishes these whether or not anyone looks. 15-month retention makes it the only record of any period when the log pipeline is broken, which is what the last week turned out to be.

It's a pulse, not analytics: `Requests` counts assets, fonts, beacons, bots and the deploy's own smoke checks, and can never be split by URL. The comment says so, so nobody quotes it as traffic.

Validated the widget JSON against CloudWatch with a throwaway dashboard (`DashboardValidationMessages: []`), since the `Region: Global` dimension renders empty rather than failing when it's wrong. Throwaway deleted.

## Checks

`type-check` 0 errors · `lint` clean · `test:unit` **1501 passed** · `format:check` clean

## Not included

The rollup still "succeeds" over zero log files, so the alarm that should have caught #110 remains unable to fire. Worth its own PR.

Refs #9