### PR TITLE
Put the keyboard under the passage, and judge the key before the key moves the expectation

### DIFF
--- a/src/engine/decks/typing.test.ts
+++ b/src/engine/decks/typing.test.ts
@@ -7,6 +7,7 @@ import {
   buildTypingDrill,
   describeTypingConfig,
   levelCredit,
+  nextChar,
   passageFor,
   typingConfigKey,
   typingDeckSpec,
@@ -303,5 +304,49 @@ describe("buildTypingDrill", () => {
       "The",
       "the",
     ]);
+  });
+});
+
+describe("nextChar", () => {
+  /*
+   * The expectation the keyboard's red is judged against (docs/typing.md
+   * §4.3), so every case below is a case where a child either does or does not
+   * get told they made a mistake. The word boundary is the one that has been
+   * wrong in production: a fully typed word wants SPACE, and a board that
+   * wanted the next word's first letter instead flared the space bar on every
+   * word a child got right.
+   */
+
+  it("wants the first letter before anything is typed", () => {
+    expect(nextChar("three", "")).toBe("t");
+  });
+
+  it("wants the letter under the cursor mid-word", () => {
+    expect(nextChar("three", "th")).toBe("r");
+    expect(nextChar("three", "thre")).toBe("e");
+  });
+
+  it("wants the SPACE that commits a finished word", () => {
+    // The buffer is exactly the word: there is no letter left, and the only
+    // key that gets out of it is the space bar.
+    expect(nextChar("three", "three")).toBe(" ");
+  });
+
+  it("still wants SPACE once the word has been over-typed", () => {
+    // The extra letters are already red in the passage above. Asking for a
+    // letter that cannot be reached would flare the way out of the word too.
+    expect(nextChar("three", "threee")).toBe(" ");
+    expect(nextChar("three", "threexyz")).toBe(" ");
+  });
+
+  it("wants SPACE for a word that isn't there at all", () => {
+    // `TypingTrack` passes "" for an index past the end of the deck.
+    expect(nextChar("", "")).toBe(" ");
+  });
+
+  it("does not fold a word's own punctuation away", () => {
+    // A sentence level types the comma, so it is a character like any other.
+    expect(nextChar("hand,", "hand")).toBe(",");
+    expect(nextChar("hand,", "hand,")).toBe(" ");
   });
 });

--- a/src/engine/decks/typing.ts
+++ b/src/engine/decks/typing.ts
@@ -376,6 +376,28 @@ export function passageFor(config: TypingConfig, seed: number): string[] {
   return words.slice(0, config.wordCount);
 }
 
+/**
+ * The character a typist is waiting on, given the live word and what they have
+ * typed of it so far.
+ *
+ * The letter at the cursor, and once every letter of the word is in, the SPACE
+ * that commits it. Space is a key like any other here and the most-missed one
+ * on the board: a child who can spell "because" and cannot find the space bar
+ * without looking types at half speed, and the thumb is the only finger the
+ * passage never names.
+ *
+ * Anything typed PAST the end of the word also asks for space, because space is
+ * what gets out of it — the extra letters are already marked wrong in the
+ * passage above and the run does not stop to be told twice.
+ *
+ * Here rather than inline in `TypingTrack` because this is the expectation the
+ * keyboard's red is decided against (docs/typing.md §4.3), and it is text in,
+ * text out — so the boundary that matters, a full word wanting a space next,
+ * can be pinned without a race running around it.
+ */
+export const nextChar = (word: string, entry: string): string =>
+  word[entry.length] ?? " ";
+
 export function buildTypingDeck(config: TypingConfig, seed: number): Card[] {
   return passageFor(config, seed).map((word) => ({
     prompt: word,

--- a/src/games/typing/TypingTrack.tsx
+++ b/src/games/typing/TypingTrack.tsx
@@ -3,7 +3,7 @@ import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useHub, usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
 import { buildDeck, configKey, deckSpec, modeOf } from "@/engine/decks";
-import { levelCredit } from "@/engine/decks/typing";
+import { levelCredit, nextChar } from "@/engine/decks/typing";
 import { cardXp } from "@/engine/progress";
 import {
   WRONG_ANSWER_PENALTY_MS,
@@ -227,26 +227,17 @@ function Track({
   /**
    * The character the passage is waiting on — the whole input to the board.
    *
-   * The letter at the cursor of the live word, and once every letter of it is
-   * typed, the SPACE that commits it. Space is a key like any other here and
-   * the most-missed one on the board: a child who can spell "because" and
-   * cannot find the space bar without looking types at half speed, and the
-   * thumb is the only finger the passage never names.
-   *
-   * Anything typed past the end of the word also asks for space, because space
-   * is what gets out of it — the extra letters are already marked wrong in the
-   * passage above and the run does not stop to be told twice.
-   *
-   * `null` whenever nothing is expected: during the 3·2·1, while the quit
-   * sheet is up, and once the last word is in and the run is saving. `live` is
-   * the flag `TypeField` is disabled on rather than a second reading of the
+   * WHICH character that is, space bar included once a word is fully typed, is
+   * `nextChar`'s to say. What is decided here is when the passage is waiting on
+   * nothing at all: `null` during the 3·2·1, while the quit sheet is up, and
+   * once the last word is in and the run is saving. That comes off `live`, the
+   * same flag `TypeField` is disabled on rather than a second reading of the
    * same two pieces of state, because the two have to agree — a key pressed at
    * a disabled field that the board marked wrong would be blaming a child for
    * a keystroke the game had already thrown away.
    */
   const live = phase === "racing" && !quitting;
-  const word = deck[index]?.answer ?? "";
-  const next = live ? (word[entry.length] ?? " ") : null;
+  const next = live ? nextChar(deck[index]?.answer ?? "", entry) : null;
 
   /**
    * How much of the board this player asked for. Resolved by the same function

--- a/src/games/typing/TypingTrack.tsx
+++ b/src/games/typing/TypingTrack.tsx
@@ -24,6 +24,8 @@ import {
 import { sfx } from "@/services/sound";
 import { Passage } from "./Passage";
 import { TypeField } from "./TypeField";
+import { keyboardMode } from "./keyboard/KeyboardSetting";
+import { LiveKeyboard } from "./keyboard/LiveKeyboard";
 import type {
   CardResult,
   Profile,
@@ -222,6 +224,38 @@ function Track({
     [deck, spec, onCard, bank, startCard, total, hasFinished],
   );
 
+  /**
+   * The character the passage is waiting on — the whole input to the board.
+   *
+   * The letter at the cursor of the live word, and once every letter of it is
+   * typed, the SPACE that commits it. Space is a key like any other here and
+   * the most-missed one on the board: a child who can spell "because" and
+   * cannot find the space bar without looking types at half speed, and the
+   * thumb is the only finger the passage never names.
+   *
+   * Anything typed past the end of the word also asks for space, because space
+   * is what gets out of it — the extra letters are already marked wrong in the
+   * passage above and the run does not stop to be told twice.
+   *
+   * `null` whenever nothing is expected: during the 3·2·1, while the quit
+   * sheet is up, and once the last word is in and the run is saving. `live` is
+   * the flag `TypeField` is disabled on rather than a second reading of the
+   * same two pieces of state, because the two have to agree — a key pressed at
+   * a disabled field that the board marked wrong would be blaming a child for
+   * a keystroke the game had already thrown away.
+   */
+  const live = phase === "racing" && !quitting;
+  const word = deck[index]?.answer ?? "";
+  const next = live ? (word[entry.length] ?? " ") : null;
+
+  /**
+   * How much of the board this player asked for. Resolved by the same function
+   * that draws the pills on the setup screen, so the two can't disagree about
+   * a profile whose field is absent — which is every profile made before the
+   * setting shipped.
+   */
+  const board = keyboardMode(profile.keyboard);
+
   if (saveError) {
     return (
       <SaveFailed
@@ -274,10 +308,16 @@ function Track({
       <TypeField
         value={entry}
         index={index}
-        disabled={phase !== "racing" || quitting}
+        disabled={!live}
         onChange={setEntry}
         onCommit={commit}
       />
+
+      {/* Under the line being typed on, and after it in the DOM as well as on
+          screen — the board is a map of the keyboard, so it reads last, and
+          `TypeField` keeps the tab order's first and only stop. Rendered
+          nothing at all on "off": see `LiveKeyboard`. */}
+      {board !== "off" && <LiveKeyboard mode={board} next={next} />}
 
       {quitting && (
         <QuitSheet

--- a/src/games/typing/keyboard/KeyboardSetting.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.tsx
@@ -19,11 +19,11 @@ import type { KeyboardMode } from "@/engine/types";
  *
  * ── Its own component, and its own defaulting ─────────────────────────────
  * `mode` is the profile's raw optional field, not a resolved one, so the
- * fallback to "guide" lives here — one read site rather than one at each
- * caller. That is also what makes the cases that matter testable without a
- * database or a router: a profile saved before this shipped has no `keyboard`
- * key at all, and a restored backup can carry a value no version of this app
- * ever wrote. Either one must land on "guide" rather than on nothing
+ * fallback to "guide" lives here — one resolver, exported, rather than a copy
+ * of it at each caller. That is also what makes the cases that matter testable
+ * without a database or a router: a profile saved before this shipped has no
+ * `keyboard` key at all, and a restored backup can carry a value no version of
+ * this app ever wrote. Either one must land on "guide" rather than on nothing
  * selected. `KeyboardSetting.test.tsx` is that test.
  */
 
@@ -49,7 +49,8 @@ const OPTIONS: SegmentedOption<KeyboardMode>[] = [
 ];
 
 /**
- * Which pill is on, for a field that may hold something else entirely.
+ * What a profile's `keyboard` field actually means, for a field that may hold
+ * something else entirely.
  *
  * Not `mode ?? DEFAULT_KEYBOARD_MODE`, because `??` only catches an absent
  * field and absent is not the only bad state. `Profile` is deliberately not
@@ -62,8 +63,13 @@ const OPTIONS: SegmentedOption<KeyboardMode>[] = [
  *
  * Resolved against `OPTIONS` rather than against a second copy of the three
  * mode names, so what comes back is by construction a pill that exists.
+ *
+ * Exported because the race reads the same field to decide what to draw
+ * (`TypingTrack`, #134), and the two must agree: a setting whose pills say
+ * "guide" over a run with no board is worse than either alone. One resolver,
+ * so there is nothing for a second read site to disagree with.
  */
-const selected = (mode?: KeyboardMode): KeyboardMode =>
+export const keyboardMode = (mode?: KeyboardMode): KeyboardMode =>
   OPTIONS.find((option) => option.value === mode)?.value ??
   DEFAULT_KEYBOARD_MODE;
 
@@ -88,7 +94,7 @@ export function KeyboardSetting({
       <span className="control__label">Keyboard</span>
       <SegmentedControl
         label="Keyboard"
-        value={selected(mode)}
+        value={keyboardMode(mode)}
         onChange={onChange}
         options={OPTIONS}
       />

--- a/src/games/typing/keyboard/KeyboardSetting.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.tsx
@@ -81,7 +81,7 @@ export function KeyboardSetting({
    * `Profile.keyboard` as it comes out of storage — absent on every profile
    * made before this shipped, and on every one whose player hasn't chosen.
    * Typed as the union, but storage is the one place that promise isn't kept;
-   * `selected` is what makes it true again.
+   * `keyboardMode` is what makes it true again.
    */
   mode?: KeyboardMode;
   onChange: (next: KeyboardMode) => void;

--- a/src/games/typing/keyboard/LiveKeyboard.test.tsx
+++ b/src/games/typing/keyboard/LiveKeyboard.test.tsx
@@ -1,0 +1,66 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { KEYS } from "@/engine/keyboard";
+
+import { LiveKeyboard } from "./LiveKeyboard";
+
+/**
+ * The one decision this component makes: who gets the hint.
+ *
+ * Everything else about the board is pinned next door — `Keyboard.test.tsx`
+ * owns the picture and the palette, `useKeyEcho.test.ts` owns the flash and
+ * the release timer. What is only true here is that "keys" and "guide" differ
+ * in the hint and in NOTHING else, which is the distinction a child is choosing
+ * between on the setup screen (docs/typing.md §4.1).
+ *
+ * Rendered rather than reasoned about, and rendered on the server, so the
+ * assertions survive a change to how the hint is expressed in markup. The echo
+ * is absent from every case below for the same reason it is absent from a real
+ * first frame: `useKeyEcho` wires itself up in an effect, and no key has been
+ * struck yet.
+ */
+
+/** Which keys the hint lit, by code — the board draws `KEYS` in order. */
+const hinted = (html: string) => {
+  const classes = [...html.matchAll(/class="(keyboard__key[^"]*)"/g)];
+  return KEYS.filter((_, index) => classes[index][1].includes("is-next")).map(
+    (key) => key.code,
+  );
+};
+
+describe("LiveKeyboard", () => {
+  it("points at the next key in guide", () => {
+    const html = renderToStaticMarkup(<LiveKeyboard mode="guide" next="f" />);
+    expect(hinted(html)).toEqual(["KeyF"]);
+  });
+
+  it("draws the same board in keys, pointing at nothing", () => {
+    const html = renderToStaticMarkup(<LiveKeyboard mode="keys" next="f" />);
+
+    // The board is all there — the mode withholds the hint, not the map.
+    expect(html.match(/class="keyboard__key/g)).toHaveLength(KEYS.length);
+    expect(hinted(html)).toEqual([]);
+  });
+
+  it("points at nothing when the passage is waiting on nothing", () => {
+    // The 3·2·1, the quit sheet, the moment after the last word: `TypingTrack`
+    // hands `null` in every state where the field is disabled.
+    const html = renderToStaticMarkup(
+      <LiveKeyboard mode="guide" next={null} />,
+    );
+    expect(hinted(html)).toEqual([]);
+  });
+
+  it("stays a picture, with nothing to focus", () => {
+    // The load-bearing one on a phone: the OS keyboard is raised by the
+    // focused `<input>`, so anything focusable down here could take the real
+    // keyboard away mid-run.
+    const html = renderToStaticMarkup(<LiveKeyboard mode="guide" next=" " />);
+
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).not.toContain("<button");
+    expect(html).not.toContain("<input");
+    expect(html).not.toContain("tabindex");
+  });
+});

--- a/src/games/typing/keyboard/LiveKeyboard.tsx
+++ b/src/games/typing/keyboard/LiveKeyboard.tsx
@@ -1,0 +1,62 @@
+import { Keyboard } from "./Keyboard";
+import { useKeyEcho } from "./useKeyEcho";
+import type { KeyboardMode } from "@/engine/types";
+
+/**
+ * The board as a typist actually meets it: the picture, plus what their hands
+ * are doing to it (docs/typing.md §4).
+ *
+ * Three pieces built apart meet here and nowhere else — `Keyboard` draws
+ * (#130), `useKeyEcho` listens (#131), `KeyboardMode` decides how much of it a
+ * child wants (#133). It exists as its own component for two reasons, both
+ * about what a keystroke is allowed to cost:
+ *
+ *   - **The echo re-renders this and not the passage.** `useKeyEcho` publishes
+ *     on every keydown and again when each key's 120ms release fires. Called
+ *     up in `TypingTrack`, every one of those would re-render the twenty words
+ *     of the passage and the lane behind them, at the speed a child types.
+ *     Called here, they re-render sixty spans and stop.
+ *   - **"Off" is off, not hidden.** The caller mounts this only when the mode
+ *     is not "off" — which is why `mode` excludes it rather than returning
+ *     `null` for it. A board that returned `null` after calling the hook would
+ *     still hold a window listener and a timer per key for a child who asked
+ *     to be rid of it.
+ *
+ * Nothing here can take focus. That is not a promise this file keeps by being
+ * careful; the board is sixty inert `<span>`s under `pointer-events: none`
+ * (§4.5), so there is no element to focus and no handler to move it. It
+ * matters more than it sounds: on a phone the OS keyboard is raised only by
+ * the focused `<input>`, so a board that stole focus would take the real
+ * keyboard away with it and end the run.
+ */
+export function LiveKeyboard({
+  mode,
+  next,
+}: {
+  /**
+   * How much board to draw. "off" is absent because that decision belongs to
+   * the caller — see above.
+   */
+  mode: Exclude<KeyboardMode, "off">;
+  /**
+   * The character the passage is waiting on, or `null` when it isn't waiting
+   * on one — before the countdown clears, and once the run is over.
+   */
+  next: string | null;
+}) {
+  /**
+   * The expectation is the real next character in BOTH modes, and only the
+   * hint is withheld in "keys".
+   *
+   * "Show me the board but not the answer" is a statement about the hint, not
+   * about the marking: a child who has stopped needing to be told which key
+   * comes next has not stopped needing to be told they hit the wrong one —
+   * that is the rung of the ladder they are on. Passing `null` here to match
+   * the hint would turn every wrong key green.
+   */
+  const { down, wrong } = useKeyEcho({ expect: next });
+
+  return (
+    <Keyboard down={down} wrong={wrong} next={mode === "guide" ? next : null} />
+  );
+}

--- a/src/games/typing/keyboard/useKeyEcho.test.ts
+++ b/src/games/typing/keyboard/useKeyEcho.test.ts
@@ -111,6 +111,26 @@ describe("createKeyEcho", () => {
     expect(missed.wrong()).toEqual(["Digit5"]);
   });
 
+  it("does not blame the space that commits a word", () => {
+    // The keystroke a child makes most often and the one this got backwards:
+    // a finished word expects SPACE, so the space bar is the RIGHT key here.
+    // It flared for a while because the echo read the expectation after the
+    // commit had already advanced it — see the capture-phase note in
+    // `useKeyEcho`. The machine's half of that contract is this assertion.
+    const keys = board();
+    keys.press("Space", " ");
+    expect(keys.down()).toEqual(["Space"]);
+    expect(keys.wrong()).toEqual([]);
+  });
+
+  it("does blame a space struck in the middle of a word", () => {
+    // The other half: space is not exempt from marking, it is only correct
+    // when it is what the passage was waiting for.
+    const keys = board();
+    keys.press("Space", "e");
+    expect(keys.wrong()).toEqual(["Space"]);
+  });
+
   it("calls CapsLock what it is", () => {
     const keys = board();
     keys.press("CapsLock", "a");

--- a/src/games/typing/keyboard/useKeyEcho.ts
+++ b/src/games/typing/keyboard/useKeyEcho.ts
@@ -172,6 +172,14 @@ export function useKeyEcho({ expect }: { expect: string | null }): KeyEcho {
    * listener binds once — a fresh binding per character would be a listener
    * churned on every keystroke, and a stale closure would judge this key
    * against the last one.
+   *
+   * A ref has the opposite hazard, and it is the one that actually bit: an
+   * expectation too FRESH for the key being judged. The keystroke that commits
+   * a word is the keystroke that moves this ref, so anything reading it after
+   * the commit has re-rendered is asking "was SPACE the right key for the NEXT
+   * word's first letter?" — and telling a child in red that they finished a
+   * word correctly. The capture flag below is what keeps the read in front of
+   * the write.
    */
   const expected = useRef(expect);
   expected.current = expect;
@@ -181,9 +189,24 @@ export function useKeyEcho({ expect }: { expect: string | null }): KeyEcho {
     const onKeyDown = (event: KeyboardEvent) =>
       board.press(event.code, expected.current);
 
-    window.addEventListener("keydown", onKeyDown);
+    // Capture, not bubble — the third argument is load-bearing.
+    //
+    // §4.3 asks for the key to be judged ON THE PRESS, before anything has
+    // re-rendered, and bubbling does not deliver that. React delegates
+    // `TypeField`'s `onKeyDown` at the island root, which is inside `window`,
+    // so it runs first; on SPACE it commits the word, queueing `setEntry("")`
+    // and `setIndex(i + 1)`. React flushes a discrete update in a microtask,
+    // and a microtask checkpoint runs BETWEEN two listeners of one real event
+    // — so by the time a bubble-phase echo saw the SPACE, the track had already
+    // re-rendered and the expectation had already advanced to the next word.
+    // Every correctly finished word flared red on the space bar.
+    //
+    // Capture runs at the very start of propagation, ahead of every handler
+    // that could move the expectation. It also survives a `stopPropagation()`
+    // anywhere between the field and the window, which bubbling would not.
+    window.addEventListener("keydown", onKeyDown, true);
     return () => {
-      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keydown", onKeyDown, true);
       // Unmounting mid-chord is one of the ways a `keyup` goes missing. There
       // is no state left to strand, but a timer that outlives the component
       // would call `setEcho` on it.

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1269,6 +1269,39 @@ label.segmented__btn {
   max-width: 46rem;
   margin-inline: auto;
   width: 100%;
+
+  /* The passage is the row of the race grid that gives — `.race` makes it
+     `minmax(0, 1fr)` while every other row is `auto`, and the keyboard below
+     the input is one of those. But a grid item still refuses to be shorter
+     than its own content unless it is told it may, so without these two a
+     short screen with the board on would grow the page instead of the row:
+     the line you type on, and then the board, would slide under the fold.
+
+     Clipping is the right end to lose. `Passage` is already a window on the
+     deck — six words behind, fourteen ahead — so what goes is more read-ahead,
+     and the live word sits near the top of it either way. */
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* A viewport too short to hold both, where the board is what goes.
+   `.race` is `min-height: calc(100dvh - var(--ad-h))` so that a race never
+   scrolls under a child's thumb, and five rows of keys are 45% of a phone
+   held in landscape — enough to break that on its own. What they would be
+   taking the height from is the passage and the line you type on, which are
+   the game; the board is the aid. So below the height at which it stops
+   fitting it isn't drawn, and it is back the moment there is room.
+
+   Nothing is written and the setting doesn't move: this is the same profile
+   in the same mode, on a screen that can't show it. Turning the pill off for
+   them would be answering a question about their eyes with a fact about
+   their window. The number is measured rather than guessed: a portrait phone
+   keeps the board and about two lines of passage down to here, and below it
+   the words are down to one line before the keys have cost anything.       */
+@media (max-height: 520px) {
+  .typing .keyboard {
+    display: none;
+  }
 }
 
 /* Generous line height and a fixed-width font: the eye is tracking one word


### PR DESCRIPTION
The board can draw itself (#130), react to what was struck (#131), point at
what comes next (#132) and be turned down to taste (#133). None of that was on
screen. This story mounts it under the passage a kid already types on, which is
step 6 of `docs/typing.md` §13 — **"KEY is done here."** Layout per §2.

`LiveKeyboard` is the assembly: `Keyboard` + `useKeyEcho` + the mode, mounted
by `TypingTrack` under `TypeField`.

## The space bar was flaring on every word a child got right

This is the bug that took the story, and it was not in the marking — it was in
which listener ran first.

`useKeyEcho` held the expectation in a ref (a fresh binding per character would
churn a listener per keystroke; a stale closure would judge this key against
the last one) and listened in the **bubble** phase. React delegates
`TypeField`'s `onKeyDown` at the island root, which is inside `window`, so it
runs first. On SPACE it commits the word — `setEntry("")`, `setIndex(i + 1)` —
React flushes that discrete update in a microtask, and **a microtask checkpoint
runs between two listeners of one real event**. So by the time the echo saw the
SPACE, the expectation had already advanced to the next word's first letter,
and the echo answered the question "was SPACE the right key for `t`?" in red.

Every correctly finished word. The single most common keystroke in the game,
marked wrong at exactly the moment a child got something right.

The fix is the third argument. **Capture** runs at the very start of
propagation, ahead of every handler that could move the expectation — the read
goes back in front of the write. It also survives a `stopPropagation()`
anywhere between the field and the window, which bubbling would not. §4.3 asks
for the key to be judged *on the press*, before anything has re-rendered;
bubble phase does not deliver that, and the reason it doesn't is subtle enough
that the comment in `useKeyEcho.ts` spells out the microtask step rather than
saying "capture, for ordering".

## `nextChar` is in the engine, and space is a character

`word[entry.length] ?? " "` — the letter at the cursor, and once the word is
fully in, the SPACE that commits it. Over-typing asks for space too: the extra
letters are already red in the passage above, and asking for a letter that can
no longer be reached would flare the way *out* of the word as well.

In `decks/typing.ts` rather than inline in the track because it is the
expectation the keyboard's red is decided against, and it is text in, text out
— so the boundary that matters, a full word wanting a space next, is pinned in
six unit tests with no race running around them. Space is also the most-missed
key on the board: the thumb is the only finger the passage never names.

## The echo re-renders sixty spans, not the passage

`useKeyEcho` is called inside `LiveKeyboard`, not up in `TypingTrack`. It
publishes on every keydown and again when each key's 120 ms release fires;
called at the track, every one of those would re-render twenty words of passage
and the ghost lane behind them, at the speed a child types.

`mode` on `LiveKeyboard` excludes `"off"` on purpose, so the caller must decide
not to mount it. A board that called the hook and returned `null` would still
hold a window listener and a timer per key for a child who asked to be rid of
it.

## "keys" withholds the hint, not the marking

Both modes judge against the real next character; only `next` is withheld from
the picture in `"keys"`. "Show me the board but not the answer" is a statement
about the hint — a child who has stopped needing to be told which key comes
next has not stopped needing to be told they hit the wrong one. That is the
rung of the ladder they are on. Passing `null` to the hook to match would turn
every wrong key green.

Resolution is `keyboardMode`, now exported from `KeyboardSetting` rather than
copied: the setup screen's pills and the race's board read one resolver, so
they cannot disagree about a profile with no `keyboard` field — which is every
profile made before #133 shipped.

## Nothing here can take focus, and that is structural

The board is sixty inert `<span>`s under `pointer-events: none` and
`aria-hidden` (§4.5), so there is no element to focus and no handler to move
focus. It matters more than it sounds: on a phone the OS keyboard is raised
only by the focused `<input>`, so a board that stole focus would take the real
keyboard away with it and end the run. It is also last in the DOM as well as on
screen — a map of the keyboard reads last, and `TypeField` keeps the tab
order's first and only stop.

## Two CSS rules, because a race must not scroll

`.race` is `min-height: calc(100dvh - var(--ad-h))` with the passage as the one
row that gives. A grid item still refuses to be shorter than its content, so
`min-height: 0` + `overflow: hidden` on the passage is what keeps the board
from growing the page and sliding the line you type on under the fold.
Clipping is the right end to lose — `Passage` is already a window on the deck.

Below `520px` of viewport height the board is not drawn at all. Five rows of
keys are ~45% of a phone held in landscape, and what they would take the height
from is the passage and the input, which are the game; the board is the aid.
Nothing is written and the pill does not move — this is the same profile in the
same mode on a screen that can't show it, and answering a question about a
child's eyes with a fact about their window would be the wrong trade.

## Out of scope

Lessons, the ladder and Hailstorm — §13 steps 7 onward. Lesson locks overriding
the toggle arrive with LES11.

## Tests

`nextChar` — cursor, word boundary, over-typed word, empty word, punctuation
inside a word (six cases, the boundary being the one that was wrong in
production). `LiveKeyboard.test.tsx` — the one decision this component makes:
`"guide"` points at `KeyF`, `"keys"` draws the whole board and points at
nothing, `null` points at nothing, and the rendered markup has no `<button>`,
no `<input>` and no `tabindex`. `useKeyEcho.test.ts` gains the machine's half
of the space contract: SPACE at a finished word is *right*, SPACE mid-word is
wrong.

`type-check` 0 errors · `lint` clean · `test:unit` **1572 passed** · `build`
static, 200 pages · smoke suite green, no console errors

Closes #134
