### PR TITLE
Race a lesson against your own lesson, not against its passage

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -335,7 +335,7 @@ lesson declares what it is _for_, and the words are produced from that:
 
 ```ts
 export type LessonKind =
-  | { type: "keys" } // letter groups: fff jjj fjf jfj
+  | { type: "keys" } // letter groups: ffff jjjj fjfj jfjf
   | { type: "words" } // words from the unlocked alphabet
   | { type: "bigrams"; focus: string[] } // words chosen to drill sequences
   | { type: "sentences" }
@@ -366,6 +366,16 @@ export type Lesson = {
 The **unlocked alphabet** at lesson _n_ is the union of `introduces` over
 lessons 1…_n_, plus space. It is computed, never written down, so moving a
 lesson moves its words with it.
+
+A drill group is **four** characters, not three, and that is arithmetic rather
+than taste: four plus the space that follows it is five, which is the
+words-per-minute convention `wordCount` is counted in, so a `keys` lesson runs
+to `wordCount × 5` characters like every other kind. That is the same figure
+`strikesFor` sizes the new-key gate against, and at three the two would
+disagree. Lesson 67 hands over six symbols and asks ten strikes of each: 60
+new characters out of the 174 that 35 groups of four and their spaces come to
+is 34%, inside §5.2's 15–35% band; out of the 139 that groups of three would
+leave, it is 43%, above the band with the generator blameless.
 
 ### 5.2 · The invariant that makes a hundred lessons safe
 

--- a/src/engine/decks/configkey.test.ts
+++ b/src/engine/decks/configkey.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import { TYPING_LEVELS } from "./typing";
+import { configKey } from "./index";
+import type { LegacyFlashConfig, RaceConfig } from "@/engine/types";
+
+/**
+ * The keys already in IndexedDB, frozen.
+ *
+ * `configKey` decides which runs may race each other as ghosts (CLAUDE.md), and
+ * a child's record book is the only copy there is — there is no server holding
+ * a second one and no deploy that can go back and rewrite it. So a change to
+ * the format doesn't fail loudly: every personal best saved under the old key
+ * is simply never found again, and a seven-year-old is told they have no best
+ * time on a level they have run twenty times.
+ *
+ * Every literal below is a key some child's run is filed under today. They are
+ * transcribed, not generated — a table built by calling the same function it
+ * checks would agree with any format at all. **If one of these fails, the
+ * change is wrong; the expectation is not.**
+ *
+ * The families each get their optional segments covered, because those are
+ * where a key grows: the clock and the explicit word set are appended only
+ * when they are in play, which is what keeps a run saved before either existed
+ * filed where it has always been.
+ */
+
+/** A config as it sits in storage, with the key it has always produced. */
+type Frozen = [name: string, config: RaceConfig, key: string];
+
+/**
+ * Arithmetic, which predates the union and so carries no `kind` (§decks/index).
+ *
+ * The second is older still: a config written before `others` replaced the
+ * min/max range, which `readConfig` widens on the way past. It is a shape
+ * TypeScript no longer describes — that is the point of pinning it — so it is
+ * cast in rather than declared.
+ */
+const legacyRange: LegacyFlashConfig = {
+  operation: "add",
+  tables: [3],
+  otherMin: 1,
+  otherMax: 5,
+  cardCount: 10,
+  inputMode: "choose",
+};
+
+const FROZEN: Frozen[] = [
+  [
+    "arithmetic, no kind",
+    {
+      operation: "multiply",
+      tables: [7],
+      others: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      cardCount: 20,
+      inputMode: "type",
+    },
+    "multiply|7|1.2.3.4.5.6.7.8.9.10.11.12|20|type",
+  ],
+  [
+    "arithmetic, timed",
+    {
+      operation: "subtract",
+      tables: [4, 2],
+      others: [3, 1],
+      cardCount: 12,
+      inputMode: "type",
+      timeLimitMs: 8000,
+    },
+    "subtract|2.4|1.3|12|type|t8000",
+  ],
+  [
+    "arithmetic, a drill of the facts a player keeps missing",
+    {
+      operation: "multiply",
+      tables: [7],
+      others: [1, 2, 3],
+      cardCount: 6,
+      inputMode: "type",
+      facts: [
+        [7, 8],
+        [6, 9],
+      ],
+    },
+    "multiply|7|1.2.3|6|type|f6:9,7:8",
+  ],
+  [
+    "arithmetic, written before `others` existed",
+    legacyRange as unknown as RaceConfig,
+    "add|3|1.2.3.4.5|10|choose",
+  ],
+  [
+    "words, a shipped list",
+    { kind: "words", listId: "dolch-1", cardCount: 12, inputMode: "choose" },
+    "words|dolch-1|12|choose",
+  ],
+  [
+    "words, timed",
+    {
+      kind: "words",
+      listId: "dolch-2",
+      cardCount: 20,
+      inputMode: "type",
+      timeLimitMs: 6000,
+    },
+    "words|dolch-2|20|type|t6000",
+  ],
+  [
+    "words, a list a parent typed in",
+    {
+      kind: "words",
+      listId: "custom-abc",
+      cardCount: 8,
+      inputMode: "type",
+      words: ["Because", "thought", "friend"],
+    },
+    "words|custom-abc|8|type|wbecause,friend,thought",
+  ],
+  // Every level this build ships, at the setup screen's default length. The
+  // ladder's lesson ids (`L07`) are a second namespace inside the same prefix,
+  // and nothing here can collide with one — no shipped level id starts with an
+  // L and a digit — which is what lets a lesson key without touching these.
+  [
+    "typing, home row",
+    { kind: "typing", levelId: "home-row", wordCount: 30 },
+    "typing|home-row|30",
+  ],
+  [
+    "typing, top row",
+    { kind: "typing", levelId: "top-row", wordCount: 30 },
+    "typing|top-row|30",
+  ],
+  [
+    "typing, every letter",
+    { kind: "typing", levelId: "common", wordCount: 30 },
+    "typing|common|30",
+  ],
+  [
+    "typing, sentences",
+    { kind: "typing", levelId: "sentences", wordCount: 30 },
+    "typing|sentences|30",
+  ],
+  [
+    "typing, verses",
+    { kind: "typing", levelId: "scripture", wordCount: 80 },
+    "typing|scripture|80",
+  ],
+  [
+    "typing, a drill of the words a player keeps fumbling",
+    {
+      kind: "typing",
+      levelId: "home-row",
+      words: ["ask", "add"],
+      wordCount: 10,
+    },
+    "typing|home-row|10|wadd,ask",
+  ],
+];
+
+describe("the keys already saved", () => {
+  for (const [name, config, key] of FROZEN) {
+    it(`is unchanged for ${name}`, () => {
+      expect(configKey(config)).toBe(key);
+    });
+  }
+
+  it("pins every typing level this build ships", () => {
+    // So that a level added later arrives with its own line above rather than
+    // quietly untested — the table is only a promise if it is complete.
+    const pinned = new Set(FROZEN.map(([, , key]) => key.split("|")[1]));
+    for (const level of TYPING_LEVELS) expect(pinned.has(level.id)).toBe(true);
+  });
+});

--- a/src/engine/decks/index.ts
+++ b/src/engine/decks/index.ts
@@ -56,7 +56,11 @@ export const isTyping = (config: RaceConfig): config is TypingConfig =>
 /** Which deck a config will file its run under — the value of `Session.mode`. */
 export function modeOf(config: RaceConfig): string {
   if (isWords(config)) return wordMode(config.listId);
-  if (isTyping(config)) return typingMode(config.levelId);
+  // A lesson wins over the level it was played at, so a ladder run files
+  // itself as `typing:L07` and stays that in the record book (docs/typing.md
+  // §5.4). Absent on every run saved before the ladder, which is why the level
+  // is still what a config without one is filed under.
+  if (isTyping(config)) return typingMode(config.lessonId ?? config.levelId);
   return config.operation;
 }
 

--- a/src/engine/decks/typing.test.ts
+++ b/src/engine/decks/typing.test.ts
@@ -263,6 +263,40 @@ describe("configKey", () => {
   it("never collides with a word or arithmetic key", () => {
     expect(typingConfigKey(config())).toMatch(/^typing\|/);
   });
+
+  it("keys a lesson on the lesson and not on its passage", () => {
+    // Lesson 7 generates its own words every time it is run, so a key that
+    // folded them in would file every attempt in a bucket of one — a child
+    // would run the lesson twenty times and never be shown their own best.
+    const monday = config({
+      lessonId: "L07",
+      words: ["all", "dad", "flash"],
+      wordCount: 25,
+    });
+    const tuesday = config({
+      lessonId: "L07",
+      words: ["gala", "sash", "half"],
+      wordCount: 25,
+    });
+    expect(typingConfigKey(monday)).toBe("typing|L07|25");
+    expect(typingConfigKey(tuesday)).toBe(typingConfigKey(monday));
+  });
+
+  it("still separates lengths within a lesson", () => {
+    // The one thing about a lesson run that can differ and still matter: a
+    // 25-word run and a 50-word one are not the same race.
+    expect(typingConfigKey(config({ lessonId: "L07", wordCount: 50 }))).toBe(
+      "typing|L07|50",
+    );
+  });
+
+  it("still folds a drill's words in, which is what makes it that drill", () => {
+    // No lesson id, so nothing changed: a parent's five tricky words are the
+    // identity of the run, and two different fives are two different races.
+    expect(
+      typingConfigKey(config({ words: ["ask", "add"], wordCount: 10 })),
+    ).toBe("typing|home-row|10|wadd,ask");
+  });
 });
 
 describe("the deck registry", () => {
@@ -272,6 +306,19 @@ describe("the deck registry", () => {
 
   it("still answers for a level this build has never heard of", () => {
     expect(deckSpec(typingMode("retired")).label).toBe("Typing");
+  });
+
+  it("names the lesson a ladder run was played at", () => {
+    // What a record book two years from now reads, long after the ladder has
+    // been re-tuned: the lesson by number and title, not "Typing".
+    expect(deckSpec("typing:L07").label).toBe("Lesson 7 · Home-row words");
+    expect(deckSpec("typing:L100").label).toBe("Lesson 100 · The Ice Exam");
+  });
+
+  it("files a lesson run under its lesson id, not its level", () => {
+    expect(modeOf(config({ lessonId: "L07", words: ["all", "dad"] }))).toBe(
+      "typing:L07",
+    );
   });
 
   it("dispatches build, key and description on the config's shape", () => {

--- a/src/engine/decks/typing.ts
+++ b/src/engine/decks/typing.ts
@@ -2,6 +2,7 @@ import type { Card, TypingConfig } from "@/engine/types";
 
 import { mulberry32, shuffled } from "@/engine/random";
 import { SCRIPTURE_CREDIT } from "@/engine/sheets/passages/credit";
+import { LESSONS } from "@/engine/typing/lessons";
 import { WORD_LISTS, listWords } from "./wordlists";
 import type { DeckSpec } from "./spec";
 
@@ -336,6 +337,13 @@ export function typingLevelForAge(age: number): TypingLevel {
 export const levelCredit = (levelId: string): string | undefined =>
   TYPING_LEVELS_BY_ID.get(levelId)?.credit;
 
+/** `count` words out of a bag, exhausting it before it repeats. */
+const drawn = (pool: readonly string[], count: number, rand: () => number) => {
+  const out: string[] = [];
+  while (out.length < count) out.push(...shuffled(pool, rand));
+  return out.slice(0, count);
+};
+
 /**
  * The words of a passage, in the order they'll be typed.
  *
@@ -345,13 +353,8 @@ export const levelCredit = (levelId: string): string | undefined =>
  * decks follow, so a short run never asks for one word four times.
  */
 export function passageFor(config: TypingConfig, seed: number): string[] {
-  if (config.words?.length) {
-    const rand = mulberry32(seed);
-    const out: string[] = [];
-    while (out.length < config.wordCount)
-      out.push(...shuffled(config.words, rand));
-    return out.slice(0, config.wordCount);
-  }
+  if (config.words?.length)
+    return drawn(config.words, config.wordCount, mulberry32(seed));
 
   const level = TYPING_LEVELS_BY_ID.get(config.levelId);
   if (!level) return [];
@@ -370,10 +373,7 @@ export function passageFor(config: TypingConfig, seed: number): string[] {
     return words.slice(0, config.wordCount);
   }
 
-  const words: string[] = [];
-  while (words.length < config.wordCount)
-    words.push(...shuffled(level.pool, rand));
-  return words.slice(0, config.wordCount);
+  return drawn(level.pool, config.wordCount, rand);
 }
 
 /**
@@ -406,13 +406,31 @@ export function buildTypingDeck(config: TypingConfig, seed: number): Card[] {
   }));
 }
 
+/**
+ * Which runs may race each other as ghosts — the lesson, or the level and its
+ * words (docs/typing.md §5.4).
+ *
+ * A drill's words *are* its identity: a parent's five tricky words at twenty
+ * words long is a different exercise from another five, and folding them in is
+ * what keeps the two apart. A lesson's words are the opposite — lesson 7
+ * generates a fresh passage every time it is run, so the same fold would give
+ * every attempt a key of its own and a child would never be shown the best
+ * they have already done. So the words are left out exactly when a lesson id
+ * is there to stand in for them.
+ *
+ * Every key written before the ladder existed is unchanged, which is not a
+ * nicety: `configKey` is how a saved run finds its ghosts, and the record book
+ * is the only copy there is (CLAUDE.md). A config with no `lessonId` takes the
+ * same two branches it always has, and no shipped level id can be mistaken for
+ * a lesson id — `configkey.test.ts` is where that is held still.
+ */
 export function typingConfigKey(config: TypingConfig) {
   const parts: Array<string | number> = [
     "typing",
-    config.levelId,
+    config.lessonId ?? config.levelId,
     config.wordCount,
   ];
-  if (config.words?.length)
+  if (!config.lessonId && config.words?.length)
     parts.push(`w${[...config.words].sort().join(",")}`);
   return parts.join("|");
 }
@@ -455,11 +473,31 @@ export function wordsPerMinute(cards: Array<{ answer: string }>, ms: number) {
   return Math.round(characters / 5 / (ms / 60000));
 }
 
+/**
+ * The ladder, by the id that goes into `Session.mode`.
+ *
+ * `lessons.ts` is the one module in `engine/typing/` the deck layer may import
+ * (docs/typing.md §5.3), and this is what it is for: a run filed under
+ * `typing:L07` has to be able to name itself in a record book two years from
+ * now, long after the ladder has been re-tuned. It carries titles and pass
+ * criteria and not one word a child types — the corpus and the generator stay
+ * on the far side of `local/no-corpus-in-decks`, and the words a lesson was
+ * played on arrive in `config.words` from the island that generated them.
+ */
+const LESSONS_BY_ID = new Map(LESSONS.map((lesson) => [lesson.id, lesson]));
+
 export function typingDeckSpec(mode: string): DeckSpec {
-  const level = TYPING_LEVELS_BY_ID.get(levelIdOf(mode));
+  const id = levelIdOf(mode);
+  // Two namespaces behind one prefix, and neither can answer for the other: a
+  // lesson id is "L07" and a level id is "home-row". A mode from neither is a
+  // level this build has retired, which still reads as a typing run.
+  const lesson = LESSONS_BY_ID.get(id);
+  const level = TYPING_LEVELS_BY_ID.get(id);
   return {
     id: mode,
-    label: level?.name ?? "Typing",
+    label: lesson
+      ? `Lesson ${lesson.n} · ${lesson.title}`
+      : (level?.name ?? "Typing"),
     world: "ice",
     // Exact, including case: at the sentence level the shift key IS the
     // exercise, so "the" and "The" are two different things to get right.

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -113,6 +113,17 @@ export type WordConfig = {
 export type TypingConfig = {
   kind: "typing";
   levelId: string;
+  /**
+   * Set when this run is a lesson from the ladder (docs/typing.md §5.4).
+   *
+   * The discriminator for a ladder run, and the one field `Session.mode` and
+   * the ghost key prefer when it is there — a lesson is the identity, not the
+   * passage. Every run of lesson 7 generates its own words, so a key built
+   * from them would file each run in a bucket of one and a child would never
+   * be shown their own best. Optional, because every run saved before the
+   * ladder existed is a level and must key exactly as it always has.
+   */
+  lessonId?: string;
   /** An explicit set, for a drill of the words a player keeps fumbling. */
   words?: string[];
   wordCount: number;

--- a/src/engine/typing/generate.ts
+++ b/src/engine/typing/generate.ts
@@ -75,14 +75,14 @@ import {
 /**
  * Characters in a drill group: `ffjj`, `QWER`, `4545`.
  *
- * Four, not the three §5.1 prints, and the reason is arithmetic rather than
- * taste. `strikesFor` in `lessons.ts` sizes the new-key gate against
- * `wordCount × 5` characters — the words-per-minute convention, five keys to a
- * word, the space included. Groups of three would make a lesson a fifth
- * shorter than the gate assumes, and lesson 67 (six new symbols, ten strikes
- * apiece) would need 60 of its 139 characters to be new: 43%, well over
- * §5.2's ceiling, with the generator doing nothing wrong. Four plus a space is
- * five, so the two halves of the ladder agree about how long a lesson is.
+ * Four, as §5.1 prints, and the reason is arithmetic rather than taste.
+ * `strikesFor` in `lessons.ts` sizes the new-key gate against `wordCount × 5`
+ * characters — the words-per-minute convention, five keys to a word, the space
+ * included. Groups of three would make a lesson a fifth shorter than the gate
+ * assumes, and lesson 67 (six new symbols, ten strikes apiece) would need 60
+ * of its 139 characters to be new: 43%, well over §5.2's ceiling, with the
+ * generator doing nothing wrong. Four plus a space is five, so the two halves
+ * of the ladder agree about how long a lesson is.
  */
 const GROUP = 4;
 

--- a/src/engine/typing/lessons.ts
+++ b/src/engine/typing/lessons.ts
@@ -41,7 +41,7 @@ import type { KeyboardMode } from "@/engine/types";
  * that as data.
  */
 export type LessonKind =
-  /** Letter groups: `fff jjj fjf jfj`. What a new key is met as. */
+  /** Letter groups: `ffff jjjj fjfj jfjf`. What a new key is met as. */
   | { type: "keys" }
   /** Words drawn from the alphabet unlocked so far. */
   | { type: "words" }


### PR DESCRIPTION
`docs/typing.md` §5.4 is one paragraph and one hazard: `typingConfigKey` folds
`config.words` into the key, which is right for a parent-authored drill and
wrong for a lesson, because every run of lesson 7 generates a different
passage. This story is that paragraph — `TypingConfig.lessonId`, `modeOf`,
`typingConfigKey`, `typingDeckSpec` — and the frozen-key test that says nothing
already saved moved. Closes #139. Design: `docs/typing.md` §5.3, §5.4, §10.

This is the story that makes #138's generator reachable from a run without the
corpus reaching an island. The words a lesson was played on arrive in
`config.words` from the typing island that generated them; the key stops
listening to them.

## A bucket of one is worse than no ghost at all

Keyed on words, every attempt at lesson 7 is its own `configKey`, and the
symptom is not an error — it is a child running the same lesson twenty times
and being told each time that they have no best. So the key drops the `w…`
segment exactly when a `lessonId` is there to stand in for it:

| run | key |
| --- | --- |
| lesson 7, Monday's passage | `typing\|L07\|25` |
| lesson 7, Tuesday's passage | `typing\|L07\|25` |
| a parent's drill, `ask` `add` | `typing\|home-row\|10\|wadd,ask` |

The drill is the other half of the same sentence. A parent's five tricky words
*are* the identity of that exercise — two different fives are two different
races — so nothing about a config without a lesson id changed, and the third
row is a literal transcribed out of what is in IndexedDB today.

`wordCount` stays in the key for a lesson, because it is the one thing about a
ladder run that can differ and still matter: a 25-word run and a 50-word run at
lesson 7 are not the same race.

## The frozen-key test is the deliverable

`configKey` decides which runs may race each other as ghosts, and a child's
record book is the only copy there is — no server holds a second one and no
deploy can go back and rewrite it. A format change doesn't fail loudly; every
personal best saved under the old key is simply never found again.

So `src/engine/decks/configkey.test.ts` pins **thirteen keys as transcribed
literals** — not generated. A table built by calling the function it checks
would agree with any format at all, including a broken one. Coverage is by
optional segment, since the optional segments are where a key grows:

| family | pinned |
| --- | --- |
| arithmetic | no `kind` at all, timed (`t8000`), a fact drill (`f6:9,7:8`), and the **pre-`others` min/max shape** that `readConfig` widens on read |
| words | a shipped list, timed, and a list a parent typed in (`wbecause,friend,thought`) |
| typing | **all five shipped levels** at the setup screen's default length, plus a drill |

A fourteenth case asserts the typing table is *complete* — every id in
`TYPING_LEVELS` appears in it — so a level added later arrives with its own
transcribed line rather than quietly untested.

**The test was written and run green against the unmodified implementation
before a line of this change**, which is the only thing that makes it a pin on
history rather than a snapshot of the new output. Re-verified on this branch by
checking out `develop`'s `typing.ts`, `index.ts` and `types.ts` under the new
test file: 14 passed.

Two namespaces now live behind the `typing:` prefix and neither can answer for
the other — a lesson id is `L07`, a level id is `home-row`, and no shipped level
id starts with an L and a digit. A mode from neither is a level this build has
retired, which still reads as "Typing".

## What the shared chunk buys

`typingDeckSpec` resolves a lesson id against `LESSONS`, so `deckSpec("typing:L07")`
labels a saved run **"Lesson 7 · Home-row words"** rather than "Typing" — which
is the point of a record book that has to be readable two years from now, long
after the ladder has been re-tuned.

| | `dist/_astro/records.*.js` |
| --- | --- |
| `develop` | 49,030 B |
| this branch | **55,377 B** |

+6.2 KB on every island, and it is the hundred lesson rows — titles and pass
criteria, not one word a child types. `lessons.ts` is the one module in
`engine/typing/` the deck layer may import and §5.3 says so explicitly; the
corpus and the generator stay behind `local/no-corpus-in-decks`, untouched, and
`decks/index.ts` builds a lesson's deck from `config.words` exactly as it builds
a drill's. The rule exists to stop 46 KB → 222 KB. This is a deliberate trade
inside that margin, and §5.3 is where it is recorded.

## Two corrections carried in

- **§5.1 now prints four-character groups.** `GROUP = 4` shipped in #138 with a
  doc block reading "Four, not the three §5.1 prints" — a claim about the design
  doc that the same branch made false, since §5.1 still printed `fff jjj fjf`.
  §5.1 now says four and gives the arithmetic: four plus its space is five, the
  wpm convention `strikesFor` sizes the new-key gate against. At three, lesson
  67's six symbols at ten strikes are 60 of 139 characters — 43%, outside §5.2's
  15–35% band with the generator blameless. At four, 60 of 174 is 34%.
  `LessonKind.keys` and `GROUP`'s own comment now agree with it.
- **quick-win:** `passageFor`'s two identical shuffle-until-full loops fold into
  one `drawn` helper — same rand, same order, same output.

## Scope

Engine only. No game, no storage, no `DB_VERSION`, no component, no migration —
`lessonId` is optional and absent on every run saved before the ladder existed,
which is exactly why those runs key as they always have. The lesson run screen
is #142 (LES08).

`type-check` 0 errors · `lint` clean · `test:unit` **1745 passed** · `build`
static, 200 pages
