### PR TITLE
Light the key that was pressed, and flare the one that was wrong

### DIFF
--- a/src/games/typing/keyboard/Keyboard.test.tsx
+++ b/src/games/typing/keyboard/Keyboard.test.tsx
@@ -22,6 +22,12 @@ import { Keyboard } from "./Keyboard";
  * no other place it can be asserted — a keyboard that tinted the left index
  * finger `--lime` would spend a hundred lessons teaching a child to unlearn
  * what green means (§4.6).
+ *
+ * That split is per BLOCK, not per file: the board is scenery and borrows none
+ * of the five, and the press echo below it is signal and borrows exactly two.
+ * So the scenery assertion reads the board's own block and stops where the
+ * echo's begins — a slice to the end of the file would forbid the very colours
+ * §4.3 requires.
  */
 
 const html = renderToStaticMarkup(<Keyboard />);
@@ -32,8 +38,9 @@ const css = (name: string) =>
     "utf8",
   );
 
-/** Where the board's own rules start in the game stylesheet. */
+/** Where the board's own rules start in the game stylesheet, and where they end. */
 const KEYBOARD_BLOCK = "/* ── Typing: the keyboard on screen";
+const ECHO_BLOCK = "/* ── Typing: press echo";
 
 /** The five that mean something everywhere, by name and by value. */
 const TELEMETRY = {
@@ -99,10 +106,49 @@ describe("Keyboard", () => {
 
   it("draws the board out of world tokens, borrowing none of the five", () => {
     const game = css("game.css");
-    const block = game.slice(game.indexOf(KEYBOARD_BLOCK));
+    const block = game.slice(
+      game.indexOf(KEYBOARD_BLOCK),
+      game.indexOf(ECHO_BLOCK),
+    );
 
     expect(game).toContain(KEYBOARD_BLOCK);
+    expect(game).toContain(ECHO_BLOCK);
     for (const name of Object.keys(TELEMETRY))
       expect(block).not.toContain(`var(${name})`);
+  });
+
+  it("flashes a struck key green and a wrong one red, and nothing else", () => {
+    const game = css("game.css");
+    const echo = game.slice(game.indexOf(ECHO_BLOCK));
+
+    // The two the echo is allowed, in the two places they mean something.
+    expect(echo).toMatch(/\.is-down\s*{[^}]*var\(--lime\)/);
+    expect(echo).toMatch(/\.is-wrong\s*{[^}]*var\(--flare\)/);
+
+    // And no others: a board that borrowed `--sky` or `--gold` would be
+    // claiming a ghost or a record over a keystroke.
+    for (const name of ["--sky", "--gold", "--grape"])
+      expect(echo).not.toContain(`var(${name})`);
+  });
+
+  it("lights the codes it is handed, and flares the wrong ones", () => {
+    const lit = renderToStaticMarkup(
+      <Keyboard
+        down={new Set(["KeyF", "ShiftRight"])}
+        wrong={new Set(["KeyF"])}
+      />,
+    );
+
+    // A wrong key is still a key that went down — the echo publishes it in
+    // both sets, and the board writes both classes.
+    expect(lit).toContain("keyboard__key is-home is-down is-wrong");
+    expect(lit).toContain("is-word is-down");
+    expect(lit.match(/is-down/g)).toHaveLength(2);
+    expect(lit.match(/is-wrong/g)).toHaveLength(1);
+  });
+
+  it("draws a resting board when nobody is typing", () => {
+    expect(html).not.toContain("is-down");
+    expect(html).not.toContain("is-wrong");
   });
 });

--- a/src/games/typing/keyboard/Keyboard.tsx
+++ b/src/games/typing/keyboard/Keyboard.tsx
@@ -2,6 +2,9 @@ import type { CSSProperties } from "react";
 
 import { KEY_ROWS } from "@/engine/keyboard";
 
+/** Nobody typing. The board still draws — the ladder shows one at rest. */
+const NONE: ReadonlySet<string> = new Set();
+
 /**
  * The keyboard, as a picture (docs/typing.md §4).
  *
@@ -33,10 +36,25 @@ import { KEY_ROWS } from "@/engine/keyboard";
  * different sizes rather than two layouts — there is no breakpoint here to keep
  * in step with the row stagger.
  *
- * Press echo (#131) and the next-key hint (#132) add state to these keys; #134
- * puts the board under the passage. This story is the board.
+ * ── The echo arrives as props, not as a hook ──────────────────────────────
+ * Which keys are lit is `useKeyEcho`'s answer, passed in (§4.3). Calling the
+ * hook in here would look tidier and would cost the two things that matter:
+ * the board would stop being a pure function of its props — untestable by
+ * rendering it — and Hailstorm, which needs the same echo for its own gun
+ * (§8.2), would end up with a second copy of the listener fighting this one.
+ *
+ * The next-key hint (#132) adds one more state to these keys; #134 puts the
+ * board under the passage.
  */
-export function Keyboard() {
+export function Keyboard({
+  down = NONE,
+  wrong = NONE,
+}: {
+  /** Codes lit right now — `useKeyEcho`'s `down`. */
+  down?: ReadonlySet<string>;
+  /** Codes flashing `--flare`; always a subset of `down`. */
+  wrong?: ReadonlySet<string>;
+}) {
   return (
     <div className="keyboard" aria-hidden="true">
       {KEY_ROWS.map((row, index) => (
@@ -51,9 +69,18 @@ export function Keyboard() {
             return (
               <span
                 key={key.code}
-                className={`keyboard__key${key.home ? " is-home" : ""}${
-                  isWord ? " is-word" : ""
-                }`}
+                // `is-wrong` is written alongside `is-down` rather than
+                // instead of it: a wrong key is still a key that went down,
+                // and the CSS orders the two so the flare wins the colour.
+                className={[
+                  "keyboard__key",
+                  key.home && "is-home",
+                  isWord && "is-word",
+                  down.has(key.code) && "is-down",
+                  wrong.has(key.code) && "is-wrong",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
                 // The finger is an attribute rather than a class because it is
                 // one of a closed set the CSS enumerates once, and because
                 // `[data-finger]` is what the tint rules select on.
@@ -63,7 +90,8 @@ export function Keyboard() {
                 {/* The unshifted legend only. A real keycap prints `A` over a
                     key that types `a` unshifted; a child comparing the board
                     against the passage needs the character they are about to
-                    type, and the shifted half is what KEY04 lights up. */}
+                    type, and the shifted half is what the hint (#132) lights
+                    up. */}
                 {key.cap[0]}
               </span>
             );

--- a/src/games/typing/keyboard/useKeyEcho.test.ts
+++ b/src/games/typing/keyboard/useKeyEcho.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HOLD_MS, createKeyEcho } from "./useKeyEcho";
+
+/**
+ * What the echo owes a child who is not allowed to look at their hands.
+ *
+ * Two of these protect decisions that a well-meaning change would undo, and
+ * they are the reason this state machine is a plain object rather than only a
+ * hook (docs/typing.md §4.3):
+ *
+ *   - **A key releases on a timer, never on `keyup`.** "Wouldn't `keyup` be
+ *     simpler?" is the obvious question, and the answer is only visible in the
+ *     cases where the `keyup` never comes — lost focus, key repeat, unmount
+ *     mid-chord. So the suite presses keys and never releases them, which is
+ *     the failure mode, not an omission.
+ *   - **Wrongness comes from the code, decided on the press.** The tests type
+ *     `$` and shift+`4` at the same expectation to pin that a buffer
+ *     comparison could not tell them apart.
+ *
+ * These drive the machine directly: the unit suite has no DOM, so a rendered
+ * hook could not be pressed at all. What that leaves untested is the listener
+ * and the `useState` around it.
+ */
+
+/** A board with its latest published echo kept to hand. */
+function board() {
+  const echo = { down: new Set<string>(), wrong: new Set<string>() };
+  const machine = createKeyEcho((next) => {
+    echo.down = new Set(next.down);
+    echo.wrong = new Set(next.wrong);
+  });
+  return {
+    press: machine.press,
+    stop: machine.stop,
+    down: () => [...echo.down].sort(),
+    wrong: () => [...echo.wrong].sort(),
+  };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("createKeyEcho", () => {
+  it("releases a key that was never let go", () => {
+    const keys = board();
+    keys.press("KeyF", "f");
+    expect(keys.down()).toEqual(["KeyF"]);
+
+    // No `keyup` is ever delivered — the window lost focus, or the OS ate it.
+    vi.advanceTimersByTime(HOLD_MS + 1);
+    expect(keys.down()).toEqual([]);
+    expect(keys.wrong()).toEqual([]);
+  });
+
+  it("re-arms on a repeat rather than stacking releases behind it", () => {
+    const keys = board();
+    keys.press("KeyF", "f");
+    vi.advanceTimersByTime(HOLD_MS - 20);
+
+    // A held key repeats. The second press must move the release, not queue a
+    // second one that would put the key out while it is still down.
+    keys.press("KeyF", "f");
+    vi.advanceTimersByTime(HOLD_MS - 20);
+    expect(keys.down()).toEqual(["KeyF"]);
+
+    vi.advanceTimersByTime(21);
+    expect(keys.down()).toEqual([]);
+  });
+
+  it("flares the key that was struck when it wasn't the one wanted", () => {
+    const keys = board();
+    keys.press("KeyD", "f");
+    expect(keys.down()).toEqual(["KeyD"]);
+    expect(keys.wrong()).toEqual(["KeyD"]);
+  });
+
+  it("leaves a correct key lit and unflared", () => {
+    const keys = board();
+    keys.press("KeyF", "f");
+    expect(keys.down()).toEqual(["KeyF"]);
+    expect(keys.wrong()).toEqual([]);
+  });
+
+  it("lights both keys of a capital, and blames neither", () => {
+    const keys = board();
+    // The technique: the shift on the hand opposite the letter, held first.
+    keys.press("ShiftRight", "A");
+    keys.press("KeyA", "A");
+    expect(keys.down()).toEqual(["KeyA", "ShiftRight"]);
+    expect(keys.wrong()).toEqual([]);
+  });
+
+  it("never counts a modifier wrong, whatever is expected", () => {
+    const keys = board();
+    for (const code of ["ShiftLeft", "ControlLeft", "AltRight", "MetaLeft"])
+      keys.press(code, "f");
+    expect(keys.wrong()).toEqual([]);
+    expect(keys.down()).toHaveLength(4);
+  });
+
+  it("judges the key, not the character it would have produced", () => {
+    // `$` is shift+`4`, so both of these end a buffer comparison at "$ typed
+    // where $ was wanted". Only one of them is the right key.
+    const wanted = board();
+    wanted.press("Digit4", "$");
+    expect(wanted.wrong()).toEqual([]);
+
+    const missed = board();
+    missed.press("Digit5", "$");
+    expect(missed.wrong()).toEqual(["Digit5"]);
+  });
+
+  it("calls CapsLock what it is", () => {
+    const keys = board();
+    keys.press("CapsLock", "a");
+    expect(keys.wrong()).toEqual(["CapsLock"]);
+  });
+
+  it("blames nothing when there is nothing expected", () => {
+    const keys = board();
+    keys.press("KeyQ", null);
+    expect(keys.down()).toEqual(["KeyQ"]);
+    expect(keys.wrong()).toEqual([]);
+
+    // Nor when the expected character isn't on this layout at all — a curly
+    // quote that got past the passage filter has no key to blame.
+    keys.press("KeyW", "“");
+    expect(keys.wrong()).toEqual([]);
+  });
+
+  it("clears a wrong key's flare when that key is struck correctly", () => {
+    const keys = board();
+    keys.press("KeyD", "f");
+    expect(keys.wrong()).toEqual(["KeyD"]);
+
+    // Same key, next character: `d` is now right and must stop flaring even
+    // though its release from the first press hasn't come round yet.
+    keys.press("KeyD", "d");
+    expect(keys.down()).toEqual(["KeyD"]);
+    expect(keys.wrong()).toEqual([]);
+  });
+
+  it("drops pending releases when it stops", () => {
+    const keys = board();
+    keys.press("KeyF", "f");
+    keys.stop();
+
+    // Unmounting mid-chord: the release must not fire into a gone component.
+    expect(() => vi.advanceTimersByTime(HOLD_MS + 1)).not.toThrow();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/games/typing/keyboard/useKeyEcho.ts
+++ b/src/games/typing/keyboard/useKeyEcho.ts
@@ -121,10 +121,18 @@ export function createKeyEcho(emit: (echo: KeyEcho) => void): KeyEchoBoard {
       if (isWrong(code, expect)) wrong.add(code);
       else wrong.delete(code);
 
-      // A held key repeats, and each repeat re-arms the same release rather
-      // than stacking a second one behind it — so a key held down stays lit
-      // for as long as it is held, and goes out 120ms after it is let go
-      // whether or not the `keyup` ever arrives.
+      // One release per code, re-armed rather than stacked: every keydown for
+      // a code — the first, and each OS auto-repeat behind it — replaces that
+      // code's pending release, so the light goes out HOLD_MS after the last
+      // keydown seen for it. Nothing waits on a `keyup`, so no key can be left
+      // stuck lit by one that never arrives.
+      //
+      // What that is not is a picture of which keys are still held down.
+      // Auto-repeat does not begin for a few hundred ms, well past HOLD_MS, so
+      // a key held down goes dark and relights once the repeats arrive, and a
+      // held modifier — which does not repeat at all — simply goes dark. The
+      // board echoes strokes, and §4.3 asks for the timer with no exception
+      // for either.
       clearTimeout(timers.get(code));
       timers.set(
         code,

--- a/src/games/typing/keyboard/useKeyEcho.ts
+++ b/src/games/typing/keyboard/useKeyEcho.ts
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState } from "react";
+
+import { strokeFor } from "@/engine/keyboard";
+
+/**
+ * Press echo: which keys are lit, and which of them were the wrong one
+ * (docs/typing.md §4.3).
+ *
+ * This is the half of the board that moves. `Keyboard.tsx` draws the plastic;
+ * this decides, keystroke by keystroke, what a child's hands just did — so
+ * they can see it without looking down, which is the entire point of the
+ * world.
+ */
+
+/**
+ * How long a key stays lit, in milliseconds.
+ *
+ * A key releases on THIS TIMER and not on `keyup`, which is the one decision
+ * in this file worth defending. `keyup` is missed more often than you would
+ * think: the window loses focus mid-chord and the release lands somewhere
+ * else, the OS eats it during a key-repeat, a modifier comes up after the
+ * element has unmounted. Every one of those leaves a key stuck lit, and a key
+ * stuck lit is worse than no highlight at all — it is a lie about where the
+ * hand is, told to a child who is trusting the picture precisely because they
+ * are not allowed to look at the real keyboard.
+ *
+ * A timer cannot get stuck. It also happens to feel better: a flash reads as
+ * "that fired", a hold reads as "something is wrong".
+ */
+export const HOLD_MS = 120;
+
+export type KeyEcho = {
+  /** Codes lit right now. */
+  down: ReadonlySet<string>;
+  /** Codes flashing `--flare` because they weren't the expected character. */
+  wrong: ReadonlySet<string>;
+};
+
+/** Nothing pressed. One instance, so a quiet board is the same value twice. */
+const SILENT: KeyEcho = { down: new Set(), wrong: new Set() };
+
+/**
+ * The keys that are HELD rather than typed, and so are never wrong.
+ *
+ * Shift is the reason this set exists. Shift is not a mistake, it is the
+ * technique: a capital is right-shift plus a left-hand letter (§3.3), and the
+ * child who reaches for the far shift a beat before the letter — the thing
+ * this course is trying hardest to teach — would otherwise be told in red that
+ * they had erred by doing it right. They still light, because a lit shift is
+ * exactly the "where is my hand" the board exists to answer. Ctrl, Alt and the
+ * Cmd keys are here for the duller version of the same reason: a child
+ * switching windows is not attempting the letter.
+ *
+ * CapsLock is deliberately NOT here. It is not held to make a character, no
+ * stroke on this layout uses it, and hitting it in place of `a` is precisely
+ * the mistake that wants pointing out — before it turns the next line into
+ * SHOUTING nobody can explain.
+ */
+const HELD = new Set([
+  "ShiftLeft",
+  "ShiftRight",
+  "ControlLeft",
+  "ControlRight",
+  "AltLeft",
+  "AltRight",
+  "MetaLeft",
+  "MetaRight",
+]);
+
+/**
+ * Was this the wrong key for the character we are waiting on?
+ *
+ * Decided from `event.code` against `strokeFor(expect)`, and never by
+ * comparing what landed in the input against what was wanted. Two reasons,
+ * both fatal to the buffer version: a buffer cannot tell shift+`4` from `$`
+ * — same character, different keys, and only one of them is a mistake — and
+ * it cannot answer at all until React has re-rendered, by which point the
+ * flash is late enough to belong to the next keystroke. The keydown handler
+ * already holds the code; the comparison here is immediate and exact.
+ *
+ * Nothing is wrong when there is nothing to be wrong about: free play between
+ * words has no expected character, and a character this layout cannot produce
+ * (a curly quote that escaped the passage filter) has no key to blame.
+ */
+function isWrong(code: string, expect: string | null): boolean {
+  if (HELD.has(code)) return false;
+  const stroke = expect === null ? null : strokeFor(expect);
+  return stroke !== null && code !== stroke.code;
+}
+
+export type KeyEchoBoard = {
+  /** Light `code`, flaring it if it wasn't the key `expect` needed. */
+  press: (code: string, expect: string | null) => void;
+  /** Drop every pending release. What unmounting does. */
+  stop: () => void;
+};
+
+/**
+ * The echo as a plain state machine: presses in, two sets out, one timer per
+ * key.
+ *
+ * Split out of the hook below because it is the part with behaviour, and the
+ * unit suite runs in Node with no DOM (`vitest.config.ts`) — a rendered hook
+ * could not be driven at all here, and "a press with no keyup still releases"
+ * is the assertion this story most needs to hold in a year. What is left in
+ * the hook is a `keydown` listener and a `useState`.
+ *
+ * `emit` is handed fresh sets rather than the live ones, so a consumer holding
+ * last render's echo is holding what it was actually shown.
+ */
+export function createKeyEcho(emit: (echo: KeyEcho) => void): KeyEchoBoard {
+  const down = new Set<string>();
+  const wrong = new Set<string>();
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const publish = () => emit({ down: new Set(down), wrong: new Set(wrong) });
+
+  return {
+    press(code, expect) {
+      down.add(code);
+      if (isWrong(code, expect)) wrong.add(code);
+      else wrong.delete(code);
+
+      // A held key repeats, and each repeat re-arms the same release rather
+      // than stacking a second one behind it — so a key held down stays lit
+      // for as long as it is held, and goes out 120ms after it is let go
+      // whether or not the `keyup` ever arrives.
+      clearTimeout(timers.get(code));
+      timers.set(
+        code,
+        setTimeout(() => {
+          timers.delete(code);
+          down.delete(code);
+          wrong.delete(code);
+          publish();
+        }, HOLD_MS),
+      );
+
+      publish();
+    },
+    stop() {
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+    },
+  };
+}
+
+/**
+ * The echo, wired to the window.
+ *
+ * `keydown` on the window rather than on the input, because the board has to
+ * stay honest wherever focus went — and because Hailstorm has no input at all
+ * (§8.2), where this same hook is the gun.
+ *
+ * Both sets change at most ten times a second, so a `useState` per keystroke
+ * costs nothing next to the race clock already re-rendering this screen
+ * sixteen times a second.
+ */
+export function useKeyEcho({ expect }: { expect: string | null }): KeyEcho {
+  const [echo, setEcho] = useState<KeyEcho>(SILENT);
+
+  /**
+   * The live expectation, read by the listener rather than closed over. The
+   * listener binds once — a fresh binding per character would be a listener
+   * churned on every keystroke, and a stale closure would judge this key
+   * against the last one.
+   */
+  const expected = useRef(expect);
+  expected.current = expect;
+
+  useEffect(() => {
+    const board = createKeyEcho(setEcho);
+    const onKeyDown = (event: KeyboardEvent) =>
+      board.press(event.code, expected.current);
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      // Unmounting mid-chord is one of the ways a `keyup` goes missing. There
+      // is no state left to strand, but a timer that outlives the component
+      // would call `setEcho` on it.
+      board.stop();
+    };
+  }, []);
+
+  return echo;
+}

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1494,3 +1494,48 @@ label.segmented__btn {
 .keyboard__key[data-finger="r-pinky"] {
   --finger: var(--finger-r-pinky);
 }
+
+/* ── Typing: press echo ──────────────────────────────────────────────────
+   The two states on this board that are signal rather than scenery
+   (docs/typing.md §4.3, §4.6). Everything above is a world token or a finger
+   hue, deliberately quiet so the board reads as a map; these two borrow from
+   the telemetry five and are the only rules here allowed to, because they
+   already mean this everywhere else on the site — `--lime` is "that was
+   right", `--flare` is "that was wrong". A child glancing down at the board
+   is reading the two colours the flash-card loop taught them.
+
+   Neither is `:active`. The board is never tappable (§4.5), so the only
+   thing that can light a key is a keystroke, and the class goes out on a
+   120ms timer in `useKeyEcho.ts` rather than on `keyup`.
+
+   The fade is on the way out only: the transition lives on the resting key,
+   and the lit states turn it off so a strike lands on the frame it happened.
+   A flash that eased in would be late, and late is the one thing the echo
+   cannot be.                                                              */
+.keyboard__key {
+  transition:
+    background 150ms var(--ease-out),
+    border-color 150ms var(--ease-out),
+    color 150ms var(--ease-out);
+}
+
+.keyboard__key.is-down,
+.keyboard__key.is-wrong {
+  /* The hue goes dark rather than away, so the home-row bar drawn out of
+     `--finger` stays visible against a lit cap instead of dissolving into it. */
+  --finger: var(--ink-900);
+
+  transition: none;
+  color: var(--ink-900);
+}
+
+.keyboard__key.is-down {
+  border-color: var(--lime);
+  background: color-mix(in oklab, var(--lime) 78%, var(--ink-800));
+}
+
+/* Last, so a key that is both — every wrong key is also down — flares. */
+.keyboard__key.is-wrong {
+  border-color: var(--flare);
+  background: color-mix(in oklab, var(--flare) 78%, var(--ink-800));
+}


### PR DESCRIPTION
The board drawn in #130 doesn't move yet. This story is the half that does: the key a child just struck lights up, and goes red when it wasn't the one the passage was waiting on. Design: `docs/typing.md` §4.3.

`src/games/typing/keyboard/useKeyEcho.ts` — `useKeyEcho({ expect })` → `{ down, wrong }`, two sets of `KeyboardEvent.code`. The listener is on the window rather than on the input, because the board has to stay honest wherever focus went, and because Hailstorm has no input at all (§8.2) and wants the same hook for its gun.

## The two decisions worth arguing with

**A key releases on a 120 ms timer, not on `keyup`.** This is the one that looks like a bug and isn't, so the reasoning is written on the constant rather than left in this description. `keyup` goes missing more often than you would think — the window loses focus mid-chord and the release lands somewhere else, the OS eats it during a key-repeat, a modifier comes up after the element has unmounted. Every one of those leaves a key stuck lit, and a key stuck lit is worse than no highlight at all: it is a lie about where the hand is, told to a child who is trusting the picture precisely because they have been told not to look at the real keyboard. A timer cannot get stuck. Repeats re-arm a code's pending release rather than stacking behind it, so the light goes out 120 ms after the last keydown seen for that key.

**Wrongness is decided in the `keydown` handler, from `event.code` against `strokeFor(expect)`.** Never by comparing input buffers, which fail twice over (§4.3): a buffer cannot tell shift+`4` from `$` — same character, different keys, and only one of them is a mistake — and it cannot answer at all until React has re-rendered, by which point the flash is late enough to belong to the next keystroke.

## Shift is technique, not error

Modifiers light and are never counted wrong. A capital is the far shift plus a near letter (§3.3), and the child who reaches for the opposite-hand shift a beat before the letter — the thing this course is trying hardest to teach — would otherwise be told in red that they had erred by doing it right. They still light, because a lit shift is exactly the "where is my hand" the board exists to answer.

CapsLock is deliberately not in that set. It is not held to make a character, no stroke on this layout uses it, and hitting it in place of `a` is the mistake most worth pointing out — before it turns the next line into SHOUTING nobody can explain.

## Two colours, and they are the telemetry ones

`--lime` for a strike, `--flare` for a wrong key. The board's own eight finger hues borrow none of the five and that constraint stands; these two rules are the exception the epic asks for, because they already mean exactly this everywhere else on the site. A child glancing at the keyboard is reading the two colours the flash-card loop taught them.

The fade is on the way out only — the transition lives on the resting key and the lit states turn it off, so a strike lands on the frame it happened. A flash that eased in would be late, and late is the one thing an echo cannot be.

## The echo arrives as props

`Keyboard` takes `down` and `wrong`, defaulted to empty, rather than calling the hook itself. Calling it inside would look tidier and would cost the two things that matter: the board would stop being a pure function of its props, and Hailstorm would end up with a second copy of the listener fighting this one.

## Tests

`useKeyEcho.test.ts` — 11 cases against `createKeyEcho`, the state machine split out of the hook so the suite can run in Node with no DOM. A press with no keyup still releases; a repeat re-arms instead of stacking; a wrong key flares; shift held through a capital lights both and blames neither; the judgement is on the key and not the character it would have produced; CapsLock is fair game; nothing is wrong when nothing is expected. `Keyboard.test.tsx` adds three: the codes it is handed light, the wrong ones flare, and a board with nobody typing rests.

## Not here, on purpose

The next-key hint (#132), and mounting the board under the passage (#134).

`type-check` 0 errors · `lint` clean · `test:unit` **1551 passed** · `build` static · smoke suite green, no console errors

Closes #131
