### PR TITLE
Say which of the three bars a lesson was missed on

### DIFF
--- a/src/engine/typing/verdict.test.ts
+++ b/src/engine/typing/verdict.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardResult } from "@/engine/types";
+
+import { LESSONS } from "./lessons";
+import type { Lesson } from "./lessons";
+import { verdictFor } from "./verdict";
+import type { Run } from "./verdict";
+
+/**
+ * What the three bars have to prove (docs/typing.md §6.1, §6.4).
+ *
+ * The interesting tests here are all the same shape: a run that a single
+ * blended score would wave through, which one of the three bars has to catch.
+ * A child who is fast and accurate and never once gets the letter the lesson
+ * was about is the case §6.4 exists for, and it is the first test below.
+ *
+ * The criteria are built here rather than taken from the ladder, because what
+ * is under test is the gate and not lesson 25's tuning — a test that read
+ * `keyStrikes` off the table would go green the day someone lowered it. The
+ * shipped hundred get their own describe at the end, asserting only what the
+ * verdict promises about any of them.
+ */
+
+/**
+ * A typed word. `ok` follows from the two strings unless it is forced, which
+ * is what the "marked right" case below needs.
+ */
+const card = (
+  answer: string,
+  given: string | null,
+  ok = given === answer,
+): CardResult => ({
+  prompt: answer,
+  answer,
+  given,
+  ok,
+  ms: 400,
+  factId: answer,
+});
+
+const times = (n: number, make: () => CardResult) =>
+  Array.from({ length: n }, make);
+
+/** `n` copies of a word, typed correctly. */
+const right = (n: number, word: string) => times(n, () => card(word, word));
+
+/** `n` copies of a word, typed as `given` instead. */
+const wrong = (n: number, word: string, given: string) =>
+  times(n, () => card(word, given));
+
+/**
+ * A run, with `correct` and `incorrect` following its cards exactly as a saved
+ * session's do. `wordCount` is the run's own copy of how long the passage — or,
+ * for a storm, the wave — was, which is what survival is measured against.
+ */
+const run = (
+  cards: CardResult[],
+  { ms = 60_000, wordCount = cards.length } = {},
+): Run => ({
+  cards,
+  config: { kind: "typing", levelId: "home-row", lessonId: "L25", wordCount },
+  correct: cards.filter((c) => c.ok).length,
+  incorrect: cards.filter((c) => !c.ok).length,
+  durationMs: ms,
+});
+
+/** A lesson that introduces `z`, with criteria the test can dictate. */
+const lessonWith = (over: Partial<Lesson> = {}): Lesson => ({
+  n: 25,
+  id: "L25",
+  block: 3,
+  title: "The last corner",
+  introduces: ["z"],
+  kind: { type: "keys" },
+  wordCount: 26,
+  keyboard: "guide",
+  pass: {
+    kind: "lesson",
+    accuracy: 0.95,
+    wpm: 12,
+    keyAccuracy: 0.9,
+    keyStrikes: 12,
+  },
+  ...over,
+});
+
+const stormWith = (over: Partial<Lesson> = {}): Lesson => ({
+  n: 4,
+  id: "L04",
+  block: 1,
+  title: "Hailstorm · First ice",
+  introduces: [],
+  kind: { type: "storm" },
+  wordCount: 0,
+  keyboard: "guide",
+  pass: { kind: "storm", survive: true, accuracy: 0.9 },
+  ...over,
+});
+
+describe("the new-key gate", () => {
+  /**
+   * §6.4, in one test. Forty-two words at 95% and 26 wpm is a pass by every
+   * measure a typing test has — and the child got `z` wrong half the times
+   * they met it, which is the only thing lesson 25 was for. Two wrong words
+   * out of forty-two is 5% of the run and 50% of the letter.
+   */
+  it("fails a run that was fast and accurate but fumbled the new key", () => {
+    const lesson = lessonWith({
+      pass: {
+        kind: "lesson",
+        accuracy: 0.95,
+        wpm: 12,
+        keyAccuracy: 0.9,
+        keyStrikes: 4,
+      },
+    });
+    const verdict = verdictFor(
+      run([...right(38, "as"), ...right(2, "zip"), ...wrong(2, "zip", "sip")]),
+      lesson,
+    );
+
+    expect(verdict.accuracy.ok).toBe(true);
+    expect(verdict.wpm.ok).toBe(true);
+    expect(verdict.keys).toEqual([
+      { key: "z", got: 0.5, need: 0.9, ok: false },
+    ]);
+    expect(verdict.passed).toBe(false);
+  });
+
+  /**
+   * The strike floor is the half of the gate a fraction cannot carry. Eleven
+   * strikes of `z` all landed reads as 100%, and `ok` still has to be false —
+   * otherwise a lesson that happened to serve the new key twice would be
+   * passed on a lucky guess.
+   */
+  it("fails a key one strike short, rather than passing it silently", () => {
+    const lesson = lessonWith();
+    const short = verdictFor(
+      run([...right(11, "zip"), ...right(20, "as")]),
+      lesson,
+    );
+
+    expect(short.accuracy.ok).toBe(true);
+    expect(short.wpm.ok).toBe(true);
+    expect(short.keys).toEqual([{ key: "z", got: 1, need: 0.9, ok: false }]);
+    expect(short.passed).toBe(false);
+
+    // The same run with the twelfth strike, to pin that it was the floor and
+    // nothing else standing between this child and the next lesson.
+    const met = verdictFor(
+      run([...right(12, "zip"), ...right(20, "as")]),
+      lesson,
+    );
+    expect(met.keys).toEqual([{ key: "z", got: 1, need: 0.9, ok: true }]);
+    expect(met.passed).toBe(true);
+  });
+
+  it("marks only the characters that differ on a word typed wrong", () => {
+    const lesson = lessonWith({
+      introduces: ["z", "i", "p"],
+      pass: {
+        kind: "lesson",
+        accuracy: 0,
+        wpm: 0,
+        keyAccuracy: 0.9,
+        keyStrikes: 1,
+      },
+    });
+    // "zip" typed as "zap": the `i` is the only character that differs.
+    const verdict = verdictFor(run(wrong(1, "zip", "zap")), lesson);
+
+    expect(verdict.keys).toEqual([
+      { key: "z", got: 1, need: 0.9, ok: true },
+      { key: "i", got: 0, need: 0.9, ok: false },
+      { key: "p", got: 1, need: 0.9, ok: true },
+    ]);
+  });
+
+  /**
+   * A character never reached is a miss, not an absence: a word abandoned
+   * halfway, or a `given` of null, has to cost the keys it never got to.
+   */
+  it("counts a character that was never reached as a miss", () => {
+    const lesson = lessonWith({
+      introduces: ["p"],
+      pass: {
+        kind: "lesson",
+        accuracy: 0,
+        wpm: 0,
+        keyAccuracy: 0.9,
+        keyStrikes: 2,
+      },
+    });
+    // "zip" abandoned after two letters, and "zip" with nothing typed at all:
+    // the `p` was never offered a keystroke either time.
+    const verdict = verdictFor(
+      run([card("zip", "zi"), card("zip", null)]),
+      lesson,
+    );
+
+    expect(verdict.keys).toEqual([{ key: "p", got: 0, need: 0.9, ok: false }]);
+  });
+
+  /**
+   * The documented approximation (§6.4): per-key stats come from the cards, so
+   * what the gate sees is what ended up on the line. A key struck wrong and
+   * backspaced away is invisible here *by construction* — the card records the
+   * word, not the keystrokes — which is the whole trade. What can be asserted
+   * is the rule that makes it true: a word the run marked right is a hit in
+   * every character, whatever `given` happens to read.
+   */
+  it("counts every character of a word marked right as a hit", () => {
+    const lesson = lessonWith({
+      pass: {
+        kind: "lesson",
+        accuracy: 0,
+        wpm: 0,
+        keyAccuracy: 0.9,
+        keyStrikes: 1,
+      },
+    });
+    const verdict = verdictFor(run([card("zip", "zip ", true)]), lesson);
+
+    expect(verdict.keys).toEqual([{ key: "z", got: 1, need: 0.9, ok: true }]);
+  });
+
+  it("has no key bars on a lesson that introduces nothing", () => {
+    const verdict = verdictFor(
+      run(right(30, "the")),
+      lessonWith({ introduces: [] }),
+    );
+
+    expect(verdict.keys).toEqual([]);
+    expect(verdict.passed).toBe(true);
+  });
+});
+
+describe("accuracy and speed", () => {
+  it("fails the speed bar alone when the typing was accurate but slow", () => {
+    // Twelve perfect words in two minutes: 48 characters is under 10 wpm.
+    const verdict = verdictFor(
+      run(right(12, "zip"), { ms: 120_000 }),
+      lessonWith(),
+    );
+
+    expect(verdict.accuracy).toEqual({ got: 1, need: 0.95, ok: true });
+    expect(verdict.keys[0].ok).toBe(true);
+    expect(verdict.wpm.ok).toBe(false);
+    expect(verdict.wpm.need).toBe(12);
+    expect(verdict.passed).toBe(false);
+  });
+
+  /**
+   * Gross wpm, with accuracy beside it rather than folded in (§6.1). The two
+   * runs typed the same number of characters in the same time, so they type at
+   * the same speed; what separates them is the accuracy bar, which is the
+   * distinction a blended net figure would hide.
+   */
+  it("reports speed gross, and accuracy separately", () => {
+    const lesson = lessonWith();
+    const clean = verdictFor(run(right(30, "zip")), lesson);
+    const sloppy = verdictFor(
+      run([...right(15, "zip"), ...wrong(15, "zip", "zap")]),
+      lesson,
+    );
+
+    expect(sloppy.wpm.got).toBe(clean.wpm.got);
+    expect(clean.accuracy.got).toBe(1);
+    expect(sloppy.accuracy.got).toBe(0.5);
+    expect(sloppy.accuracy.ok).toBe(false);
+  });
+
+  /**
+   * A run that never started — quit at the 3·2·1, or a save that arrived with
+   * nothing in it. Every bar is a division, and all three denominators are
+   * zero here.
+   */
+  it("does not divide by zero on a run with no cards", () => {
+    const verdict = verdictFor(run([], { ms: 0 }), lessonWith());
+
+    expect(verdict.accuracy.got).toBe(0);
+    expect(verdict.wpm.got).toBe(0);
+    expect(verdict.keys).toEqual([{ key: "z", got: 0, need: 0.9, ok: false }]);
+    expect(verdict.passed).toBe(false);
+  });
+});
+
+describe("a storm level", () => {
+  /** Twenty letters faced, nineteen shot: survive plus accuracy, both met. */
+  const wave = [...right(19, "f"), ...wrong(1, "j", "k")];
+
+  it("passes a wave survived at the accuracy bar", () => {
+    const verdict = verdictFor(run(wave), stormWith());
+
+    expect(verdict.accuracy).toEqual({ got: 0.95, need: 0.9, ok: true });
+    expect(verdict.passed).toBe(true);
+  });
+
+  /**
+   * §8.7: dying at letter 18 of 40 saves a session with eighteen cards. Every
+   * one of them can be a hit and the run still has not survived.
+   */
+  it("fails a run that ended early, however accurate it was", () => {
+    const verdict = verdictFor(
+      run(right(18, "f"), { wordCount: 40 }),
+      stormWith(),
+    );
+
+    expect(verdict.accuracy.ok).toBe(true);
+    expect(verdict.passed).toBe(false);
+  });
+
+  it("has no speed bar to clear and no keys to gate", () => {
+    const verdict = verdictFor(run(wave), stormWith());
+
+    expect(verdict.wpm).toEqual({ got: 0, need: 0, ok: true });
+    expect(verdict.keys).toEqual([]);
+  });
+});
+
+describe("against the shipped ladder", () => {
+  const lesson = (id: string): Lesson => {
+    const found = LESSONS.find((l) => l.id === id);
+    if (!found) throw new Error(`no lesson ${id}`);
+    return found;
+  };
+
+  it("gives one bar per character the lesson introduces", () => {
+    // Lesson 25 hands over `z` and `/` together.
+    const verdict = verdictFor(run(right(26, "zip")), lesson("L25"));
+
+    expect(verdict.keys.map((k) => k.key)).toEqual(["z", "/"]);
+    // A key the passage never served is short of strikes, not merely inaccurate.
+    expect(verdict.keys[1]).toEqual({ key: "/", got: 0, need: 0.9, ok: false });
+  });
+
+  it("leaves the keys empty on a review lesson", () => {
+    expect(verdictFor(run(right(40, "the")), lesson("L41")).keys).toEqual([]);
+  });
+});

--- a/src/engine/typing/verdict.test.ts
+++ b/src/engine/typing/verdict.test.ts
@@ -156,6 +156,31 @@ describe("the new-key gate", () => {
     expect(met.passed).toBe(true);
   });
 
+  /**
+   * The other half of the same boundary: `keyAccuracy` is a floor to reach,
+   * not one to clear. Nine `z` out of ten is exactly 90%, and a child who hits
+   * the bar on the nose has met it — a `>` where `>=` belongs would send them
+   * round again for landing precisely what was asked.
+   */
+  it("passes a key struck exactly at the accuracy bar", () => {
+    const lesson = lessonWith({
+      pass: {
+        kind: "lesson",
+        accuracy: 0,
+        wpm: 0,
+        keyAccuracy: 0.9,
+        keyStrikes: 10,
+      },
+    });
+    const verdict = verdictFor(
+      run([...right(9, "zip"), ...wrong(1, "zip", "sip")]),
+      lesson,
+    );
+
+    expect(verdict.keys).toEqual([{ key: "z", got: 0.9, need: 0.9, ok: true }]);
+    expect(verdict.passed).toBe(true);
+  });
+
   it("marks only the characters that differ on a word typed wrong", () => {
     const lesson = lessonWith({
       introduces: ["z", "i", "p"],
@@ -180,6 +205,14 @@ describe("the new-key gate", () => {
   /**
    * A character never reached is a miss, not an absence: a word abandoned
    * halfway, or a `given` of null, has to cost the keys it never got to.
+   *
+   * The run therefore mixes one `p` that *was* struck with two that were not,
+   * so what is asserted is the fraction and not just a bar that reads empty.
+   * An implementation that skipped past the end of `given` — counting neither
+   * a strike nor a hit — would leave `p` at 1/1 rather than 1/3, and a bar
+   * asserted only as `got: 0, ok: false` would go green for both. That is the
+   * lenient direction and it matters: abandoned words containing the new key
+   * would simply stop counting against it.
    */
   it("counts a character that was never reached as a miss", () => {
     const lesson = lessonWith({
@@ -189,17 +222,20 @@ describe("the new-key gate", () => {
         accuracy: 0,
         wpm: 0,
         keyAccuracy: 0.9,
-        keyStrikes: 2,
+        keyStrikes: 3,
       },
     });
-    // "zip" abandoned after two letters, and "zip" with nothing typed at all:
-    // the `p` was never offered a keystroke either time.
+    // "zip" typed out, "zip" abandoned after two letters, and "zip" with
+    // nothing typed at all — the two shapes a `given` short of its answer can
+    // take. The `p` was offered a keystroke once out of three.
     const verdict = verdictFor(
-      run([card("zip", "zi"), card("zip", null)]),
+      run([card("zip", "zip"), card("zip", "zi"), card("zip", null)]),
       lesson,
     );
 
-    expect(verdict.keys).toEqual([{ key: "p", got: 0, need: 0.9, ok: false }]);
+    expect(verdict.keys).toEqual([
+      { key: "p", got: 1 / 3, need: 0.9, ok: false },
+    ]);
   });
 
   /**
@@ -212,6 +248,7 @@ describe("the new-key gate", () => {
    */
   it("counts every character of a word marked right as a hit", () => {
     const lesson = lessonWith({
+      introduces: ["i"],
       pass: {
         kind: "lesson",
         accuracy: 0,
@@ -220,9 +257,13 @@ describe("the new-key gate", () => {
         keyStrikes: 1,
       },
     });
-    const verdict = verdictFor(run([card("zip", "zip ", true)]), lesson);
+    // `given` disagrees with the answer *at the introduced key itself*, and
+    // the run marked the card right anyway. Reading `given` regardless of the
+    // mark would score `i` at 0 and fail the gate; the mark wins, which is
+    // what forgiving a correction means in practice.
+    const verdict = verdictFor(run([card("zip", "zap", true)]), lesson);
 
-    expect(verdict.keys).toEqual([{ key: "z", got: 1, need: 0.9, ok: true }]);
+    expect(verdict.keys).toEqual([{ key: "i", got: 1, need: 0.9, ok: true }]);
   });
 
   it("has no key bars on a lesson that introduces nothing", () => {

--- a/src/engine/typing/verdict.ts
+++ b/src/engine/typing/verdict.ts
@@ -1,0 +1,228 @@
+import type { CardResult, Session } from "@/engine/types";
+
+import { wordsPerMinute } from "@/engine/decks/typing";
+import { accuracyOf } from "@/engine/records";
+import type { Lesson, PassCriteria } from "./lessons";
+
+/**
+ * Did this run pass this lesson, and if not, which part missed
+ * (docs/typing.md §6.1, §6.4)?
+ *
+ * Three bars rather than one score, for a reason that is about a seven-year-old
+ * and not about statistics: **a single number tells you that you failed and not
+ * what to do**. Three bars, each either full or not, say "you were fast enough
+ * and not accurate enough" or "you have `x` but not `z`", which is an
+ * instruction a child can act on. A blended "net WPM" — the industry default —
+ * hides exactly the distinction a beginner most needs.
+ *
+ * So this module never returns a percentage and a verdict. It returns the three
+ * criteria side by side, each with what was asked and what arrived, and leaves
+ * `passed` as the conjunction of them. What draws them is LES09's problem; what
+ * they mean is this file's.
+ */
+
+/**
+ * One criterion, as a results screen draws it: how far you got, what was asked,
+ * and whether that is a full bar.
+ *
+ * `got` and `need` are in the criterion's own units — a fraction 0–1 for the
+ * two accuracy bars, words per minute for the speed one — so a bar renders as
+ * `got / need` capped at full without anything having to know which bar it is
+ * holding.
+ */
+export type Bar = { got: number; need: number; ok: boolean };
+
+/** A bar for one newly-introduced character. `key` is that character. */
+export type KeyBar = Bar & { key: string };
+
+/**
+ * The three bars and their conjunction.
+ *
+ * The order they are *shown* in is the order they matter — accuracy, then the
+ * new keys, then speed (§6.1) — and the order they are written in here is the
+ * doc's. A renderer should follow §6.1 rather than the field order.
+ */
+export type Verdict = {
+  passed: boolean;
+  accuracy: Bar;
+  wpm: Bar;
+  /** One per newly-introduced key. Empty on a review or a checkpoint. */
+  keys: KeyBar[];
+};
+
+/**
+ * The parts of a run a verdict is decided on.
+ *
+ * A `Pick` rather than the whole `Session` for the same reason `records.ts`
+ * takes `Scored`: what passes a lesson is what the child did, not which profile
+ * did it or when. A caller holding a run that has not been saved yet — the
+ * results screen, which shows the bars before the write comes back — can still
+ * ask.
+ */
+export type Run = Pick<
+  Session,
+  "cards" | "config" | "correct" | "incorrect" | "durationMs"
+>;
+
+/** The lesson arm of the criteria, which is the arm with a gate on it. */
+type LessonPass = Extract<PassCriteria, { kind: "lesson" }>;
+
+const bar = (got: number, need: number): Bar => ({
+  got,
+  need,
+  ok: got >= need,
+});
+
+/**
+ * Did the wave get all the way through, or did the run end early (§8.7)?
+ *
+ * A Hailstorm run is a `Session` like any other, and the one thing that is
+ * different about it is that it can stop in the middle: dying at letter 18 of
+ * 40 saves a session with eighteen cards, `correct`, `incorrect` and
+ * `durationMs` all honest, and the `survive` criterion simply not met. So
+ * surviving is "you faced every letter the wave had", and the wave's length
+ * (§8.3's `count`) is read off the run's own config rather than off today's
+ * ladder — the same rule `configKey` follows (§5.4). A wave re-tuned from forty
+ * letters to thirty next year must not hand a pass, in hindsight, to a run that
+ * died at eighteen.
+ *
+ * A run whose config carries no length counts as survived. That is the lenient
+ * direction on purpose: a storm level opens no door on the ladder (§8.8), so
+ * being wrong here costs a line on a results screen and never a lesson.
+ */
+const survived = (run: Run) =>
+  run.cards.length >=
+  (run.config?.kind === "typing" ? run.config.wordCount : 0);
+
+/**
+ * The new-key gate, one bar per character the lesson introduces (§6.4).
+ *
+ * This is the criterion that turns a hundred typing tests into a hundred
+ * lessons. Accuracy and speed together still miss the thing the lesson was
+ * *for*: a lesson that introduces `z` can be passed at 95% and 12 wpm while
+ * getting `z` wrong every single time it appears, because `z` is 3% of the
+ * text. So every introduced character must be struck correctly at least
+ * `keyAccuracy` of the time, over at least `keyStrikes` strikes — and the
+ * generator is tested to put that many occurrences in the passage at every
+ * seed (§5.2), so the gate can never be unpassable through bad luck.
+ *
+ * No lesson introduces the space bar — it is unlocked from lesson 1, in
+ * `keys.ts` — so the key that commits every word is never one of these bars.
+ *
+ * ── Per-key stats come from the cards, not from keystrokes ───────────────────
+ * A `CardResult` carries `answer` and `given`, so a word typed right
+ * contributes a hit to each of its characters and a word typed wrong
+ * contributes a miss to each character that differs from the answer.
+ *
+ * That is a deliberate, documented approximation, and what it forgives is a
+ * **correction**: a key struck wrong and then backspaced away counts as a hit,
+ * because what ended up on the line is right. The trade was taken knowingly.
+ * Recording raw keystrokes would mean a new field on `Session` — a shared
+ * engine type that every game on this site reads and writes — for one game's
+ * benefit; and it would mean the gate measures something the child cannot see
+ * on the results screen, which lists the words they typed. Being failed on `z`
+ * by a `z` that is not in any of them is unexplainable at seven. Measuring what
+ * ended up on the line is both simpler and more explicable, and if it ever
+ * proves too soft the fix is a `noBackspace` flag on the lesson rather than a
+ * schema change.
+ *
+ * The comparison is positional, which errs the other way: `zip` typed as `zzip`
+ * marks every character after the insertion wrong. Both halves are the same
+ * bargain — this describes the text, not the fingers.
+ */
+function keyBars(
+  cards: CardResult[],
+  introduces: readonly string[],
+  pass: LessonPass,
+): KeyBar[] {
+  const tally = new Map(
+    introduces.map((key) => [key, { strikes: 0, hits: 0 }]),
+  );
+
+  for (const card of cards) {
+    // A card marked right is right in every character, whatever `given` holds.
+    // That is the forgiveness above, and it also keeps the gate agreeing with
+    // the mark the child was shown on the screen: marking is the deck spec's
+    // to do, and a verdict that second-guessed it would fail a key the run had
+    // already called correct.
+    const typed = card.ok ? card.answer : (card.given ?? "");
+    // Indexed rather than iterated, because the two strings have to stay
+    // aligned: `typed[i]` is what was offered for `answer[i]`, and a character
+    // never reached — a word cut short, or a `given` of null on a timeout — is
+    // `undefined`, which differs, which is a miss.
+    for (let i = 0; i < card.answer.length; i++) {
+      const seen = tally.get(card.answer[i]);
+      if (!seen) continue;
+      seen.strikes += 1;
+      if (typed[i] === card.answer[i]) seen.hits += 1;
+    }
+  }
+
+  return introduces.map((key) => {
+    const { strikes, hits } = tally.get(key) ?? { strikes: 0, hits: 0 };
+    const got = strikes === 0 ? 0 : hits / strikes;
+    return {
+      key,
+      got,
+      need: pass.keyAccuracy,
+      // Deliberately not `got >= need`. The strike floor is the second half of
+      // the gate and a fraction cannot carry it: three strikes of `z` all
+      // landed is a lucky guess, not a key learnt, and a run that met `z` once
+      // would otherwise pass it at 100%. So a bar can read full and still not
+      // be `ok`, and `ok` is what `passed` and the results screen go by.
+      ok: strikes >= pass.keyStrikes && got >= pass.keyAccuracy,
+    };
+  });
+}
+
+/**
+ * Three bars and a pass, for one run of one lesson.
+ *
+ * Pure, and stored nowhere. A lesson is passed if a session exists that meets
+ * its criteria, which is a filter over sessions the hub has already loaded
+ * (§6.5) — so there is no `passedLessons` field, no new object store and no
+ * `DB_VERSION` bump behind this. Tune lesson 40's wpm down next year and every
+ * child who was one wpm short is through, with no backfill, and with nothing
+ * that can disagree with the record book.
+ *
+ * `deckSpec` never throws on a mode it does not know, and this is the same
+ * promise one layer up: a `Lesson` is the only thing that says what passing it
+ * means, so a run and the lesson it was played on are all there is to ask.
+ */
+export function verdictFor(run: Run, lesson: Lesson): Verdict {
+  // Whole-lesson accuracy, from the run's own counters — `accuracyOf` is the
+  // site's one definition of the word, and a second one here would let the
+  // results screen and the record book quietly disagree about the same run. It
+  // returns 0 rather than NaN for a run with nothing in it.
+  const accuracy = bar(accuracyOf(run), lesson.pass.accuracy);
+
+  if (lesson.pass.kind === "storm")
+    return {
+      // Survive plus accuracy, which is all a storm level is marked on.
+      passed: accuracy.ok && survived(run),
+      accuracy,
+      // A storm has no passage, so it has no words per minute — §5.6 prints —
+      // in that column. Zero against a need of zero says "not a passage"
+      // rather than "typed nothing", the same thing `wordCount: 0` says about
+      // a storm level on the ladder, and `ok` stays true so a bar a storm does
+      // not have can never fail one.
+      wpm: { got: 0, need: 0, ok: true },
+      // A storm level introduces nothing, and its criteria carry no
+      // `keyAccuracy` to gate anything with.
+      keys: [],
+    };
+
+  // Gross wpm, reused unchanged from the deck family that already counts it:
+  // every keystroke counts, right or wrong, and accuracy stands beside it as
+  // its own bar instead of being folded in. A child who types fast and misses
+  // half of it should see both numbers, not one that hides which is which.
+  const wpm = bar(wordsPerMinute(run.cards, run.durationMs), lesson.pass.wpm);
+  const keys = keyBars(run.cards, lesson.introduces, lesson.pass);
+
+  return {
+    passed: accuracy.ok && wpm.ok && keys.every((key) => key.ok),
+    accuracy,
+    wpm,
+    keys,
+  };
+}


### PR DESCRIPTION
`docs/typing.md` §6.1–§6.4 as one pure function: `verdictFor(run, lesson)` in
`src/engine/typing/verdict.ts`, plus the suite that holds it. Closes #140.
Engine only — no game, no storage, no `DB_VERSION` bump.

## Three bars, not one score

A single blended number tells a seven-year-old that they failed and not what to
do. So the verdict is three criteria side by side — accuracy, speed, and one bar
per character the lesson introduces — each carrying `{ got, need, ok }` in its
own units, with `passed` left as the conjunction:

| bar | asks |
| --- | --- |
| accuracy | whole-lesson, via `accuracyOf` — the site's one definition of the word |
| wpm | **gross**, `wordsPerMinute` reused unchanged, accuracy standing beside it |
| keys | one per introduced character, each gated on fraction **and** strike count |

"You were fast enough and not accurate enough", or "you have `x` but not `z`",
is an instruction. Net WPM — the industry default — folds the two together and
hides exactly the distinction a beginner most needs, so nothing here blends.

Nothing is stored. A verdict is a function of a run and the lesson it was played
on (§6.5), which is what lets lesson 40's wpm be re-tuned next year with every
child who was one wpm short going through, no backfill and nothing that can
disagree with the record book. `Run` is a `Pick` of `Session` for the same
reason `records.ts` takes `Scored`: the results screen can ask before the write
comes back.

## The new-key gate is the half no other course has

A lesson that introduces `z` can be passed at 95% accuracy and 12 wpm while
getting `z` wrong every single time it appears, because `z` is 3% of the text.
The gate is what turns a hundred typing tests into a hundred lessons: every
introduced character struck right at least `keyAccuracy` of the time, over at
least `keyStrikes` strikes.

The floor is a **separate condition, not a low fraction** — three strikes of `z`
all landed is a lucky guess, so `ok` is `strikes >= keyStrikes && got >= need`
and a bar can read full while still not being `ok`. The generator is tested to
put that many occurrences in the passage at every seed (§5.2), so the gate can
never be unpassable through bad luck.

## Per-key stats come from the cards, and that forgives a correction

A `CardResult` carries `answer` and `given`, so a word typed right is a hit in
each of its characters and a word typed wrong is a miss in each character that
differs, compared positionally.

What that forgives is a **correction**: a key struck wrong and then backspaced
away counts as a hit, because what ended up on the line is right. The trade is
documented where it is made, and it was taken knowingly:

- raw keystrokes would mean a new field on `Session` — a shared engine type that
  every game on this site reads and writes — for one game's benefit;
- and the gate would then measure something the child cannot see. The results
  screen lists the words they typed; being failed on a `z` that is in none of
  them is unexplainable at seven.

It errs the other way too — `zip` typed as `zzip` marks everything after the
insertion wrong. Both halves are the same bargain: this describes the text, not
the fingers. If it ever proves too soft, the fix is a `noBackspace` flag on the
lesson rather than a schema change.

A storm level is marked on `survive` plus accuracy (§8.7). Surviving is having
faced every letter the wave had, read off the run's **own** config, so a wave
re-tuned from forty letters to thirty cannot hand a pass, in hindsight, to a run
that died at eighteen.

## Three tests strengthened, each against the mutant it exists to catch

The second commit changes no production code. Three assertions in the suite were
satisfiable by an implementation that was wrong on the criterion this story
exists for:

| test | mutant it now fails |
| --- | --- |
| "counts a character that was never reached as a miss" | fed only cards whose `p` was unreached, so `got` was 0 either way. Now mixes one struck `p` with two unreached and asserts 1/3 — only true if unreached strikes are tallied. The old version let abandoned words stop counting against the new key |
| "counts every character of a word marked right as a hit" | differed from its answer only by a trailing space, past `answer.length` and so never compared — the forced `ok` was never exercised. Now differs at the introduced key itself, so reading `given` regardless of `card.ok` fails |
| "passes a key struck exactly at the accuracy bar" | new. Nine `z` of ten is exactly the bar. The suite pinned one strike below `keyStrikes` failing, but nothing caught a `>` where `>=` belongs |

All three pass against `verdict.ts` as shipped, and each fails against its
mutant. Also covered: a run that is fast and accurate but fumbles the new key,
a run one strike short failing on that key rather than passing silently, a run
with zero cards not dividing by zero, and the shipped ladder giving one bar per
introduced character with none on a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
