### PR TITLE
Practise a lesson without anything chasing you

### DIFF
--- a/src/engine/decks/typing.test.ts
+++ b/src/engine/decks/typing.test.ts
@@ -190,6 +190,22 @@ describe("passageFor", () => {
   it("returns nothing rather than throwing for a level that doesn't exist", () => {
     expect(passageFor(config({ levelId: "no-such-level" }), 1)).toEqual([]);
   });
+
+  /**
+   * A lesson's words arrive in the same field a drill's do, and are not the
+   * same kind of thing. The ladder generates them in order — sentences, their
+   * capitals and their full stops (docs/typing.md §5.1, §5.3) — so dealing
+   * them out again would put the stops in the middle of the passage.
+   */
+  it("keeps a lesson's passage in the order the ladder generated it", () => {
+    const passage = ["The", "cat", "sat", "down."];
+    const words = passageFor(
+      config({ lessonId: "L24", words: passage, wordCount: 4 }),
+      // Any seed at all: a passage is not drawn, so none of them can shuffle it.
+      99,
+    );
+    expect(words).toEqual(passage);
+  });
 });
 
 describe("buildTypingDeck", () => {

--- a/src/engine/decks/typing.ts
+++ b/src/engine/decks/typing.ts
@@ -2,7 +2,7 @@ import type { Card, TypingConfig } from "@/engine/types";
 
 import { mulberry32, shuffled } from "@/engine/random";
 import { SCRIPTURE_CREDIT } from "@/engine/sheets/passages/credit";
-import { LESSONS } from "@/engine/typing/lessons";
+import { lessonById } from "@/engine/typing/lessons";
 import { WORD_LISTS, listWords } from "./wordlists";
 import type { DeckSpec } from "./spec";
 
@@ -353,6 +353,20 @@ const drawn = (pool: readonly string[], count: number, rand: () => number) => {
  * decks follow, so a short run never asks for one word four times.
  */
 export function passageFor(config: TypingConfig, seed: number): string[] {
+  /**
+   * A lesson's words are a PASSAGE; a drill's are a bag.
+   *
+   * Both arrive in the same field, because both are a config that carries its
+   * own words (docs/typing.md §5.3) — but they are not the same kind of thing.
+   * The ladder generates a lesson's text in order and at length, sentences and
+   * their full stops included (§5.1), so dealing it out again would shuffle the
+   * stops into the middle of it. A parent's five tricky words are the opposite:
+   * there is no order to keep and the bag is short, so it is drawn from until
+   * the run is long enough. The lesson id is what tells the two apart, exactly
+   * as it does in `typingConfigKey` below.
+   */
+  if (config.lessonId && config.words?.length)
+    return config.words.slice(0, config.wordCount);
   if (config.words?.length)
     return drawn(config.words, config.wordCount, mulberry32(seed));
 
@@ -484,14 +498,12 @@ export function wordsPerMinute(cards: Array<{ answer: string }>, ms: number) {
  * on the far side of `local/no-corpus-in-decks`, and the words a lesson was
  * played on arrive in `config.words` from the island that generated them.
  */
-const LESSONS_BY_ID = new Map(LESSONS.map((lesson) => [lesson.id, lesson]));
-
 export function typingDeckSpec(mode: string): DeckSpec {
   const id = levelIdOf(mode);
   // Two namespaces behind one prefix, and neither can answer for the other: a
   // lesson id is "L07" and a level id is "home-row". A mode from neither is a
   // level this build has retired, which still reads as a typing run.
-  const lesson = LESSONS_BY_ID.get(id);
+  const lesson = lessonById(id);
   const level = TYPING_LEVELS_BY_ID.get(id);
   return {
     id: mode,

--- a/src/engine/typing/lessons.test.ts
+++ b/src/engine/typing/lessons.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { LESSONS } from "./lessons";
+import { LESSONS, lessonById } from "./lessons";
 import type { Lesson } from "./lessons";
 import { strokeFor } from "../keyboard";
 
@@ -55,6 +55,23 @@ describe("the shape of the ladder", () => {
     expect(lesson(7).id).toBe("L07");
     expect(lesson(50).id).toBe("L50");
     expect(lesson(100).id).toBe("L100");
+  });
+
+  /**
+   * The other half of that promise: the id has to resolve back. A screen asks
+   * "is this run a lesson?" with a config in hand and gets the lesson or
+   * nothing — never a throw, because a saved run outlives the ladder it was
+   * played on and every one of these three cases reaches a live screen.
+   */
+  it("resolves an id back to its lesson, and anything else to null", () => {
+    expect(lessonById("L07")).toBe(lesson(7));
+    expect(lessonById("L100")).toBe(lesson(100));
+    // A free-play config, which simply has no lesson id.
+    expect(lessonById(undefined)).toBeNull();
+    // A level id, which shares the `typing:` prefix and is not on the ladder.
+    expect(lessonById("home-row")).toBeNull();
+    // A lesson a later build re-cut away from under a run already saved.
+    expect(lessonById("L101")).toBeNull();
   });
 
   it("puts ten lessons in each of ten blocks", () => {

--- a/src/engine/typing/lessons.ts
+++ b/src/engine/typing/lessons.ts
@@ -504,3 +504,25 @@ function toLesson(row: Row): Lesson {
 
 /** The ladder, in order. Exactly a hundred, and `LESSONS[i].n === i + 1`. */
 export const LESSONS: readonly Lesson[] = ROWS.map(toLesson);
+
+/**
+ * The same hundred by the id a run is filed under.
+ *
+ * `TypingConfig.lessonId` and the half of `Session.mode` after the `typing:`
+ * prefix are the same string, and this is the one place it is resolved.
+ */
+const BY_ID = new Map(LESSONS.map((lesson) => [lesson.id, lesson]));
+
+/**
+ * The lesson with this id, or `null` for anything that is not one.
+ *
+ * Total on purpose, and in both directions: `undefined` is the ordinary answer
+ * for a free-play config, which simply has no `lessonId`, and an id from a
+ * build that has since re-cut the ladder is a run that must still open rather
+ * than a case to throw on. It is the same promise `deckSpec` makes one layer
+ * up — a saved run outlives the ladder it was played on (CLAUDE.md) — and it
+ * is what lets a screen ask "is this a lesson?" and get the lesson back in the
+ * same breath.
+ */
+export const lessonById = (id?: string | null): Lesson | null =>
+  (id ? BY_ID.get(id) : undefined) ?? null;

--- a/src/games/race/Hud.tsx
+++ b/src/games/race/Hud.tsx
@@ -9,12 +9,25 @@ export function Hud({
   answered,
   total,
   onQuit,
+  penalty = true,
 }: {
   elapsedMs: number;
   misses: number;
   answered: number;
   total: number;
   onQuit: () => void;
+  /**
+   * Whether a wrong answer costs time, which is a thing about the run rather
+   * than about this header. True in a race, and default because a race is what
+   * this header was built for. False on a typing lesson: three seconds a miss
+   * is a race mechanic, and on a lesson it double-counts accuracy — which has a
+   * bar of its own there — and makes the wpm figure a lie, because the number
+   * stops being words per minute of anything (docs/typing.md §7).
+   *
+   * The miss count still comes in, because it is still true; what changes is
+   * whether it is charged for.
+   */
+  penalty?: boolean;
 }) {
   return (
     <header className="race__hud">
@@ -24,7 +37,7 @@ export function Hud({
 
       <div className="race__clock u-mono">
         <span className="race__clock-time">{clock(elapsedMs)}</span>
-        {misses > 0 && (
+        {penalty && misses > 0 && (
           <span className="race__penalty">
             +{(misses * WRONG_ANSWER_PENALTY_MS) / 1000}s
           </span>

--- a/src/games/typing/LessonBars.test.tsx
+++ b/src/games/typing/LessonBars.test.tsx
@@ -1,0 +1,133 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { lessonById } from "@/engine/typing/lessons";
+import type { CardResult, TypingConfig } from "@/engine/types";
+
+import { LessonBars } from "./LessonBars";
+
+/**
+ * The bars a lesson is run against, while it is being run
+ * (docs/typing.md §7, §6.1).
+ *
+ * What the numbers mean is pinned next door in `verdict.test.ts`, and this
+ * file deliberately does not re-test it: these bars come from `verdictFor`
+ * precisely so that the HUD and the results screen cannot drift apart by a
+ * rounding rule. What is only true here is the three decisions this component
+ * makes on top of it — which bars are shown, which of many keys is worth a
+ * bar, and that a bar cannot report more than full.
+ */
+
+/** Lesson 1: `f` and `j`, at 95% accuracy, 8 wpm, and 12 strikes a key. */
+const L01 = lessonById("L01")!;
+/** Lesson 7: the first words, and it introduces nothing — so no key bar. */
+const L07 = lessonById("L07")!;
+
+const config: TypingConfig = {
+  kind: "typing",
+  levelId: "L01",
+  lessonId: "L01",
+  wordCount: 24,
+};
+
+/** A word as the loop records it: right when what was given matches. */
+const card = (answer: string, given = answer): CardResult => ({
+  prompt: answer,
+  answer,
+  given,
+  ok: given === answer,
+  ms: 2500,
+  factId: answer,
+});
+
+const times = (n: number, make: () => CardResult) =>
+  Array.from({ length: n }, make);
+
+type Row = { label: string; ok: boolean; width: string; value: string };
+
+/** The bars as drawn, in the order they were drawn. */
+const rows = (html: string): Row[] =>
+  html
+    .split('<div class="passbar')
+    .slice(1)
+    .map((chunk) => ({
+      ok: /^[^>]*is-ok/.test(chunk),
+      label: /passbar__label">([^<]*)</.exec(chunk)![1],
+      width: /style="width:([^"]*)"/.exec(chunk)![1],
+      value: /passbar__value u-mono">([^<]*)</.exec(chunk)![1],
+    }));
+
+const render = (lesson = L01, cards: CardResult[] = [], elapsedMs = 60000) =>
+  rows(
+    renderToStaticMarkup(
+      <LessonBars
+        lesson={lesson}
+        config={config}
+        cards={cards}
+        elapsedMs={elapsedMs}
+      />,
+    ),
+  );
+
+describe("LessonBars", () => {
+  it("shows accuracy, then the new key, then speed", () => {
+    // §6.1's order, which is the order they matter: a child who is failing
+    // both should be told about the accuracy first.
+    expect(render().map((row) => row.label)).toEqual([
+      "Accuracy",
+      "New key f",
+      "Speed",
+    ]);
+  });
+
+  it("draws an empty bar for a run that hasn't started", () => {
+    // The first frame, behind the 3·2·1: no cards, and a clock that is already
+    // running. Nothing divides by nothing, and no bar claims to be full.
+    expect(render().map((row) => row.width)).toEqual(["0%", "0%", "0%"]);
+    expect(render().every((row) => !row.ok)).toBe(true);
+  });
+
+  it("fills and marks each bar the run has met", () => {
+    // Twenty-four four-letter words in a minute: 24 wpm against a bar of 8,
+    // every word right, and both new keys struck 48 times apiece.
+    const done = [
+      ...times(12, () => card("ffff")),
+      ...times(12, () => card("jjjj")),
+    ];
+    expect(render(L01, done)).toEqual([
+      { label: "Accuracy", ok: true, width: "100%", value: "100%" },
+      { label: "New key f", ok: true, width: "100%", value: "100%" },
+      { label: "Speed", ok: true, width: "100%", value: "24" },
+    ]);
+  });
+
+  /**
+   * The one that matters at seven. A lesson introduces two keys as a rule and
+   * fifteen at lesson 31, and the gate is every one of them at once (§6.4) —
+   * so the bar worth the room is the key that is holding you up, and naming it
+   * is the instruction.
+   */
+  it("names the key that is holding the run up", () => {
+    const drill = [
+      ...times(12, () => card("ffff")),
+      // Every `j` word ends on an `f`: three strikes of `j` land, one misses.
+      ...times(12, () => card("jjjj", "jjjf")),
+    ];
+    const [accuracy, key] = render(L01, drill);
+
+    expect(key).toMatchObject({ label: "New key j", ok: false, value: "75%" });
+    // 75% of a bar that wants 90%: most of the way along it, and not there.
+    expect(Number.parseFloat(key.width)).toBeCloseTo(83.3, 1);
+    // Half the words wrong, so the bar it is really failing on is the first.
+    expect(accuracy).toMatchObject({ ok: false, value: "50%" });
+  });
+
+  it("has no key bar on a lesson that introduces nothing", () => {
+    // Every review lesson and every checkpoint. There is no third thing being
+    // asked, and a bar for it would be one that can never move.
+    expect(render(L07, [card("dad")]).map((row) => row.label)).toEqual([
+      "Accuracy",
+      "Speed",
+    ]);
+  });
+});

--- a/src/games/typing/LessonBars.tsx
+++ b/src/games/typing/LessonBars.tsx
@@ -1,0 +1,157 @@
+import { percent } from "@/engine/format";
+import { verdictFor, type Bar, type KeyBar } from "@/engine/typing/verdict";
+import type { Lesson } from "@/engine/typing/lessons";
+import type { CardResult, RaceConfig } from "@/engine/types";
+
+/**
+ * What the lesson is asking for, filling as the child does it
+ * (docs/typing.md §7, §6.1).
+ *
+ * This is what a lesson has where a race has the ghost lane. Nothing is
+ * chasing you here — what you are chasing is the criteria, and the point of
+ * putting them on screen while the run is live is that you can watch yourself
+ * meet them. Three bars rather than one number for the reason the whole
+ * verdict exists: a single score tells a seven-year-old that they failed and
+ * not what to do, where "fast enough, not accurate enough" is an instruction.
+ *
+ * The bars are the SAME ones the results screen will draw, because they come
+ * from the same `verdictFor` over the run so far — cards in, elapsed in, three
+ * bars out. A HUD that counted accuracy its own way would drift from the
+ * verdict by a rounding rule and tell a child they had it a word before they
+ * did.
+ */
+
+/**
+ * The verdict is recomputed every time the clock ticks — about sixteen times a
+ * second — so it walks the cards that often. That is a pass over at most
+ * `lesson.wordCount` (150 at the top of the ladder) doing character compares,
+ * next to a screen that is already re-rendering the passage at that rate. It is
+ * measured in microseconds and it buys the one thing worth having: there is no
+ * second definition of "how it is going" to disagree with the one that decides
+ * whether the lesson was passed.
+ */
+export function LessonBars({
+  lesson,
+  config,
+  cards,
+  elapsedMs,
+}: {
+  lesson: Lesson;
+  /** The run's own config, which is all `verdictFor` reads it for. */
+  config: RaceConfig;
+  /** The words committed so far, in order. */
+  cards: CardResult[];
+  /** The stopwatch, so speed is speed *now* and not speed at the last word. */
+  elapsedMs: number;
+}) {
+  const correct = cards.filter((card) => card.ok).length;
+  const verdict = verdictFor(
+    {
+      cards,
+      config,
+      correct,
+      incorrect: cards.length - correct,
+      durationMs: elapsedMs,
+    },
+    lesson,
+  );
+
+  const key = weakest(verdict.keys);
+
+  return (
+    <section className="passbars" aria-label="What this lesson asks for">
+      {/* §6.1's order, which is the order they matter: accuracy, then the new
+          keys, then speed. */}
+      <Meter
+        label="Accuracy"
+        bar={verdict.accuracy}
+        value={percent(verdict.accuracy.got)}
+        target={percent(verdict.accuracy.need)}
+      />
+      {/* Absent on a review lesson and on every checkpoint — they introduce
+          nothing, so there is no third thing being asked and a bar for it
+          would be a bar that can never move (§6.1). */}
+      {key && (
+        <Meter
+          label={`New key ${key.key}`}
+          bar={key}
+          value={percent(key.got)}
+          target={percent(key.need)}
+        />
+      )}
+      <Meter
+        label="Speed"
+        bar={verdict.wpm}
+        value={String(Math.round(verdict.wpm.got))}
+        target={`${verdict.wpm.need} wpm`}
+      />
+    </section>
+  );
+}
+
+/**
+ * The new keys, as one bar.
+ *
+ * A lesson introduces two characters as a rule, six at lesson 67 and fifteen at
+ * lesson 31 — and fifteen bars over a live passage is a wall rather than a
+ * signal. So the bar shown is the key that is holding you up, because the gate
+ * is every key at once (§6.4): the run is only through when the weakest one is,
+ * and naming it is the instruction the child needs.
+ *
+ * "Weakest" is a not-yet-passed key before a lower fraction, which is not the
+ * same ordering. A key struck right three times reads 100% and is still not
+ * `ok`, because the strike floor is the half of the gate a fraction cannot
+ * carry — so a bar that looks full and one that looks nearly full can be the
+ * failing one and the passing one respectively.
+ */
+function weakest(keys: KeyBar[]): KeyBar | null {
+  return keys.reduce<KeyBar | null>((worst, key) => {
+    if (!worst) return key;
+    if (worst.ok !== key.ok) return worst.ok ? key : worst;
+    return key.got < worst.got ? key : worst;
+  }, null);
+}
+
+/**
+ * One criterion: what it wants, how far you are, and whether that is full.
+ *
+ * The fill is `got / need` capped, so a bar cannot report more than a full one
+ * — being at 40 wpm against a target of 12 is a full bar and not a bar and a
+ * half. `--lime` at the top of it because a met criterion is the same green
+ * "correct" is everywhere else on this site (CLAUDE.md, the telemetry five),
+ * and a plain fill below it because "not yet" is not "wrong" — `--flare`
+ * would tell a child mid-run that they had failed something they are three
+ * words from passing.
+ */
+function Meter({
+  label,
+  bar,
+  value,
+  target,
+}: {
+  label: string;
+  bar: Bar;
+  /** The reading, in this bar's own units. */
+  value: string;
+  /** What it has to reach, in the same units. */
+  target: string;
+}) {
+  // A storm level asks nothing of the speed column and carries `need: 0` to
+  // say so (§5.6). Nothing divides by that.
+  const filled = bar.need <= 0 ? 1 : Math.min(1, bar.got / bar.need);
+
+  return (
+    <div className={`passbar${bar.ok ? " is-ok" : ""}`}>
+      <span className="passbar__label">{label}</span>
+      {/* The picture of a number the text beside it already gives, so a screen
+          reader is handed the number once rather than a bar it cannot see. */}
+      <span className="passbar__track" aria-hidden="true">
+        <span className="passbar__fill" style={{ width: `${filled * 100}%` }} />
+      </span>
+      <span className="passbar__value u-mono">
+        {value}
+        <span className="passbar__need"> / {target}</span>
+      </span>
+    </div>
+  );
+}

--- a/src/games/typing/TypingTrack.tsx
+++ b/src/games/typing/TypingTrack.tsx
@@ -294,12 +294,17 @@ function Track({
    * How much of the board is on screen: `lesson.keyboard ?? profile.keyboard ??
    * "guide"`, which is the one line §4.2 asks for.
    *
-   * The lesson wins where it has an opinion, and most of them don't — a lesson
-   * carrying `null` defers to the child, which is the ordinary case. The two
-   * ends of the ladder are where the override earns its keep: lesson 1 forces
-   * `guide`, because a child who has never seen a keyboard cannot be asked to
-   * guess, and every checkpoint forces `off`, because a checkpoint that can be
-   * passed while reading the answer off the screen measures nothing.
+   * On the ladder as it stands, the lesson always wins: every one of the
+   * hundred names a mode, so `?? keyboardMode(profile.keyboard)` is free play's
+   * arm — plus the defensive one, for a lesson that ever carries `null`. The
+   * pins run the ladder's whole length, not just its ends, and the reasoning is
+   * clearest there: lesson 1 forces `guide`, because a child who has never seen
+   * a keyboard cannot be asked to guess, and every checkpoint forces `off`,
+   * because a checkpoint that can be passed while reading the answer off the
+   * screen measures nothing. `keyboardLocked` consequently reads the same as
+   * unlocked here — #145, the lesson brief and its keyboard lock, is where an
+   * unlocked lesson seeds the control instead of overriding it and the player
+   * gets the choice back.
    *
    * The player's half is resolved by the same function that draws the pills on
    * the setup screen, so the two can't disagree about a profile whose field is

--- a/src/games/typing/TypingTrack.tsx
+++ b/src/games/typing/TypingTrack.tsx
@@ -11,6 +11,7 @@ import {
   cumulativeSplits,
   sessionsFor,
 } from "@/engine/records";
+import { lessonById } from "@/engine/typing/lessons";
 import {
   Hud,
   Lane,
@@ -22,6 +23,7 @@ import {
   useRaceFinish,
 } from "@/games/race";
 import { sfx } from "@/services/sound";
+import { LessonBars } from "./LessonBars";
 import { Passage } from "./Passage";
 import { TypeField } from "./TypeField";
 import { keyboardMode } from "./keyboard/KeyboardSetting";
@@ -50,6 +52,20 @@ import type {
  * - **Space is the whole interface.** No Enter, no submit button. Backspace
  *   works inside the current word and nowhere else, because a typing test that
  *   lets you walk back through a finished passage isn't measuring anything.
+ *
+ * ── And the same loop with the race taken out ────────────────────────────────
+ * A run from the ladder is a lesson, and a lesson is not a race
+ * (docs/typing.md §7). It is this component with four things removed and one
+ * added, all of them off `config.lessonId` and none of them a second loop:
+ * no ghost, no lane, no wrong-answer penalty, no starting gun in the copy —
+ * and the three pass bars filling live where the rival's gap would be.
+ *
+ * One component rather than two because of what is NOT different: space still
+ * commits a word and a word is still a `Card`. Keeping that is what makes the
+ * record book, the splits, the trouble list, XP and the drill builder work on
+ * lessons for free, and it is the single highest-leverage thing here not to
+ * change. Free play — the five levels, their ghosts and their personal bests —
+ * runs through these same lines and is untouched by any of it.
  */
 export default function TypingTrack() {
   const { profileId } = useParams();
@@ -105,9 +121,32 @@ function Track({
   finish,
   navigate,
 }: TrackProps) {
-  const { config, seed, ghost } = pending;
+  const { config, seed } = pending;
   const spec = deckSpec(modeOf(config));
   const deck = useMemo(() => buildDeck(config, seed), [config, seed]);
+
+  /**
+   * The lesson this run is, or `null` when it is free play — the one switch
+   * every difference below hangs off (§7).
+   *
+   * Read from the config rather than from a route or a prop, so that what a run
+   * IS travels with the run: `pending` is what the countdown, the save and the
+   * results screen all read, and a second source for "is this a lesson" is a
+   * second thing to get out of step with `modeOf`, which files the run under
+   * this same id. `lessonById` is total — a config with no lesson id, and one
+   * naming a lesson this build has re-cut, both land here as free play.
+   */
+  const lesson = lessonById(config.lessonId);
+
+  /**
+   * Nothing is chasing you on a lesson (§7).
+   *
+   * The ladder never offers a rival, so this is belt and braces — but it is the
+   * one value the lane, the gap, the overtake sound and `beatGhost` all hang
+   * off, so making it null HERE is what makes "no ghost" true of the whole
+   * screen rather than of the four places that would each have to remember.
+   */
+  const ghost = lesson ? null : pending.ghost;
   const ghostSplits = useMemo(
     () => (ghost ? cumulativeSplits(ghost.session) : null),
     [ghost],
@@ -144,7 +183,19 @@ function Track({
     index,
     onTimeout: () => {},
   });
-  const raceElapsed = elapsed() + misses.current * WRONG_ANSWER_PENALTY_MS;
+  /**
+   * The clock a rival is measured against — and on a lesson, just the clock.
+   *
+   * **No `WRONG_ANSWER_PENALTY_MS` on a lesson** (§7). Three seconds a miss is
+   * a race mechanic: it is there to make a wrong answer cost something when the
+   * only thing a race counts is time. A lesson already counts accuracy, on a
+   * bar of its own, so charging for it again double-counts it — and it would
+   * make the wpm figure a lie, because a "minute" with penalties folded into it
+   * is not a minute and the number stops being words per minute of anything.
+   * Free play keeps every second of it; free play is a race.
+   */
+  const raceElapsed =
+    elapsed() + (lesson ? 0 : misses.current * WRONG_ANSWER_PENALTY_MS);
 
   const rival = useGhostGap({ splits: ghostSplits, raceElapsed, index, total });
 
@@ -240,12 +291,21 @@ function Track({
   const next = live ? nextChar(deck[index]?.answer ?? "", entry) : null;
 
   /**
-   * How much of the board this player asked for. Resolved by the same function
-   * that draws the pills on the setup screen, so the two can't disagree about
-   * a profile whose field is absent — which is every profile made before the
-   * setting shipped.
+   * How much of the board is on screen: `lesson.keyboard ?? profile.keyboard ??
+   * "guide"`, which is the one line §4.2 asks for.
+   *
+   * The lesson wins where it has an opinion, and most of them don't — a lesson
+   * carrying `null` defers to the child, which is the ordinary case. The two
+   * ends of the ladder are where the override earns its keep: lesson 1 forces
+   * `guide`, because a child who has never seen a keyboard cannot be asked to
+   * guess, and every checkpoint forces `off`, because a checkpoint that can be
+   * passed while reading the answer off the screen measures nothing.
+   *
+   * The player's half is resolved by the same function that draws the pills on
+   * the setup screen, so the two can't disagree about a profile whose field is
+   * absent — which is every profile made before the setting shipped.
    */
-  const board = keyboardMode(profile.keyboard);
+  const board = lesson?.keyboard ?? keyboardMode(profile.keyboard);
 
   if (saveError) {
     return (
@@ -269,6 +329,11 @@ function Track({
           <span key={countdown} className="countdown__num u-display">
             {countdown === 0 ? "GO" : countdown}
           </span>
+          {/* The 3·2·1 stays on a lesson, because it is the moment the hands go
+              on the home row and that is worth keeping for its own sake — but
+              it is not a starting gun there, so it doesn't talk like one
+              (§7). */}
+          {lesson && <p className="countdown__note">Fingers on home row</p>}
         </div>
       )}
 
@@ -278,16 +343,30 @@ function Track({
         answered={answered}
         total={total}
         onQuit={() => setQuitting(true)}
+        penalty={!lesson}
       />
 
-      <Lane
-        profile={profile}
-        ghost={ghost}
-        mePos={answered / total}
-        ghostPos={rival.position}
-        gap={rival.gap}
-        note="Space moves you on"
-      />
+      {/* The lane is the race; the bars are the lesson. They stand in the same
+          place because they answer the same question — how is this going —
+          and a lesson answers it with the criteria rather than with a rival
+          (§7). */}
+      {lesson ? (
+        <LessonBars
+          lesson={lesson}
+          config={config}
+          cards={results.current}
+          elapsedMs={elapsed()}
+        />
+      ) : (
+        <Lane
+          profile={profile}
+          ghost={ghost}
+          mePos={answered / total}
+          ghostPos={rival.position}
+          gap={rival.gap}
+          note="Space moves you on"
+        />
+      )}
 
       <Passage
         deck={deck}

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -584,6 +584,72 @@ label.segmented__btn {
   opacity: 0.8;
 }
 
+/* ── The three bars, where a lesson keeps its lane ─────────────────────────
+   A lesson is not a race (docs/typing.md §7): nothing is chasing you, so what
+   stands where the ghost lane stands is what you ARE chasing — accuracy, the
+   new keys, and speed — filling as the run goes. Same row of the race grid,
+   same job, different question answered. */
+
+.passbars {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.passbar {
+  display: grid;
+  /* Label, bar, reading. The bar takes what the two ends don't, so a long key
+     name can't squeeze it to nothing. */
+  grid-template-columns: minmax(5.5rem, auto) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.passbar__label {
+  font-size: var(--step--2);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--chalk-dim);
+}
+
+.passbar__track {
+  height: 0.55rem;
+  border-radius: 999px;
+  border: 1px solid var(--hairline);
+  background: rgb(0 0 0 / 25%);
+  overflow: hidden;
+}
+
+.passbar__fill {
+  display: block;
+  height: 100%;
+  /* "Not yet" is not "wrong". A bar short of its target is drawn in the
+     player's own tint and never in --flare, which on this site means a wrong
+     answer and would tell a child mid-run that they had failed something they
+     are three words from passing. */
+  background: var(--tint, var(--accent));
+  transition: width 0.3s var(--ease-out);
+}
+
+/* Met, in the same green "correct" is everywhere else — one of the five
+   colours that mean the same thing in every world (CLAUDE.md). */
+.passbar.is-ok .passbar__fill {
+  background: var(--lime);
+}
+
+.passbar__value {
+  font-size: var(--step--1);
+  font-weight: 700;
+}
+
+.passbar.is-ok .passbar__value {
+  color: var(--lime);
+}
+
+.passbar__need {
+  font-weight: 400;
+  color: var(--chalk-dim);
+}
+
 /* ── The card ──────────────────────────────────────────────────────────── */
 
 .card {
@@ -840,6 +906,15 @@ label.segmented__btn {
   color: var(--go);
   animation: pop 0.45s var(--ease-spring) both;
   text-shadow: 0 0 60px color-mix(in oklab, var(--go) 40%, transparent);
+}
+
+/* What the 3·2·1 is for on a lesson, where it is not a starting gun (§7). */
+.countdown__note {
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--chalk-dim);
 }
 
 /* ── Results ───────────────────────────────────────────────────────────── */

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -896,7 +896,15 @@ label.segmented__btn {
   inset: 0;
   z-index: 40;
   display: grid;
+
+  /* `align-content` matters here because a lesson puts a second child in the
+     overlay (the home-row note, §7). Left at its default the two rows stretch
+     to fill the viewport and each child centres inside its own half, which
+     drops the note hundreds of pixels below the numeral and on top of the
+     keyboard. Centring the track group keeps the two as one stack. */
   place-items: center;
+  align-content: center;
+  gap: 0.75rem;
   background: rgb(7 8 13 / 88%);
   backdrop-filter: blur(4px);
 }


### PR DESCRIPTION
`docs/typing.md` §7 is four bullets and a promise: the lesson run is the
existing `TypingTrack` with the race taken out of it, and free play is
untouched. This story is those four bullets. Closes #142. Design:
`docs/typing.md` §7, §9.

This is the first story in the epic that a child can see. #138 gave it text,
#139 gave a run a lesson id, #140 gave the three bars and #141 gave the ladder
its next tile — none of which had a screen. This is the screen, and the whole of
it is one component with four things removed and one added.

## One component, because of what is *not* different

The temptation is a second track: a lesson has no ghost, no rival, no penalty
and a different header, which is enough differences to feel like a different
game. It isn't, and the reason is the line that doesn't change — **space commits
a word, and a word is a `Card`**. Keep that and the record book, the splits, XP,
the trouble list and the drill builder all work on lessons for free, because
none of them ever learn that lessons exist. A lesson saves a `Session` under
`typing:L06` and everything downstream reads it as one more run.

So the differences hang off one value:

```ts
const lesson = lessonById(config.lessonId);
```

Read from the **config**, not from a route or a prop, so that what a run *is*
travels with the run. `pending` is what the countdown, the save and the results
screen all read, and `modeOf` files the run under this same id — a second source
for "is this a lesson" is a second thing to get out of step with the first.
`lessonById` is total in both directions: a free-play config simply has no
`lessonId`, and a run saved against a lesson a later build has re-cut still
opens rather than throwing. It moved into `lessons.ts` from the private map
`decks/typing.ts` was keeping, since two callers now ask the same question.

| on a lesson | why |
| --- | --- |
| `ghost = null` | the ladder never offers a rival, but nulling it **here** is what makes "no ghost" true of the lane, the gap, the overtake sound and `beatGhost` at once, rather than of four places that each have to remember |
| no `Lane`, no rival list | nothing is chasing you |
| no `WRONG_ANSWER_PENALTY_MS` | below |
| `penalty={false}` on the `Hud` | the miss count still arrives, because it is still true; what changes is whether it is charged for |
| `LessonBars` where the lane stood | same row of the grid, same question — how is this going — answered with the criteria instead of a rival |

## The penalty is the one that would have been easy to keep

Three seconds a miss exists to make a wrong answer cost something when the only
thing a race counts is time. A lesson already counts accuracy, on a bar of its
own — so charging for it again **double-counts it**, and worse, it makes the wpm
figure a lie. A "minute" with penalties folded into it is not a minute, and the
number stops being words per minute of anything. A child who missed four words
would be shown a speed nobody typed, on the same screen that asks them to reach
10 wpm.

```ts
const raceElapsed =
  elapsed() + (lesson ? 0 : misses.current * WRONG_ANSWER_PENALTY_MS);
```

Free play keeps every second of it. Free play is a race.

## The bars are the verdict, not a second opinion

`LessonBars` calls `verdictFor` over the run so far — cards in, elapsed in,
three bars out — which is the **same function** the results screen will use to
decide whether the lesson was passed. A HUD that counted accuracy its own way
would drift by a rounding rule and tell a child they had it a word before they
did.

It recomputes on every clock tick, about sixteen times a second, walking at most
150 cards. That is microseconds beside a passage that is already re-rendering at
that rate, and it buys the one thing worth having: there is no second definition
of "how it is going".

Three decisions inside it:

- **One key bar, not fifteen.** A lesson introduces two characters as a rule,
  six at lesson 67 and fifteen at lesson 31 — and fifteen bars over a live
  passage is a wall rather than a signal. The bar shown is the key **holding you
  up**, because the gate is every key at once (§6.4): the run is only through
  when the weakest one is, and naming it is the instruction. "Weakest" is
  not-yet-passed before lower-fraction, which is a different ordering — a key
  struck right three times reads 100% and is still not `ok`, because the strike
  floor is the half of the gate a fraction cannot carry.
- **No key bar at all** on a review lesson or a checkpoint. They introduce
  nothing, so a third bar there is a bar that can never move.
- **A short bar is drawn in the player's own tint, never `--flare`.** "Not yet"
  is not "wrong", and `--flare` means a wrong answer everywhere else on this
  site — it would tell a child mid-run that they had failed something they are
  three words from passing. `--lime` when met, the same green "correct" is in
  every world.

## Two things found on the way

**A lesson's words are a passage; a drill's are a bag.** Both arrive in
`config.words`, and `passageFor` was dealing both out with `drawn` — which for a
lesson shuffles the text the ladder generated *in order*, full stops and all,
and scatters the stops through the middle of it. The lesson id is what tells the
two apart, exactly as it already does in `typingConfigKey`. A parent's five
tricky words have no order to keep and are drawn from as before.

**The countdown overlay only ever had one child.** `.countdown` is a fixed,
full-viewport grid; adding the home-row note gave it two implicit rows, which
stretched to fill the screen with each child centring inside its own half. The
caption landed 258–408px below the numeral, on top of the keyboard picture.
`align-content: center` plus a gap makes the two read as one stack — measured in
Chromium at 2px separation on 1300×1100 and 1280×800, 7px at 390×844. Free play
has one child there and is pixel-identical.

## The rest of §7, and the two guards

The **3·2·1 stays**, because it is the moment the hands go on the home row and
that is worth keeping for its own sake — but it is not a starting gun on a
lesson, so it doesn't talk like one. "Fingers on home row" under the numeral.

The **keyboard** resolves as §4.2 asks: `lesson.keyboard ?? profile.keyboard ??
"guide"`, with `next` fed from the current character as before. On the ladder as
shipped the lesson always wins — all hundred name a mode — so the profile arm is
free play's plus a defensive path. Lesson 1 forces `guide`, because a child who
has never seen a keyboard cannot be asked to guess; every checkpoint forces
`off`, because a checkpoint passed while reading the answer off the screen
measures nothing. Giving an unlocked lesson's choice back to the player is #145.

§9's routing is **unchanged** — no new route, no new provider, `pending` drives
the run exactly as today. The two navigation guards at the top of `TypingTrack`
and `TypingResults` were each written after a real bug and reworking the routing
around them is how they come back, so this story routes nothing.

## Free play, in a browser

The claim that matters most here is a negative one, so it was checked rather
than asserted. Driven in Chromium against the built site: the ice world boots,
a profile is made, a level starts with the **ghost lane present and no pass
bars**, a wrong word still shows **+3s**, space commits, the results screen
reports 451 words a minute, and the session is in IndexedDB after a reload. No
console errors.

The lesson side was driven the same way, through a temporary local hook (the
ladder that will do this properly is #144, and it is not in this branch): the
home-row note sits 12px under the numeral, there is **no lane and no rival
list**, lesson 6 shows three bars and lesson 7 shows two, the fills move as the
run goes on (`0% → 97.166% / 55.5556% / 100%`), **no `+3s` ever appears**, and
the run lands in the record book under `typing:L06`. The hook was reverted
before this branch was pushed; the diff contains no route to a lesson.

## Scope

No results screen (#143) and no ladder (#144) — a lesson run is reachable from
neither yet, by design. No storage change, no `DB_VERSION` bump, no migration,
no new `Session` field. `TypingTrack` and `LessonBars` are both inside the
300-line cap with comments skipped, and the allowlist stays deleted.

`type-check` 0 errors · `lint` clean · `test:unit` **1780 passed** · `build`
static, 200 pages · `test:smoke` all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
