### PR TITLE
Give the rollup's PR a check it can actually pass

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -139,6 +139,13 @@ jobs:
             esac
           fi
 
+          # Give the PR a check to satisfy. Nothing starts CI on its own here:
+          # events raised with GITHUB_TOKEN don't trigger workflows, so this PR
+          # would otherwise sit blocked forever waiting for a required "CI"
+          # context that never appears. Dispatching it runs the real suite
+          # against this branch's head commit.
+          gh workflow run ci.yml --ref "$BRANCH"
+
           gh pr merge "$BRANCH" --auto --squash --delete-branch
 
       - name: Say so if this stopped working

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,19 @@ on:
     branches: [develop, main]
   push:
     branches: [develop, main]
+  # Dispatchable so the monthly analytics rollup can get its own PR checked.
+  #
+  # GitHub deliberately does not start workflows for events raised with
+  # GITHUB_TOKEN — that is what stops a workflow triggering itself forever — so
+  # a PR opened by .github/workflows/analytics.yml receives NO checks at all.
+  # With "CI" required on develop, its PR is then blocked for want of a check
+  # that can never run, and auto-merge waits indefinitely.
+  #
+  # A dispatched run attaches its check to the head SHA of the ref it runs on,
+  # and branch protection evaluates required contexts against that SHA, so
+  # dispatching this against the rollup branch satisfies the gate honestly:
+  # the suite really does run, on exactly the commit being merged.
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
#119 taught the monthly job to open a PR instead of pushing to `develop`. The PR then sat blocked forever:

```
mergeStateStatus: BLOCKED
checks: []
```

**No checks at all.** GitHub deliberately does not start workflows for events raised with `GITHUB_TOKEN` — the rule that stops a workflow triggering itself. So the bot's PR receives nothing, `CI` stays required and unsatisfiable, and auto-merge waits on a check that can never arrive. #122 had to be merged with `--admin`.

## The fix

`ci.yml` becomes dispatchable, and the rollup dispatches it against the branch it just pushed:

```sh
git push --force-with-lease origin "$BRANCH"
gh pr create …
gh workflow run ci.yml --ref "$BRANCH"
gh pr merge "$BRANCH" --auto --squash --delete-branch
```

A dispatched run attaches its check to the head SHA of the ref it runs on, and branch protection evaluates required contexts against that SHA. So the gate is satisfied **honestly** — the full suite really runs, on exactly the commit being merged. Nothing is waived.

## Why not the alternatives

- **A stored PAT** would make CI trigger normally, but this repo has no long-lived credentials anywhere by design (AWS is OIDC); adding one for a monthly data commit is a poor trade.
- **A ruleset bypass for the Actions app** would work without a secret, but restructures `develop`'s protection from classic branch protection for one job's benefit.
- **Dropping `CI` as required** weakens the gate for every PR.

This keeps the protection, the gate and the credential model exactly as they were.