### PR TITLE
Know which keys a lesson has taught, and which it has not

### DIFF
--- a/src/engine/typing/keys.test.ts
+++ b/src/engine/typing/keys.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { canType, unlockedAt } from "./keys";
+import { LESSONS } from "./lessons";
+import type { Lesson } from "./lessons";
+import { KEYS, strokeFor } from "../keyboard";
+
+/**
+ * The unlocked alphabet, asserted as a set of characters rather than a size
+ * (docs/typing.md §5.1, §5.2).
+ *
+ * A count is the wrong assertion here: "thirty-one characters at lesson 30" is
+ * satisfied by thirty-one *wrong* characters, and the failure this module
+ * exists to prevent is one specific key being in a set it has no business
+ * being in. So every expectation below is spelled out, and the ones that
+ * cannot be — the hundredth lesson's — are computed from the ladder itself so
+ * that re-ordering it re-derives the answer instead of breaking the test.
+ */
+
+/** A set of characters as one sorted string, so a diff prints readably. */
+const chars = (set: ReadonlySet<string>) => [...set].sort().join("");
+
+/** The same, for an expectation written in whatever order reads best. */
+const sorted = (text: string) => [...text].sort().join("");
+
+const byN = new Map(LESSONS.map((l) => [l.n, l]));
+const introducedBy = (n: number) => byN.get(n)?.introduces ?? [];
+
+/** Every character this board can produce, however far up the ladder. */
+const EVERYTHING = new Set(
+  KEYS.flatMap((k) => k.cap).filter((legend) => legend.length === 1),
+);
+
+/** Every character the ladder hands over, anywhere, plus the space bar. */
+const EVER_INTRODUCED = new Set([" ", ...LESSONS.flatMap((l) => l.introduces)]);
+
+/** `KeyboardEvent.code` → the character that key types unshifted. */
+const BASE = new Map(
+  KEYS.filter((k) => k.cap[0].length === 1).map((k) => [k.code, k.cap[0]]),
+);
+
+const CAPITALS = /^[A-Z]$/;
+const capitalsIn = (set: ReadonlySet<string>) =>
+  [...set].filter((ch) => CAPITALS.test(ch));
+
+describe("unlockedAt", () => {
+  /**
+   * Block 1 is the eight home keys plus the inside reach, and `;` is one of
+   * the eight — the right pinky rests on it (§5.6, lesson 5 · Both pinkies).
+   * Lessons 7–10 introduce nothing, so the alphabet block 1 ends on is the
+   * alphabet lesson 6 left behind.
+   */
+  it("is exactly the home row and the space bar at the end of block 1", () => {
+    expect(chars(unlockedAt(10))).toBe(sorted("asdfghjkl; "));
+    expect(chars(unlockedAt(6))).toBe(chars(unlockedAt(10)));
+  });
+
+  /**
+   * Block 3 finishes the alphabet, and it brings the comma and the full stop
+   * with it because that is physically where they are (§5.5) — plus the slash,
+   * which came in at lesson 25 alongside `z` as the last bottom-row corner.
+   * `;` and `/` both come back in block 7 in their punctuation role; the union
+   * does not care, which is the point of that note in the table.
+   */
+  it("is every letter, and no capital, at the end of block 3", () => {
+    expect(chars(unlockedAt(30))).toBe(
+      sorted("abcdefghijklmnopqrstuvwxyz;,./ "),
+    );
+    expect(capitalsIn(unlockedAt(30))).toEqual([]);
+  });
+
+  /**
+   * The whole ladder, against the ladder's own `introduces`. This is the
+   * assertion that says nothing is silently dropped anywhere in the hundred:
+   * every shifted character block 7 teaches has its base key and its shift
+   * behind it, or it would be missing here.
+   */
+  it("covers everything the hundred lessons introduce", () => {
+    expect(chars(unlockedAt(100))).toBe(chars(EVER_INTRODUCED));
+    for (const ch of unlockedAt(100)) expect(strokeFor(ch), ch).not.toBeNull();
+  });
+
+  /**
+   * And covers nothing else. The ten legends on the board that no lesson ever
+   * teaches: the backquote key, both bracket keys, and the four shifted
+   * characters — `^ < > |` — whose base keys the ladder does teach. A closure
+   * over unlocked *keys* rather than a union of introduced *characters* would
+   * hand all four of those over for free, `<` and `>` from lesson 31.
+   */
+  it("never hands over a character no lesson taught", () => {
+    const untaught = [...EVERYTHING].filter((ch) => !unlockedAt(100).has(ch));
+    expect(sorted(untaught.join(""))).toBe(sorted("`~[]{}|^<>"));
+  });
+
+  /**
+   * The union, stated one lesson at a time. Every step of the ladder adds
+   * exactly what that lesson introduces and takes nothing away — which is what
+   * "computed, never written down" has to mean if moving a lesson is to move
+   * its alphabet with it.
+   */
+  it("grows by exactly what each lesson introduces, and never shrinks", () => {
+    for (let n = 1; n <= 100; n++) {
+      const expected = new Set([...unlockedAt(n - 1), ...introducedBy(n)]);
+      expect(chars(unlockedAt(n)), `lesson ${n}`).toBe(chars(expected));
+    }
+  });
+
+  /**
+   * Total, like `deckSpec(mode)`: a session saved against a ladder that has
+   * since been re-tuned still has to open its record book, and the number in
+   * its mode string may not be on the ladder any more — or may not parse.
+   */
+  it("clamps a lesson number that is not on the ladder", () => {
+    expect(chars(unlockedAt(0))).toBe(" ");
+    expect(chars(unlockedAt(-3))).toBe(" ");
+    expect(chars(unlockedAt(Number.NaN))).toBe(" ");
+    expect(chars(unlockedAt(101))).toBe(chars(unlockedAt(100)));
+    expect(chars(unlockedAt(1e6))).toBe(chars(unlockedAt(100)));
+    expect(chars(unlockedAt(10.9))).toBe(chars(unlockedAt(10)));
+  });
+});
+
+describe("the shift rule", () => {
+  /**
+   * The subtle one. Every letter is unlocked at lesson 26 and every capital
+   * needs one of them, so a rule that only checked the letter would hand a
+   * child the whole of block 4 four lessons early — and with it the one
+   * technique the block exists to teach.
+   */
+  it("gives no capital before block 4, however old the letter is", () => {
+    for (let n = 0; n <= 30; n++)
+      expect(capitalsIn(unlockedAt(n)), `lesson ${n}`).toEqual([]);
+    expect(unlockedAt(30).has("a")).toBe(true);
+    expect(unlockedAt(30).has("A")).toBe(false);
+  });
+
+  /**
+   * And gives them one shift at a time. Lesson 31 is the right shift, which
+   * reaches the left hand's letters and only those; `M` is a left-shift
+   * capital and waits for lesson 32. Two lessons, twenty-six characters, and
+   * the opposite-hand rule as the only way either of them works.
+   */
+  it("arrives one shift at a time, in the hand each shift reaches", () => {
+    expect(sorted(capitalsIn(unlockedAt(31)).join(""))).toBe(
+      sorted("QWERTASDFGZXCVB"),
+    );
+    for (const ch of capitalsIn(unlockedAt(31)))
+      expect(strokeFor(ch)?.shift, ch).toBe("ShiftRight");
+    expect(sorted(capitalsIn(unlockedAt(32)).join(""))).toBe(
+      sorted("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+    );
+  });
+
+  /**
+   * Both halves, over the whole ladder: nothing needing a shift is unlocked
+   * without its base key, and nothing needing a shift is unlocked before a
+   * capital has taught that shift. Block 7's `!` and `?` are the ones this
+   * covers that block 4's capitals do not — they arrive assuming the child
+   * already knows to hold shift, and this is the assertion that they do.
+   */
+  it("needs both the base key and a shift, everywhere on the ladder", () => {
+    for (let n = 0; n <= 100; n++) {
+      const set = unlockedAt(n);
+      const taught = new Set(
+        capitalsIn(set).map((ch) => strokeFor(ch)?.shift ?? null),
+      );
+      for (const ch of set) {
+        const stroke = strokeFor(ch);
+        if (!stroke?.shift) continue;
+        expect(taught.has(stroke.shift), `${ch} at lesson ${n}`).toBe(true);
+        expect(set.has(BASE.get(stroke.code) ?? ""), `${ch} at ${n}`).toBe(
+          true,
+        );
+      }
+    }
+  });
+});
+
+describe("canType", () => {
+  it("passes text a child at that lesson has every key for", () => {
+    expect(canType("a glass flask", 10)).toBe(true);
+    expect(canType("a quick fox.", 24)).toBe(true);
+    expect(canType("", 1)).toBe(true);
+  });
+
+  it("fails on a key the ladder has not reached yet", () => {
+    // `w`, `e`, `m` and `t` are all block 2 or later.
+    expect(canType("glad we met", 10)).toBe(false);
+    // The full stop arrives with `x`, at lesson 24.
+    expect(canType("a quick fox.", 23)).toBe(false);
+    // Both digits are block 6, and they arrive in different lessons.
+    expect(canType("45", 51)).toBe(true);
+    expect(canType("42", 51)).toBe(false);
+    expect(canType("42", 54)).toBe(true);
+  });
+
+  it("fails on a capital until the shift that reaches it is taught", () => {
+    expect(canType("ask", 30)).toBe(true);
+    expect(canType("Ask", 30)).toBe(false);
+    expect(canType("Ask", 31)).toBe(true);
+    // `M` is the right hand's, so it needs the left shift — lesson 32.
+    expect(canType("Man", 31)).toBe(false);
+    expect(canType("Man", 32)).toBe(true);
+  });
+
+  it("fails on a character the board cannot produce, at any lesson", () => {
+    // The curly quotation marks `decks/typing.ts` had to hand-exclude from the
+    // Scripture pool. No lesson unlocks them because no key produces them.
+    expect(canType("“yes”", 100)).toBe(false);
+    expect(canType("café", 100)).toBe(false);
+  });
+
+  /**
+   * The story's whole point, stated as one loop: no lesson asks for a key it
+   * has not taught. The generator's own reachability test (§5.2) is this
+   * assertion over the words it produces; this is it over the keys the lesson
+   * declares, which is the half that can be checked before the generator
+   * exists.
+   */
+  it("can type the new keys of every lesson, at that lesson", () => {
+    for (const lesson of LESSONS)
+      expect(canType(lesson.introduces.join(""), lesson.n), lesson.id).toBe(
+        true,
+      );
+  });
+});
+
+/**
+ * The gate, on a ladder that gets it wrong.
+ *
+ * Today's hundred never introduce a shifted character before its base key or
+ * before block 4 has taught a shift, so every assertion above still passes
+ * with the rule deleted — the union alone satisfies them. That is exactly why
+ * these two are here: the rule is for the ladder somebody re-orders, and a
+ * rule with no test is a rule the next reader deletes as dead weight.
+ */
+describe("a ladder that introduces a key too early", () => {
+  const lesson = (n: number, introduces: string): Lesson => ({
+    n,
+    id: `L${n}`,
+    block: 1,
+    title: `lesson ${n}`,
+    introduces: [...introduces],
+    kind: { type: "keys" },
+    wordCount: 20,
+    keyboard: "guide",
+    pass: {
+      kind: "lesson",
+      accuracy: 0.95,
+      wpm: 8,
+      keyAccuracy: 0.9,
+      keyStrikes: 12,
+    },
+  });
+
+  /** `unlockedAt` built over a ladder of our own, not the hundred. */
+  const ladderOf = async (lessons: Lesson[]) => {
+    vi.resetModules();
+    vi.doMock("./lessons", () => ({ LESSONS: lessons }));
+    try {
+      return (await import("./keys")).unlockedAt;
+    } finally {
+      vi.doUnmock("./lessons");
+    }
+  };
+
+  it("withholds punctuation until a capital has taught its shift", async () => {
+    // `?` is shift-`/`, and `/` is not a letter — so nothing on this ladder
+    // has put a shift under anybody's pinky, and `?` cannot be struck.
+    const unlockedAt = await ladderOf([lesson(1, "z/"), lesson(2, "?")]);
+    expect(unlockedAt(2).has("/")).toBe(true);
+    expect(unlockedAt(2).has("?")).toBe(false);
+  });
+
+  it("withholds a capital until its own letter arrives", async () => {
+    const unlockedAt = await ladderOf([lesson(1, "A"), lesson(2, "a")]);
+    expect(unlockedAt(1).has("A")).toBe(false);
+    expect(unlockedAt(2).has("A")).toBe(true);
+  });
+});

--- a/src/engine/typing/keys.ts
+++ b/src/engine/typing/keys.ts
@@ -1,0 +1,180 @@
+import { KEYS, reachable, strokeFor } from "@/engine/keyboard";
+import type { Stroke } from "@/engine/keyboard";
+import { LESSONS } from "./lessons";
+
+/**
+ * What a child may be asked to type at lesson n (docs/typing.md §5.1, §5.2).
+ *
+ * The **unlocked alphabet** at lesson n is the union of `introduces` over
+ * lessons 1…n, plus space. It is *computed here, never written down*, which is
+ * the whole point: a per-block alphabet spelled out in a table is a second
+ * source of truth that a re-ordered ladder walks away from silently, and the
+ * failure it produces is a lesson asking a five-year-old for a key nobody has
+ * shown them. Move a lesson and its alphabet moves with it, because there is
+ * nowhere else for the alphabet to be.
+ *
+ * This is the module the reachability test (§5.2) is built out of — "every
+ * character of every word a lesson can generate is producible from the keys
+ * unlocked at that lesson" — and it is why the layout had to be in the engine
+ * rather than the view (§3.1): the curriculum, not the picture, is what asks
+ * the keyboard questions.
+ *
+ * ── The two halves of a shifted character ────────────────────────────────────
+ * `A` is not `a`. `strokeFor("A")` names KeyA *and* ShiftRight, so a character
+ * is only unlocked once both keys are — which is why the capitals are not
+ * available at lesson 30 even though every letter is. A naive union would hand
+ * them over the moment the letters arrived and block 4 would have nothing left
+ * to teach.
+ */
+
+/** The one character no lesson introduces, because words are made of them. */
+const SPACE = " ";
+
+type ShiftCode = NonNullable<Stroke["shift"]>;
+
+/**
+ * `KeyboardEvent.code` → the character that key types on its own.
+ *
+ * The inverse of half of `strokeFor`, and the only way back from a stroke to
+ * the base character a shifted one is built on: `A` names KeyA, and KeyA's
+ * unshifted legend is `a`. Word legends ("Tab", "Shift") are left out, so a
+ * modifier has no base character and can never satisfy the check below.
+ */
+const UNSHIFTED = new Map(
+  KEYS.filter((k) => k.cap[0].length === 1).map((k) => [k.code, k.cap[0]]),
+);
+
+/** Single lowercase letters, which is what makes a shifted character a capital. */
+const LETTER = /^[a-z]$/;
+
+/**
+ * The shift a character teaches, or null if it teaches none.
+ *
+ * A shift is not a character, so it can never appear in `introduces` — and yet
+ * it plainly has to be unlocked by something, or `A` is either free from
+ * lesson 1 or unreachable forever. What unlocks it is block 4's capitals
+ * (§5.5): "A shift is not a character, so what these two lessons introduce is
+ * the set of capitals each one *reaches*", and each teaches only the shift it
+ * is actually held with — lesson 31's fifteen left-hand capitals are all
+ * right-shift, so ShiftLeft is still locked when lesson 31 ends.
+ *
+ * Every *other* shifted character on the board — `!`, `?`, `:`, `"` — arrives
+ * in block 7, thirty lessons later, and arrives assuming the child already
+ * knows to hold shift. So a capital is what teaches a shift and punctuation is
+ * not, which is what gives the rule below its teeth: a punctuation lesson
+ * dragged up in front of block 4 loses its keys instead of quietly teaching a
+ * technique nobody has been shown.
+ */
+function shiftTaughtBy(ch: string): ShiftCode | null {
+  const stroke = strokeFor(ch);
+  if (!stroke?.shift) return null;
+  const base = UNSHIFTED.get(stroke.code);
+  return base && LETTER.test(base) ? stroke.shift : null;
+}
+
+/**
+ * The introduced characters that can actually be struck, given the shifts.
+ *
+ * Three ways a character fails to make it out of the union:
+ *
+ *   - **The board cannot produce it.** `strokeFor` is null — a curly quote
+ *     that reached `introduces` by way of a copy-paste. `reachable` checks
+ *     this too, but the alphabet is handed to other callers (the generator's
+ *     pools, Hailstorm's waves) and it should not carry a character no
+ *     keyboard can type.
+ *   - **No shift has been taught yet.** The capitals at lesson 30.
+ *   - **Its base key has not arrived.** `_` before `-`, `?` before `/`. Today's
+ *     ladder never does this — the test at lesson 100 asserts the whole union
+ *     survives — and the reason to drop rather than to trust is that dropping
+ *     is the safe direction: a lesson that loses its own new keys fails §5.2's
+ *     reachability test loudly, where handing a child an untaught key fails
+ *     silently, in front of them.
+ */
+function strikeable(
+  unlocked: ReadonlySet<string>,
+  shifts: ReadonlySet<ShiftCode>,
+): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const ch of unlocked) {
+    const stroke = strokeFor(ch);
+    if (!stroke) continue;
+    if (!stroke.shift) {
+      out.add(ch);
+      continue;
+    }
+    if (!shifts.has(stroke.shift)) continue;
+    const base = UNSHIFTED.get(stroke.code);
+    if (base !== undefined && unlocked.has(base)) out.add(ch);
+  }
+  return out;
+}
+
+/**
+ * Every alphabet on the ladder, indexed by lesson number.
+ *
+ * Built once, walking the lessons in order of `n` rather than array order —
+ * `n` is the number in `Session.mode` and the array is a table someone will
+ * one day re-order in place, so "lessons 1…n" means what it says. Index 0 is
+ * the alphabet before the ladder starts, which is the space bar and nothing
+ * else.
+ *
+ * A hundred sets of a hundred characters is a few thousand strings held for
+ * the life of the process, and the alternative is rebuilding the union on
+ * every call from a generator that asks per lesson, per seed, per word.
+ */
+const ALPHABETS: readonly ReadonlySet<string>[] = (() => {
+  const unlocked = new Set([SPACE]);
+  const shifts = new Set<ShiftCode>();
+  const alphabets: ReadonlySet<string>[] = [strikeable(unlocked, shifts)];
+
+  for (const lesson of [...LESSONS].sort((a, b) => a.n - b.n)) {
+    for (const ch of lesson.introduces) {
+      unlocked.add(ch);
+      const shift = shiftTaughtBy(ch);
+      if (shift) shifts.add(shift);
+    }
+    // A gap in the numbering carries the previous alphabet forward rather than
+    // leaving a hole `unlockedAt` would return `undefined` from. The ladder is
+    // 1–100 with no gaps and lessons.test.ts pins that; this is what keeps the
+    // signature honest anyway.
+    while (alphabets.length < lesson.n)
+      alphabets.push(alphabets[alphabets.length - 1]);
+    alphabets[lesson.n] = strikeable(unlocked, shifts);
+  }
+
+  return alphabets;
+})();
+
+/**
+ * The characters a child has met by the end of lesson `n`, plus space.
+ *
+ * Total, and never throws: a lesson number off the end of the ladder is the
+ * whole alphabet and one before the start is the space bar, for the same
+ * reason `deckSpec(mode)` never throws — a saved session outlives the ladder
+ * it was run on, and a record book from two re-tunings ago still has to open.
+ * A number parsed out of one of those saved modes can be `NaN`, which clamps
+ * to nothing at all rather than to an alphabet somebody was never given.
+ *
+ * The set is shared, not copied. It is `ReadonlySet` because every caller
+ * reads it; one that mutates it would be editing the curriculum for everybody
+ * else in the tab.
+ */
+export function unlockedAt(n: number): ReadonlySet<string> {
+  const last = ALPHABETS.length - 1;
+  const i = Number.isFinite(n) ? Math.min(Math.max(Math.floor(n), 0), last) : 0;
+  return ALPHABETS[i];
+}
+
+/**
+ * Can every character of `text` be typed by a child at lesson `n`?
+ *
+ * The composition the generator is checked against (§5.2), and the two halves
+ * are different questions: `unlockedAt` is the curriculum's — don't use a key
+ * they haven't met — and `strokeFor`, inside `reachable`, is the layout's —
+ * don't use a character this board cannot produce at all. That second half is
+ * what catches prose pulled from the passage library before a child meets a
+ * curly quote they can never satisfy.
+ */
+export function canType(text: string, n: number): boolean {
+  return reachable(text, unlockedAt(n));
+}


### PR DESCRIPTION
`docs/typing.md` §5.2 is one sentence — *"every character of every word a lesson
can generate must be producible from the keys unlocked at that lesson"* — and it
is the sentence that makes a hundred re-orderable lessons safe. This story is the
module that sentence is built out of: `src/engine/typing/keys.ts`, exporting
`unlockedAt(n)` and `canType(text, n)`. Design: `docs/typing.md` §3.1, §5.1, §5.2.

Nothing imports it yet. The generator (#137) will, to build each lesson's word
pool, and the reachability test over all hundred lessons at every seed is the
thing that lands with it.

## The alphabet is computed, so it cannot disagree with the ladder

`unlockedAt(n)` is the union of `introduces` over lessons 1…*n*, plus space —
**derived from `LESSONS[]`, written down nowhere**. That is the whole point. A
per-block alphabet spelled out in its own table is a second source of truth, and
the way it goes wrong is that someone re-orders the ladder, the table stays where
it was, and the failure surfaces as a lesson asking a five-year-old for a key
nobody has shown them. Move a lesson and its alphabet moves with it, because
there is nowhere else for the alphabet to live.

The union walks the lessons sorted by `n`, not in array order, because `n` is
half of the id in `Session.mode` and the array is a table someone will one day
re-order in place. "Lessons 1…*n*" has to keep meaning what it says.

## A shifted character needs two keys, so it needs both unlocked

`A` is not `a`. `strokeFor("A")` names KeyA *and* ShiftRight, and a character is
strikeable only once both are unlocked — which is why **`unlockedAt(30)` has all
26 letters and not one capital**. A naive union would hand the capitals over the
moment the letters arrived, and block 4 would have nothing left to teach.

A shift is not a character, so it can never appear in `introduces`, and yet it
plainly has to be unlocked by something or `A` is either free from lesson 1 or
unreachable forever. What unlocks it is block 4's capitals (§5.5): each of
lessons 31 and 32 introduces *the set of capitals one shift reaches*, so each
teaches only the shift it is actually held with. Lesson 31's fifteen left-hand
capitals are all right-shift — ShiftLeft is still locked when 31 ends, which is
why `M` waits for 32.

Every other shifted character on the board — `!` `?` `:` `"` — arrives in block
7, thirty lessons later, assuming the child already knows to hold shift. So a
capital teaches a shift and punctuation does not, and that is what gives the rule
teeth: `?!` dragged up in front of block 4 **loses its keys** rather than quietly
assuming a technique nobody has been shown.

Dropping is the safe direction in all three failure cases — a board that cannot
produce the character, a shift not yet taught, a base key not yet arrived. A
lesson that loses its own new keys fails §5.2's reachability test loudly. Handing
a child an untaught key fails silently, in front of them.

## `canType` is two different questions

`unlockedAt` asks the curriculum's — don't use a key they haven't met.
`strokeFor`, inside `reachable`, asks the layout's — don't use a character this
board cannot produce at all. The second half is what catches prose lifted from
the passage library carrying a curly quote no keyboard can satisfy, which is the
reason the layout had to be in the engine rather than the view (§3.1): the
curriculum, not the picture, is what asks the keyboard questions.

`unlockedAt` is total and never throws, for the same reason `deckSpec(mode)`
doesn't — a saved session outlives the ladder it was run on, and a record book
from two re-tunings ago still has to open. Off the end of the ladder is the whole
alphabet, before the start is the space bar, and a `NaN` parsed out of an old
mode clamps to nothing rather than to an alphabet somebody was never given. The
hundred sets are built once and shared as `ReadonlySet`, because the generator
asks per lesson, per seed, per word — and a caller that mutated one would be
editing the curriculum for everybody else in the tab.

## Tests assert set contents, not sizes

`keys.test.ts`, 19 cases. A size assertion passes for the wrong reason the first
time two mistakes cancel, so every alphabet claim is an exact set: lesson 10 is
the home row plus space and nothing else, lesson 30 is every letter with `; , . /`
and no capital, lesson 100 is exactly what the hundred introduce. The ten legends
this board can produce that no lesson ever teaches (`` ` ~ [ ] { } | ^ < > ``)
stay out at every lesson — the alphabet is what was taught, not what exists.

Today's ladder loses nothing to the shift rule, which means the rule is invisible
to every test written against the real `LESSONS`. So two cases build a
**deliberately wrong ladder** — punctuation moved in front of block 4, a capital
moved in front of its own letter — and assert the keys are withheld. Both fail if
the rule is deleted, which is the only way to pin a guard that today's data never
trips.

## Out of scope

The generator itself (#137), and the §5.2 reachability run over all hundred
lessons at many seeds that it brings with it. This is the module that test is
made of, not the test.

`type-check` 0 errors · `lint` clean · `test:unit` **1614 passed** · `build`
static, 200 pages

Closes #136
