### PR TITLE
The physical keyboard, as data in the engine

### DIFF
--- a/src/engine/keyboard.test.ts
+++ b/src/engine/keyboard.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import { KEYS, KEY_ROWS, reachable, strokeFor } from "./keyboard";
+import type { KeyDef } from "./keyboard";
+import { TYPING_LEVELS } from "./decks/typing";
+
+const BY_CODE = new Map(KEYS.map((k) => [k.code, k]));
+
+/** What a stroke actually produces, read back off the key it names. */
+const typed = (ch: string): string | null => {
+  const stroke = strokeFor(ch);
+  if (!stroke) return null;
+  const key = BY_CODE.get(stroke.code);
+  if (!key) return null;
+  return stroke.shift ? key.cap[1] : key.cap[0];
+};
+
+/** Every character this board can produce, which is what the pools live off. */
+const EVERYTHING = new Set(
+  KEYS.flatMap((k) => k.cap).filter((legend) => legend.length === 1),
+);
+
+const LETTERS = "abcdefghijklmnopqrstuvwxyz";
+const DIGITS = "0123456789";
+/** The punctuation the shipped typing pools use, plus what block 7 adds. */
+const PUNCTUATION = "`-=[]\\;',./~!@#$%^&*()_+{}|:\"<>? ";
+
+const hand = (key: KeyDef) => (key.finger.startsWith("l-") ? "l" : "r");
+
+describe("strokeFor", () => {
+  it("round-trips every letter, in both cases", () => {
+    for (const ch of LETTERS + LETTERS.toUpperCase()) {
+      expect(typed(ch), ch).toBe(ch);
+    }
+  });
+
+  it("round-trips every digit and every shipped punctuation mark", () => {
+    for (const ch of DIGITS + PUNCTUATION) {
+      expect(typed(ch), ch).toBe(ch);
+    }
+  });
+
+  it("round-trips everything the board can produce", () => {
+    // The two lists above are what we meant to ship; this is what the table
+    // actually carries. A key added with a legend nobody can type would slip
+    // past the named lists and be caught here.
+    for (const ch of EVERYTHING) {
+      expect(typed(ch), ch).toBe(ch);
+    }
+  });
+
+  it("leaves a plain character unshifted", () => {
+    expect(strokeFor("a")).toEqual({
+      code: "KeyA",
+      shift: null,
+      finger: "l-pinky",
+    });
+    expect(strokeFor(" ")).toEqual({
+      code: "Space",
+      shift: null,
+      finger: "thumb",
+    });
+  });
+
+  it("takes the shift on the opposite hand", () => {
+    // The whole point of returning a *specific* shift: left pinky on shift and
+    // left pinky on `a` is not a thing hands can do.
+    expect(strokeFor("A")).toEqual({
+      code: "KeyA",
+      shift: "ShiftRight",
+      finger: "l-pinky",
+    });
+    expect(strokeFor(":")).toEqual({
+      code: "Semicolon",
+      shift: "ShiftLeft",
+      finger: "r-pinky",
+    });
+    expect(strokeFor("$")).toEqual({
+      code: "Digit4",
+      shift: "ShiftRight",
+      finger: "l-index",
+    });
+  });
+
+  it("never asks one hand to hold shift and press the key", () => {
+    for (const ch of EVERYTHING) {
+      const stroke = strokeFor(ch)!;
+      if (!stroke.shift) continue;
+      const key = BY_CODE.get(stroke.code)!;
+      expect(stroke.shift, ch).toBe(
+        hand(key) === "l" ? "ShiftRight" : "ShiftLeft",
+      );
+    }
+  });
+
+  it("returns null for a character this layout cannot produce", () => {
+    // The curly quotation marks in the Bible release, which decks/typing.ts
+    // had to hand-exclude from the Scripture pool. A verse carrying one is
+    // unpassable rather than hard, because typing marks exactly.
+    expect(strokeFor("“")).toBeNull();
+    expect(strokeFor("”")).toBeNull();
+    expect(strokeFor("’")).toBeNull();
+    expect(strokeFor("—")).toBeNull();
+    expect(strokeFor("é")).toBeNull();
+  });
+
+  it("does not answer for a key that types nothing", () => {
+    for (const legend of ["Tab", "Shift", "Caps", "Enter", "Bksp", "Ctrl"]) {
+      expect(strokeFor(legend), legend).toBeNull();
+    }
+  });
+});
+
+describe("reachable", () => {
+  it("passes text made only of unlocked characters", () => {
+    const homeRow = new Set([..."asdfghjkl", " "]);
+    expect(reachable("a glass flask", homeRow)).toBe(true);
+  });
+
+  it("fails on a character the child has not been given yet", () => {
+    const homeRow = new Set([..."asdfghjkl", " "]);
+    expect(reachable("glad we met", homeRow)).toBe(false);
+    // Unlocking `a` does not hand a child `A` — shift is its own lesson.
+    expect(reachable("Ask", homeRow)).toBe(false);
+  });
+
+  it("fails on a character the board cannot produce, however unlocked", () => {
+    // Both halves of the check matter: a curly quote in a set of unlocked
+    // characters is still a key nobody has.
+    expect(reachable("“yes”", new Set([..."“yes”"]))).toBe(false);
+  });
+
+  it("is true of empty text", () => {
+    expect(reachable("", new Set())).toBe(true);
+  });
+
+  for (const level of TYPING_LEVELS) {
+    it(`can type every character of the ${level.id} pool`, () => {
+      // The levels that ship today, against the board as it is. This is the
+      // check that would have caught the curly quotation marks by itself.
+      for (const entry of level.pool) {
+        expect(reachable(entry, EVERYTHING), entry).toBe(true);
+      }
+    });
+  }
+});
+
+describe("the board", () => {
+  it("gives every key a unique code", () => {
+    expect(BY_CODE.size).toBe(KEYS.length);
+  });
+
+  it("puts the fingers on eight home keys and the space bar", () => {
+    expect(KEYS.filter((k) => k.home).map((k) => k.code)).toEqual([
+      "KeyA",
+      "KeyS",
+      "KeyD",
+      "KeyF",
+      "KeyJ",
+      "KeyK",
+      "KeyL",
+      "Semicolon",
+      "Space",
+    ]);
+  });
+
+  it("lays every row out end to end, 15 units wide", () => {
+    // `x` is stored per key rather than computed, so a typo in the table is a
+    // silently overlapping key — and in Hailstorm, a letter falling down the
+    // wrong column. This is the arithmetic nobody has to do at runtime.
+    for (const row of KEY_ROWS) {
+      let edge = 0;
+      for (const key of row) {
+        expect(key.x, key.code).toBe(edge);
+        edge += key.width ?? 1;
+      }
+      expect(edge, `row ${row[0].row}`).toBe(15);
+    }
+  });
+
+  it("keeps each row on one row number", () => {
+    KEY_ROWS.forEach((row, n) => {
+      for (const key of row) expect(key.row, key.code).toBe(n);
+    });
+  });
+});

--- a/src/engine/keyboard.test.ts
+++ b/src/engine/keyboard.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { KEYS, KEY_ROWS, reachable, strokeFor } from "./keyboard";
-import type { KeyDef } from "./keyboard";
+import type { Finger, KeyDef } from "./keyboard";
 import { TYPING_LEVELS } from "./decks/typing";
 
 const BY_CODE = new Map(KEYS.map((k) => [k.code, k]));
@@ -26,6 +26,48 @@ const DIGITS = "0123456789";
 const PUNCTUATION = "`-=[]\\;',./~!@#$%^&*()_+{}|:\"<>? ";
 
 const hand = (key: KeyDef) => (key.finger.startsWith("l-") ? "l" : "r");
+
+/** Unshifted legend → the key that carries it. Word legends are not unique. */
+const BY_LEGEND = new Map(
+  KEYS.filter((k) => k.cap[0].length === 1).map((k) => [k.cap[0], k]),
+);
+
+/**
+ * The finger assignment the module header claims, written out as data.
+ *
+ * Column by column, the way it is taught: the characters that column's finger
+ * types, then the codes of the keys in it that type nothing. Spelling it out
+ * here rather than reading it off `KEYS` is the point — this is the expected
+ * value, and a one-character slip in the table has to disagree with it.
+ */
+const FINGERS: [Finger, string, ...string[]][] = [
+  [
+    "l-pinky",
+    "`1qaz",
+    "Tab",
+    "CapsLock",
+    "ShiftLeft",
+    "ControlLeft",
+    "MetaLeft",
+  ],
+  ["l-ring", "2wsx"],
+  ["l-middle", "3edc"],
+  ["l-index", "45rtfgvb"],
+  ["thumb", " ", "AltLeft", "AltRight"],
+  ["r-index", "67yuhjnm"],
+  ["r-middle", "8ik,"],
+  ["r-ring", "9ol."],
+  [
+    "r-pinky",
+    "p0-=[]\\;'/",
+    "Backspace",
+    "Enter",
+    "ShiftRight",
+    "MetaRight",
+    "ContextMenu",
+    "ControlRight",
+  ],
+];
 
 describe("strokeFor", () => {
   it("round-trips every letter, in both cases", () => {
@@ -182,5 +224,57 @@ describe("the board", () => {
     KEY_ROWS.forEach((row, n) => {
       for (const key of row) expect(key.row, key.code).toBe(n);
     });
+  });
+
+  it("resolves each key's own legends back to that key", () => {
+    // The round-trip tests above walk *characters*, so they cannot see a
+    // legend that appears twice: `STROKES` is first-writer-wins, so the second
+    // key is silently shadowed and every one of those assertions still passes.
+    // This walks keys instead, and asks the question the module exists to
+    // answer — `code`, not `key`, so that the picture and the Hailstorm lane
+    // light the switch that was actually pressed (docs/typing.md §3.2). A
+    // shadowed key cannot answer for its own cap, and fails here.
+    //
+    // What no assertion in this file can catch is two keys whose legends are
+    // swapped wholesale: that board is self-consistent, and only the finger
+    // test below sees it — and only when the swap crosses a finger column.
+    for (const key of KEYS) {
+      const [unshifted, shifted] = key.cap;
+      if (unshifted.length === 1) {
+        const stroke = strokeFor(unshifted);
+        expect(stroke?.code, `${key.code} → ${unshifted}`).toBe(key.code);
+        expect(stroke?.shift, `${key.code} → ${unshifted}`).toBeNull();
+      }
+      // The space bar is the one key whose two caps are the same character,
+      // so its shifted legend is the unshifted stroke. Every other pair
+      // differs, and the shifted half must ask for a shift.
+      if (shifted.length === 1 && shifted !== unshifted) {
+        const stroke = strokeFor(shifted);
+        expect(stroke?.code, `${key.code} → ${shifted}`).toBe(key.code);
+        expect(stroke?.shift, `${key.code} → ${shifted}`).not.toBeNull();
+      }
+    }
+  });
+
+  it("puts every key on the finger the standard assignment gives it", () => {
+    // The assignment is the thing being taught, and three consumers read it:
+    // the curriculum's mirrored-pair ordering (§5.5), the next-key hint's
+    // finger colour, and Hailstorm's eight shield zones (§8.5), where a wrong
+    // finger puts the hole under the wrong hand. Nothing else in this file
+    // would notice a typo — the opposite-hand test compares only the hand.
+    const expected = new Map<string, Finger>();
+    for (const [finger, legends, ...codes] of FINGERS) {
+      for (const ch of legends) {
+        const key = BY_LEGEND.get(ch);
+        expect(key, ch).toBeDefined();
+        expected.set(key!.code, finger);
+      }
+      for (const code of codes) expected.set(code, finger);
+    }
+
+    expect(expected.size, "every key is spoken for").toBe(KEYS.length);
+    for (const key of KEYS) {
+      expect(key.finger, key.code).toBe(expected.get(key.code));
+    }
   });
 });

--- a/src/engine/keyboard.ts
+++ b/src/engine/keyboard.ts
@@ -1,0 +1,266 @@
+/**
+ * The physical keyboard, as data.
+ *
+ * A *picture* of a keyboard belongs in the view. The keyboard itself does not,
+ * because three of its four consumers are not pictures (docs/typing.md §3.1):
+ *
+ *   - The **curriculum** needs to know that `e` is the left middle finger on
+ *     the top row, so "introduce one key per hand" is a rule the lesson list
+ *     can be checked against rather than a claim in a comment.
+ *   - The **generator** needs `reachable()` — is every character of this word
+ *     producible from the keys unlocked so far? That is the invariant which
+ *     makes a hundred lessons safe to re-order (§5.2), and it is a pure
+ *     function over this table.
+ *   - **Hailstorm** needs a key's horizontal position, because that is the lane
+ *     its letter falls down (§8.2): `f` falls onto `f`, and `y` falls between
+ *     `g` and `h` because that is where `y` is. The game is not themed around a
+ *     keyboard, it is teaching the layout geometrically the whole time.
+ *
+ * Only the fourth consumer draws it. Put the layout in the view and the other
+ * three have to import upwards, which the lint boundary correctly forbids.
+ *
+ * ── US ANSI QWERTY, and nothing else ─────────────────────────────────────────
+ * The site is `en` and typing marks punctuation exactly, so a UK board — where
+ * `"` is shift-`2` and `@` is shift-`'` — would fail a punctuation lesson for a
+ * child who is doing everything right. That is a real limitation and it is
+ * written down here rather than discovered later. It is also a cheap one to
+ * lift: the layout is data behind one function, so a second board is a second
+ * table plus a profile field, and `strokeFor` is the only caller that would
+ * have to learn about it (§3.4).
+ */
+
+/**
+ * Which finger presses a key, in touch-typing's standard assignment.
+ *
+ * `thumb` is one finger rather than two because only the space bar is struck
+ * with it and either thumb will do — nothing downstream needs to know which.
+ */
+export type Finger =
+  | "l-pinky"
+  | "l-ring"
+  | "l-middle"
+  | "l-index"
+  | "thumb"
+  | "r-index"
+  | "r-middle"
+  | "r-ring"
+  | "r-pinky";
+
+export type KeyDef = {
+  /**
+   * `KeyboardEvent.code`. "KeyF", "Semicolon", "Digit4", "Space".
+   *
+   * `code`, not `key`. `KeyboardEvent.key` reports the character that was
+   * produced, which is the wrong question for "light up the key that was
+   * pressed": shift+`4` produces `$` and there is no `$` key to light. `code`
+   * is the physical switch, which is exactly what the picture draws and
+   * exactly what the falling-letter lane is a column of.
+   */
+  code: string;
+  /**
+   * Unshifted and shifted legends: ["a","A"], ["4","$"], ["/","?"].
+   *
+   * A key that produces no character carries a word — "Tab", "Shift", "Bksp" —
+   * never a glyph like "⌫". `strokeFor` indexes the legends that are a single
+   * character, so a word legend is what keeps a modifier out of the answer to
+   * "which key types this?" without needing a second field to exclude it.
+   */
+  cap: [string, string];
+  /** 0 = number row, 1 = top, 2 = home, 3 = bottom, 4 = space. */
+  row: 0 | 1 | 2 | 3 | 4;
+  finger: Finger;
+  /** True for a s d f — j k l ; and the space bar. Where the fingers rest. */
+  home?: boolean;
+  /** Width in key units. 1 unless it is a modifier or the space bar. */
+  width?: number;
+  /** Left edge in key units, from the left edge of the board. */
+  x: number;
+};
+
+/**
+ * One row's worth of keys, left to right.
+ *
+ * `x` is written down rather than accumulated because the row stagger is not
+ * derivable from anything — it is a fact about the plastic. Row 1 starts a
+ * third of a unit in, row 2 a little further, row 3 further still. Storing it
+ * costs one number per key and leaves no arithmetic for anybody to trust.
+ */
+const key = (
+  code: string,
+  cap: [string, string],
+  row: KeyDef["row"],
+  finger: Finger,
+  x: number,
+  extra?: { home?: true; width?: number },
+): KeyDef => ({ code, cap, row, finger, x, ...extra });
+
+/**
+ * The board, as rows — 15 key units wide, which is what the view scales off a
+ * single `--key` custom property and what Hailstorm measures its lanes in.
+ *
+ * Fingers are the standard assignment: the index fingers take two columns
+ * each (`4 5 r t f g v b` on the left, `6 7 y u h j n m` on the right) and the
+ * pinkies take everything outboard of `q a z` and `p ; /`. That is the thing
+ * being taught, so it is written once here rather than inferred from `x`.
+ */
+export const KEY_ROWS: KeyDef[][] = [
+  // Row 0 — the number row.
+  [
+    key("Backquote", ["`", "~"], 0, "l-pinky", 0),
+    key("Digit1", ["1", "!"], 0, "l-pinky", 1),
+    key("Digit2", ["2", "@"], 0, "l-ring", 2),
+    key("Digit3", ["3", "#"], 0, "l-middle", 3),
+    key("Digit4", ["4", "$"], 0, "l-index", 4),
+    key("Digit5", ["5", "%"], 0, "l-index", 5),
+    key("Digit6", ["6", "^"], 0, "r-index", 6),
+    key("Digit7", ["7", "&"], 0, "r-index", 7),
+    key("Digit8", ["8", "*"], 0, "r-middle", 8),
+    key("Digit9", ["9", "("], 0, "r-ring", 9),
+    key("Digit0", ["0", ")"], 0, "r-pinky", 10),
+    key("Minus", ["-", "_"], 0, "r-pinky", 11),
+    key("Equal", ["=", "+"], 0, "r-pinky", 12),
+    key("Backspace", ["Bksp", "Bksp"], 0, "r-pinky", 13, { width: 2 }),
+  ],
+  // Row 1 — the top row.
+  [
+    key("Tab", ["Tab", "Tab"], 1, "l-pinky", 0, { width: 1.5 }),
+    key("KeyQ", ["q", "Q"], 1, "l-pinky", 1.5),
+    key("KeyW", ["w", "W"], 1, "l-ring", 2.5),
+    key("KeyE", ["e", "E"], 1, "l-middle", 3.5),
+    key("KeyR", ["r", "R"], 1, "l-index", 4.5),
+    key("KeyT", ["t", "T"], 1, "l-index", 5.5),
+    key("KeyY", ["y", "Y"], 1, "r-index", 6.5),
+    key("KeyU", ["u", "U"], 1, "r-index", 7.5),
+    key("KeyI", ["i", "I"], 1, "r-middle", 8.5),
+    key("KeyO", ["o", "O"], 1, "r-ring", 9.5),
+    key("KeyP", ["p", "P"], 1, "r-pinky", 10.5),
+    key("BracketLeft", ["[", "{"], 1, "r-pinky", 11.5),
+    key("BracketRight", ["]", "}"], 1, "r-pinky", 12.5),
+    key("Backslash", ["\\", "|"], 1, "r-pinky", 13.5, { width: 1.5 }),
+  ],
+  // Row 2 — home. The eight keys the hands are put on and returned to.
+  [
+    key("CapsLock", ["Caps", "Caps"], 2, "l-pinky", 0, { width: 1.75 }),
+    key("KeyA", ["a", "A"], 2, "l-pinky", 1.75, { home: true }),
+    key("KeyS", ["s", "S"], 2, "l-ring", 2.75, { home: true }),
+    key("KeyD", ["d", "D"], 2, "l-middle", 3.75, { home: true }),
+    key("KeyF", ["f", "F"], 2, "l-index", 4.75, { home: true }),
+    key("KeyG", ["g", "G"], 2, "l-index", 5.75),
+    key("KeyH", ["h", "H"], 2, "r-index", 6.75),
+    key("KeyJ", ["j", "J"], 2, "r-index", 7.75, { home: true }),
+    key("KeyK", ["k", "K"], 2, "r-middle", 8.75, { home: true }),
+    key("KeyL", ["l", "L"], 2, "r-ring", 9.75, { home: true }),
+    key("Semicolon", [";", ":"], 2, "r-pinky", 10.75, { home: true }),
+    key("Quote", ["'", '"'], 2, "r-pinky", 11.75),
+    key("Enter", ["Enter", "Enter"], 2, "r-pinky", 12.75, { width: 2.25 }),
+  ],
+  // Row 3 — the bottom row, and the two shifts.
+  [
+    key("ShiftLeft", ["Shift", "Shift"], 3, "l-pinky", 0, { width: 2.25 }),
+    key("KeyZ", ["z", "Z"], 3, "l-pinky", 2.25),
+    key("KeyX", ["x", "X"], 3, "l-ring", 3.25),
+    key("KeyC", ["c", "C"], 3, "l-middle", 4.25),
+    key("KeyV", ["v", "V"], 3, "l-index", 5.25),
+    key("KeyB", ["b", "B"], 3, "l-index", 6.25),
+    key("KeyN", ["n", "N"], 3, "r-index", 7.25),
+    key("KeyM", ["m", "M"], 3, "r-index", 8.25),
+    key("Comma", [",", "<"], 3, "r-middle", 9.25),
+    key("Period", [".", ">"], 3, "r-ring", 10.25),
+    key("Slash", ["/", "?"], 3, "r-pinky", 11.25),
+    key("ShiftRight", ["Shift", "Shift"], 3, "r-pinky", 12.25, { width: 2.75 }),
+  ],
+  // Row 4 — the space bar, and the modifiers nothing here types with.
+  [
+    key("ControlLeft", ["Ctrl", "Ctrl"], 4, "l-pinky", 0, { width: 1.25 }),
+    key("MetaLeft", ["Cmd", "Cmd"], 4, "l-pinky", 1.25, { width: 1.25 }),
+    key("AltLeft", ["Alt", "Alt"], 4, "thumb", 2.5, { width: 1.25 }),
+    key("Space", [" ", " "], 4, "thumb", 3.75, { home: true, width: 6.25 }),
+    key("AltRight", ["Alt", "Alt"], 4, "thumb", 10, { width: 1.25 }),
+    key("MetaRight", ["Cmd", "Cmd"], 4, "r-pinky", 11.25, { width: 1.25 }),
+    key("ContextMenu", ["Menu", "Menu"], 4, "r-pinky", 12.5, { width: 1.25 }),
+    key("ControlRight", ["Ctrl", "Ctrl"], 4, "r-pinky", 13.75, { width: 1.25 }),
+  ],
+];
+
+/** Every key on the board, rows flattened. Row order is left-to-right, top-down. */
+export const KEYS: KeyDef[] = KEY_ROWS.flat();
+
+export type Stroke = {
+  /** The letter key. */
+  code: string;
+  /** Which shift to hold, or null. Always the hand OPPOSITE `code`. */
+  shift: "ShiftLeft" | "ShiftRight" | null;
+  /** The finger that presses `code`. The shift is always a pinky. */
+  finger: Finger;
+};
+
+/**
+ * The shift on the other hand from this finger.
+ *
+ * Typing `A` with the left pinky on shift and the left pinky on `a` is
+ * impossible; the technique is right-shift plus left-`a`, and teaching it is
+ * the single most-skipped thing in typing courses aimed at children. So the
+ * hint highlights the shift a child can actually reach, which means knowing
+ * which hand the letter is on.
+ *
+ * `thumb` falls to the same branch as the right hand and never reaches it:
+ * the space bar is the only thumb key and both its caps are a space, so no
+ * thumb stroke ever needs a shift. The choice is only ever about two hands.
+ */
+const oppositeShift = (finger: Finger): "ShiftLeft" | "ShiftRight" =>
+  finger.startsWith("l-") ? "ShiftRight" : "ShiftLeft";
+
+/**
+ * Character → the stroke that produces it, built once from the table above.
+ *
+ * Only single-character legends are indexed, which is what keeps "Tab" and
+ * "Shift" out of it. First writer wins: no legend appears twice on this board,
+ * and the round-trip test would catch it if a future one did.
+ */
+const STROKES = new Map<string, Stroke>();
+for (const k of KEYS) {
+  const [unshifted, shifted] = k.cap;
+  if (unshifted.length === 1 && !STROKES.has(unshifted))
+    STROKES.set(unshifted, { code: k.code, shift: null, finger: k.finger });
+  if (shifted.length === 1 && !STROKES.has(shifted))
+    STROKES.set(shifted, {
+      code: k.code,
+      shift: oppositeShift(k.finger),
+      finger: k.finger,
+    });
+}
+
+/**
+ * How to type one character, or `null` if this layout cannot produce it.
+ *
+ * That null is load-bearing rather than defensive: it is what `reachable()` is
+ * built out of, and it is what would have caught the curly quotation marks
+ * that `decks/typing.ts` had to hand-exclude from the Scripture pool — a verse
+ * containing one is unpassable rather than hard, because typing marks exactly.
+ */
+export function strokeFor(ch: string): Stroke | null {
+  return STROKES.get(ch) ?? null;
+}
+
+/**
+ * Can every character of `text` be typed with the keys unlocked so far?
+ *
+ * `keys` is the unlocked *alphabet* — the characters those keys produce, which
+ * is the form a lesson declares (`Lesson.introduces`) and the form the ladder
+ * accumulates. A capital is its own entry because shift is its own lesson:
+ * unlocking `a` does not hand a child `A`, and a generator that assumed it
+ * would write a word nobody at that lesson can type.
+ *
+ * Both halves matter. The `keys` check is the curriculum's — don't use a key
+ * they haven't met. The `strokeFor` check is the layout's — don't use a
+ * character this board cannot produce at all, which is how prose pulled from
+ * the passage library gets its curly quotes and dashes caught before a child
+ * meets them.
+ */
+export function reachable(text: string, keys: ReadonlySet<string>): boolean {
+  for (const ch of text) {
+    if (!keys.has(ch)) return false;
+    if (!strokeFor(ch)) return false;
+  }
+  return true;
+}

--- a/src/engine/keyboard.ts
+++ b/src/engine/keyboard.ts
@@ -32,8 +32,9 @@
 /**
  * Which finger presses a key, in touch-typing's standard assignment.
  *
- * `thumb` is one finger rather than two because only the space bar is struck
- * with it and either thumb will do — nothing downstream needs to know which.
+ * `thumb` is one finger rather than two because either thumb will do for the
+ * keys it covers — the space bar and the two Alts — and nothing downstream
+ * needs to know which.
  */
 export type Finger =
   | "l-pinky"
@@ -203,9 +204,10 @@ export type Stroke = {
  * hint highlights the shift a child can actually reach, which means knowing
  * which hand the letter is on.
  *
- * `thumb` falls to the same branch as the right hand and never reaches it:
- * the space bar is the only thumb key and both its caps are a space, so no
- * thumb stroke ever needs a shift. The choice is only ever about two hands.
+ * `thumb` falls to the same branch as the right hand and never reaches it: no
+ * thumb key carries a single-character *shifted* legend — the space bar's two
+ * caps are both a space, and the Alts are words — so no thumb stroke ever needs
+ * a shift. The choice is only ever about two hands.
  */
 const oppositeShift = (finger: Finger): "ShiftLeft" | "ShiftRight" =>
   finger.startsWith("l-") ? "ShiftRight" : "ShiftLeft";
@@ -215,7 +217,11 @@ const oppositeShift = (finger: Finger): "ShiftLeft" | "ShiftRight" =>
  *
  * Only single-character legends are indexed, which is what keeps "Tab" and
  * "Shift" out of it. First writer wins: no legend appears twice on this board,
- * and the round-trip test would catch it if a future one did.
+ * and a second key carrying one would be shadowed here rather than rejected.
+ * The round-trip tests cannot see that — they walk characters, and a shadowed
+ * key never comes up. What rules it out is the key-side test, "resolves each
+ * key's own legends back to that key", which walks the board in this direction
+ * instead: a shadowed key does not answer for its own cap, and fails.
  */
 const STROKES = new Map<string, Stroke>();
 for (const k of KEYS) {


### PR DESCRIPTION
Closes #129. Design: `docs/typing.md` §3. Epic code **KEY01**, first story of #157.

## What

`src/engine/keyboard.ts` — US ANSI QWERTY as data, plus the two pure functions over it. No React, no Astro, no services; nothing imports it yet.

- `KEY_ROWS` / `KEYS` — every key as a `KeyDef`: `code` (`KeyboardEvent.code`), `cap` (unshifted and shifted legends), `row`, `finger`, `home`, `width`, `x`.
- `strokeFor(ch)` → `{ code, shift, finger }` or `null`.
- `reachable(text, keys)` → can every character of this text be typed with the keys unlocked so far.

## Why it is engine and not view

Three of the four consumers are not pictures (§3.1): the curriculum needs to know that `e` is left-middle-finger to check "one new key per hand", the lesson generator needs `reachable()`, and Hailstorm needs a key's horizontal position because that is the lane its letter falls down. Put the layout in the view and the other three have to import upwards, which the lint boundary correctly forbids.

## The three decisions worth arguing with

- **`code`, not `key`** (§3.2). `KeyboardEvent.key` reports the character produced, which is the wrong question for "light up the key that was pressed" — shift+`4` produces `$` and there is no `$` key to light.
- **`x` is stored, not accumulated.** The row stagger is a fact about the plastic, not arithmetic. One number per key, and no running total anybody has to trust.
- **The shift is on the opposite hand** (§3.3). `A` is right-shift plus left-`a`; left pinky on both is impossible. `strokeFor` returns the shift a child can actually reach, which is the thing every children's typing course skips.

`strokeFor` returning `null` is load-bearing rather than defensive: `reachable()` is built out of it, and it is what would have caught the curly quotation marks that `decks/typing.ts` had to hand-exclude from the Scripture pool.

## Tests

`src/engine/keyboard.test.ts` — 22 cases. Every letter, digit and shipped punctuation mark round-trips through `strokeFor`; every character of every existing `TYPING_LEVELS` pool is `reachable`; a curly quotation mark returns `null`. The board itself is checked from the key side too — unique codes, nine home positions, each row 15 units end to end, and each key's own legends resolving back to that key, which is what rules out a duplicate legend shadowing a key in the lookup.

## Scope

US ANSI QWERTY only, and the limit is recorded rather than discovered (§3.4): a UK board would fail a punctuation lesson for a child doing everything right. Lifting it later is a second table plus a profile field, with `strokeFor` the only caller that has to learn about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
