### PR TITLE
Tell the orchestrator the truth about gh pr merge

### DIFF
--- a/.claude/skills/run-orchestrator/SKILL.md
+++ b/.claude/skills/run-orchestrator/SKILL.md
@@ -180,8 +180,11 @@ Launch each with the **Agent** tool (`subagent_type: general-purpose`).
 >    `npm run build`, then the browser smoke test — `npm run preview &` and
 >    `npm run test:smoke`. If anything fails, stop and report `❌`.
 > 2. Push; open a PR **targeting `<BASE>`**: `gh pr create --base <BASE>`.
-> 3. Merge: `gh pr merge <PR> --squash --delete-branch`, then
->    `git checkout <BASE> && git pull --ff-only`.
+> 3. Merge: `gh pr merge <PR> --auto --squash`. `--auto` queues the merge
+>    behind the required check and fires the moment it goes green. Never
+>    `--admin`, which bypasses CI. `--delete-branch` does not fire through the
+>    auto-merge path, so delete the branch locally and on the remote afterwards
+>    and verify. Then `git checkout <BASE> && git pull --ff-only`.
 > 4. Tick issue #N's checkbox in the epic body (`gh issue edit <EPIC>`).
 > 5. **Report exactly one line:** `✅ #N done — PR #<num> merged into <BASE>` or
 >    `❌ #N blocked — <reason>`.
@@ -212,8 +215,14 @@ ships to production on the next `develop` → `main` release merge.
 - **`preflight` fails on untracked files too** — a stray scratch file blocks the
   next issue. That's intentional; clean or commit it.
 - **The checkbox is the progress source of truth**, not issue open/closed state.
-- **CI is a required check on `develop`** here (unlike monilibrium, where the
-  repo is private and protection isn't available), so Wrap-up's `gh pr merge`
-  waits for CI. That's expected — don't retry it as though it hung.
+- **`gh pr merge` does NOT wait for CI — always pass `--auto`.** CI is a
+  required check on `develop` here (unlike monilibrium, where the repo is
+  private and protection isn't available). A bare `gh pr merge --squash` calls
+  the merge API immediately and is rejected with "base branch policy prohibits
+  the merge" whenever the check is still pending — which looks like a flaky
+  branch-protection rule and is really a race the caller lost. This text used
+  to claim the merge waits; it does not, and two of the six PRs in epic #157
+  were rejected on that advice before it was measured. `--auto` is
+  deterministic: it queues and merges the instant CI is green.
 - **Never mark a stage from expectation.** Record `ok` only after the agent
   actually returned its line.


### PR DESCRIPTION
## What

Two hunks in `.claude/skills/run-orchestrator/SKILL.md`: Wrap-up now merges with `gh pr merge <PR> --auto --squash`, and the Gotcha that claimed the merge waits for CI is corrected.

## Why

The old text said:

> so Wrap-up's `gh pr merge` waits for CI. That's expected — don't retry it as though it hung.

It doesn't wait. Without `--auto`, `gh pr merge` calls the merge API immediately and takes a 405 if the required check is still pending. Every Wrap-up agent believed the docs and fired as soon as it had a PR, so whether the merge landed came down to whether CI happened to be green yet.

Across epic #157 that produced 4 clean merges and 2 rejections with "base branch policy prohibits the merge" — same branch, same author, same CI. It reads like a flaky protection rule, and I went looking at `develop`'s settings first. They're fine, and were identical for all six PRs: `strict: true`, one required context (`CI`), conversation resolution required, no rulesets.

What settled it was the gap between CI going green and the merge landing:

| PR | CI green | merged | gap |
|---|---|---|---|
| #161 | 03:32:29 | 03:32:47 | 18s |
| #162 | 03:50:26 | 03:50:46 | 20s |
| #163 | 04:11:56 | 04:11:57 | **1s** |
| #164 | 04:33:15 | 04:33:26 | 11s |
| #165 | 04:58:32 | 04:58:33 | **1s** |

The 1s gaps are the auto-merge queue firing the instant the check flipped — those are the two that were rejected first and retried with `--auto`. The 11–20s gaps are an agent polling, seeing green, then merging. No configuration difference, just a race.

`--auto` queues behind the required check and merges deterministically. Also now stated rather than left to be rediscovered: `--delete-branch` does not fire through the auto-merge path (delete and verify afterwards), and `--admin` is off-limits because it bypasses CI rather than waiting for it.

No repo settings were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)