### PR TITLE
Open the next lesson from the runs already saved

### DIFF
--- a/src/engine/typing/ladder.test.ts
+++ b/src/engine/typing/ladder.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardResult, Session } from "@/engine/types";
+
+import { typingMode } from "@/engine/decks/typing";
+import { ladderProgress } from "./ladder";
+import { LESSONS } from "./lessons";
+import type { Lesson } from "./lessons";
+
+/**
+ * What deriving progress has to prove (docs/typing.md §6.5, §6.6, §8.8).
+ *
+ * Four of these are the reason the module exists rather than a stored
+ * `passedLessons` set, and each of them is a bug a stored one would have:
+ * unlocking on `max` survives the day the oldest sessions are pruned; a storm
+ * level never holds a child up; a checkpoint passed out of order carries them
+ * to it; and re-tuning a lesson's criteria clears the runs that were one wpm
+ * short without anything being written back.
+ *
+ * The runs below are built against the shipped ladder on purpose — unlike
+ * `verdict.test.ts`, which dictates its own criteria because what it tests is
+ * the gate. What is under test here is which door a set of saved runs opens,
+ * and the doors are the hundred.
+ */
+
+const byN = new Map(LESSONS.map((l) => [l.n, l]));
+const lesson = (n: number): Lesson => {
+  const found = byN.get(n);
+  if (!found) throw new Error(`no lesson ${n}`);
+  return found;
+};
+
+const card = (answer: string, given: string | null): CardResult => ({
+  prompt: answer,
+  answer,
+  given,
+  ok: given === answer,
+  ms: 400,
+  factId: answer,
+});
+
+let saved = 0;
+
+/**
+ * A run of `lesson`, filed exactly as the island files one: `typing:L44` for
+ * its mode, its cards, counters that follow them, and its own copy of how long
+ * the passage — or the wave — was.
+ *
+ * `durationMs` is worked back from the words per minute asked for, so a test
+ * can sit a run exactly on a lesson's speed bar or exactly one under it.
+ */
+function run(
+  of: Lesson,
+  cards: CardResult[],
+  { wpm, wordCount = cards.length }: { wpm?: number; wordCount?: number } = {},
+): Session {
+  const correct = cards.filter((c) => c.ok).length;
+  // The same five-characters-is-a-word the deck family counts in, plus the
+  // space that committed each one.
+  const characters = cards.reduce((sum, c) => sum + c.answer.length + 1, 0);
+  return {
+    id: `s${(saved += 1)}`,
+    profileId: "p1",
+    game: "flashcards",
+    mode: typingMode(of.id),
+    configKey: `typing|${of.id}|${of.wordCount}`,
+    config: {
+      kind: "typing",
+      levelId: of.id,
+      lessonId: of.id,
+      wordCount,
+    },
+    seed: 7,
+    finishedAt: "2026-08-19T10:00:00.000Z",
+    durationMs: wpm ? (characters / 5) * (60_000 / wpm) : 60_000,
+    correct,
+    incorrect: cards.length - correct,
+    bestStreak: correct,
+    xpEarned: 0,
+    ghostSessionId: null,
+    beatGhost: null,
+    cards,
+  };
+}
+
+/** The words a clean run of a lesson is made of: each new key, struck often
+ * enough that the gate is satisfied, or home-row words where none arrive. */
+const wordsFor = (of: Lesson) =>
+  of.introduces.length
+    ? of.introduces.map((key) =>
+        key.repeat(of.pass.kind === "lesson" ? of.pass.keyStrikes : 1),
+      )
+    : ["all", "flask", "glad"];
+
+/** Every word typed right, at exactly the speed the lesson asks for. */
+const passing = (of: Lesson, wpm?: number) =>
+  run(
+    of,
+    wordsFor(of).map((word) => card(word, word)),
+    { wpm: of.pass.kind === "lesson" ? (wpm ?? of.pass.wpm) : undefined },
+  );
+
+/** A wave that ended early — eighteen letters of a forty-letter storm (§8.7). */
+const diedInTheStorm = (of: Lesson) =>
+  run(
+    of,
+    ["a", "s", "d"].map((letter) => card(letter, letter)),
+    { wordCount: 40 },
+  );
+
+/**
+ * Re-tune a lesson's speed bar for the length of one test, and put it back.
+ *
+ * Standing in for the deploy that lowers lesson 41 from 18 wpm to 17 after a
+ * hundred children have found it too fast. Nothing else about the world
+ * changes — least of all the sessions, which is the point.
+ */
+function retuned(n: number, wpm: number, body: () => void) {
+  const pass = lesson(n).pass;
+  if (pass.kind !== "lesson") throw new Error(`lesson ${n} has no speed bar`);
+  const was = pass.wpm;
+  pass.wpm = wpm;
+  try {
+    body();
+  } finally {
+    pass.wpm = was;
+  }
+}
+
+describe("a child who has done nothing", () => {
+  it("has cleared nothing and is pointed at lesson 1", () => {
+    const progress = ladderProgress([]);
+    expect(progress.cleared.size).toBe(0);
+    expect(progress.best).toBe(0);
+    expect(progress.next).toBe(1);
+  });
+
+  /**
+   * The ladder is the hundred and nothing else is on it. A typing *level*, a
+   * parent's drill and a spelling race all sit in the same record book — and
+   * `typing:home-row` is one `typing:` prefix away from a lesson, which is the
+   * mistake worth pinning.
+   */
+  it("is not advanced by runs that are not lessons", () => {
+    const notALesson = (mode: string): Session => ({
+      ...passing(lesson(30)),
+      mode,
+    });
+    const progress = ladderProgress([
+      notALesson("typing:home-row"),
+      notALesson("words:dolch-1"),
+      notALesson("×"),
+    ]);
+    expect(progress.best).toBe(0);
+    expect(progress.next).toBe(1);
+  });
+
+  /** Fast enough, and half of it wrong. Lesson 41 asks 95%. */
+  it("is not advanced by a run that missed a bar", () => {
+    const sloppy = run(lesson(41), [card("all", "all"), card("glad", "glaf")], {
+      wpm: 30,
+    });
+    expect(ladderProgress([sloppy]).cleared.has(41)).toBe(false);
+  });
+});
+
+describe("unlocking", () => {
+  it("clears a lesson passed and opens the one after it", () => {
+    const progress = ladderProgress([passing(lesson(1))]);
+    expect(progress.cleared.has(1)).toBe(true);
+    expect(progress.best).toBe(1);
+    expect(progress.next).toBe(2);
+  });
+
+  /**
+   * §6.6, and the whole of the placement test. A nine-year-old who already
+   * types opens checkpoint 30, passes it, and starts at 31 — with no session
+   * for a single lesson below it.
+   *
+   * Note what `cleared` does *not* say: 1–29 are not in it, because nothing
+   * was ever run at them and this set is proof rather than permission. They
+   * are behind the child all the same, because `best` is what the ladder locks
+   * against and `best` is a maximum.
+   */
+  it("carries a child to the checkpoint they passed", () => {
+    const progress = ladderProgress([passing(lesson(30))]);
+    expect(progress.cleared.has(30)).toBe(true);
+    expect(progress.cleared.has(29)).toBe(false);
+    expect(progress.best).toBe(30);
+    expect(progress.next).toBe(31);
+  });
+
+  /** A maximum, not the latest: a child revisiting lesson 5 keeps their place. */
+  it("takes the highest pass, whatever order the runs are in", () => {
+    const progress = ladderProgress([
+      passing(lesson(60)),
+      passing(lesson(5)),
+      passing(lesson(6)),
+    ]);
+    expect(progress.best).toBe(60);
+    expect(progress.next).toBe(61);
+  });
+
+  it("stops at the top of the ladder", () => {
+    const progress = ladderProgress([passing(lesson(100))]);
+    expect(progress.best).toBe(100);
+    expect(progress.next).toBe(100);
+  });
+
+  /**
+   * §6.6's reason for `max` over `count`. `MAX_SESSIONS_PER_PROFILE` prunes
+   * the *oldest* runs, so the first thing a child 2000 runs in loses is the
+   * proof that they ever passed lesson 1 — and a tally would answer "you have
+   * cleared three lessons, go and do lesson 4".
+   */
+  it("does not re-lock anything when the oldest session is pruned", () => {
+    const runs = [
+      passing(lesson(1)),
+      passing(lesson(5)),
+      passing(lesson(6)),
+      passing(lesson(7)),
+    ];
+    const whole = ladderProgress(runs);
+    const pruned = ladderProgress(runs.slice(1));
+
+    expect(pruned.cleared.has(1)).toBe(false);
+    expect(pruned.cleared.size).toBe(whole.cleared.size - 1);
+    // A count would have moved; the maximum does not.
+    expect(pruned.best).toBe(whole.best);
+    expect(pruned.next).toBe(whole.next);
+    expect(pruned.next).toBe(8);
+  });
+});
+
+describe("Hailstorm never gates the ladder", () => {
+  /**
+   * §8.8 and decision 24. A tablet has no keys to press, so a child who can do
+   * the whole course cannot play the game — and a reward that blocks you is
+   * not a reward.
+   */
+  it("opens lesson 46 when 44 is cleared, whatever happened at 45", () => {
+    const failed = ladderProgress([
+      passing(lesson(44)),
+      diedInTheStorm(lesson(45)),
+    ]);
+    expect(failed.cleared.has(45)).toBe(false);
+    expect(failed.best).toBe(44);
+    expect(failed.next).toBe(46);
+
+    // And the same for a child who never opened the storm at all. Stepped
+    // over, not skipped: 45 is below `next`, so the storm stays open.
+    expect(ladderProgress([passing(lesson(44))]).next).toBe(46);
+  });
+
+  /**
+   * A storm level is a `Session` like any other (§8.7), so surviving one is a
+   * pass like any other. It is worth nothing extra and costs nothing to
+   * honour: reaching lesson 45 needed 44, and keeping the storm's proof is one
+   * more run that can hold a child's place after the older ones are pruned.
+   */
+  it("still clears a wave that was survived", () => {
+    const progress = ladderProgress([passing(lesson(45))]);
+    expect(progress.cleared.has(45)).toBe(true);
+    expect(progress.best).toBe(45);
+    expect(progress.next).toBe(46);
+  });
+});
+
+describe("criteria that change", () => {
+  /**
+   * §6.5's second claim, which is the one a stored flag cannot make: tune
+   * lesson 41's speed bar down and every child who was one wpm short is
+   * through — with no backfill, no migration and nothing written back to a
+   * record book that holds the only copy there is.
+   */
+  it("clears a run that was one wpm short, without touching it", () => {
+    const asked = lesson(41).pass;
+    if (asked.kind !== "lesson") throw new Error("lesson 41 has no speed bar");
+    const runs = [passing(lesson(41), asked.wpm - 1)];
+    const asSaved = structuredClone(runs[0]);
+
+    expect(ladderProgress(runs).cleared.has(41)).toBe(false);
+
+    retuned(41, asked.wpm - 1, () => {
+      // A fresh array only because the memo is keyed on identity; in the app
+      // the criteria change with a deploy and the sessions are read back out
+      // of IndexedDB on the next load.
+      expect(ladderProgress([...runs]).cleared.has(41)).toBe(true);
+    });
+
+    // The backfill that never happened.
+    expect(runs[0]).toEqual(asSaved);
+  });
+});
+
+describe("the memo", () => {
+  it("answers the same array with the same object", () => {
+    const runs = [passing(lesson(1))];
+    expect(ladderProgress(runs)).toBe(ladderProgress(runs));
+  });
+
+  it("re-derives for a different array", () => {
+    const runs = [passing(lesson(1))];
+    const copy = [...runs];
+    expect(ladderProgress(copy)).not.toBe(ladderProgress(runs));
+    expect(ladderProgress(copy)).toEqual(ladderProgress(runs));
+  });
+});

--- a/src/engine/typing/ladder.ts
+++ b/src/engine/typing/ladder.ts
@@ -1,0 +1,136 @@
+import type { Session } from "@/engine/types";
+
+import { typingMode } from "@/engine/decks/typing";
+import { LESSONS } from "./lessons";
+import { verdictFor } from "./verdict";
+
+/**
+ * How far up the ladder a child has got (docs/typing.md §6.5, §6.6).
+ *
+ * Everything here is **derived from the sessions the hub has already loaded**.
+ * There is no `passedLessons` field, no new object store and no `DB_VERSION`
+ * bump behind it, and three things fall out of that which are worth more than
+ * the memo below costs (decision 14):
+ *
+ *   - **No migration, ever.** Not for this, and not when the criteria change.
+ *   - **It self-heals.** Tune lesson 40's wpm down and every child who was one
+ *     wpm short is through, with no backfill and nothing to re-run.
+ *   - **It cannot disagree with the record book.** A stored flag and a session
+ *     list are two sources of truth for one fact, and they drift the first
+ *     time a save half-fails.
+ *
+ * This is the same kind of function as `records.ts`'s `factStats` and
+ * `tableProgress`: sessions in, an answer about a child in, nothing written
+ * down. Which sessions belong to which child is the caller's to say — hand it
+ * `sessionsFor(sessions, profile.id)`, exactly as the progress screens do.
+ */
+
+export type LadderProgress = {
+  /** Every lesson number cleared. */
+  cleared: ReadonlySet<number>;
+  /** The highest cleared. 0 if none. */
+  best: number;
+  /**
+   * What the ladder points at, and the top of what is open: a lesson is
+   * unlocked when its number is at or below this.
+   */
+  next: number;
+};
+
+/**
+ * The ladder by the string a saved run is filed under, which is what a session
+ * carries: `Session.mode` is `typing:L07` for a lesson (§5.4).
+ *
+ * Keyed on the whole mode rather than on the id inside it so that the two
+ * namespaces behind the `typing:` prefix cannot answer for each other. A run
+ * of the `home-row` level is not lesson 7 and misses this map, which is the
+ * right answer rather than a case to handle: the ladder is the hundred, and a
+ * level, a drill or a spelling race is simply not on it.
+ */
+const BY_MODE = new Map(
+  LESSONS.map((lesson) => [typingMode(lesson.id), lesson]),
+);
+
+/** The same hundred by the number a child sees, for walking up the ladder. */
+const BY_NUMBER = new Map(LESSONS.map((lesson) => [lesson.n, lesson]));
+
+/** The top of the ladder — a hundred today, and read off it rather than typed. */
+const LAST = LESSONS.reduce((top, lesson) => Math.max(top, lesson.n), 0);
+
+/**
+ * The first lesson above `best` that can actually hold a child up (§8.8).
+ *
+ * A Hailstorm level never gates: lesson 46 opens when 44 is cleared, whatever
+ * happened at 45. Two reasons and either alone is sufficient (decision 24) —
+ * **a tablet has no keys to press**, so a child on an iPad who can do the whole
+ * course cannot play the game and would be locked out at lesson 4; and **a
+ * reward that blocks you is not a reward**, which is the opposite of what the
+ * storm levels were put on the ladder for.
+ *
+ * So the pointer is carried over them. It is carried rather than made to jump:
+ * everything at or below `next` is open, so a storm it steps over stays
+ * playable — skippable is not the same as skipped.
+ */
+function carriedOverStorms(best: number): number {
+  let next = best + 1;
+  while (BY_NUMBER.get(next)?.kind.type === "storm") next += 1;
+  return Math.min(next, LAST);
+}
+
+function derive(sessions: Session[]): LadderProgress {
+  const cleared = new Set<number>();
+
+  for (const session of sessions) {
+    const lesson = BY_MODE.get(session.mode);
+    // Nothing to learn from a second pass at a lesson already cleared, and
+    // `verdictFor` walks every card of the run — so the pass over 2000
+    // sessions costs one verdict per lesson, not one per run.
+    if (!lesson || cleared.has(lesson.n)) continue;
+    // A `Session` is a `Run`: what passes a lesson is what the child did, not
+    // which profile did it or when.
+    if (verdictFor(session, lesson).passed) cleared.add(lesson.n);
+  }
+
+  // ── Unlock is `max(cleared) + 1`, not `count(cleared)` (§6.6) ─────────────
+  // Counting would be brittle in a way that only shows up years in:
+  // `MAX_SESSIONS_PER_PROFILE` prunes the *oldest* sessions, so a child 2000
+  // runs in loses the proof that they ever passed lesson 1 and would be sent
+  // back to `fff jjj` by a tally. Taking the maximum means losing old proof
+  // costs nothing as long as one later run survives.
+  //
+  // It is also the whole of the placement test. **Any checkpoint may be
+  // attempted at any time** (decision 16), and passing one sets `best` to its
+  // number, which clears everything below it by this same line — a
+  // nine-year-old who already types opens checkpoint 40, passes it and starts
+  // at 41. That is a skip-ahead, a placement test and the ordering rule in one
+  // sentence, and it is one sentence precisely because nothing here treats a
+  // checkpoint specially. Nor does the loop above ask whether a lesson was
+  // unlocked when it was run: failing costs nothing, so trying one is free.
+  let best = 0;
+  for (const n of cleared) best = Math.max(best, n);
+
+  return { cleared, best, next: carriedOverStorms(best) };
+}
+
+/**
+ * Remembered per sessions array (§6.5).
+ *
+ * The pass is over up to `MAX_SESSIONS_PER_PROFILE` (2000) runs and this is
+ * called from render, so the answer is kept against the array it was derived
+ * from — weakly, so a profile switch or a reload drops it with the sessions
+ * themselves. The array is the whole key: the ladder and its criteria are
+ * fixed at module load, so the same sessions can only ever mean the same
+ * progress in one build. Callers slicing per profile should hold that slice
+ * still (a `useMemo`, as the progress screens already do), or every render
+ * hands over a fresh array and pays for the pass again.
+ */
+const MEMO = new WeakMap<Session[], LadderProgress>();
+
+export function ladderProgress(sessions: Session[]): LadderProgress {
+  const known = MEMO.get(sessions);
+  if (known) return known;
+
+  const progress = derive(sessions);
+  MEMO.set(sessions, progress);
+  return progress;
+}

--- a/src/engine/typing/ladder.ts
+++ b/src/engine/typing/ladder.ts
@@ -31,8 +31,30 @@ export type LadderProgress = {
   /** The highest cleared. 0 if none. */
   best: number;
   /**
-   * What the ladder points at, and the top of what is open: a lesson is
-   * unlocked when its number is at or below this.
+   * What the ladder points at: `best + 1`, carried past any Hailstorm level
+   * standing in the way (§8.8) and capped at the top of the ladder. On a
+   * profile with no runs at all it is 1.
+   *
+   * **It is not the whole unlock rule.** A screen that opens a tile on
+   * `n <= next` alone is wrong in the direction that locks a child out. A
+   * lesson is openable when *either* of these holds (§6.6):
+   *
+   *   - **`n <= next`** — everything up to and including the pointer, the
+   *     storm levels it stepped over included. The pointer is carried over
+   *     them rather than made to jump, so a storm stays playable: skippable
+   *     is not the same as skipped, and no storm level ever gates the lesson
+   *     after it (decision 24).
+   *   - **the lesson is a checkpoint** (`lesson.checkpoint`, every tenth —
+   *     10, 20 … 100). **All ten are always open**, at every value of `next`,
+   *     including on a profile that has never run anything (decision 16).
+   *     That is the placement test: a nine-year-old who already types opens
+   *     checkpoint 40, passes it, and starts at 41 — rather than being sent
+   *     to `fff jjj` for a week. Gate the checkpoints on `next` and that
+   *     express lane is gone, with nothing on screen looking broken.
+   *
+   * Nothing else gates, and a failed attempt costs nothing (§6.6), so opening
+   * a checkpoint early is free — which is what makes "just try one" the
+   * whole of the levelling advice.
    */
   next: number;
 };
@@ -82,9 +104,11 @@ function derive(sessions: Session[]): LadderProgress {
 
   for (const session of sessions) {
     const lesson = BY_MODE.get(session.mode);
-    // Nothing to learn from a second pass at a lesson already cleared, and
-    // `verdictFor` walks every card of the run — so the pass over 2000
-    // sessions costs one verdict per lesson, not one per run.
+    // `verdictFor` walks every card of the run, and there is nothing to learn
+    // from a second pass at a lesson already cleared — so what the `cleared`
+    // guard buys is that repeat passes are free, however many times a child
+    // replays a lesson they have beaten. Runs of a lesson *not* yet cleared
+    // each still pay a verdict, retries included, until one of them clears it.
     if (!lesson || cleared.has(lesson.n)) continue;
     // A `Session` is a `Run`: what passes a lesson is what the child did, not
     // which profile did it or when.


### PR DESCRIPTION
`docs/typing.md` §6.5 and §6.6 as one pure function: `ladderProgress(sessions)`
in `src/engine/typing/ladder.ts`, returning `{ cleared, best, next }`, plus the
suite that holds it. Closes #141. Engine only — no game, no storage, no
`DB_VERSION` bump.

This is the story that makes the hundred lessons a *ladder* rather than a list.
#140 gave it `verdictFor` — the question to ask of one run — and this asks it of
the record book.

## Nothing is stored, so nothing can drift

There is no `passedLessons` field, no new object store, no `Profile` field and
no read-migration in `migrate.ts`. A lesson is cleared if any session filed
under its mode satisfies `verdictFor`, computed over the sessions the hub has
already loaded. Three things fall out of that (§6.5), and all three are worth
more than the memo costs:

- **No migration, ever.** Not for this, and not when the criteria change.
- **It self-heals.** Tune lesson 41's wpm down and every child who was one wpm
  short is through, with no backfill and nothing to re-run.
- **It cannot disagree with the record book.** A stored flag and a session list
  are two sources of truth for one fact, and they drift the first time a save
  half-fails.

It is the same shape as `records.ts`'s `factStats` and `tableProgress`: sessions
in, an answer about a child out, nothing written down. Which sessions belong to
which child stays the caller's to say — hand it `sessionsFor(sessions, id)`,
exactly as the progress screens already do.

## Unlock is `max(cleared) + 1`, not `count(cleared)`

A tally reads correct and is brittle in a way that only surfaces years in.
`MAX_SESSIONS_PER_PROFILE` prunes the **oldest** runs, so a child 2000 races in
loses the proof that they ever passed lesson 1 — and a count would send them
back to `fff jjj` the day it drops, with nothing on screen looking broken.
Taking the maximum means losing old proof costs nothing as long as one later
run survives.

`"does not re-lock anything when the oldest session is pruned"` is that test.

## Checkpoints are one rule, not two

Nothing in this file reads `lesson.checkpoint` when clearing. **All ten
checkpoints are always open** — at every value of `next`, including on a profile
that has never run anything — and passing one sets `best` to its number, which
clears everything below it by the same `max` line. Passing 30 clears 1–29 as a
*consequence*, not as a special case.

That is the placement test, the skip-ahead and the ordering rule in one
sentence, and it is one sentence precisely because there is no branch for it. A
nine-year-old who already types opens checkpoint 40, passes it, and starts at 41
rather than doing `fff jjj` for a week. Nor does the loop ask whether a lesson
was *unlocked* when it was run: `cleared` records proof, not permission, and
failing costs nothing (§6.6) — so "just try one" is the whole of the levelling
advice.

The half that lives in the docstring is the half a UI has to be told, because it
is not expressible as a single number: a screen that opens a tile on `n <= next`
alone locks all ten checkpoints and deletes the express lane. `LadderProgress.next`
now states both halves where the ladder screen (#144) will read it.

## Storm levels never gate

§8.8, decision 24. `next` is **carried** over a Hailstorm level rather than
stopped by one — lesson 46 opens when 44 is cleared, whatever happened at 45.
Two reasons and either alone is sufficient: a tablet has no keys to press, so a
child on an iPad who can do the whole course would be locked out at lesson 4;
and a reward that blocks you is not a reward.

Carried rather than *jumped*, deliberately: everything at or below `next` is
open, so the storm it stepped over stays playable. Skippable is not the same as
skipped. A survived wave still clears normally.

## The memo

A `WeakMap` keyed on the sessions array. The pass is over up to 2000 runs and
this is called from render, so the answer is kept against the array it was
derived from — weakly, so a profile switch or a reload drops it with the
sessions themselves.

The array is the whole key, and that is sound because `HubContext.saveSession`
does `setSessions((current) => [...current, result.session])` — a new run is a
new array, so it can never be answered from a stale memo. The ladder and its
criteria are fixed at module load, so the same sessions can only mean the same
progress within one build. Callers slicing per profile should hold that slice
still in a `useMemo`, or every render hands over a fresh array and pays for the
pass again; the docstring says so.

## Tests

`ladder.test.ts`, 308 lines. Beyond the four the story asked for — checkpoint 30
unlocking 31, the pruned lesson-1 session re-locking nothing, a failed storm not
blocking the lesson after it, and criteria tuned down retroactively clearing a
run that was one wpm short with no backfill — it covers: a profile with no runs
pointed at lesson 1; runs that are not lessons (a level, a drill, a spelling
race) not advancing anything, since the `typing:` prefix has two namespaces and
neither may answer for the other; a run that missed a bar clearing nothing;
order-independence, so the highest pass wins whatever order the runs arrive in;
the cap at the top of the ladder; a survived wave still clearing; and the memo
answering the same array with the same object while re-deriving for a different
one.

## Scope

Engine only. No component, no service, no schema. The ladder UI is #144 (LES10).

`type-check` 0 errors · `lint` clean · `test:unit` **1773 passed** · `build`
static, 200 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
