### PR TITLE
Draw the keyboard, so nobody has to look down at the real one

### DIFF
--- a/src/games/typing/keyboard/Keyboard.test.tsx
+++ b/src/games/typing/keyboard/Keyboard.test.tsx
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { KEYS } from "@/engine/keyboard";
+
+import { Keyboard } from "./Keyboard";
+
+/**
+ * What the board owes a child, a screen reader, and the next story.
+ *
+ * The two things worth pinning here are both things a well-meaning change
+ * would undo. The first is that this board is INERT: no control, no tab stop,
+ * nothing to press. "Make the keys tappable" is the single most natural
+ * feature request this component will ever attract, and saying yes to it turns
+ * a touch-typing tutor into a hunt-and-peck trainer (docs/typing.md §4.5).
+ *
+ * The second is the palette. The finger hues are checked against the telemetry
+ * five by reading the stylesheet, because that rule lives in CSS and there is
+ * no other place it can be asserted — a keyboard that tinted the left index
+ * finger `--lime` would spend a hundred lessons teaching a child to unlearn
+ * what green means (§4.6).
+ */
+
+const html = renderToStaticMarkup(<Keyboard />);
+
+const css = (name: string) =>
+  readFileSync(
+    fileURLToPath(new URL(`../../../styles/${name}`, import.meta.url)),
+    "utf8",
+  );
+
+/** Where the board's own rules start in the game stylesheet. */
+const KEYBOARD_BLOCK = "/* ── Typing: the keyboard on screen";
+
+/** The five that mean something everywhere, by name and by value. */
+const TELEMETRY = {
+  "--lime": "#c8ff41",
+  "--flare": "#ff4d6d",
+  "--sky": "#4cc4ff",
+  "--gold": "#ffc53d",
+  "--grape": "#a78bfa",
+};
+
+describe("Keyboard", () => {
+  it("is a picture, not sixty announcements", () => {
+    expect(html).toContain('aria-hidden="true"');
+  });
+
+  it("is not tappable — no control, no tab stop, no role", () => {
+    expect(html).not.toContain("<button");
+    expect(html).not.toContain("tabindex");
+    expect(html).not.toContain("role=");
+  });
+
+  it("draws every key the engine defines, and no others", () => {
+    const drawn = html.match(/class="keyboard__key/g) ?? [];
+    expect(drawn).toHaveLength(KEYS.length);
+  });
+
+  it("takes its geometry from the engine rather than from CSS", () => {
+    // `f` is 4.75 units in and one wide; the space bar is 6.25 wide. Both are
+    // written on the element, so the stagger can't drift from the table.
+    expect(html).toContain("--x:4.75");
+    expect(html).toContain("--w:6.25");
+  });
+
+  it("marks the eight home keys and the space bar, and nothing else", () => {
+    const marked = html.match(/is-home/g) ?? [];
+    expect(marked).toHaveLength(KEYS.filter((k) => k.home).length);
+    expect(marked).toHaveLength(9);
+  });
+
+  it("names the finger on every key, so the tint has something to hang on", () => {
+    for (const key of KEYS)
+      expect(html).toContain(`data-finger="${key.finger}"`);
+  });
+
+  it("has eight finger hues, and not one of them is a telemetry colour", () => {
+    const declarations = [
+      ...css("tokens.css").matchAll(/(--finger-[a-z-]+):\s*([^;]+);/g),
+    ];
+
+    // Eight, not nine: either thumb presses the space bar, so a hue there
+    // would be naming a choice the technique does not make.
+    expect(declarations).toHaveLength(8);
+    expect(declarations.map(([, name]) => name)).not.toContain(
+      "--finger-thumb",
+    );
+
+    for (const [, , value] of declarations)
+      for (const [name, hex] of Object.entries(TELEMETRY)) {
+        expect(value).not.toContain(name);
+        expect(value.toLowerCase()).not.toContain(hex);
+      }
+  });
+
+  it("draws the board out of world tokens, borrowing none of the five", () => {
+    const game = css("game.css");
+    const block = game.slice(game.indexOf(KEYBOARD_BLOCK));
+
+    expect(game).toContain(KEYBOARD_BLOCK);
+    for (const name of Object.keys(TELEMETRY))
+      expect(block).not.toContain(`var(${name})`);
+  });
+});

--- a/src/games/typing/keyboard/Keyboard.tsx
+++ b/src/games/typing/keyboard/Keyboard.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties } from "react";
+
+import { KEY_ROWS } from "@/engine/keyboard";
+
+/**
+ * The keyboard, as a picture (docs/typing.md §4).
+ *
+ * The board itself is not defined here — `@/engine/keyboard` owns the layout,
+ * the finger assignment and the geometry, because three of its four consumers
+ * are not pictures (§3.1). This file is the fourth: markup and class names over
+ * that table, and nothing that a lesson generator or Hailstorm would have to
+ * import a component to read.
+ *
+ * ── Spans, and why every one of them ──────────────────────────────────────
+ * Sixty-odd `<span>`s rather than sixty-odd `<button>`s, and the whole board is
+ * `aria-hidden="true"`. Both halves of that are the story, not an oversight:
+ *
+ *   - **Never tappable, on any device** (§4.5). A board you can press is a
+ *     hunt-and-peck trainer — it teaches finding a key by eye and pressing it
+ *     with whichever finger is closest, which is exactly the habit this world
+ *     exists to prevent. On a tablet the software keyboard is already the
+ *     interface; this is a map of it, not a second one. The `<span>`s carry no
+ *     handler and `pointer-events: none` covers the rest.
+ *   - **Silent to a screen reader** (§4.4). Announcing sixty keys is a denial
+ *     of service, not an accommodation, and every piece of state this shows is
+ *     already in the passage: the live word is `aria-current`, the characters
+ *     are text, the errors are in the DOM. So the picture stays a picture.
+ *
+ * ── One dial ──────────────────────────────────────────────────────────────
+ * The board is fifteen key units wide and each key knows its own left edge in
+ * those units, so the whole thing scales off a single `--key` custom property
+ * in `game.css`. A phone in landscape and a laptop get the same layout at
+ * different sizes rather than two layouts — there is no breakpoint here to keep
+ * in step with the row stagger.
+ *
+ * Press echo (#131) and the next-key hint (#132) add state to these keys; #134
+ * puts the board under the passage. This story is the board.
+ */
+export function Keyboard() {
+  return (
+    <div className="keyboard" aria-hidden="true">
+      {KEY_ROWS.map((row, index) => (
+        // The row index is a stable key: the layout is a constant, and nothing
+        // reorders it.
+        <div className="keyboard__row" key={index}>
+          {row.map((key) => {
+            // A word legend — "Shift", "Bksp", "Caps" — is set smaller so it
+            // fits a one-unit cap's worth of room without shrinking the letters
+            // that a child is actually reading.
+            const isWord = key.cap[0].length > 1;
+            return (
+              <span
+                key={key.code}
+                className={`keyboard__key${key.home ? " is-home" : ""}${
+                  isWord ? " is-word" : ""
+                }`}
+                // The finger is an attribute rather than a class because it is
+                // one of a closed set the CSS enumerates once, and because
+                // `[data-finger]` is what the tint rules select on.
+                data-finger={key.finger}
+                style={{ "--x": key.x, "--w": key.width ?? 1 } as CSSProperties}
+              >
+                {/* The unshifted legend only. A real keycap prints `A` over a
+                    key that types `a` unshifted; a child comparing the board
+                    against the passage needs the character they are about to
+                    type, and the shifted half is what KEY04 lights up. */}
+                {key.cap[0]}
+              </span>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1369,3 +1369,128 @@ label.segmented__btn {
   color: var(--accent);
   text-align: center;
 }
+
+/* ── Typing: the keyboard on screen ──────────────────────────────────────
+   A picture of the board, drawn from the layout in engine/keyboard.ts so a
+   child never has to look down at the real one (docs/typing.md §4).
+
+   Every colour here is a world token or a finger token mixed into one, which
+   is what lets the same board sit in the glacier without a single `[data-
+   world="ice"]` rule underneath it. The keycaps are the world's ink, the
+   legends are its chalk, and the eight hues on top are the same in all of
+   them because a finger doesn't change biome.                             */
+
+.keyboard {
+  /* The one dial. The board is fifteen key units wide and every key knows its
+     own left edge in those units, so a key is a fifteenth of the room there
+     is — floored so it stays legible on a narrow phone, capped so it doesn't
+     become furniture on a desktop. The dvh term is what makes a phone in
+     landscape work: five rows and the passage above them are sharing about
+     390px of height, and width alone would happily spend all of it. */
+  --key: clamp(1.05rem, min(5.6vw, 9dvh), 2.4rem);
+  --key-gap: calc(var(--key) * 0.09);
+
+  display: grid;
+  gap: var(--key-gap);
+  width: calc(15 * var(--key));
+  margin-inline: auto;
+
+  /* Never tappable, on any device (§4.5). There is no handler on any of these
+     spans to fire; `pointer-events` is what stops one added later from having
+     anywhere to fire, and stops the board eating a tap meant for the field
+     underneath it. `user-select` is the other half — a long press on a phone
+     should not offer to copy the letter `f`. */
+  pointer-events: none;
+  user-select: none;
+}
+
+.keyboard__row {
+  position: relative;
+  height: var(--key);
+}
+
+/* Positioned off the `x` the engine writes down rather than laid out by flex,
+   because the row stagger is a fact about the plastic and not something gap
+   arithmetic arrives at: the home row starts 1.75 units in, the top row 1.5,
+   and no rule relates the two. */
+.keyboard__key {
+  /* The thumb has no hue of its own — see tokens.css. Its keys inherit this
+     neutral, which is the world's own quiet grey. */
+  --finger: var(--chalk-dim);
+
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--x) * var(--key));
+  width: calc(var(--w) * var(--key) - var(--key-gap));
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border: 1px solid color-mix(in oklab, var(--finger) 38%, transparent);
+  border-radius: calc(var(--key) * 0.2);
+  background: color-mix(in oklab, var(--finger) 13%, var(--ink-800));
+  box-shadow: inset 0 -0.1em 0 rgb(0 0 0 / 22%);
+
+  font-family: var(--font-mono);
+  font-size: calc(var(--key) * 0.42);
+  line-height: 1;
+  color: color-mix(in oklab, var(--finger) 45%, var(--chalk));
+}
+
+/* Modifiers and the ones that do something rather than type something carry a
+   word — "Shift", "Bksp", "Caps" — which has to fit the same cap as one
+   letter without shrinking the letters a child is actually reading. */
+.keyboard__key.is-word {
+  font-size: calc(var(--key) * 0.26);
+  color: var(--chalk-dim);
+}
+
+/* Where the hands rest. On real plastic only `f` and `j` are ridged; here all
+   eight home keys and the space bar carry the bar, because on screen the
+   thing being shown is the whole resting position rather than the two keys
+   you find it by touch with. */
+.keyboard__key.is-home::after {
+  content: "";
+  position: absolute;
+  bottom: calc(var(--key) * 0.11);
+  width: calc(var(--key) * 0.34);
+  height: max(1.5px, calc(var(--key) * 0.06));
+  border-radius: 2px;
+  background: color-mix(in oklab, var(--finger) 70%, var(--chalk));
+}
+
+/* The eight hues, attached to the closed set of fingers the engine assigns.
+   `thumb` is absent on purpose and falls through to the neutral above. */
+.keyboard__key[data-finger="l-index"] {
+  --finger: var(--finger-l-index);
+}
+
+.keyboard__key[data-finger="l-middle"] {
+  --finger: var(--finger-l-middle);
+}
+
+.keyboard__key[data-finger="l-ring"] {
+  --finger: var(--finger-l-ring);
+}
+
+.keyboard__key[data-finger="l-pinky"] {
+  --finger: var(--finger-l-pinky);
+}
+
+.keyboard__key[data-finger="r-index"] {
+  --finger: var(--finger-r-index);
+}
+
+.keyboard__key[data-finger="r-middle"] {
+  --finger: var(--finger-r-middle);
+}
+
+.keyboard__key[data-finger="r-ring"] {
+  --finger: var(--finger-r-ring);
+}
+
+.keyboard__key[data-finger="r-pinky"] {
+  --finger: var(--finger-r-pinky);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -20,6 +20,37 @@
   --gold: #ffc53d; /* records and trophies */
   --grape: #a78bfa; /* badges */
 
+  /* ── The eight fingers ─────────────────────────────────────────────────
+     Which finger presses a key, on the keyboard picture in the typing world
+     (docs/typing.md §4.6). Here rather than in a world block because the
+     finger that types `f` is the same finger in every biome, and because
+     Hailstorm colours a falling letter by the finger that stops it — the two
+     halves have to agree or the shield is teaching a different lesson than
+     the board.
+
+     None of the eight is one of the five above, and that is the constraint,
+     not a coincidence: a board that used --lime for "left index finger" would
+     spend a hundred lessons teaching a child to unlearn the one signal this
+     site is consistent about. They are deliberately DESATURATED for the same
+     reason — the board is scenery a child glances at, and a keyboard as loud
+     as a correct answer would win every fight for attention it entered.
+
+     The pattern is a temperature and a walk. The left hand is warm and the
+     right hand is cool, so the hand a key belongs to is legible before any
+     individual colour is — which is the half of the split that matters, and
+     the half a child gets wrong at `g` and `h`. Within a hand the hue walks
+     outward from the index finger, so neighbouring columns never share a
+     family. There is no ninth: the space bar is pressed by EITHER thumb, and
+     a colour there would be naming a choice the technique does not make.  */
+  --finger-l-index: #c2a276; /* sand */
+  --finger-l-middle: #c08d76; /* clay */
+  --finger-l-ring: #bb8686; /* rose */
+  --finger-l-pinky: #b3849f; /* mauve */
+  --finger-r-index: #8db77f; /* sage */
+  --finger-r-middle: #71b0aa; /* teal */
+  --finger-r-ring: #7fa3c6; /* steel */
+  --finger-r-pinky: #9490c8; /* periwinkle */
+
   /* ── Type ──────────────────────────────────────────────────────────────
      See fonts.css for why these three and why they're self-hosted. Lilita
      One has no weight axis on purpose; `font-weight` on a display element is


### PR DESCRIPTION
The board a child glances at while typing, drawn over the layout that landed in the engine with #129. This story renders that table — it does not redefine it.

`src/games/typing/keyboard/Keyboard.tsx` walks `KEY_ROWS` and writes each key's `x` and width onto the element as custom properties, so the row stagger comes from the engine rather than from CSS that has to be kept in step with it. The home row starts 1.75 units in and the top row 1.5, and no rule relates the two — that's a fact about the plastic, not something gap arithmetic arrives at.

## Two things that look like oversights and aren't

**Non-interactive `<span>`s, plus `pointer-events: none` over the whole board.** A keyboard you can press is a hunt-and-peck trainer — it teaches finding a key by eye and pressing it with whichever finger is closest, which is the one habit this world exists to prevent (`docs/typing.md` §4.5). On a tablet the software keyboard is already the interface; this is a map of it, not a second one.

**`aria-hidden="true"` on the board.** Sixty-six keys announcing themselves is a denial of service, not an accommodation, and every piece of state shown here is already carried by the passage — the live word is `aria-current`, the characters are text, the errors are in the DOM (§4.4). The toggle that shows and hides it, when it lands, is a real kit `Toggle`; that one is a control.

## Eight finger hues, not nine

New in `tokens.css`. Not nine, because either thumb presses the space bar and a colour there would name a choice the technique doesn't make.

**None of them is one of the telemetry five.** That's the constraint, not a coincidence (§4.6): a board tinting the left index finger `--lime` would spend a hundred lessons teaching a child to unlearn the one signal this site is consistent about. They're deliberately desaturated for the same reason — the board is scenery, and a keyboard as loud as a correct answer wins every fight for attention it enters.

The pattern is a temperature and a walk: left hand warm, right hand cool, so the hand a key belongs to is legible before any individual colour is — which is the half a child gets wrong, at `g` and `h`. Within a hand the hue walks outward from the index finger so neighbouring columns never share a family.

They live in `tokens.css` rather than a world block because the finger that types `f` is the same finger in every biome, and because Hailstorm will colour a falling letter by the finger that stops it — the two halves have to agree or the shield teaches a different lesson than the board.

## One dial

Everything else is a world token, so the same board reads in the glacier and in every other block without a rule of its own — the keycaps are the world's ink, the legends its chalk.

The whole board scales off a single `--key`: `clamp(1.05rem, min(5.6vw, 9dvh), 2.4rem)`. Floored so it stays legible on a narrow phone, capped so it doesn't become furniture on a desktop, with a `dvh` term because five rows and a passage share about 390px of height on a phone held sideways and width alone would happily spend all of it. One layout at different sizes, not two layouts with a breakpoint between them.

## Not here, on purpose

Press echo (#131), the next-key hint (#132) and mounting the board under the passage (#134).

`type-check` 0 errors · `lint` clean · `test:unit` **1537 passed** · `build` static · smoke suite green, no console errors

Closes #130
