### PR TITLE
Grant the rollup the scope to dispatch its own check

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -32,6 +32,12 @@ permissions:
   id-token: write # OIDC, to read the log bucket
   contents: write # to push the branch the counts ride in on
   pull-requests: write # to open that branch's PR and set it to auto-merge
+  # To dispatch ci.yml against that branch. `workflow_dispatch` is one of the
+  # two events (with `repository_dispatch`) that GITHUB_TOKEN is still allowed
+  # to raise, which is the whole reason this route works — but raising it needs
+  # this scope, and without it the call is a bare 403 "Resource not accessible
+  # by integration" that names neither the permission nor the workflow.
+  actions: write
   issues: write # to complain if this stops working
 
 jobs:


### PR DESCRIPTION
Follow-up to #124, found by running it.

Dispatching a workflow needs `actions: write`. Without it:

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
```

— which names neither the missing permission nor the workflow.

Worth stating in the file why this route works at all: `workflow_dispatch` is one of the two events (with `repository_dispatch`) that `GITHUB_TOKEN` is still permitted to raise. Every *other* event it raises is ignored, which is exactly why the bot's PR gets no checks in the first place — so the exception is load-bearing here, not incidental.