### PR TITLE
Say what actually unblocks the rollup PR: a click, not a dispatch

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -32,12 +32,6 @@ permissions:
   id-token: write # OIDC, to read the log bucket
   contents: write # to push the branch the counts ride in on
   pull-requests: write # to open that branch's PR and set it to auto-merge
-  # To dispatch ci.yml against that branch. `workflow_dispatch` is one of the
-  # two events (with `repository_dispatch`) that GITHUB_TOKEN is still allowed
-  # to raise, which is the whole reason this route works — but raising it needs
-  # this scope, and without it the call is a bare 403 "Resource not accessible
-  # by integration" that names neither the permission nor the workflow.
-  actions: write
   issues: write # to complain if this stops working
 
 jobs:
@@ -94,10 +88,26 @@ jobs:
       # every run exited at "nothing to commit" before reaching it. The first
       # run with real data was the first run to fail.
       #
-      # Auto-merge is what keeps it hands-off: the PR merges itself the moment
-      # CI is green, so the gate is honoured without a human in the loop each
-      # month. If CI ever fails the PR simply stays open, which is a visible
-      # failure rather than a silent one.
+      # Auto-merge then lands it the moment CI is green, and a PR left open is
+      # a visible failure rather than a silent one.
+      #
+      # ⚠️ It needs ONE CLICK a month. GitHub parks the CI run for a
+      # bot-authored PR at `action_required` — its recursion guard, expressed
+      # as "needs approval" rather than "no run" — so the required check stays
+      # unsatisfied until someone presses "Approve and run". After that it
+      # merges itself.
+      #
+      # Dispatching ci.yml against the branch was tried and does NOT help:
+      # the dispatched run does produce a passing `CI` check on the head SHA,
+      # but GitHub credits only PR-associated runs to the PR, so
+      # `statusCheckRollup` stays empty and the merge stays blocked. All it
+      # bought was a second six-minute run nobody reads.
+      #
+      # The only way to remove the click is to open the PR as a real user —
+      # a stored PAT or GitHub App token — which this repo has so far avoided
+      # for anything, AWS included. Nothing is lost by waiting: the counts sit
+      # in the open PR, and the rollup overwrites per-day, so a month merged
+      # late is corrected rather than doubled.
       - name: Open a PR with the numbers
         env:
           GH_TOKEN: ${{ github.token }}
@@ -145,14 +155,9 @@ jobs:
             esac
           fi
 
-          # Give the PR a check to satisfy. Nothing starts CI on its own here:
-          # events raised with GITHUB_TOKEN don't trigger workflows, so this PR
-          # would otherwise sit blocked forever waiting for a required "CI"
-          # context that never appears. Dispatching it runs the real suite
-          # against this branch's head commit.
-          gh workflow run ci.yml --ref "$BRANCH"
-
           gh pr merge "$BRANCH" --auto --squash --delete-branch
+
+          echo "::notice::The PR needs one 'Approve and run' click on its CI run, then it merges itself."
 
       - name: Say so if this stopped working
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,10 @@ on:
     branches: [develop, main]
   push:
     branches: [develop, main]
-  # Dispatchable so the monthly analytics rollup can get its own PR checked.
-  #
-  # GitHub deliberately does not start workflows for events raised with
-  # GITHUB_TOKEN — that is what stops a workflow triggering itself forever — so
-  # a PR opened by .github/workflows/analytics.yml receives NO checks at all.
-  # With "CI" required on develop, its PR is then blocked for want of a check
-  # that can never run, and auto-merge waits indefinitely.
-  #
-  # A dispatched run attaches its check to the head SHA of the ref it runs on,
-  # and branch protection evaluates required contexts against that SHA, so
-  # dispatching this against the rollup branch satisfies the gate honestly:
-  # the suite really does run, on exactly the commit being merged.
+  # Runnable by hand against any branch. Added while trying to get the monthly
+  # analytics PR checked automatically — which it does not do, because GitHub
+  # credits only PR-associated runs to a PR (see analytics.yml) — but useful on
+  # its own for re-running the suite on a branch without pushing to it.
   workflow_dispatch:
 
 concurrency:

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -62,8 +62,15 @@ opens a PR with the result that merges itself once CI is green.
 
 It opens a PR rather than pushing because `develop` requires the CI check and
 a direct push from Actions carries none — the protected-branch hook declines
-it. If a rollup PR is ever sitting open, CI failed on it; the numbers are
-waiting, not lost.
+it.
+
+**That PR needs one click a month.** GitHub parks the CI run on a bot-authored
+PR at `action_required`, so the required check stays unsatisfied until someone
+presses "Approve and run"; after that auto-merge lands it. Nothing is lost by
+leaving it: the counts sit in the open PR, and the rollup overwrites per-day,
+so a month merged late is corrected rather than doubled. Removing the click
+means opening the PR as a real user — a stored PAT or App token — which this
+repo has avoided for everything so far, AWS included.
 
 If the bucket is empty the job now **fails** rather than quietly counting
 nothing. CloudFront logs every request including crawlers, so zero files means


### PR DESCRIPTION
#124 claimed that dispatching `ci.yml` against the rollup branch would satisfy the required check. **It doesn't**, and leaving that claim in the file is worse than the gap it was trying to close.

## What actually happens

The dispatched run really does attach a passing check to the head SHA:

```
$ gh api repos/…/commits/$SHA/check-runs
CI: completed/success [github-actions]
```

But the PR stayed blocked, with an empty rollup:

```
{"checks":[],"merge":"BLOCKED","state":"OPEN"}
```

GitHub credits only **PR-associated** runs to a PR. A green CI check was sitting on the exact commit being merged and counted for nothing.

The real blocker is that GitHub parks the CI run for a bot-authored PR at `action_required` — the recursion guard, expressed as "needs approval" rather than "no run". Approving it started the run, and auto-merge landed #127 the moment it went green.

## So

The dispatch and the `actions: write` scope it needed are removed — all they bought was a second six-minute run nobody reads. `ci.yml` keeps `workflow_dispatch`, which is independently useful for re-running the suite on a branch without pushing to it, with a comment that no longer claims more than that.

The job now prints a `::notice::` saying what's needed, and `docs/analytics.md` states it plainly.

## The remaining click

One "Approve and run" per month. **Nothing is lost by leaving it** — the counts sit in the open PR, and the rollup overwrites per-day rather than accumulating, so a month merged late is corrected rather than doubled.

The only way to remove it is to open the PR as a real user, via a stored PAT or GitHub App token. This repo has avoided long-lived credentials for everything so far, AWS included, so that's a trade worth making deliberately rather than by default — happy to wire it up if you'd rather have it fully hands-off.