### PR TITLE
Choose each lesson's words to teach what that lesson is about

### DIFF
--- a/src/engine/typing/generate.test.ts
+++ b/src/engine/typing/generate.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from "vitest";
+
+import { generate } from "./generate";
+import { canType, unlockedAt } from "./keys";
+import { LESSONS } from "./lessons";
+import type { Lesson } from "./lessons";
+import { WORDS } from "./lexicon";
+
+/**
+ * The three invariants that make a hundred generated lessons safe
+ * (docs/typing.md §5.2, §12).
+ *
+ * This is the test the three stories before it were for. The hundred specs
+ * gave it something to walk, `unlockedAt` gave it the question to ask of every
+ * character, and the corpus gave the generator something to answer with — and
+ * what it buys is the ladder being *editable*: move a lesson, re-order a
+ * block, hand a key over two lessons earlier, and the text follows or this
+ * file says which lesson it stopped following at.
+ *
+ *   1. **Reachability.** Every character of every lesson, at every seed, is
+ *      producible on the board and unlocked by that lesson.
+ *   2. **The new key shows up enough.** Every introduced character occurs at
+ *      least `pass.keyStrikes` times, at every seed, so the new-key gate
+ *      (§6.4) can never be unpassable through bad luck.
+ *   3. **A lesson is mostly review.** New keys are 15–35% of the characters:
+ *      below that it is not a lesson about them, above it a memory test.
+ *
+ * Each is asserted over all hundred lessons crossed with a spread of seeds,
+ * because a generator is a distribution and one seed is an anecdote. Failures
+ * are collected rather than thrown at the first one: "lessons 61, 63 and 67
+ * are short of strikes" is a finding about the ladder, where "lesson 61 is"
+ * is a bug report you have to fix three times.
+ *
+ * ── The one lesson invariant 3 cannot cover, and why that is not a licence ───
+ * At lesson 1 the unlocked alphabet is `f`, `j` and the space bar. There is no
+ * review to be had, so a lesson that is 15–35% new keys is not merely
+ * undesirable there, it is arithmetically impossible — and §5.5 asks for
+ * exactly what the ladder does instead: "three lessons of `fff jjj fjf` is
+ * standard and correct". So the band is asserted wherever the ladder has
+ * anything to review and a *stronger* claim — every character is a new key —
+ * where it has not. Both halves are derived from `unlockedAt`, never from a
+ * list of excused lesson numbers, which is what keeps the exception honest: a
+ * re-ordered ladder that leaves lesson 40 with nothing to review is reported
+ * by the same line rather than covered by it.
+ */
+
+/** §5.2's band. Not a knob — see the note above before touching either end. */
+const MIN_NEW_SHARE = 0.15;
+const MAX_NEW_SHARE = 0.35;
+
+/**
+ * Enough seeds that a rare draw is not a lucky pass.
+ *
+ * Sixteen crossed with a hundred lessons is sixteen hundred generations, which
+ * runs in under a second because the corpus is filtered once per lesson. The
+ * seeds are spread rather than 0–15: `mulberry32` is well-behaved over
+ * neighbouring seeds, but the numbers a run actually uses come from
+ * `randomSeed()` and look nothing like a counter.
+ */
+const SEEDS = [
+  0, 1, 2, 7, 42, 99, 128, 1000, 4242, 65535, 123456, 999983, 2147483647,
+  16777216, 31337, 8675309,
+];
+
+/** Every lesson that has text — the storms have a wave instead (§8.3). */
+const WITH_TEXT = LESSONS.filter((lesson) => lesson.wordCount > 0);
+
+/** The lessons the new-key invariants are about. */
+const INTRODUCING = WITH_TEXT.filter((lesson) => lesson.introduces.length > 0);
+
+/** A lesson's text as a child meets it: the words, and the spaces between. */
+const textOf = (lesson: Lesson, seed: number) =>
+  generate(lesson, seed).join(" ");
+
+/** What the ladder has given this lesson that it did not give it today. */
+const reviewAt = (lesson: Lesson) =>
+  [...unlockedAt(lesson.n)].filter(
+    (ch) => ch !== " " && !lesson.introduces.includes(ch),
+  );
+
+/** How many of `text`'s characters are in `chars`. */
+const countOf = (text: string, chars: readonly string[]) => {
+  const wanted = new Set(chars);
+  return [...text].filter((ch) => wanted.has(ch)).length;
+};
+
+describe("the reachability invariant", () => {
+  /**
+   * The one §5.2 calls "the test that makes the ladder editable", and the only
+   * one whose failure a child would meet as a key they have never been shown.
+   *
+   * `canType` is asked per character rather than per word so the report names
+   * the character: "L27 needs 'q'" is a curriculum bug you can act on.
+   */
+  it("never asks for a key the lesson has not taught", () => {
+    const offenders: string[] = [];
+    for (const lesson of WITH_TEXT)
+      for (const seed of SEEDS) {
+        const unreachable = new Set(
+          [...textOf(lesson, seed)].filter((ch) => !canType(ch, lesson.n)),
+        );
+        for (const ch of unreachable)
+          offenders.push(`${lesson.id} seed ${seed}: ${JSON.stringify(ch)}`);
+      }
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * Reachability is about characters; this is about the words they make.
+   *
+   * A lesson asks for `wordCount` words because that is what its wpm bar is
+   * computed against (§6.3): a lesson that quietly ran nine words short would
+   * report a speed nobody typed. Storm levels are the exception the type
+   * already carries — `wordCount` is 0 and the wave decides the length.
+   */
+  it("produces exactly the number of words the lesson asks for", () => {
+    const offenders: string[] = [];
+    for (const lesson of LESSONS)
+      for (const seed of SEEDS) {
+        const words = generate(lesson, seed);
+        if (words.length !== lesson.wordCount)
+          offenders.push(
+            `${lesson.id} seed ${seed}: ${words.length} of ${lesson.wordCount}`,
+          );
+        if (words.some((word) => word === "" || word.includes(" ")))
+          offenders.push(`${lesson.id} seed ${seed}: a word holds a space`);
+      }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("the new-key invariant", () => {
+  /**
+   * The gate in §6.4 waits for `keyStrikes` strikes of each new character
+   * before it will judge that key at all. If the text does not contain that
+   * many, the lesson cannot be passed however well it is typed — and the child
+   * has no way of knowing why, because everything they typed was right.
+   */
+  it("strikes every new key at least as often as its gate demands", () => {
+    const offenders: string[] = [];
+    for (const lesson of INTRODUCING) {
+      const strikes =
+        lesson.pass.kind === "lesson" ? lesson.pass.keyStrikes : 0;
+      for (const seed of SEEDS) {
+        const text = textOf(lesson, seed);
+        for (const ch of lesson.introduces) {
+          const struck = countOf(text, [ch]);
+          if (struck < strikes)
+            offenders.push(
+              `${lesson.id} seed ${seed}: ${ch} × ${struck}, needs ${strikes}`,
+            );
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * §5.2's band, everywhere the ladder has review to give.
+   *
+   * The floor and the ceiling fail differently and both matter: under 15% the
+   * lesson is not about the keys it claims to introduce, and over 35% it has
+   * stopped being typing practice and become a memory test of two keys.
+   */
+  it("keeps the new keys between 15% and 35% of the characters", () => {
+    const offenders: string[] = [];
+    for (const lesson of INTRODUCING) {
+      if (reviewAt(lesson).length === 0) continue;
+      for (const seed of SEEDS) {
+        const text = textOf(lesson, seed);
+        const share = countOf(text, lesson.introduces) / text.length;
+        if (share < MIN_NEW_SHARE || share > MAX_NEW_SHARE)
+          offenders.push(
+            `${lesson.id} seed ${seed}: ${(share * 100).toFixed(1)}%`,
+          );
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * The other side of that exception, asserted rather than assumed.
+   *
+   * Lesson 1 is the whole of it today: `f`, `j` and the space bar, so every
+   * character that is not a space is a new key by necessity. Writing it down
+   * as its own expectation is what stops "the ladder had nothing to review" —
+   * true and unavoidable at lesson 1 — from becoming a silent excuse the day
+   * somebody moves a lesson into a place where it is neither.
+   */
+  it("spends a lesson with nothing to review entirely on its new keys", () => {
+    const nothingToReview = INTRODUCING.filter(
+      (lesson) => reviewAt(lesson).length === 0,
+    );
+    expect(nothingToReview.map((lesson) => lesson.id)).toEqual(["L01"]);
+
+    for (const lesson of nothingToReview)
+      for (const seed of SEEDS) {
+        const text = textOf(lesson, seed);
+        const letters = text.replace(/ /g, "");
+        expect(countOf(letters, lesson.introduces), lesson.id).toBe(
+          letters.length,
+        );
+      }
+  });
+});
+
+describe("generate", () => {
+  /**
+   * Deterministic in `(lesson, seed)`, like every other deck on this site.
+   *
+   * Not a nicety: a lesson is re-rendered on every mount of the results screen
+   * and re-read out of the record book months later, and a run whose text
+   * changed underneath it would show a child a passage they never typed.
+   */
+  it("gives the same text for the same lesson and seed", () => {
+    for (const lesson of WITH_TEXT)
+      expect(generate(lesson, 4242)).toEqual(generate(lesson, 4242));
+  });
+
+  /**
+   * …and a different one for a different seed, or the ladder is a hundred
+   * fixed passages a child could learn by heart.
+   *
+   * Counted across the ladder rather than asserted per lesson: lesson 8 draws
+   * from ten words and lesson 1 from two keys, so a handful of collisions is
+   * the pool being small rather than the seed being ignored.
+   */
+  it("gives different text for different seeds", () => {
+    const same = WITH_TEXT.filter(
+      (lesson) => textOf(lesson, 1) === textOf(lesson, 2),
+    );
+    expect(same.length).toBeLessThan(WITH_TEXT.length / 10);
+  });
+
+  /** A storm level has a wave, not a passage (§8.3). */
+  it("gives a storm level no text at all", () => {
+    for (const lesson of LESSONS.filter((l) => l.kind.type === "storm"))
+      expect(generate(lesson, 7)).toEqual([]);
+  });
+});
+
+describe("a lesson's kind decides its text", () => {
+  const kindOf = (n: number) =>
+    LESSONS.find((lesson) => lesson.n === n) as Lesson;
+
+  /**
+   * A drill is groups of one length, so the lesson is as long in characters as
+   * `strikesFor` assumed when it sized the gate (five to a word, the space
+   * included). It is also what a drill looks like on the page.
+   */
+  it("keys · lays the new keys into even letter groups", () => {
+    for (const lesson of LESSONS.filter((l) => l.kind.type === "keys"))
+      for (const word of generate(lesson, 99))
+        expect(word.length, `${lesson.id}: ${word}`).toBe(4);
+  });
+
+  /**
+   * Lesson 8's focus is `ll`, `ss` and `dd` at nine unlocked letters, where
+   * `ss` has exactly one word in the corpus. Round-robin over the sequences is
+   * what gets that word drilled at all, so the assertion is that every focus
+   * turns up — not that the words are evenly spread.
+   */
+  it("bigrams · chooses words for the sequences they contain", () => {
+    for (const lesson of LESSONS) {
+      if (lesson.kind.type !== "bigrams") continue;
+      const words = generate(lesson, 7);
+      for (const focus of lesson.kind.focus)
+        expect(
+          words.some((word) => word.includes(focus)),
+          `${lesson.id} · ${focus}`,
+        ).toBe(true);
+      for (const word of words)
+        expect(
+          lesson.kind.focus.some((focus) => word.includes(focus)),
+          `${lesson.id}: ${word}`,
+        ).toBe(true);
+    }
+  });
+
+  /**
+   * Whole sentences, split on spaces and never on meaning. The last one may be
+   * cut short by the lesson's length; the ones before it arrive entire, which
+   * is what the first word being a sentence's first word tests for.
+   */
+  it("sentences · splits English rather than assembling it", () => {
+    const words = generate(kindOf(36), 11);
+    expect(words[0]).toMatch(/^[A-Z]/);
+    const stops = words.filter((word) => /[.?!]$/.test(word));
+    expect(stops.length).toBeGreaterThan(2);
+  });
+
+  /** Real prose from the library, long enough to be a paragraph (§5.6, 71–100). */
+  it("passage · draws whole paragraphs", () => {
+    const words = generate(kindOf(100), 3);
+    expect(words.length).toBe(150);
+    expect(words.join(" ")).toContain(". ");
+  });
+
+  /**
+   * Ages, dates, scores and prices — figures with a shape, not digits at
+   * random. Lesson 57 is the one that asks, and the hyphen has not arrived
+   * yet, so a score is absent there rather than rewritten into something a
+   * child cannot type.
+   */
+  it("numbers · gives every token a figure in it", () => {
+    for (const word of generate(kindOf(57), 5)) expect(word).toMatch(/[0-9]/);
+  });
+
+  /** Prose with numbers in it — both halves, in every lesson that asks. */
+  it("mixed · puts figures inside sentences", () => {
+    for (const n of [58, 60, 92, 95]) {
+      const words = generate(kindOf(n), 13);
+      expect(
+        words.some((word) => /[0-9]/.test(word)),
+        `L${n}`,
+      ).toBe(true);
+      expect(
+        words.filter((word) => /^[a-z]+$/.test(word)).length,
+        `L${n}`,
+      ).toBeGreaterThan(words.length / 3);
+    }
+  });
+
+  /** Short words at pace (§5.6, block 9). */
+  it("sprint · keeps the words short", () => {
+    const words = generate(kindOf(81), 21);
+    const long = words.filter((word) => word.length > 4);
+    expect(long).toEqual([]);
+  });
+
+  /**
+   * The lessons §5.6 names by their pool: "The twenty-five" is the twenty-five
+   * commonest words, and "Names, and the word I" is the names.
+   */
+  it("words · uses the pool the lesson is named after", () => {
+    const twentyFive = new Set(WORDS.slice(0, 25));
+    for (const word of generate(kindOf(41), 6))
+      expect(twentyFive).toContain(word);
+    for (const word of generate(kindOf(33), 6))
+      expect(word, `L33: ${word}`).toMatch(/^[A-Z]/);
+  });
+});
+
+describe("a bag is exhausted before it repeats", () => {
+  /**
+   * The rule the other decks follow: a run does not ask for one word four
+   * times while another never comes up. Lesson 27 draws thirty-five words from
+   * a pool of hundreds, so every one of them should be different.
+   */
+  it("never repeats a word while the pool has one left", () => {
+    const words = generate(
+      LESSONS.find((lesson) => lesson.n === 27) as Lesson,
+      55,
+    );
+    expect(new Set(words).size).toBe(words.length);
+  });
+
+  /**
+   * And where the pool is smaller than the lesson it is emptied before it is
+   * refilled, which is the only reason a tiny bag is usable at all.
+   *
+   * Lesson 8 is the smallest on the ladder: `ll`, `ss` and `dd` at nine
+   * unlocked letters is ten words in the whole corpus, one of them for `ss`.
+   * Its twenty-five slots therefore *have* to repeat — repetition is what a
+   * pairs lesson is — and what the bag rule buys is that every one of the ten
+   * is met before any of them comes round a third time.
+   */
+  it("empties a small pool before drawing from it again", () => {
+    const lesson = LESSONS.find((l) => l.n === 8) as Lesson;
+    const focus = lesson.kind.type === "bigrams" ? lesson.kind.focus : [];
+    const pool = focus.flatMap((pair) =>
+      WORDS.filter((word) => word.includes(pair) && canType(word, lesson.n)),
+    );
+    expect(pool.length).toBeGreaterThan(0);
+
+    const words = generate(lesson, 12);
+    expect(words.every((word) => /(.)\1/.test(word))).toBe(true);
+    for (const word of pool) expect(words, word).toContain(word);
+  });
+});

--- a/src/engine/typing/generate.ts
+++ b/src/engine/typing/generate.ts
@@ -1,0 +1,658 @@
+import { between, mulberry32, shuffled } from "@/engine/random";
+
+import { canType, unlockedAt } from "./keys";
+import type { Lesson } from "./lessons";
+import {
+  ALTERNATING,
+  HARD_PAIRS,
+  LEFT_HAND,
+  NAMES,
+  PASSAGES,
+  RIGHT_HAND,
+  SENTENCES,
+  WORDS,
+} from "./lexicon";
+
+/**
+ * A lesson's text, generated from its spec (docs/typing.md §5.1, §5.2, §5.3).
+ *
+ * `generate(lesson, seed)` is the whole of this module's surface, and it is
+ * deterministic in the pair: the same lesson and the same seed produce the
+ * same words in the same order, on any device, for ever. That is the rule
+ * every other deck on this site already follows — a ghost is only a race if
+ * both runs saw the same cards — and here it is also what makes a saved run
+ * legible: `Session.mode` says `typing:L07` and the seed says which lesson 7.
+ *
+ * ── Why a strategy per kind, rather than one shuffle ─────────────────────────
+ * A single "pick words the child can type" would satisfy the reachability
+ * invariant and teach almost nothing. What a lesson is *for* is written on it,
+ * and the eight kinds want eight different things:
+ *
+ *   - **keys** meets a new key, so it is letter groups in a drill rhythm,
+ *     weighted to the new keys and padded out with the ones already learnt.
+ *   - **words** wants real words, commonest first, because a child who can
+ *     type `the` fluently can type a third of English.
+ *   - **bigrams** wants words chosen *because* they carry the focus pairs, so
+ *     one hand shape comes round again and again inside ordinary spelling.
+ *   - **sentences** and **passage** want English, split on spaces and never on
+ *     meaning: that is where the space bar and the full stop get learnt.
+ *   - **numbers** and **mixed** want figures that mean something — an age, a
+ *     date, a score, a price — because random digits teach the row and nothing
+ *     else.
+ *   - **sprint** wants the short, common words, at pace.
+ *
+ * ── The three invariants this module exists to satisfy ───────────────────────
+ * §5.2, and `generate.test.ts` is where they are actually asserted:
+ *
+ *   1. **Reachability.** Every character produced satisfies `canType(ch, n)`.
+ *      Every pool is filtered through it rather than trusted, which is what
+ *      lets the ladder be re-ordered by editing one array.
+ *   2. **The new key shows up enough.** Each introduced character occurs at
+ *      least `pass.keyStrikes` times, at every seed, or the new-key gate
+ *      (§6.4) is unpassable through no fault of the child's.
+ *   3. **A lesson is mostly review.** New keys are 15–35% of the characters.
+ *
+ * The third has one exception, and it is a fact about the ladder rather than a
+ * concession by the generator: at lesson 1 the unlocked alphabet is `f`, `j`
+ * and the space bar, so there is no review to be had and the drill is all new
+ * keys. §5.5 asks for exactly that ("three lessons of `fff jjj fjf` is
+ * standard and correct"). `keyDrill` therefore spends the whole lesson on the
+ * new keys when nothing else is unlocked, and the test states the exception in
+ * the same derived terms — a lesson with review available is 15–35% new — so a
+ * re-ordered ladder that leaves lesson 40 with nothing to review is named by
+ * the test rather than quietly excused by it.
+ *
+ * ── Why this file may import the corpus ──────────────────────────────────────
+ * `local/no-corpus-in-decks` bans `lexicon.ts` and this module from every
+ * engine file the deck layer can reach, and exempts these two. The way a run
+ * gets its words is `TypingConfig.words`: the ladder screen, inside the typing
+ * island, calls `generate` and hands the result to the deck. Nothing under
+ * `decks/` ever imports this (§5.3, and the 222 KB it cost the last time).
+ */
+
+// ── The shape of a drill ─────────────────────────────────────────────────────
+
+/**
+ * Characters in a drill group: `ffjj`, `QWER`, `4545`.
+ *
+ * Four, not the three §5.1 prints, and the reason is arithmetic rather than
+ * taste. `strikesFor` in `lessons.ts` sizes the new-key gate against
+ * `wordCount × 5` characters — the words-per-minute convention, five keys to a
+ * word, the space included. Groups of three would make a lesson a fifth
+ * shorter than the gate assumes, and lesson 67 (six new symbols, ten strikes
+ * apiece) would need 60 of its 139 characters to be new: 43%, well over
+ * §5.2's ceiling, with the generator doing nothing wrong. Four plus a space is
+ * five, so the two halves of the ladder agree about how long a lesson is.
+ */
+const GROUP = 4;
+
+/**
+ * How much of a drill the new keys should be — the middle of §5.2's 15–35%.
+ *
+ * A target rather than a limit. Where the gate asks for more than this (a
+ * lesson handing over six keys at twelve strikes each), the gate wins and the
+ * lesson runs denser: a lesson nobody can pass is a worse failure than a
+ * lesson that leans hard on its new keys, and the band test is what says so
+ * out loud if the two ever stop being reconcilable.
+ */
+const TARGET_NEW_SHARE = 0.25;
+
+/**
+ * Up to this many new keys get an opening group of their own: `ffff jjjj`.
+ *
+ * A run of one key is how a key is met, and it is the first thing every typing
+ * course prints. It stops being useful when a lesson hands over eleven or
+ * fifteen keys at once — block 4's two shift lessons — where fifteen groups of
+ * `QQQQ` would be half the lesson and would spend the entire new-key budget
+ * before the drill got to using them. Those lessons take four distinct new
+ * keys per group instead, which is `QWER TASD` and reads as the drill it is.
+ */
+const RUN_KEYS_MAX = 4;
+
+// ── The shape of a word run ──────────────────────────────────────────────────
+
+/**
+ * How sharply a draw leans on the front of the corpus.
+ *
+ * `WORDS` is frequency-ordered, so `index = length × random²` is a frequency
+ * weighting and nothing more elaborate is needed: the commonest quarter of a
+ * pool takes half the draws, and the tail still turns up often enough that two
+ * seeds are not the same lesson.
+ */
+const FREQ_BIAS = 2;
+
+/**
+ * The window a `words` lesson draws inside, in words per word asked for.
+ *
+ * The coarse half of the same weighting. A lesson of thirty-five words reaching
+ * into two thousand would meet its fifteen-hundredth-commonest word about as
+ * often as anything else worth practising, and "practise the words you will
+ * actually write" is the point of a frequency-ordered corpus. The tail is not
+ * wasted: it is what the bigram lessons filter and what keeps the early
+ * alphabets from emptying.
+ */
+const WINDOW_PER_WORD = 6;
+
+/** …and never a window so small that two seeds produce the same lesson. */
+const WINDOW_MIN = 120;
+
+/** A sprint word is a short one. Five characters is a "word"; these are less. */
+const SPRINT_MAX_LEN = 4;
+
+/** Below this a filtered pool has stopped being a bag and become a loop. */
+const MIN_BAG = 12;
+
+// ── Pools that exist for one lesson ──────────────────────────────────────────
+
+/**
+ * The lessons whose subject is a particular pool, by number.
+ *
+ * `LessonKind` carries a payload for exactly one thing — `bigrams.focus` —
+ * because a title is otherwise spec enough for the generator. The eleven below
+ * are the exceptions §5.6 names in words: "The twenty-five" is the twenty-five,
+ * "Hands that take turns" is the alternating list, "Names, and the word I" is
+ * the names. The corpus was built with those lessons written on it
+ * (`lexicon.ts` says so in every one of their doc blocks), so the table that
+ * connects them lives here, beside the only module that reads it, rather than
+ * as a second payload on a type the deck layer imports.
+ *
+ * Keyed by `n` for the same reason `BIGRAMS` in `lessons.ts` is: a row of §5.6
+ * carries its number with it, and a lesson that is genuinely re-numbered has
+ * changed which lesson it is.
+ */
+type Source = (lesson: Lesson, rand: () => number) => readonly string[];
+
+/** Lesson 41, "The twenty-five", and lesson 48, "The hundred". A slice. */
+const TOP_TWENTY_FIVE = WORDS.slice(0, 25);
+const TOP_HUNDRED = WORDS.slice(0, 100);
+
+/** Lesson 47, "One hand at a time" — both hands' lists, one after the other. */
+const ONE_HAND = [...LEFT_HAND, ...RIGHT_HAND];
+
+/** Lesson 33, "Names, and the word I". The one capital English insists on. */
+const NAMES_AND_I = ["I", ...NAMES];
+
+/** Lesson 84, "Sprint · The hard pairs" — the same words lesson 44 drills. */
+const HARD_PAIR_WORDS = WORDS.filter((word) =>
+  HARD_PAIRS.some((pair) => word.includes(pair)),
+);
+
+const POOLS = new Map<number, Source>([
+  [33, () => NAMES_AND_I],
+  [41, () => TOP_TWENTY_FIVE],
+  [46, () => ALTERNATING],
+  [47, () => ONE_HAND],
+  [48, () => TOP_HUNDRED],
+  // "The sight words, again" — which is what the front of a frequency-ordered
+  // corpus is. The list is not repeated anywhere; it is the same hundred.
+  [74, () => TOP_HUNDRED],
+  [82, () => ALTERNATING],
+  [84, () => HARD_PAIR_WORDS],
+  // "Sprint · Capitals": every name is a capital with a reason to be there.
+  [85, () => NAMES],
+  [86, (lesson, rand) => figures(lesson, rand, lesson.wordCount) ?? []],
+  [87, (lesson) => punctuated(lesson)],
+]);
+
+// ── Bags ─────────────────────────────────────────────────────────────────────
+
+/**
+ * A bag that is emptied before it is refilled — the rule the other decks
+ * follow, so a short lesson never asks for one word four times while another
+ * never comes up at all.
+ *
+ * Refilling reshuffles, so a pool smaller than the lesson repeats in a
+ * different order each time round rather than looping.
+ */
+function bag<T>(items: readonly T[], rand: () => number): () => T {
+  let deck: T[] = [];
+  let next = 0;
+  return () => {
+    if (next >= deck.length) {
+      deck = shuffled(items, rand);
+      next = 0;
+    }
+    return deck[next++];
+  };
+}
+
+/**
+ * The same rule, with the draw weighted towards the front of the pool.
+ *
+ * Frequency weighting and bag exhaustion pull against each other — the first
+ * wants `the` often, the second wants it once — so the compromise is drawing
+ * *without replacement* from a biased index: every word is gone until the bag
+ * is empty, and which one goes first is decided by how common it is.
+ */
+function frequencyBag(
+  pool: readonly string[],
+  rand: () => number,
+): () => string {
+  let rest: string[] = [];
+  return () => {
+    if (rest.length === 0) rest = pool.slice();
+    return rest.splice(Math.floor(rest.length * rand() ** FREQ_BIAS), 1)[0];
+  };
+}
+
+// ── Filtering a pool onto a lesson's alphabet ────────────────────────────────
+
+/**
+ * Lowercase the characters this lesson has not been given, and only those.
+ *
+ * The sentence pool holds English as it is printed — a capital at the front, a
+ * name in the middle — because it has to still be English at lesson 40. Lesson
+ * 30 asks for sentences a whole block before either shift is taught, and
+ * folding the case for it is this module's job (`lexicon.ts` says as much):
+ * the unlocked alphabet is in hand here and is not in the corpus.
+ *
+ * Conditional on the character rather than on the lesson, so the fold is a
+ * no-op the moment block 4 has run and a sentence keeps its capitals for the
+ * seventy lessons after it. What folding cannot rescue — a digit, a hyphen, a
+ * speech mark — is left alone and dropped by the filter below.
+ */
+function fold(text: string, n: number): string {
+  const alphabet = unlockedAt(n);
+  let out = "";
+  for (const ch of text) out += alphabet.has(ch) ? ch : ch.toLowerCase();
+  return out;
+}
+
+/**
+ * A pool filtered onto a lesson's alphabet, remembered.
+ *
+ * The reachability test generates every lesson at many seeds, and each
+ * generation would otherwise walk two thousand words character by character.
+ * The ladder and the corpus are both fixed at module load, so the answer is
+ * too; a `WeakMap` keyed by the pool means a caller can hand over a slice
+ * without leaking it for the life of the process.
+ */
+const FILTERED = new WeakMap<
+  readonly string[],
+  Map<string, readonly string[]>
+>();
+
+function filtered(
+  pool: readonly string[],
+  n: number,
+  prose: boolean,
+): readonly string[] {
+  let byLesson = FILTERED.get(pool);
+  if (!byLesson) {
+    byLesson = new Map();
+    FILTERED.set(pool, byLesson);
+  }
+  const key = `${n}:${prose ? "p" : "w"}`;
+  const cached = byLesson.get(key);
+  if (cached) return cached;
+
+  const usable = (prose ? pool.map((text) => fold(text, n)) : pool).filter(
+    (text) => canType(text, n),
+  );
+  byLesson.set(key, usable);
+  return usable;
+}
+
+/** Words a child at lesson `n` can spell, exactly as the corpus writes them. */
+const spellable = (pool: readonly string[], n: number) =>
+  filtered(pool, n, false);
+
+/** Prose a child at lesson `n` can type, once its case has been folded. */
+const readable = (pool: readonly string[], n: number) =>
+  filtered(pool, n, true);
+
+// ── keys · letter groups in a drill rhythm ───────────────────────────────────
+
+/**
+ * `ffff jjjj fjfj fdfd dkdk` — a new key, met and then used.
+ *
+ * Three sorts of group, in the proportions §5.2's band asks for:
+ *
+ *   - **new**, four characters of the keys that arrived today. One run per key
+ *     opens the lesson, and the rest are woven so a pair alternates.
+ *   - **mixed**, two new and two already learnt, which is the actual exercise:
+ *     the finger has to come back to the new key from somewhere.
+ *   - **review**, four characters of two older keys, which is what the other
+ *     two thirds of the lesson are made of.
+ *
+ * The new characters come off a round-robin over the day's keys, so a lesson
+ * introducing fifteen capitals spreads them evenly rather than spending its
+ * budget on the first three: every key ends up with `floor(target / keys)` at
+ * worst, which is what makes the `keyStrikes` guarantee provable rather than
+ * lucky. The groups are then shuffled — after the opening runs, which stay
+ * where a child will meet them first.
+ */
+function keyDrill(lesson: Lesson, rand: () => number): string[] {
+  const alphabet = unlockedAt(lesson.n);
+  // Through the alphabet rather than straight off the row: a character its own
+  // lesson cannot strike — a capital before either shift is taught — must not
+  // reach the text, and the `keyStrikes` test is what reports it.
+  const fresh = lesson.introduces.filter((ch) => alphabet.has(ch));
+  const older = [...alphabet].filter((ch) => ch !== " " && !fresh.includes(ch));
+
+  const slots = lesson.wordCount * GROUP;
+  // The lesson's length in characters, spaces between the groups included —
+  // the denominator §5.2's band is a share of.
+  const chars = slots + lesson.wordCount - 1;
+  const strikes = lesson.pass.kind === "lesson" ? lesson.pass.keyStrikes : 0;
+  const wanted = Math.max(
+    Math.round(chars * TARGET_NEW_SHARE),
+    fresh.length * strikes,
+  );
+  // Nothing to review is not an error, it is lesson 1: the whole drill is the
+  // two keys it hands over, because the alphabet is those two keys.
+  const target =
+    fresh.length === 0
+      ? 0
+      : older.length === 0
+        ? slots
+        : Math.min(wanted, slots);
+
+  // Half the new characters in groups of their own and half in company, which
+  // is `4a + 2b = target` with `a = b`. The odd character left over when the
+  // target is odd takes a group with three review characters.
+  const pure = older.length === 0 ? lesson.wordCount : Math.floor(target / 6);
+  const paired = Math.floor((target - pure * GROUP) / 2);
+  const single = (target - pure * GROUP) % 2;
+  const runs =
+    fresh.length <= RUN_KEYS_MAX && pure >= fresh.length ? fresh.length : 0;
+
+  const order = shuffled(fresh, rand);
+  let turn = 0;
+  const nextFresh = (count: number) =>
+    Array.from({ length: count }, () => order[turn++ % order.length]);
+
+  const draw = bag(older.length > 0 ? older : fresh, rand);
+  const nextOlder = (count: number) => Array.from({ length: count }, draw);
+  // Two keys, twice each: `dkdk`, `ddkk`, `kddk`. A review group is a rhythm
+  // rather than four characters at random, because that is what a drill line
+  // in a typing course looks like and it is easier to read back.
+  const pair = () => {
+    const [x, y] = nextOlder(2);
+    return [x, x, y, y];
+  };
+
+  const groups: string[] = [];
+  for (let i = 0; i < runs; i++) groups.push(order[i].repeat(GROUP));
+  for (let i = runs; i < pure; i++)
+    groups.push(shuffled(nextFresh(GROUP), rand).join(""));
+  for (let i = 0; i < paired; i++)
+    groups.push(shuffled([...nextFresh(2), ...nextOlder(2)], rand).join(""));
+  if (single === 1)
+    groups.push(shuffled([...nextFresh(1), ...nextOlder(3)], rand).join(""));
+  while (groups.length < lesson.wordCount)
+    groups.push(shuffled(pair(), rand).join(""));
+
+  return [...groups.slice(0, runs), ...shuffled(groups.slice(runs), rand)];
+}
+
+// ── words, bigrams and sprints · the corpus, filtered ────────────────────────
+
+/** `count` words drawn out of a pool, or null if the pool is empty. */
+function drawWords(
+  pool: readonly string[],
+  count: number,
+  rand: () => number,
+): string[] | null {
+  if (pool.length === 0) return null;
+  const draw = frequencyBag(pool, rand);
+  return Array.from({ length: count }, () => draw());
+}
+
+/**
+ * Real words, commonest first, that this lesson's alphabet can spell.
+ *
+ * The pool is the lesson's own if §5.6 gave it one, and the corpus otherwise,
+ * narrowed to a window whose size follows the lesson's length. Both halves are
+ * frequency weighting: which words are in the bag, and which of them is drawn
+ * first.
+ */
+function wordRun(lesson: Lesson, rand: () => number): string[] | null {
+  const source = POOLS.get(lesson.n);
+  const pool = spellable(source ? source(lesson, rand) : WORDS, lesson.n);
+  const window = source
+    ? pool
+    : pool.slice(0, Math.max(WINDOW_MIN, lesson.wordCount * WINDOW_PER_WORD));
+  return drawWords(window, lesson.wordCount, rand);
+}
+
+/**
+ * Words chosen *because* they contain the focus sequences.
+ *
+ * Round-robin over the sequences rather than one pooled bag, so `th`, `he`,
+ * `er` and `re` each get a quarter of the lesson however many words the corpus
+ * offers for them. Lesson 8 is the case that shapes this: at nine letters
+ * unlocked, `ss` has exactly one word in the whole corpus, and a pooled draw
+ * would spend the lesson on `ll` and never drill the pair a child is there for.
+ */
+function bigramRun(
+  lesson: Lesson,
+  focus: readonly string[],
+  rand: () => number,
+): string[] | null {
+  const bags = focus
+    .map((pair) =>
+      spellable(
+        WORDS.filter((word) => word.includes(pair)),
+        lesson.n,
+      ),
+    )
+    .filter((pool) => pool.length > 0)
+    .map((pool) => frequencyBag(pool, rand));
+  if (bags.length === 0) return null;
+  return Array.from({ length: lesson.wordCount }, (_, i) =>
+    bags[i % bags.length](),
+  );
+}
+
+/**
+ * Short, common words at pace.
+ *
+ * The length filter is a preference, not a rule: lesson 85 sprints names and
+ * lesson 82 the alternating list, and a pool that the filter cuts below a
+ * bagful is used whole rather than turned into a loop of six words.
+ */
+function sprintRun(lesson: Lesson, rand: () => number): string[] | null {
+  const source = POOLS.get(lesson.n);
+  const pool = spellable(source ? source(lesson, rand) : WORDS, lesson.n);
+  const short = pool.filter((word) => word.length <= SPRINT_MAX_LEN);
+  const window = short.length >= MIN_BAG ? short : pool;
+  return drawWords(
+    window.slice(0, Math.max(WINDOW_MIN, lesson.wordCount * WINDOW_PER_WORD)),
+    lesson.wordCount,
+    rand,
+  );
+}
+
+/**
+ * Lesson 87, "Sprint · Punctuation" — short words wearing the marks.
+ *
+ * The marks are whatever the ladder has taught by then, which is all of them
+ * at lesson 87 and would be a comma and a full stop at lesson 30. Nothing is
+ * invented: the words are the corpus's and the marks are the alphabet's, so
+ * the pool cannot outrun the reachability invariant.
+ */
+function punctuated(lesson: Lesson): readonly string[] {
+  const alphabet = unlockedAt(lesson.n);
+  const marks = [...".,?!;:"].filter((mark) => alphabet.has(mark));
+  if (marks.length === 0) return [];
+  const short = spellable(WORDS, lesson.n)
+    .filter((word) => word.length <= SPRINT_MAX_LEN)
+    .slice(0, WINDOW_MIN);
+  return short.map((word, i) => word + marks[i % marks.length]);
+}
+
+// ── sentences and passages · English, split on spaces ────────────────────────
+
+/**
+ * Whole sentences, or whole passages, split into the words they are made of.
+ *
+ * Never split on meaning: a sentence goes in entire, so the capital at the
+ * front and the stop at the end land where a child expects them. The only cut
+ * is the last one, where the lesson reaches its length mid-sentence — the same
+ * trade `decks/typing.ts` makes, and for the same reason: a passage that stops
+ * mid-sentence is better than one that starts mid-sentence.
+ */
+function proseRun(
+  lesson: Lesson,
+  pool: readonly string[],
+  rand: () => number,
+): string[] | null {
+  const usable = readable(pool, lesson.n);
+  if (usable.length === 0) return null;
+  const draw = bag(usable, rand);
+  const words: string[] = [];
+  while (words.length < lesson.wordCount) words.push(...draw().split(" "));
+  return words;
+}
+
+// ── numbers and mixed · figures that mean something ──────────────────────────
+
+/**
+ * The figures a lesson can be built out of, and what each one costs.
+ *
+ * Ages, dates, scores and prices (§5.6, lesson 57) rather than digits at
+ * random: a date has a shape, and typing `14/6/2019` teaches the number row
+ * *and* the reach to the slash in the order a child will actually need them.
+ * `needs` is the punctuation the shape cannot be written without, checked
+ * against the unlocked alphabet before the shape is offered — which is why a
+ * score is absent until the hyphen arrives at lesson 63 rather than being
+ * quietly rewritten as two separate numbers.
+ */
+const FIGURES: { needs: string; make: (rand: () => number) => string }[] = [
+  /** An age. */
+  { needs: "", make: (rand) => `${between(5, 12, rand)}` },
+  /** A year — a birthday, a date on a coin. */
+  { needs: "", make: (rand) => `${between(1990, 2026, rand)}` },
+  /** How many of something. */
+  { needs: "", make: (rand) => `${between(11, 99, rand)}` },
+  /** A date. */
+  {
+    needs: "/",
+    make: (rand) =>
+      `${between(1, 28, rand)}/${between(1, 12, rand)}/${between(1990, 2026, rand)}`,
+  },
+  /** A price. */
+  {
+    needs: ".",
+    make: (rand) =>
+      `${between(1, 30, rand)}.${String(between(0, 99, rand)).padStart(2, "0")}`,
+  },
+  /** A time. */
+  {
+    needs: ":",
+    make: (rand) =>
+      `${between(1, 12, rand)}:${String(between(0, 59, rand)).padStart(2, "0")}`,
+  },
+  /** A score. */
+  {
+    needs: "-",
+    make: (rand) => `${between(0, 9, rand)}-${between(0, 9, rand)}`,
+  },
+];
+
+/**
+ * `count` figures this lesson can type, or null if it can type none.
+ *
+ * Every token is checked rather than trusted: `needs` clears the punctuation,
+ * and `canType` clears the digits, which is what keeps a number lesson honest
+ * on a ladder where the number row arrives two keys at a time.
+ */
+function figures(
+  lesson: Lesson,
+  rand: () => number,
+  count: number,
+): string[] | null {
+  const alphabet = unlockedAt(lesson.n);
+  const usable = FIGURES.filter((figure) =>
+    [...figure.needs].every((ch) => alphabet.has(ch)),
+  );
+  if (usable.length === 0) return null;
+
+  const out: string[] = [];
+  for (let tries = 0; out.length < count && tries < count * 8; tries++) {
+    const token = usable[Math.floor(rand() * usable.length)].make(rand);
+    if (canType(token, lesson.n)) out.push(token);
+  }
+  return out.length >= count ? out : null;
+}
+
+/**
+ * Prose with numbers in it — a sentence that carries a figure, then one that
+ * does not, so the digits are spread through the lesson rather than heaped at
+ * one end.
+ *
+ * The corpus grades its sentences by what they hold and the number-bearing
+ * ones are the last band, so they are a filter here rather than a second pool.
+ * Where the ladder has digits but the pool has no sentence a child can yet
+ * read, a pair of generated figures stands in — the lesson is still words and
+ * numbers together, which is what its title promises.
+ */
+const NUMERIC_SENTENCES = SENTENCES.filter((text) => /[0-9]/.test(text));
+const PLAIN_SENTENCES = SENTENCES.filter((text) => !/[0-9]/.test(text));
+
+function mixedRun(lesson: Lesson, rand: () => number): string[] | null {
+  const plain = readable(PLAIN_SENTENCES, lesson.n);
+  if (plain.length === 0) return null;
+  const numeric = readable(NUMERIC_SENTENCES, lesson.n);
+  const drawPlain = bag(plain, rand);
+  const drawNumeric = numeric.length > 0 ? bag(numeric, rand) : null;
+
+  const words: string[] = [];
+  while (words.length < lesson.wordCount) {
+    words.push(
+      ...(drawNumeric
+        ? drawNumeric().split(" ")
+        : (figures(lesson, rand, 2) ?? [])),
+    );
+    words.push(...drawPlain().split(" "));
+  }
+  return words;
+}
+
+// ── The front door ───────────────────────────────────────────────────────────
+
+/** The strategy a lesson's kind asks for, or null if its pool came up empty. */
+function forKind(lesson: Lesson, rand: () => number): string[] | null {
+  switch (lesson.kind.type) {
+    case "keys":
+      return keyDrill(lesson, rand);
+    case "words":
+      return wordRun(lesson, rand);
+    case "bigrams":
+      return bigramRun(lesson, lesson.kind.focus, rand);
+    case "sentences":
+      return proseRun(lesson, SENTENCES, rand);
+    case "passage":
+      return proseRun(lesson, PASSAGES, rand);
+    case "numbers":
+      return figures(lesson, rand, lesson.wordCount);
+    case "mixed":
+      return mixedRun(lesson, rand);
+    case "sprint":
+      return sprintRun(lesson, rand);
+    case "storm":
+      // A storm level has no passage. Its length is its wave's, and `wordCount`
+      // is already 0 — this is here so the switch is exhaustive rather than
+      // because anything asks.
+      return [];
+  }
+}
+
+/**
+ * The words of `lesson`, at `seed`. Deterministic in the pair, and total.
+ *
+ * Two fallbacks under the strategy, because a lesson that cannot find its own
+ * material must still produce text a child can type: prose falls back to
+ * words, and words to a drill of the keys unlocked so far. Neither fires on
+ * today's ladder — every lesson's own pool is stocked, and `lexicon.test.ts`
+ * counts them — and both exist because the alternative to a fallback is an
+ * empty passage in front of a seven-year-old, or a loop that never fills.
+ */
+export function generate(lesson: Lesson, seed: number): string[] {
+  if (lesson.wordCount <= 0) return [];
+  const rand = mulberry32(seed);
+  const text =
+    forKind(lesson, rand) ?? wordRun(lesson, rand) ?? keyDrill(lesson, rand);
+  return text.slice(0, lesson.wordCount);
+}

--- a/src/engine/typing/keys.test.ts
+++ b/src/engine/typing/keys.test.ts
@@ -117,6 +117,12 @@ describe("unlockedAt", () => {
     expect(chars(unlockedAt(101))).toBe(chars(unlockedAt(100)));
     expect(chars(unlockedAt(1e6))).toBe(chars(unlockedAt(100)));
     expect(chars(unlockedAt(10.9))).toBe(chars(unlockedAt(10)));
+    // Off the end is off the end however far off it is, which is what the doc
+    // block says and what `NaN` — a mode string that did not parse — is not.
+    expect(chars(unlockedAt(Number.POSITIVE_INFINITY))).toBe(
+      chars(unlockedAt(100)),
+    );
+    expect(chars(unlockedAt(Number.NEGATIVE_INFINITY))).toBe(" ");
   });
 });
 

--- a/src/engine/typing/keys.ts
+++ b/src/engine/typing/keys.ts
@@ -152,8 +152,11 @@ const ALPHABETS: readonly ReadonlySet<string>[] = (() => {
  * whole alphabet and one before the start is the space bar, for the same
  * reason `deckSpec(mode)` never throws — a saved session outlives the ladder
  * it was run on, and a record book from two re-tunings ago still has to open.
- * A number parsed out of one of those saved modes can be `NaN`, which clamps
- * to nothing at all rather than to an alphabet somebody was never given.
+ * `Infinity` is off the end like any other overshoot, and `-Infinity` is
+ * before the start; only `NaN` is turned away, because it is not a lesson
+ * number that missed but a `Number("L7x")` that failed, and the safe answer to
+ * a question nobody asked is nothing at all rather than an alphabet somebody
+ * was never given.
  *
  * The set is shared, not copied. It is `ReadonlySet` because every caller
  * reads it; one that mutates it would be editing the curriculum for everybody
@@ -161,7 +164,7 @@ const ALPHABETS: readonly ReadonlySet<string>[] = (() => {
  */
 export function unlockedAt(n: number): ReadonlySet<string> {
   const last = ALPHABETS.length - 1;
-  const i = Number.isFinite(n) ? Math.min(Math.max(Math.floor(n), 0), last) : 0;
+  const i = Number.isNaN(n) ? 0 : Math.min(Math.max(Math.floor(n), 0), last);
   return ALPHABETS[i];
 }
 


### PR DESCRIPTION
`docs/typing.md` §5.1 says a lesson is a spec and its text is generated; §5.2
names the three invariants that make a hundred generated lessons safe to ship
to a five-year-old. This story is `src/engine/typing/generate.ts` and the test
file that holds those three invariants down. Closes #138. Design:
`docs/typing.md` §5.1, §5.2, §5.3.

This is the payoff story of phase 0. #135 gave it a hundred specs to walk, #136
gave it `canType` — the question to ask of every character — and #137 gave it a
corpus to answer with. None of those three could be checked against anything
until there was text. Now they can, and the answer is that the ladder is
*editable*: move a lesson, re-order a block, hand a key over two lessons
earlier, and either the text follows or one line of a test names the lesson it
stopped following at.

## The three invariants, and what "holds" means

All three hold over **every lesson × every seed tried** — 200 seeds while this
was being written, 500 independently in review — with zero failures of any
kind:

| | what it asserts | failures |
|---|---|---|
| **Reachability** | every character satisfies `canType(ch, n)` | 0 |
| **Strike floor** | every introduced key struck ≥ `pass.keyStrikes` times | 0 |
| **The band** | new keys are 15–35% of the characters | 0 |

The committed test runs 16 spread seeds rather than 500, because sixteen
hundred generations run in under a second and CI is a gate rather than a
search. The seeds are spread (`42`, `65535`, `2147483647`) rather than `0–15`:
`mulberry32` is well-behaved over neighbouring seeds, but the numbers a real
run uses come from `randomSeed()` and look nothing like a counter.

Failures are collected rather than thrown at the first one. "Lessons 61, 63 and
67 are short of strikes" is a finding about the ladder; "lesson 61 is" is a bug
report you get to fix three times.

## The strike floor is algebraic, not probabilistic

The second invariant is the one that would otherwise be a coin toss, and it is
the one a child meets worst: the new-key gate (§6.4) waits for `keyStrikes`
strikes of each new character before it will judge that key at all, so a lesson
whose text came up short **cannot be passed however well it is typed** — and
the child has no way of knowing why, because everything they typed was right.

So `keyDrill` does not sample and hope. It sizes the drill first:

```ts
const wanted = Math.max(
  Math.round(chars * TARGET_NEW_SHARE),   // 25% — the middle of §5.2's band
  fresh.length * strikes,                 // …or the gate, whichever is larger
);
```

then round-robins the fresh characters into those slots, so each new key gets
its share of a total that already covers the gate. The minimum is structural.
No seed can be unlucky, because no seed decides how many new characters there
are — only which order they arrive in. `TARGET_NEW_SHARE` is a target rather
than a limit for exactly this reason: where the gate asks for more than 25%
(six keys at twelve strikes), the gate wins and the lesson runs denser, and the
band test is what says so out loud if the two ever stop being reconcilable.

## Lesson 1 is the one exception, and it is derived

At lesson 1 the unlocked alphabet is `f`, `j` and the space bar. There is no
review to be had, so "15–35% new keys" is not merely undesirable there — it is
**arithmetically impossible**, and §5.5 asks for precisely what the ladder does
instead: "three lessons of `fff jjj fjf` is standard and correct".

The excused set is therefore computed from `unlockedAt(lesson.n)` minus
`lesson.introduces` — a lesson is excused when the ladder has given it nothing
to review — and never from a list of lesson numbers somebody typed. What it is
excused *into* is a stronger claim, asserted rather than skipped: every
non-space character is a new key, 100%, at every seed.

Then the derived set is pinned:

```ts
expect(nothingToReview.map((lesson) => lesson.id)).toEqual(["L01"]);
```

That line is the tripwire and it is the point of the whole arrangement. A
re-ordered ladder that strands lesson 40 with nothing to review does not get
quietly waved through the band test by the same clause that legitimately
excuses lesson 1 — it fails, by name, on the pin. The exception stays one
lesson wide unless somebody changes it on purpose.

## A drill group is four characters, not the three §5.1 prints

`GROUP = 4` (`ffjj`, `QWER`, `4545`), and the reason is arithmetic rather than
taste.

`strikesFor` in `lessons.ts` sizes the new-key gate against `wordCount × 5`
characters — the words-per-minute convention, five keys to a word with the
space included. Groups of three make a lesson a fifth shorter than the gate
assumed it would be, and the two halves of the ladder then disagree about how
long a lesson is. Lesson 67 is where that disagreement becomes visible: six new
symbols at ten strikes each is 60 required characters, and at `GROUP = 3` the
lesson is 35 groups plus 34 spaces — 139 characters. 60/139 is **43.2%**, well
outside §5.2's ceiling, with the generator doing nothing wrong and no seed to
blame.

Four plus a space is five. The gate's assumption and the drill's length are the
same number again, and lesson 67 lands inside the band without special-casing.

## `unlockedAt(Infinity)` now does what its docstring always said

`keys.ts` documented "one past the end is the whole alphabet", and the guard
was `Number.isFinite(n) ? clamp : 0` — so `Infinity`, the most literal way to
ask for one past the end, fell into the `NaN` branch and returned lesson 0: the
space bar. The doc block was right and the code was wrong, so the code moved:

```ts
const i = Number.isNaN(n) ? 0 : Math.min(Math.max(Math.floor(n), 0), last);
```

`NaN` is still turned away, and the docstring now says why it is the only one:
it is not a lesson number that overshot but a `Number("L7x")` that failed, and
the safe answer to a question nobody asked is nothing at all rather than an
alphabet somebody was never given. `-Infinity` clamps to the space bar like any
other undershoot. Softening the docstring to match the code was the other
option available and it was the wrong one — no caller wants `Infinity` to mean
"beginner".

## The strategies

Eight kinds, eight strategies, because "pick words the child can type" would
satisfy reachability and teach almost nothing:

- **keys** — even letter groups in a drill rhythm, weighted to the new keys. Up
  to four new keys get an opening run of their own (`ffff jjjj`); past that —
  block 4's shift lessons hand over eleven and fifteen at once — fifteen groups
  of `QQQQ` would be half the lesson, so those take four distinct new keys per
  group and read as `QWER TASD`.
- **words** — real words, frequency-weighted via `index = length × random²`, so
  the commonest quarter takes half the draws and the tail still shows up.
- **bigrams** — words chosen *because* they carry the focus pairs, round-robin
  over the sequences. Lesson 8 is why: `ll`, `ss` and `dd` at nine unlocked
  letters is ten words in the whole corpus, and `ss` has exactly one. Without
  the round robin that word never gets drilled.
- **sentences** / **passage** — English split on spaces, never on meaning.
- **numbers** / **mixed** — ages, dates, scores and prices. Lesson 57 asks for
  figures before the hyphen has been taught, so a score is simply absent there
  rather than rewritten into something a child cannot type.
- **sprint** — the short, common words at pace.
- **storm** levels get no text at all; they have a wave (§8.3).

A word bag is exhausted before it repeats, the rule the other decks already
follow. Lesson 27 draws 35 words from hundreds and repeats none; lesson 8 draws
25 from ten and *has* to repeat — repetition is what a pairs lesson is — and
what the bag buys there is that all ten are met before any comes round a third
time.

## Scope

Engine only. No game, no storage, no `DB_VERSION`, no component. Wiring this
into a run is #139 (LES05) — nothing calls `generate` yet. The corpus ban from
#137 needed no edit: `generate.ts` was already exempt from
`local/no-corpus-in-decks` and already named in its message, so this landed
without touching `eslint.config.mjs` and without a byte reaching the shared
deck chunk.

## Tests

`generate.test.ts`, 380 lines. The three invariants above, plus: exact
`wordCount` per lesson at every seed (the wpm bar in §6.3 is computed against
it, so a lesson nine words short would report a speed nobody typed);
determinism in `(lesson, seed)`, and non-determinism across seeds counted over
the ladder rather than per lesson, since lesson 8's ten-word pool colliding is
the pool being small and not the seed being ignored; and one case per kind
asserting it did the thing it is named after.

`keys.test.ts` gains the two ends: `unlockedAt(+Infinity)` is the full ladder
alphabet, `unlockedAt(-Infinity)` is the space bar.

`type-check` 0 errors · `lint` clean · `test:unit` **1726 passed** · `build`
static, 200 pages
