### PR TITLE
Decode CloudFront's field encoding before parsing a beacon

### DIFF
--- a/analytics/counts.json
+++ b/analytics/counts.json
@@ -13,11 +13,12 @@
       },
       "events": {
         "profile_added": 2,
+        "race_end:finished": 1,
         "race_end:quit": 1,
         "race_start": 2
       },
       "decks": {
-        "words%3Adolch-1": 2
+        "words:dolch-1": 2
       }
     }
   }

--- a/scripts/rollup-analytics.mjs
+++ b/scripts/rollup-analytics.mjs
@@ -99,6 +99,29 @@ export const isPageView = (row) => {
  * lie. This is a floor, not a complete list — anything that says it is a bot
  * is taken at its word, and anything that lies is counted as a person.
  */
+/**
+ * Undo the encoding CloudFront applies to log FIELDS.
+ *
+ * Every field it writes is percent-encoded on the way into the file, on top of
+ * whatever encoding the value already carried. A beacon sent as
+ * `deck=words%3Adolch-1` is therefore logged as `deck=words%253Adolch-1`, and
+ * anything that decodes only once — `URLSearchParams`, for instance — yields
+ * `words%3Adolch-1` and writes that mangled id into a file that is kept
+ * forever.
+ *
+ * `try` because the input is a query string from the open internet and
+ * `decodeURIComponent` throws on a malformed sequence — a single stray `%`
+ * from a scanner would otherwise take down the whole monthly run. A line we
+ * can't decode is worth skipping; it is not worth losing the month over.
+ */
+const decodeField = (value) => {
+  try {
+    return decodeURIComponent(value ?? "");
+  } catch {
+    return value ?? "";
+  }
+};
+
 const BOT =
   /bot|crawler|spider|crawling|slurp|bingpreview|facebookexternalhit|headlesschrome|lighthouse|curl|wget|python-requests/i;
 
@@ -167,14 +190,16 @@ export async function tally(dir) {
 
       const date = row["date"];
       if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
-      if (BOT.test(decodeURIComponent(row["cs(User-Agent)"] ?? ""))) continue;
+      if (BOT.test(decodeField(row["cs(User-Agent)"]))) continue;
 
       if (!days.has(date)) days.set(date, emptyDay());
       const day = days.get(date);
 
       if (row["cs-uri-stem"] === "/_e/px.gif") {
+        // Decode CloudFront's field encoding FIRST, then parse. Parsing
+        // first would leave every value still holding one layer of it.
         const q = new URLSearchParams(
-          row["cs-uri-query"] === "-" ? "" : row["cs-uri-query"],
+          row["cs-uri-query"] === "-" ? "" : decodeField(row["cs-uri-query"]),
         );
         const event = q.get("e");
         if (!event) continue;

--- a/scripts/rollup-analytics.test.mjs
+++ b/scripts/rollup-analytics.test.mjs
@@ -196,3 +196,56 @@ describe("tally, over the first real hour of logs", () => {
     expect(day.decks).toEqual({ multiply: 1 });
   });
 });
+
+describe("CloudFront's field encoding", () => {
+  // The log holds `deck=words%253Adolch-1`: the beacon encoded the colon once,
+  // and CloudFront encoded the whole field again on the way into the file.
+  // Decoding only once wrote `words%3Adolch-1` into the permanent record.
+  it("is undone before the query is parsed, so a deck id keeps its colon", async () => {
+    const day = await count([
+      row({
+        ip: "1.2.3.4",
+        uri: "/_e/px.gif",
+        query: "e=race_start&deck=words%253Adolch-1&input=type&n=1",
+        status: 200,
+        type: "image/gif",
+      }),
+    ]);
+    expect(day.decks).toEqual({ "words:dolch-1": 1 });
+  });
+
+  it("is undone for the user-agent too, so bots stay filtered", async () => {
+    const day = await count([
+      row({
+        ip: "1.2.3.4",
+        uri: "/",
+        status: 200,
+        type: "text/html;charset=UTF-8",
+        ua: GOOGLEBOT,
+      }),
+    ]);
+    expect(day).toBeUndefined();
+  });
+
+  // A stray `%` from a scanner makes decodeURIComponent throw. Losing the
+  // month's numbers to one malformed request would be a poor trade.
+  it("survives a malformed percent-sequence rather than losing the run", async () => {
+    const day = await count([
+      row({
+        ip: "1.2.3.4",
+        uri: "/_e/px.gif",
+        query: "e=race_start&deck=%&n=1",
+        status: 200,
+        type: "image/gif",
+      }),
+      row({
+        ip: "1.2.3.4",
+        uri: "/",
+        status: 200,
+        type: "text/html;charset=UTF-8",
+      }),
+    ]);
+    expect(day.pageViews).toBe(1);
+    expect(day.events).toEqual({ race_start: 1 });
+  });
+});


### PR DESCRIPTION
The first race the site ever recorded went into the permanent file as:

```json
"decks": { "words%3Adolch-1": 2 }
```

## Why

CloudFront percent-encodes every log **field** on the way into the file, on top of whatever encoding the value already carried. The beacon sends `deck=words%3Adolch-1`, so the raw log holds:

```
e=race_start&deck=words%253Adolch-1&input=type&n=1
```

`URLSearchParams` decodes exactly once, yielding `words%3Adolch-1`.

The user-agent was already being decoded for the bot test, so the double encoding was known about — the query string just never got the same treatment. Both now go through one `decodeField`, and the order matters: **decode the field, then parse it.** Parsing first leaves every value still holding a layer.

## The helper swallows decode errors on purpose

`decodeURIComponent` throws on a malformed sequence, and the input is a query string from the open internet. A single stray `%` from a scanner would otherwise end the monthly run and take the month's numbers with it — the same class of failure as counting nothing and calling it success (#119). A line that can't be decoded is worth skipping; the month is not worth losing.

Covered by a test that sends `deck=%` and asserts the surrounding rows still count.

## Verified

Against the real logs:

```
DECKS RACED
       2  words:dolch-1
```

`counts.json` is regenerated here, which also picks up the `race_end:finished` the earlier run was a few minutes too early to see.

The new test fails against the unfixed code (`× is undone before the query is parsed`) rather than passing vacuously.

`lint` clean · `type-check` 0 errors · `test:unit` **1506 passed** · `format:check` clean