### PR TITLE
Stop an apt mirror failing a green build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,36 @@ jobs:
       # loop (create a profile → race → results → reload) against the built
       # output. It caught a routing regression that skipped the results screen
       # entirely while still saving the run, which no unit test would have seen.
+      # Split deliberately. The browser download is cacheable; `--with-deps` is
+      # not, because it shells out to apt. On 2026-08-19 azure.archive.ubuntu.com
+      # hung inside it for eighteen minutes and ate this job's whole twenty-minute
+      # budget, three runs running, with every real gate step having already
+      # passed — and `develop` push runs were timing out identically at the time.
+      #
+      # So the apt half is bounded and retried, and failing it is a warning
+      # rather than the job. If the libraries genuinely aren't there the smoke
+      # test below goes red, which is the signal we actually want; ubuntu-latest
+      # ships them already, so a dead mirror should cost two minutes and a note,
+      # not a red build on green code.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright system dependencies
+        timeout-minutes: 8
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 150 npx playwright install-deps chromium; then exit 0; fi
+            echo "::warning::playwright install-deps attempt $attempt failed or timed out; retrying"
+            sleep 15
+          done
+          echo "::warning::playwright install-deps never completed — continuing, because ubuntu-latest ships these libraries and the smoke test will fail if it does not"
+
       - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
+        timeout-minutes: 5
+        run: npx playwright install chromium
 
       - name: Smoke test the built site
         run: |


### PR DESCRIPTION
## What

Splits `npx playwright install --with-deps chromium` into its two halves in `ci.yml`, caches the browser, and stops a dead apt mirror from failing an otherwise-green build.

## Why

CI failed three times today on nothing in the code. From the run logs: `azure.archive.ubuntu.com` hung inside `--with-deps` for eighteen minutes and consumed the whole 20-minute job budget. Type-check, lint, format check, build, the static-output assertion and 1726 unit tests had all already passed in each of those runs — only the browser install hung. `develop` push runs were hitting the identical timeout at the same time, so it was the mirror, not this repo.

Cost was real: PR #171 took 59 minutes end to end, almost all of it waiting on apt.

## How

The two halves have different failure modes, so they are now different steps:

| | |
| --- | --- |
| **Browser download** | Deterministic and cacheable → `actions/cache` on `package-lock.json`, own 5-minute bound |
| **`install-deps` (apt)** | Flaky and external → 150s per attempt, 3 attempts, then a warning |

**Continuing past a failed `install-deps` is the deliberate choice.** `ubuntu-latest` already ships Chromium's system libraries, so the usual outcome of a dead mirror is that nothing was needed. And if they genuinely are missing, the smoke test three steps later fails — which is the signal worth having. What this gives up is a red build on green code; every real gate is untouched.

No change to `deploy.yml`. Production still deploys only from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)