### PR TITLE
Let a kid decide how much of the keyboard is on screen

### DIFF
--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,3 +1,19 @@
+/**
+ * What the typing game puts on screen under the passage (docs/typing.md §4.1).
+ *
+ * One field rather than `showKeyboard` + `showHint`, because three of the four
+ * boolean combinations are meaningful and the fourth — a hint pointing at a
+ * board that isn't drawn — is nonsense. A union cannot express the nonsense,
+ * so no reader has to decide what to do when it arrives.
+ */
+export type KeyboardMode =
+  /** Not on screen at all. */
+  | "off"
+  /** The board, with its finger colours. No hint. */
+  | "keys"
+  /** The board, plus the next key — and its shift — lit. */
+  | "guide";
+
 export type Profile = {
   id: string;
   name: string;
@@ -5,6 +21,17 @@ export type Profile = {
   color: string;
   age: number;
   soundOn: boolean;
+  /**
+   * How much of the keyboard this player wants (§4.2). Absent means "guide",
+   * and absent is the ordinary state: every profile made before this shipped
+   * lacks the field, and nothing writes it until a child chooses. One default,
+   * at one read site, rather than a value copied into `create` as well.
+   *
+   * Optional precisely so this costs no `DB_VERSION` bump and no migration —
+   * profiles are read straight through, unlike sessions, whose widening lives
+   * in `engine/migrate.ts`.
+   */
+  keyboard?: KeyboardMode;
   xp: number;
   badges: string[];
   createdAt: string;

--- a/src/games/typing/TypingSetup.tsx
+++ b/src/games/typing/TypingSetup.tsx
@@ -15,7 +15,8 @@ import { bestRun, ghostsFor, sessionsFor } from "@/engine/records";
 import { randomSeed } from "@/engine/random";
 import { RivalList } from "@/games/race";
 import { sfx } from "@/services/sound";
-import type { TypingConfig } from "@/engine/types";
+import { KeyboardSetting } from "./keyboard/KeyboardSetting";
+import type { KeyboardMode, TypingConfig } from "@/engine/types";
 
 const LENGTHS = [20, 30, 50, 80];
 
@@ -28,7 +29,7 @@ const LENGTHS = [20, 30, 50, 80];
  */
 export default function TypingSetup() {
   const { profileId } = useParams();
-  const { profiles, sessions } = useHub();
+  const { profiles, sessions, updateProfile, notify } = useHub();
   const profile = usePlayer(profileId);
   const { start } = useRace();
   const navigate = useNavigate();
@@ -58,6 +59,23 @@ export default function TypingSetup() {
   const mine = sessionsFor(sessions, profile.id, key);
   const best = bestRun(mine);
   const bestWpm = best ? wordsPerMinute(best.cards, best.durationMs) : null;
+
+  /**
+   * Saved to the profile the moment it moves, unlike everything else on this
+   * screen: a level and a length describe one run, but how much of the
+   * keyboard you need is about the child, and it should still be true next
+   * week without being chosen again. Same shape as the sound toggle in
+   * `TopBar` — write, and say so if the write didn't land, because the pills
+   * are drawn from the profile and would otherwise silently spring back.
+   */
+  async function chooseKeyboard(next: KeyboardMode) {
+    sfx.tap();
+    try {
+      await updateProfile(profile!.id, { keyboard: next });
+    } catch {
+      notify("Could not save the keyboard setting", "bad");
+    }
+  }
 
   function launch() {
     const ghost = rivals.find((g) => g.session.id === rivalId) ?? null;
@@ -141,6 +159,11 @@ export default function TypingSetup() {
               ))}
             </div>
           </div>
+
+          <KeyboardSetting
+            mode={profile.keyboard}
+            onChange={(next) => void chooseKeyboard(next)}
+          />
 
           <p className="numbers__note">
             {bestWpm === null

--- a/src/games/typing/keyboard/KeyboardSetting.test.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.test.tsx
@@ -11,9 +11,10 @@ import { KeyboardSetting } from "./KeyboardSetting";
  * `Profile.keyboard` is optional and gets no migration on purpose
  * (docs/typing.md §10): profiles are read straight out of IndexedDB, unlike
  * sessions, and the only copy of a child's record book is the one on their
- * device. The price of that decision is that "the field isn't there" is a
- * state the UI meets forever, not a state that gets tidied up one release
- * later — so it is pinned here, in the file that resolves it.
+ * device. The price of that decision is that "the field isn't there" — and
+ * "the field says something else", since a restored backup is stored whole and
+ * unchecked — are states the UI meets forever, not states that get tidied up
+ * one release later. So both are pinned here, in the file that resolves them.
  *
  * The other assertion is that this is a control. The board it governs is sixty
  * inert spans and must stay that way (§4.5); the thing that shows and hides it
@@ -54,6 +55,22 @@ describe("KeyboardSetting", () => {
     // setting that claims not to be on any of its three settings.
     expect(chosen(html)).toEqual(["guide"]);
     expect(html).toContain("Show the next key");
+  });
+
+  it("renders an unrecognised keyboard value on guide", () => {
+    // What restore can hand back: `services/hub.ts#importAll` puts a profile
+    // into the store exactly as the file had it, so a hand-edited backup
+    // reaches this component carrying a value the type says cannot exist. The
+    // cast is the point of the test — no in-app path can produce this.
+    const restored = { ...legacy, keyboard: "gide" } as unknown as Profile;
+
+    const html = renderToStaticMarkup(
+      <KeyboardSetting mode={restored.keyboard} onChange={() => {}} />,
+    );
+
+    // One pill, the default one — the same requirement as the missing field.
+    // A `??` fallback would pass "gide" through and check none of the three.
+    expect(chosen(html)).toEqual(["guide"]);
   });
 
   it("shows the mode a player has chosen", () => {

--- a/src/games/typing/keyboard/KeyboardSetting.test.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.test.tsx
@@ -1,0 +1,81 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { Profile } from "@/engine/types";
+
+import { KeyboardSetting } from "./KeyboardSetting";
+
+/**
+ * The setting, and the profile that predates it.
+ *
+ * `Profile.keyboard` is optional and gets no migration on purpose
+ * (docs/typing.md §10): profiles are read straight out of IndexedDB, unlike
+ * sessions, and the only copy of a child's record book is the one on their
+ * device. The price of that decision is that "the field isn't there" is a
+ * state the UI meets forever, not a state that gets tidied up one release
+ * later — so it is pinned here, in the file that resolves it.
+ *
+ * The other assertion is that this is a control. The board it governs is sixty
+ * inert spans and must stay that way (§4.5); the thing that shows and hides it
+ * is the opposite, and "reachable by keyboard, announced with a name" is the
+ * difference between the two.
+ */
+
+/** A player from before this shipped: every field but `keyboard`. */
+const legacy: Profile = {
+  id: "kid-1",
+  name: "Ada",
+  emoji: "🚀",
+  color: "#7c3aed",
+  age: 7,
+  soundOn: true,
+  xp: 340,
+  badges: ["first-race"],
+  createdAt: "2026-03-01T09:00:00.000Z",
+};
+
+/** Which pill is selected, read back off the radio that carries `checked`. */
+const chosen = (html: string) =>
+  html
+    .split("<input")
+    .filter((chunk) => chunk.includes("checked"))
+    .map((chunk) => /value="([^"]+)"/.exec(chunk)?.[1]);
+
+describe("KeyboardSetting", () => {
+  it("renders a profile that has no keyboard field, on guide", () => {
+    // `legacy.keyboard` is `undefined`, which is exactly what the profile
+    // store hands back for a record written before the field existed.
+    const html = renderToStaticMarkup(
+      <KeyboardSetting mode={legacy.keyboard} onChange={() => {}} />,
+    );
+
+    // One pill selected, not none: a radiogroup with nothing checked would
+    // also "render without error", and it would leave a child looking at a
+    // setting that claims not to be on any of its three settings.
+    expect(chosen(html)).toEqual(["guide"]);
+    expect(html).toContain("Show the next key");
+  });
+
+  it("shows the mode a player has chosen", () => {
+    const html = renderToStaticMarkup(
+      <KeyboardSetting mode="off" onChange={() => {}} />,
+    );
+    expect(chosen(html)).toEqual(["off"]);
+  });
+
+  it("is a named radio group, because this one is a control", () => {
+    const html = renderToStaticMarkup(
+      <KeyboardSetting mode="keys" onChange={() => {}} />,
+    );
+
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain('aria-label="Keyboard"');
+    // Three real radios sharing one name — arrow keys move between them and
+    // the set is a single tab stop. A row of buttons announces as three
+    // unrelated toggles and costs three stops.
+    expect(html.match(/type="radio"/g)?.length).toBe(3);
+    expect(
+      new Set([...html.matchAll(/name="([^"]+)"/g)].map((m) => m[1])).size,
+    ).toBe(1);
+  });
+});

--- a/src/games/typing/keyboard/KeyboardSetting.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.tsx
@@ -20,9 +20,10 @@ import type { KeyboardMode } from "@/engine/types";
  * ── Its own component, and its own defaulting ─────────────────────────────
  * `mode` is the profile's raw optional field, not a resolved one, so the
  * fallback to "guide" lives here — one read site rather than one at each
- * caller. That is also what makes the case that matters testable without a
+ * caller. That is also what makes the cases that matter testable without a
  * database or a router: a profile saved before this shipped has no `keyboard`
- * key at all, and rendering it must land on "guide" rather than on nothing
+ * key at all, and a restored backup can carry a value no version of this app
+ * ever wrote. Either one must land on "guide" rather than on nothing
  * selected. `KeyboardSetting.test.tsx` is that test.
  */
 
@@ -47,6 +48,25 @@ const OPTIONS: SegmentedOption<KeyboardMode>[] = [
   { value: "guide", label: "Guide", hint: "Show the next key" },
 ];
 
+/**
+ * Which pill is on, for a field that may hold something else entirely.
+ *
+ * Not `mode ?? DEFAULT_KEYBOARD_MODE`, because `??` only catches an absent
+ * field and absent is not the only bad state. `Profile` is deliberately not
+ * read-migrated (docs/typing.md §10), and a restored backup is written into
+ * the store exactly as the file had it (`services/storage/db.ts`, driven by
+ * `services/hub.ts#importAll`) — so a hand-edited record reaches this
+ * component with a `keyboard` the type says is impossible. Handed straight to
+ * `SegmentedControl`, that draws a radiogroup with no pill checked: a child
+ * looking at a setting that claims to be on none of its three settings.
+ *
+ * Resolved against `OPTIONS` rather than against a second copy of the three
+ * mode names, so what comes back is by construction a pill that exists.
+ */
+const selected = (mode?: KeyboardMode): KeyboardMode =>
+  OPTIONS.find((option) => option.value === mode)?.value ??
+  DEFAULT_KEYBOARD_MODE;
+
 export function KeyboardSetting({
   mode,
   onChange,
@@ -54,6 +74,8 @@ export function KeyboardSetting({
   /**
    * `Profile.keyboard` as it comes out of storage — absent on every profile
    * made before this shipped, and on every one whose player hasn't chosen.
+   * Typed as the union, but storage is the one place that promise isn't kept;
+   * `selected` is what makes it true again.
    */
   mode?: KeyboardMode;
   onChange: (next: KeyboardMode) => void;
@@ -66,7 +88,7 @@ export function KeyboardSetting({
       <span className="control__label">Keyboard</span>
       <SegmentedControl
         label="Keyboard"
-        value={mode ?? DEFAULT_KEYBOARD_MODE}
+        value={selected(mode)}
         onChange={onChange}
         options={OPTIONS}
       />

--- a/src/games/typing/keyboard/KeyboardSetting.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.tsx
@@ -1,0 +1,75 @@
+import { SegmentedControl, type SegmentedOption } from "@/components/ui/kit";
+import type { KeyboardMode } from "@/engine/types";
+
+/**
+ * Choosing how much of the keyboard is on screen (docs/typing.md §4.2).
+ *
+ * The board itself is deliberately inert — sixty `<span>`s, `aria-hidden`,
+ * nothing to press, because a tappable keyboard is a hunt-and-peck trainer
+ * (§4.5). This is the opposite case and it is why the two live side by side:
+ * *this* is a control, so it is a real kit primitive with a name, a role and
+ * arrow keys, and not a row of `<Button pressed>` dressed as one.
+ *
+ * ── Three pills, because there are three modes ────────────────────────────
+ * `SegmentedControl` rather than a `Toggle`: a switch can only say on or off,
+ * and the whole point of `KeyboardMode` is that "board without the hint" is a
+ * real place to stand between the two (§4.1). It is the rung a child climbs
+ * before turning the board off entirely, and it is where most of the learning
+ * happens — so it cannot be the thing you reach by unchecking half a pair.
+ *
+ * ── Its own component, and its own defaulting ─────────────────────────────
+ * `mode` is the profile's raw optional field, not a resolved one, so the
+ * fallback to "guide" lives here — one read site rather than one at each
+ * caller. That is also what makes the case that matters testable without a
+ * database or a router: a profile saved before this shipped has no `keyboard`
+ * key at all, and rendering it must land on "guide" rather than on nothing
+ * selected. `KeyboardSetting.test.tsx` is that test.
+ */
+
+/**
+ * What a player who has never chosen gets.
+ *
+ * "guide" rather than "off" because the two mistakes are not the same size:
+ * showing the hint to a child who didn't need it costs a glance, and hiding it
+ * from a child who did costs a downward look at the real keyboard — which is
+ * the habit this whole world exists to prevent, and it sets in fast.
+ */
+export const DEFAULT_KEYBOARD_MODE: KeyboardMode = "guide";
+
+/**
+ * Named for what a child sees, not for what the field is called. The hints do
+ * the explaining, because "Keys" and "Guide" only differ in a way you can
+ * describe — one draws the board, the other also points at the next key.
+ */
+const OPTIONS: SegmentedOption<KeyboardMode>[] = [
+  { value: "off", label: "Off", hint: "No keyboard" },
+  { value: "keys", label: "Keys", hint: "Show the board" },
+  { value: "guide", label: "Guide", hint: "Show the next key" },
+];
+
+export function KeyboardSetting({
+  mode,
+  onChange,
+}: {
+  /**
+   * `Profile.keyboard` as it comes out of storage — absent on every profile
+   * made before this shipped, and on every one whose player hasn't chosen.
+   */
+  mode?: KeyboardMode;
+  onChange: (next: KeyboardMode) => void;
+}) {
+  return (
+    <div className="control">
+      {/* A span, not a `<label>`: the group's accessible name comes from
+          `SegmentedControl`'s own `aria-label`, and a second label pointing at
+          a radiogroup would announce it twice. This one is for the eye. */}
+      <span className="control__label">Keyboard</span>
+      <SegmentedControl
+        label="Keyboard"
+        value={mode ?? DEFAULT_KEYBOARD_MODE}
+        onChange={onChange}
+        options={OPTIONS}
+      />
+    </div>
+  );
+}

--- a/src/services/profiles.ts
+++ b/src/services/profiles.ts
@@ -1,4 +1,4 @@
-import type { Profile } from "@/engine/types";
+import type { KeyboardMode, Profile } from "@/engine/types";
 
 import * as store from "./storage/db";
 
@@ -52,6 +52,17 @@ function validate(input: Partial<NewProfile>, partial: boolean) {
   return out;
 }
 
+/**
+ * The three modes, as a runtime check.
+ *
+ * The type stops a caller in this codebase writing "gide"; nothing stops a
+ * restored backup or a hand-edited record, and this is the layer that turns bad
+ * input into no change rather than a corrupt profile. Absent is a legal state
+ * (it reads as "guide"), so failing the check simply leaves the field alone.
+ */
+const isKeyboardMode = (value: unknown): value is KeyboardMode =>
+  value === "off" || value === "keys" || value === "guide";
+
 /** Names are the only thing players use to tell each other apart on the picker. */
 async function assertNameFree(name: string, exceptId?: string) {
   const existing = await store.allProfiles();
@@ -100,6 +111,12 @@ export async function update(
     ...(Object.hasOwn(patch, "soundOn")
       ? { soundOn: Boolean(patch.soundOn) }
       : {}),
+    // Same reasoning as `soundOn`: a setting, not text. Only the three modes
+    // are written, so a patch carrying anything else leaves the profile on
+    // whatever it was on — a bad value here would otherwise sit in storage
+    // until a child chose again, and the read site would have to defend
+    // against it forever.
+    ...(isKeyboardMode(patch.keyboard) ? { keyboard: patch.keyboard } : {}),
   };
   await store.putProfile(updated);
   return updated;

--- a/src/services/profiles.ts
+++ b/src/services/profiles.ts
@@ -55,10 +55,17 @@ function validate(input: Partial<NewProfile>, partial: boolean) {
 /**
  * The three modes, as a runtime check.
  *
- * The type stops a caller in this codebase writing "gide"; nothing stops a
- * restored backup or a hand-edited record, and this is the layer that turns bad
- * input into no change rather than a corrupt profile. Absent is a legal state
- * (it reads as "guide"), so failing the check simply leaves the field alone.
+ * This is `soundOn`'s coercion held to a union instead of to `Boolean`: it
+ * covers an in-app patch, which is the only thing that reaches `update`.
+ * Absent is a legal state (it reads as "guide"), so failing the check simply
+ * leaves the field alone.
+ *
+ * It is *not* a defence against a corrupt record, and shouldn't be read as
+ * one. A restored backup goes into the store whole and never passes through
+ * here, and a hand-edited record is already in the store — the `...existing`
+ * spread below copies it back out untouched. That case is defended where such
+ * a value is actually seen: `games/typing/keyboard/KeyboardSetting.tsx`
+ * resolves anything that isn't one of the three to "guide" on read.
  */
 const isKeyboardMode = (value: unknown): value is KeyboardMode =>
   value === "off" || value === "keys" || value === "guide";
@@ -113,9 +120,8 @@ export async function update(
       : {}),
     // Same reasoning as `soundOn`: a setting, not text. Only the three modes
     // are written, so a patch carrying anything else leaves the profile on
-    // whatever it was on — a bad value here would otherwise sit in storage
-    // until a child chose again, and the read site would have to defend
-    // against it forever.
+    // whatever it was on rather than parking a bad value in storage until a
+    // child chooses again.
     ...(isKeyboardMode(patch.keyboard) ? { keyboard: patch.keyboard } : {}),
   };
   await store.putProfile(updated);


### PR DESCRIPTION
The board can draw itself (#130), react to what was struck (#131) and point at
what comes next (#132). This story is the switch that decides which of those a
child sees. Design: `docs/typing.md` §4.2, §10.

`KeyboardMode = "off" | "keys" | "guide"` joins `engine/types.ts`, and `Profile`
gains `keyboard?: KeyboardMode`.

## One field, not two booleans

`showKeyboard` + `showHint` would have been the obvious shape and the wrong one.
Three of its four combinations are meaningful; the fourth — a hint pointing at a
board that isn't drawn — is nonsense, and a boolean pair can hold it. A union
can't, so nobody downstream ever has to decide what to do when the impossible
state turns up.

## No `DB_VERSION` bump and no migration

Deliberately. The field is **optional and defaulted at the read site**, so a
profile written before this shipped is already valid — there is nothing to widen
(§10, and §4.2 says so in as many words). Sessions are read-migrated because
`engine/migrate.ts` has to hold a shape change permanently: the device holds the
only copy of a child's record book. A profile pays neither cost for an optional
field, and `Profile` is not read-migrated today.

The price is that "the field isn't there" is a state the UI meets forever rather
than one a later release tidies away, and the suite pins it rather than trusting
it. Absent stays the ordinary state on purpose — `create` does not write the
field either, so "guide" lives at one read site instead of being copied into the
profile constructor as a second source of truth.

`"guide"` rather than `"off"` because the two mistakes are different sizes:
showing the hint to a child who didn't need it costs a glance; hiding it from one
who did costs a downward look at the real keyboard, which is the exact habit this
world exists to prevent.

## A segmented control, because there are three modes

The acceptance criteria offered a `Toggle`; this is a kit `SegmentedControl`.
"Board without the hint" is a real place to stand between on and off — the rung a
child climbs before turning the board off entirely, and where most of the
learning happens — so it must not be the thing you reach by unchecking half a
pair.

It is also the mirror of the board itself. The keyboard is sixty inert `<span>`s
under `aria-hidden` because a tappable keyboard is a hunt-and-peck trainer
(§4.5). This one **is** a control, so it is a real radio group with a name and
arrow keys, not a row of `<Button pressed>` dressed as one. It writes to the
profile the moment it moves, like the sound toggle, and says so if the write
didn't land — the pills are drawn from the profile and would otherwise silently
spring back.

## Resolution runs through the options, not through `??`

`mode ?? DEFAULT_KEYBOARD_MODE` catches an absent field and nothing else, and
absent is not the only bad state a read site meets. `importAll` writes a restored
backup into the store whole, so a hand-edited record can arrive carrying
`keyboard: "gide"` — typed as impossible, and handed straight to
`SegmentedControl` it draws a radiogroup with **no pill checked**: a child looking
at a setting that claims to be on none of its three settings. Resolving against
`OPTIONS` means the answer is by construction a pill that exists.

That is also why `services/profiles.ts#update` claims only what it does. Its new
branch sits beside `soundOn`'s with the same reasoning — a setting, not
user-entered text — and it is the union's version of `Boolean()`: only the three
modes are written, so an in-app patch carrying anything else leaves the profile
on whatever it was on. It never sees a restored backup, because that value does
not pass through `update` at all.

## Out of scope

Lessons overriding or **locking** the setting is the rest of §4.2 and arrives
with the ladder (LES11). Mounting the board under the passage is #134. Nothing
reads `keyboard` to draw a board yet — this story stores and sets it.

## Tests

`KeyboardSetting.test.tsx` — a profile with no `keyboard` key lands on "guide"
with exactly one pill selected; an unrecognised value does the same; a chosen
mode shows as chosen; and the group is a named radiogroup, because a radiogroup
with nothing checked would render without error and still tell a child their
setting is on none of its settings.

`type-check` 0 errors · `lint` clean · `test:unit` **1560 passed** · `build`
static, 200 pages · smoke suite green, no console errors

Closes #133
