### PR TITLE
Show the next key, and the shift on the hand that can reach it

### DIFF
--- a/src/games/typing/keyboard/Keyboard.test.tsx
+++ b/src/games/typing/keyboard/Keyboard.test.tsx
@@ -40,7 +40,24 @@ const css = (name: string) =>
 
 /** Where the board's own rules start in the game stylesheet, and where they end. */
 const KEYBOARD_BLOCK = "/* ── Typing: the keyboard on screen";
+const HINT_BLOCK = "/* ── Typing: the next-key hint";
 const ECHO_BLOCK = "/* ── Typing: press echo";
+
+/**
+ * Which key codes the hint lights for a character, in board order.
+ *
+ * The board draws `KEY_ROWS` flattened, which is `KEYS`, so the nth rendered
+ * cap is the nth key in the table — the codes never reach the markup (they
+ * would be sixty attributes nothing reads), and this is how a class gets named
+ * back to the key that wears it.
+ */
+const hinted = (next: string | null) => {
+  const lit = renderToStaticMarkup(<Keyboard next={next} />);
+  const classes = [...lit.matchAll(/class="(keyboard__key[^"]*)"/g)];
+  return KEYS.filter((_, index) => classes[index][1].includes("is-next")).map(
+    (key) => key.code,
+  );
+};
 
 /** The five that mean something everywhere, by name and by value. */
 const TELEMETRY = {
@@ -108,10 +125,11 @@ describe("Keyboard", () => {
     const game = css("game.css");
     const block = game.slice(
       game.indexOf(KEYBOARD_BLOCK),
-      game.indexOf(ECHO_BLOCK),
+      game.indexOf(HINT_BLOCK),
     );
 
     expect(game).toContain(KEYBOARD_BLOCK);
+    expect(game).toContain(HINT_BLOCK);
     expect(game).toContain(ECHO_BLOCK);
     for (const name of Object.keys(TELEMETRY))
       expect(block).not.toContain(`var(${name})`);
@@ -147,8 +165,59 @@ describe("Keyboard", () => {
     expect(lit.match(/is-wrong/g)).toHaveLength(1);
   });
 
+  it("points at the next key in `--go`, and not in a press colour", () => {
+    const game = css("game.css");
+    const hint = game.slice(game.indexOf(HINT_BLOCK), game.indexOf(ECHO_BLOCK));
+
+    // `--go` is per-world and already means "press this" — the button that
+    // started the run is the same colour. A hint drawn in `--lime` would be
+    // indistinguishable from the flash that says "you just pressed that".
+    expect(hint).toMatch(/\.is-next\s*{/);
+    expect(hint).toContain("var(--go)");
+    for (const name of Object.keys(TELEMETRY))
+      expect(hint).not.toContain(`var(${name})`);
+
+    // And the hint is written ABOVE the echo, so a hinted key that is struck
+    // flashes rather than staying dressed as an instruction.
+    expect(game.indexOf(HINT_BLOCK)).toBeLessThan(game.indexOf(ECHO_BLOCK));
+  });
+
+  it("lights the single key a plain character is typed with", () => {
+    expect(hinted("f")).toEqual(["KeyF"]);
+    expect(hinted(" ")).toEqual(["Space"]);
+  });
+
+  it("lights a shifted character's letter AND the shift on the other hand", () => {
+    // The whole point of the hint. Left-pinky shift plus left-pinky `a` is
+    // physically impossible, so `A` is right-shift-plus-left-`a` — and which
+    // hand takes the shift is what typing courses for children skip.
+    expect(hinted("A")).toEqual(["KeyA", "ShiftRight"]);
+
+    // The mirror, so this can't pass by always naming the right shift: `?` is
+    // the right pinky's, so the LEFT shift is the reachable one.
+    expect(hinted("?")).toEqual(["ShiftLeft", "Slash"]);
+  });
+
+  it("lights nothing for no expectation, or a key this board hasn't got", () => {
+    // Nothing expected: the run hasn't started, or has finished.
+    expect(hinted(null)).toEqual([]);
+
+    // A curly quote that survived the passage filter. `strokeFor` answers
+    // null, and null lights nothing rather than throwing (§3.3).
+    expect(hinted("“")).toEqual([]);
+  });
+
+  it("keeps the hint on the key being struck, and stacks it under the flash", () => {
+    const lit = renderToStaticMarkup(
+      <Keyboard next="f" down={new Set(["KeyF"])} />,
+    );
+
+    expect(lit).toContain("keyboard__key is-home is-next is-down");
+  });
+
   it("draws a resting board when nobody is typing", () => {
     expect(html).not.toContain("is-down");
     expect(html).not.toContain("is-wrong");
+    expect(html).not.toContain("is-next");
   });
 });

--- a/src/games/typing/keyboard/Keyboard.tsx
+++ b/src/games/typing/keyboard/Keyboard.tsx
@@ -113,9 +113,12 @@ export function Keyboard({
                 // `is-wrong` is written alongside `is-down` rather than
                 // instead of it: a wrong key is still a key that went down,
                 // and the CSS orders the two so the flare wins the colour.
-                // `is-next` stacks the same way, and loses to both: on the
-                // frame a hinted key is struck the child should see the
-                // strike, not the instruction they have just followed.
+                // `is-next` stacks the same way and loses the cap to both —
+                // border, fill and legend go to the echo, whose rules are
+                // written after it — but only the cap: the hint's ring and
+                // its pulse are properties the echo never declares, so they
+                // ride out the strike. On the frame a hinted key is struck,
+                // the strike is the louder of the two, not the only one.
                 className={[
                   "keyboard__key",
                   key.home && "is-home",

--- a/src/games/typing/keyboard/Keyboard.tsx
+++ b/src/games/typing/keyboard/Keyboard.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
 
-import { KEY_ROWS } from "@/engine/keyboard";
+import { KEY_ROWS, strokeFor } from "@/engine/keyboard";
 
 /** Nobody typing. The board still draws — the ladder shows one at rest. */
 const NONE: ReadonlySet<string> = new Set();
@@ -43,18 +43,53 @@ const NONE: ReadonlySet<string> = new Set();
  * rendering it — and Hailstorm, which needs the same echo for its own gun
  * (§8.2), would end up with a second copy of the listener fighting this one.
  *
- * The next-key hint (#132) adds one more state to these keys; #134 puts the
- * board under the passage.
+ * ── The hint is a character, not a set of codes ───────────────────────────
+ * `next` is the character the passage is waiting on, and the board asks
+ * `strokeFor` which keys produce it (§3.3). It is not two code props, because
+ * "which shift goes with `A`" is a fact about the layout and the layout lives
+ * in the engine — a caller that computed it would be a second copy of the
+ * table's opinion, free to disagree with the one Hailstorm and the curriculum
+ * read.
+ *
+ * WHEN the hint is on is not decided here: that is `KeyboardMode` (#133), and
+ * a mode of "keys" simply passes `next={null}`. #134 puts the board under the
+ * passage.
  */
 export function Keyboard({
   down = NONE,
   wrong = NONE,
+  next = null,
 }: {
   /** Codes lit right now — `useKeyEcho`'s `down`. */
   down?: ReadonlySet<string>;
   /** Codes flashing `--flare`; always a subset of `down`. */
   wrong?: ReadonlySet<string>;
+  /**
+   * The character to point at, or `null` for no hint at all.
+   *
+   * `null` is the ordinary state, not an error: the run hasn't started, the
+   * run has finished, or the mode is "keys" and nothing is being pointed at.
+   */
+  next?: string | null;
 }) {
+  /**
+   * The keys the hint lights: the character's own key, and — for a capital or
+   * any other shifted character — the shift on the OPPOSITE hand.
+   *
+   * That opposite hand is the whole pedagogical point rather than a detail.
+   * Left-pinky-shift plus left-pinky-`a` is physically impossible; `A` is
+   * right-shift-plus-left-`a`, and which shift to reach for is the single
+   * most-skipped thing in typing courses aimed at children. Lighting both keys
+   * is what makes the hint teach the technique instead of merely locating the
+   * letter.
+   *
+   * `strokeFor` has already decided the hand (§3.3) and this does not
+   * second-guess it. It also answers `null` for a character this layout cannot
+   * produce — a curly quote that survived the passage filter — which lights
+   * nothing rather than throwing, exactly as `next: null` does.
+   */
+  const hint = next === null ? null : strokeFor(next);
+
   return (
     <div className="keyboard" aria-hidden="true">
       {KEY_ROWS.map((row, index) => (
@@ -66,16 +101,26 @@ export function Keyboard({
             // fits a one-unit cap's worth of room without shrinking the letters
             // that a child is actually reading.
             const isWord = key.cap[0].length > 1;
+            // Both halves of the stroke, from the one lookup. `hint.shift` is
+            // `null` for an unshifted character and no key's code is `null`,
+            // so an ordinary letter lights exactly one key.
+            const isNext =
+              hint !== null &&
+              (key.code === hint.code || key.code === hint.shift);
             return (
               <span
                 key={key.code}
                 // `is-wrong` is written alongside `is-down` rather than
                 // instead of it: a wrong key is still a key that went down,
                 // and the CSS orders the two so the flare wins the colour.
+                // `is-next` stacks the same way, and loses to both: on the
+                // frame a hinted key is struck the child should see the
+                // strike, not the instruction they have just followed.
                 className={[
                   "keyboard__key",
                   key.home && "is-home",
                   isWord && "is-word",
+                  isNext && "is-next",
                   down.has(key.code) && "is-down",
                   wrong.has(key.code) && "is-wrong",
                 ]
@@ -90,8 +135,9 @@ export function Keyboard({
                 {/* The unshifted legend only. A real keycap prints `A` over a
                     key that types `a` unshifted; a child comparing the board
                     against the passage needs the character they are about to
-                    type, and the shifted half is what the hint (#132) lights
-                    up. */}
+                    type. The shifted half is never printed — a capital is
+                    shown by lighting the shift beside the letter, which is
+                    the thing being taught. */}
                 {key.cap[0]}
               </span>
             );

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1506,13 +1506,15 @@ label.segmented__btn {
    run and the focus ring around it — so the hint is per-world scenery rather
    than a sixth telemetry signal a child has to be taught.
 
-   It is deliberately NOT shaped like a press. A strike fills the whole cap
-   with `--lime` for 120ms and is gone; the hint is a ring and a breath around
-   an otherwise ordinary key, and it stays there until the key is struck. Two
-   different colours doing two different things would still read as one
-   flashing board if both were fills, and the child has to be able to tell "you
-   just pressed that" from "press this next" while looking at the board rather
-   than at their hands.
+   It is not shaped like a press, but the difference is degree and shape
+   rather than fill and no fill: both tint the cap. A strike floods it at 78%
+   `--lime` for 120ms and is gone; the hint is a 20% `--go` wash — a fifth of
+   that — under a ring that breathes, and it stays until the key is struck.
+   Two fills of the same weight would read as one flashing board however
+   different their hues, so the hint's is kept well under the echo's and
+   carries the one thing the echo has not got. The child has to be able to
+   tell "you just pressed that" from "press this next" while looking at the
+   board rather than at their hands.
 
    For a capital, TWO keys carry this at once — the letter, and the shift on
    the opposite hand. That pair is the technique being taught and the reason
@@ -1523,9 +1525,15 @@ label.segmented__btn {
    as a passage is typed, and easing that move reads as the pointer travelling
    rather than teleporting. A press has to be instant; an instruction does not.
 
-   Placed ABOVE the press echo so the cascade lands the right way round — a
-   hinted key that is struck flashes, rather than staying dressed as an
-   instruction the child has already followed.                             */
+   Placed ABOVE the press echo so the cascade lands the right way round on the
+   three properties the two blocks share: border, fill and legend are declared
+   again below and win the cap, so a hinted key that is struck flashes. The
+   ring and its breath are not in that contest — the echo declares neither
+   `box-shadow` nor `animation`, and an animation would outrank a normal
+   declaration even if it did — so the strike lands inside a still-breathing
+   `--go` halo. That is the wanted reading: for those 120ms the strike is the
+   louder of the two, not the only one, and the ring leaves with the hint when
+   the passage moves on.                                                    */
 .keyboard__key.is-next {
   border-color: var(--go);
   background: color-mix(in oklab, var(--go) 20%, var(--ink-800));

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1418,6 +1418,11 @@ label.segmented__btn {
      neutral, which is the world's own quiet grey. */
   --finger: var(--chalk-dim);
 
+  /* The lip under a keycap. Named because every rule that adds a shadow of
+     its own has to restate it — `box-shadow` replaces rather than adds — and
+     a key that lost its lip while being pointed at would look pressed. */
+  --key-lip: inset 0 -0.1em 0 rgb(0 0 0 / 22%);
+
   position: absolute;
   top: 0;
   bottom: 0;
@@ -1431,7 +1436,7 @@ label.segmented__btn {
   border: 1px solid color-mix(in oklab, var(--finger) 38%, transparent);
   border-radius: calc(var(--key) * 0.2);
   background: color-mix(in oklab, var(--finger) 13%, var(--ink-800));
-  box-shadow: inset 0 -0.1em 0 rgb(0 0 0 / 22%);
+  box-shadow: var(--key-lip);
 
   font-family: var(--font-mono);
   font-size: calc(var(--key) * 0.42);
@@ -1493,6 +1498,61 @@ label.segmented__btn {
 
 .keyboard__key[data-finger="r-pinky"] {
   --finger: var(--finger-r-pinky);
+}
+
+/* ── Typing: the next-key hint ───────────────────────────────────────────
+   Go here next (docs/typing.md §3.3, §4.1). Drawn in `--go`, which is the
+   world's own "press this" — the same colour as the button that started the
+   run and the focus ring around it — so the hint is per-world scenery rather
+   than a sixth telemetry signal a child has to be taught.
+
+   It is deliberately NOT shaped like a press. A strike fills the whole cap
+   with `--lime` for 120ms and is gone; the hint is a ring and a breath around
+   an otherwise ordinary key, and it stays there until the key is struck. Two
+   different colours doing two different things would still read as one
+   flashing board if both were fills, and the child has to be able to tell "you
+   just pressed that" from "press this next" while looking at the board rather
+   than at their hands.
+
+   For a capital, TWO keys carry this at once — the letter, and the shift on
+   the opposite hand. That pair is the technique being taught and the reason
+   the hint exists at all; `strokeFor` picks the hand, and Keyboard.tsx records
+   why.
+
+   The fade is allowed here, unlike on the echo: the hint moves from key to key
+   as a passage is typed, and easing that move reads as the pointer travelling
+   rather than teleporting. A press has to be instant; an instruction does not.
+
+   Placed ABOVE the press echo so the cascade lands the right way round — a
+   hinted key that is struck flashes, rather than staying dressed as an
+   instruction the child has already followed.                             */
+.keyboard__key.is-next {
+  border-color: var(--go);
+  background: color-mix(in oklab, var(--go) 20%, var(--ink-800));
+  color: var(--go);
+
+  /* Two shadows: the cap's own lip, restated so the key still looks
+     pressable, plus an outward ring that is the hint. */
+  box-shadow:
+    var(--key-lip),
+    0 0 0 max(2px, calc(var(--key) * 0.06))
+      color-mix(in oklab, var(--go) 34%, transparent);
+
+  /* A slow breath, not a blink. Fast enough to draw the eye down to the board
+     and back, slow enough that five rows of it aren't a strobe. The keyframe
+     ends where it starts, so `prefers-reduced-motion` — which globally clamps
+     every animation to one 0.001ms pass (base.css) — leaves the static ring
+     above exactly as it is, and the hint survives with only its motion gone. */
+  animation: key-hint 1.6s var(--ease-out) infinite;
+}
+
+@keyframes key-hint {
+  50% {
+    box-shadow:
+      var(--key-lip),
+      0 0 0 max(2px, calc(var(--key) * 0.06))
+        color-mix(in oklab, var(--go) 8%, transparent);
+  }
 }
 
 /* ── Typing: press echo ──────────────────────────────────────────────────


### PR DESCRIPTION
The board from #130 draws, and #131 made it react to what was pressed. This story is the half that points *forward*: the key the passage is waiting on lights up before it is struck, so a child who doesn't know where `?` lives can find it without looking down. Design: `docs/typing.md` §3.3, §4.1.

`Keyboard` takes one new prop — `next`, the **character** being waited on — and asks `strokeFor` which keys produce it (§3.3).

## The hint is a character, not a set of codes

Two code props would have been the smaller diff and the wrong shape. "Which shift goes with `A`" is a fact about the layout, and the layout lives in the engine; a caller that computed it would be a second copy of the table's opinion, free to drift from the one Hailstorm and the curriculum read. The board is handed the character and looks the answer up.

## Shift is the whole point

For a shifted character **two** keys light: the letter, and the shift on the **opposite hand**. Left-pinky-shift plus left-pinky-`a` is physically impossible — `A` is right-shift-plus-left-`a` — and which hand takes the shift is the single most-skipped thing in typing courses aimed at children. That is what makes this a hint that teaches the technique rather than one that merely locates the letter, so both `Keyboard.tsx` and the stylesheet record why, and the suite pins both hands: `A` → `["KeyA", "ShiftRight"]` and, so it can't pass by always naming the right shift, `?` → `["ShiftLeft", "Slash"]`.

`strokeFor` picks the hand. This component does not second-guess it.

## Not shaped like a press — and the difference isn't fill

`--go`, the per-world "press this" already worn by the button that starts a run, never a sixth telemetry colour.

The honest description of the contrast is **degree and shape**, not fill and no fill: both states tint the cap. A strike floods it at 78% `--lime` for 120 ms and is gone; the hint is a 20% `--go` wash — a fifth of that — under a ring that breathes at 1.6 s, and it persists until the key is struck. Two fills of the same weight read as one flashing board however different their hues, so the hint's is kept well under the echo's and carries the thing the echo hasn't got.

The fade is allowed here, where #131 forbade it on the echo. The hint travels key to key as a passage is typed, and easing that move reads as a pointer moving rather than teleporting. A press has to be instant; an instruction does not.

**Cascade, stated precisely.** The hint block sits above the press echo, and the two share exactly three properties — border, fill and legend — which the echo redeclares and wins, so a hinted key that is struck flashes rather than staying dressed as an instruction already followed. The ring and its breath are not in that contest: the echo declares neither `box-shadow` nor `animation`, and an animated value would outrank a normal declaration even if one were added. A struck hinted key flashes lime **inside a still-breathing halo** — wanted, and now written down, because a later reader was one step from adding a `box-shadow` to `is-down` and expecting it to take effect.

`prefers-reduced-motion` costs nothing here: the keyframe ends where it starts, so the global 0.001 ms clamp in `base.css` leaves the static ring exactly as it is. The hint survives with only its motion gone.

## Both quiet cases light nothing, neither throws

`next={null}` is the ordinary state, not an error — the run hasn't started, the run has finished, or the mode is `"keys"`. And a character this layout cannot produce (a curly quote that survived the passage filter) gets `null` back from `strokeFor`. Both light nothing.

## Out of scope, on purpose

**When** the hint is on is not decided here — that is `KeyboardMode` (#133), where a mode of `"keys"` simply passes `next={null}`. #134 mounts the board under the passage.

## Also

`--key-lip` names the keycap's inset lip in `game.css`. `box-shadow` replaces rather than adds, so every rule that draws a shadow of its own has to restate the lip or the key looks pressed while being pointed at — it was on its third literal copy. No visual change.

## Tests

Five new cases in `Keyboard.test.tsx`: a plain character lights one key; a shifted one lights the letter and the far shift, both hands pinned; `null` and an unproducible character light nothing; a hinted key that is struck keeps both classes in the right order; and the stylesheet assertions check the hint is `--go`, borrows none of the telemetry five, and is written above the echo block.

`type-check` 0 errors · `lint` clean · `test:unit` **1556 passed** · `build` static, 200 pages · smoke suite green, no console errors

Closes #132
