### PR TITLE
Say what a missed lesson costs, not what it scored

### DIFF
--- a/src/engine/typing/ladder.ts
+++ b/src/engine/typing/ladder.ts
@@ -1,7 +1,7 @@
 import type { Session } from "@/engine/types";
 
 import { typingMode } from "@/engine/decks/typing";
-import { LESSONS } from "./lessons";
+import { LESSONS, lessonNumbered } from "./lessons";
 import { verdictFor } from "./verdict";
 
 /**
@@ -73,9 +73,6 @@ const BY_MODE = new Map(
   LESSONS.map((lesson) => [typingMode(lesson.id), lesson]),
 );
 
-/** The same hundred by the number a child sees, for walking up the ladder. */
-const BY_NUMBER = new Map(LESSONS.map((lesson) => [lesson.n, lesson]));
-
 /** The top of the ladder — a hundred today, and read off it rather than typed. */
 const LAST = LESSONS.reduce((top, lesson) => Math.max(top, lesson.n), 0);
 
@@ -95,7 +92,7 @@ const LAST = LESSONS.reduce((top, lesson) => Math.max(top, lesson.n), 0);
  */
 function carriedOverStorms(best: number): number {
   let next = best + 1;
-  while (BY_NUMBER.get(next)?.kind.type === "storm") next += 1;
+  while (lessonNumbered(next)?.kind.type === "storm") next += 1;
   return Math.min(next, LAST);
 }
 

--- a/src/engine/typing/lessons.ts
+++ b/src/engine/typing/lessons.ts
@@ -526,3 +526,17 @@ const BY_ID = new Map(LESSONS.map((lesson) => [lesson.id, lesson]));
  */
 export const lessonById = (id?: string | null): Lesson | null =>
   (id ? BY_ID.get(id) : undefined) ?? null;
+
+/** The same hundred by the number a child sees, for walking up the ladder. */
+const BY_NUMBER = new Map(LESSONS.map((lesson) => [lesson.n, lesson]));
+
+/**
+ * The lesson at this rung, or `null` for a number off either end of the ladder.
+ *
+ * Total for the same reason `lessonById` is: the callers are screens asking
+ * where a child goes next, and `best + 1` at the top of the hundred, or a rung
+ * a re-cut ladder no longer has, is an answer to give rather than a case to
+ * throw on.
+ */
+export const lessonNumbered = (n: number): Lesson | null =>
+  BY_NUMBER.get(n) ?? null;

--- a/src/games/typing/LessonBars.tsx
+++ b/src/games/typing/LessonBars.tsx
@@ -1,7 +1,7 @@
-import { percent } from "@/engine/format";
-import { verdictFor, type Bar, type KeyBar } from "@/engine/typing/verdict";
+import { verdictFor } from "@/engine/typing/verdict";
 import type { Lesson } from "@/engine/typing/lessons";
 import type { CardResult, RaceConfig } from "@/engine/types";
+import { PassBars } from "./PassBars";
 
 /**
  * What the lesson is asking for, filling as the child does it
@@ -14,11 +14,13 @@ import type { CardResult, RaceConfig } from "@/engine/types";
  * verdict exists: a single score tells a seven-year-old that they failed and
  * not what to do, where "fast enough, not accurate enough" is an instruction.
  *
- * The bars are the SAME ones the results screen will draw, because they come
- * from the same `verdictFor` over the run so far — cards in, elapsed in, three
+ * The bars are the SAME ones the results screen draws — literally `PassBars`,
+ * off the same `verdictFor` over the run so far: cards in, elapsed in, three
  * bars out. A HUD that counted accuracy its own way would drift from the
  * verdict by a rounding rule and tell a child they had it a word before they
- * did.
+ * did. What is only true here is the run-so-far half: the run being marked is
+ * still going, so this module builds it, and `PassBars` never has to know
+ * whether the clock has stopped.
  */
 
 /**
@@ -56,102 +58,5 @@ export function LessonBars({
     lesson,
   );
 
-  const key = weakest(verdict.keys);
-
-  return (
-    <section className="passbars" aria-label="What this lesson asks for">
-      {/* §6.1's order, which is the order they matter: accuracy, then the new
-          keys, then speed. */}
-      <Meter
-        label="Accuracy"
-        bar={verdict.accuracy}
-        value={percent(verdict.accuracy.got)}
-        target={percent(verdict.accuracy.need)}
-      />
-      {/* Absent on a review lesson and on every checkpoint — they introduce
-          nothing, so there is no third thing being asked and a bar for it
-          would be a bar that can never move (§6.1). */}
-      {key && (
-        <Meter
-          label={`New key ${key.key}`}
-          bar={key}
-          value={percent(key.got)}
-          target={percent(key.need)}
-        />
-      )}
-      <Meter
-        label="Speed"
-        bar={verdict.wpm}
-        value={String(Math.round(verdict.wpm.got))}
-        target={`${verdict.wpm.need} wpm`}
-      />
-    </section>
-  );
-}
-
-/**
- * The new keys, as one bar.
- *
- * A lesson introduces two characters as a rule, six at lesson 67 and fifteen at
- * lesson 31 — and fifteen bars over a live passage is a wall rather than a
- * signal. So the bar shown is the key that is holding you up, because the gate
- * is every key at once (§6.4): the run is only through when the weakest one is,
- * and naming it is the instruction the child needs.
- *
- * "Weakest" is a not-yet-passed key before a lower fraction, which is not the
- * same ordering. A key struck right three times reads 100% and is still not
- * `ok`, because the strike floor is the half of the gate a fraction cannot
- * carry — so a bar that looks full and one that looks nearly full can be the
- * failing one and the passing one respectively.
- */
-function weakest(keys: KeyBar[]): KeyBar | null {
-  return keys.reduce<KeyBar | null>((worst, key) => {
-    if (!worst) return key;
-    if (worst.ok !== key.ok) return worst.ok ? key : worst;
-    return key.got < worst.got ? key : worst;
-  }, null);
-}
-
-/**
- * One criterion: what it wants, how far you are, and whether that is full.
- *
- * The fill is `got / need` capped, so a bar cannot report more than a full one
- * — being at 40 wpm against a target of 12 is a full bar and not a bar and a
- * half. `--lime` at the top of it because a met criterion is the same green
- * "correct" is everywhere else on this site (CLAUDE.md, the telemetry five),
- * and a plain fill below it because "not yet" is not "wrong" — `--flare`
- * would tell a child mid-run that they had failed something they are three
- * words from passing.
- */
-function Meter({
-  label,
-  bar,
-  value,
-  target,
-}: {
-  label: string;
-  bar: Bar;
-  /** The reading, in this bar's own units. */
-  value: string;
-  /** What it has to reach, in the same units. */
-  target: string;
-}) {
-  // A storm level asks nothing of the speed column and carries `need: 0` to
-  // say so (§5.6). Nothing divides by that.
-  const filled = bar.need <= 0 ? 1 : Math.min(1, bar.got / bar.need);
-
-  return (
-    <div className={`passbar${bar.ok ? " is-ok" : ""}`}>
-      <span className="passbar__label">{label}</span>
-      {/* The picture of a number the text beside it already gives, so a screen
-          reader is handed the number once rather than a bar it cannot see. */}
-      <span className="passbar__track" aria-hidden="true">
-        <span className="passbar__fill" style={{ width: `${filled * 100}%` }} />
-      </span>
-      <span className="passbar__value u-mono">
-        {value}
-        <span className="passbar__need"> / {target}</span>
-      </span>
-    </div>
-  );
+  return <PassBars lesson={lesson} verdict={verdict} />;
 }

--- a/src/games/typing/LessonResults.tsx
+++ b/src/games/typing/LessonResults.tsx
@@ -1,0 +1,228 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useHub } from "@/components/state/HubContext";
+import { useRace, type RaceOutcome } from "@/components/state/RaceContext";
+import TopBar from "@/components/TopBar";
+import { Button, Confetti } from "@/components/ui/kit";
+import { isTyping } from "@/engine/decks";
+import { levelCredit } from "@/engine/decks/typing";
+import { clock } from "@/engine/format";
+import { randomSeed } from "@/engine/random";
+import { cumulativeSplits, sessionsFor } from "@/engine/records";
+import { ladderProgress } from "@/engine/typing/ladder";
+import { verdictFor } from "@/engine/typing/verdict";
+import { Rewards } from "@/games/race";
+import { SplitsTable } from "@/games/flashcards/results/SplitsTable";
+import { sfx } from "@/services/sound";
+import { PassBars } from "./PassBars";
+import { lessonConfig } from "./lessonRun";
+import { missNote, nextNote } from "./lessonNotes";
+import type { Lesson } from "@/engine/typing/lessons";
+import type { Profile } from "@/engine/types";
+
+/**
+ * Whether the lesson was passed, and what to do next (docs/typing.md §6.1, §9).
+ *
+ * The free-play screen next door is a **scoreline** — a wpm, an accuracy, a
+ * clock and a rival — because free play is a race and a race is decided on a
+ * number. A lesson is not (§7). What is on trial here is three criteria, and
+ * the job of this screen is to turn a failure into an instruction: not "68%",
+ * but "you were fast enough; the `z` key needs more practice". A child who
+ * misses a lesson and cannot tell which of the three cost them has been handed
+ * a wall, and a wall is what makes a seven-year-old stop climbing.
+ *
+ * So the bars lead, in §6.1's order, and the sentence under the headline names
+ * the gap. `missNote` and `nextNote` decide what that sentence says; this file
+ * only puts it on the screen.
+ *
+ * **Retries are unlimited and unpenalised.** There is no attempt counter here
+ * and nothing anywhere that stores one — a lesson is passed if a session exists
+ * that meets its criteria (§6.5), so a failed run costs a child exactly the
+ * time it took and nothing else. Trying a checkpoint you are nowhere near
+ * being free is the whole of the levelling advice (§6.6), and it is only true
+ * because failing is.
+ */
+export default function LessonResults({
+  lesson,
+  outcome,
+  profile,
+}: {
+  lesson: Lesson;
+  outcome: RaceOutcome;
+  profile: Profile;
+}) {
+  const { sessions } = useHub();
+  const { start, clear } = useRace();
+  const navigate = useNavigate();
+
+  const { session, newBadges, bonuses } = outcome;
+  const verdict = verdictFor(session, lesson);
+
+  /**
+   * Held still across renders, because `ladderProgress` memoises on the array
+   * it is handed and a fresh slice every render would pay for the pass over
+   * every saved run every time (§6.5). The run that has just finished is
+   * already in `sessions` — `saveSession` appends before `finish` hands over —
+   * so what this reads is the ladder *after* this attempt, which is the only
+   * version of it that can say a lesson just opened.
+   */
+  const mine = useMemo(
+    () => sessionsFor(sessions, profile.id),
+    [sessions, profile.id],
+  );
+  const opened = nextNote(lesson, ladderProgress(mine));
+
+  /**
+   * A Hailstorm level is a different game on a different route (§8, §9), and
+   * this screen is only ever reached by one because a storm run is an ordinary
+   * `Session` and the results route is shared. Until #159 builds the wave there
+   * is nothing here that could start one, so the two run actions stand down
+   * rather than hand a child a lesson-shaped run of a level that has no
+   * passage. Everything else on the screen — the bars, the reason, the rewards
+   * — reads a storm correctly.
+   */
+  const storm = lesson.pass.kind === "storm";
+
+  /**
+   * Where the ladder will live (§9).
+   *
+   * `#/p/:id` is the setup screen until #144 turns it into the hundred tiles.
+   * Every way off this screen points at the route rather than at today's
+   * screen, which is what makes that story a swap rather than a hunt for the
+   * links that guessed.
+   */
+  const ladder = `/p/${profile.id}`;
+
+  /** The lesson the "Next lesson" button opens, when there is one to offer. */
+  const nextLesson = verdict.passed && !storm ? opened.next : null;
+
+  // Through the deck registry's own guard rather than reading `kind` here:
+  // narrowing the config union is `decks/index.ts`'s job and nowhere else's.
+  // A lesson's words come from the lexicon, which asks for no credit (§5.3) —
+  // but the line is drawn from the config exactly as free play draws it, so a
+  // lesson whose words ever come from a source that wants naming names it.
+  const credit = isTyping(session.config)
+    ? levelCredit(session.config.levelId)
+    : undefined;
+
+  /** Fresh words, no ghost, no attempt counter. */
+  function run(of: Lesson) {
+    sfx.whoosh();
+    const seed = randomSeed();
+    start({
+      profileId: profile.id,
+      config: lessonConfig(of, seed),
+      seed,
+      ghost: null,
+    });
+    navigate(`/p/${profile.id}/go`, { replace: true });
+  }
+
+  return (
+    <main className="results">
+      <Confetti burst={verdict.passed ? 1 : 0} />
+      <TopBar
+        profile={outcome.profileAfter}
+        back={{ to: ladder, label: "Typing" }}
+      />
+
+      <section className="results__head anim-rise">
+        <p className="u-eyebrow">
+          Lesson {lesson.n} · {lesson.title}
+        </p>
+        {/* Plain words, read once. "Not yet" rather than "Failed": the run
+            below it says what to change, and nothing on this screen has taken
+            anything away. */}
+        <h1 className="u-display results__title">
+          {verdict.passed ? "You passed" : "Not yet"}
+        </h1>
+        {/* The whole point of the screen, in one line: a lesson that was
+            missed says which of the three cost it, and one that was passed
+            says which lesson that just opened. */}
+        <p className="results__lede">
+          {verdict.passed ? opened.text : missNote(lesson, verdict)}
+        </p>
+      </section>
+
+      <section className="panel anim-rise">
+        <PassBars lesson={lesson} verdict={verdict} />
+      </section>
+
+      <section className="scoreline panel anim-rise">
+        <div className="stat">
+          <span className="stat__value">
+            {session.correct}
+            <span className="scoreline__of">
+              /{session.correct + session.incorrect}
+            </span>
+          </span>
+          <span className="stat__label">Words</span>
+        </div>
+        <div className="stat">
+          <span className="stat__value">{clock(session.durationMs)}</span>
+          {/* The clock, and only the clock. A lesson carries no
+              `WRONG_ANSWER_PENALTY_MS` (§7) — charging three seconds a miss
+              would double-count the accuracy bar right above it — so there is
+              no "+ penalties" to label here. Free play is a race and still
+              has both; see the label it draws next door. */}
+          <span className="stat__label">Time</span>
+        </div>
+        <div className="stat stat--xp">
+          <span className="stat__value">
+            +{session.xpEarned.toLocaleString()}
+          </span>
+          <span className="stat__label">XP earned</span>
+        </div>
+      </section>
+
+      {/* The same strip a race pays out through, so a lesson is worth the same
+          XP, the same levels and the same badges as one. */}
+      <Rewards
+        levelledUpTo={outcome.levelledUpTo}
+        bonuses={bonuses}
+        newBadges={newBadges}
+      />
+
+      <div className="results__actions">
+        {!storm && (
+          <Button variant="go" onClick={() => run(lesson)}>
+            Try again
+          </Button>
+        )}
+        {nextLesson && (
+          <Button variant="accent" onClick={() => run(nextLesson)}>
+            Next lesson
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          onClick={() => {
+            clear();
+            navigate(ladder);
+          }}
+        >
+          Back to the ladder
+        </Button>
+        {/* One record book for both games, and it lives with the flash
+            cards — same origin, same storage, so it already has this run. */}
+        <a
+          className="btn btn--ghost"
+          href={`/flash-cards#/p/${profile.id}/progress`}
+        >
+          Record book
+        </a>
+      </div>
+
+      <SplitsTable
+        session={session}
+        ghost={null}
+        mySplits={cumulativeSplits(session)}
+        ghostSplits={null}
+      />
+      {/* The splits list every word of the passage back, one to a row, which is
+          where a child sees which words went wrong — and it is the only place
+          the text appears on this screen, so the credit belongs under it. */}
+      {credit && <p className="passage__credit">{credit}</p>}
+    </main>
+  );
+}

--- a/src/games/typing/PassBars.test.tsx
+++ b/src/games/typing/PassBars.test.tsx
@@ -1,0 +1,60 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { lessonById } from "@/engine/typing/lessons";
+import type { Verdict } from "@/engine/typing/verdict";
+
+import { PassBars } from "./PassBars";
+
+/**
+ * The bars, drawn (docs/typing.md §6.1).
+ *
+ * The lesson arm is exercised end to end next door in `LessonBars.test.tsx`,
+ * over a real `verdictFor` — three bars, their order, and a bar that cannot
+ * report more than full. What is only true here is the arm that has no live
+ * screen to test it through: a Hailstorm level, whose verdict carries a speed
+ * bar it was never asked for.
+ */
+
+/** Lesson 4 is a Hailstorm level: no passage, so no words per minute. */
+const STORM = lessonById("L04")!;
+/** Lesson 7 is the first words lesson, and introduces nothing. */
+const L07 = lessonById("L07")!;
+
+const labels = (verdict: Verdict, lesson = STORM) =>
+  [
+    ...renderToStaticMarkup(
+      <PassBars lesson={lesson} verdict={verdict} />,
+    ).matchAll(/passbar__label">([^<]*)</g),
+  ].map((match) => match[1]);
+
+/** Exactly what `verdictFor` hands back for a run that died in the wave. */
+const deadInTheStorm: Verdict = {
+  passed: false,
+  accuracy: { got: 0.96, need: 0.9, ok: true },
+  wpm: { got: 0, need: 0, ok: true },
+  keys: [],
+};
+
+describe("PassBars", () => {
+  /**
+   * The bug this arm exists to avoid. §6.1's verdict gives a storm `wpm: {
+   * got: 0, need: 0, ok: true }` — a bar a storm cannot fail — and a `need` of
+   * zero draws as a full one. Three full bars over the word "failed" is a
+   * child being shown a screen that contradicts itself, so the column a storm
+   * was never asked for is not drawn at all and `missNote` says what the wave
+   * did instead.
+   */
+  it("draws no speed bar on a Hailstorm level", () => {
+    expect(labels(deadInTheStorm)).toEqual(["Accuracy"]);
+  });
+
+  it("keeps the speed bar on a lesson that introduces nothing", () => {
+    // The neighbouring case, and the one that says the rule above is about
+    // storms rather than about an empty `keys` array: a review lesson has no
+    // key bar and is still marked on speed.
+    expect(
+      labels({ ...deadInTheStorm, wpm: { got: 9, need: 8, ok: true } }, L07),
+    ).toEqual(["Accuracy", "Speed"]);
+  });
+});

--- a/src/games/typing/PassBars.tsx
+++ b/src/games/typing/PassBars.tsx
@@ -1,0 +1,114 @@
+import { percent } from "@/engine/format";
+import type { Lesson } from "@/engine/typing/lessons";
+import type { Bar, Verdict } from "@/engine/typing/verdict";
+import { weakestKey } from "./lessonNotes";
+
+/**
+ * The three bars a lesson is judged on (docs/typing.md §6.1).
+ *
+ * Three rather than one score, for a reason about a seven-year-old and not
+ * about statistics: a single number tells you that you failed and not what to
+ * do, where "fast enough, not accurate enough" is an instruction. Each bar is
+ * visibly full or visibly short of its mark, and they are shown in the order
+ * they matter — **accuracy, then the new keys, then speed** — which is also the
+ * order they should be fixed in.
+ *
+ * One component for both places the bars appear: filling live under a lesson in
+ * `LessonBars`, and standing still under its verdict on the results screen. The
+ * bars a child watched fill are the bars they are then marked against, drawn by
+ * the same lines from the same `Verdict` — a results screen that re-drew them
+ * its own way could tell a child they had it a word before they did.
+ */
+export function PassBars({
+  lesson,
+  verdict,
+}: {
+  lesson: Lesson;
+  verdict: Verdict;
+}) {
+  const key = weakestKey(verdict.keys);
+
+  return (
+    <section className="passbars" aria-label="What this lesson asks for">
+      <Meter
+        label="Accuracy"
+        bar={verdict.accuracy}
+        value={percent(verdict.accuracy.got)}
+        target={percent(verdict.accuracy.need)}
+      />
+      {/* Absent on a review lesson and on every checkpoint — they introduce
+          nothing, so there is no third thing being asked and a bar for it
+          would be a bar that can never move (§6.1). Which of many keys gets
+          the room is `weakestKey`'s to say. */}
+      {key && (
+        <Meter
+          label={`New key ${key.key}`}
+          bar={key}
+          value={percent(key.got)}
+          target={percent(key.need)}
+        />
+      )}
+      {/* ── No speed bar on a Hailstorm level (§5.6, §6.1) ──────────────────
+          A storm has no passage, so it has no words per minute, and §6.1's
+          verdict says so with `{ got: 0, need: 0, ok: true }` — a bar that can
+          never fail one. That is right for the model and unreadable on screen:
+          drawn, it is a full green bar sitting over the word the child has
+          just been told, which reads as a bug rather than as "not asked for".
+          §5.6 prints — in that column for the same reason. So the column is
+          simply not there, and `missNote` says in words what the wave did. */}
+      {lesson.pass.kind !== "storm" && (
+        <Meter
+          label="Speed"
+          bar={verdict.wpm}
+          value={String(Math.round(verdict.wpm.got))}
+          target={`${verdict.wpm.need} wpm`}
+        />
+      )}
+    </section>
+  );
+}
+
+/**
+ * One criterion: what it wants, how far you are, and whether that is full.
+ *
+ * The fill is `got / need` capped, so a bar cannot report more than a full one
+ * — being at 40 wpm against a target of 12 is a full bar and not a bar and a
+ * half. `--lime` at the top of it because a met criterion is the same green
+ * "correct" is everywhere else on this site (CLAUDE.md, the telemetry five),
+ * and a plain fill below it because "not yet" is not "wrong" — `--flare`
+ * would tell a child mid-run that they had failed something they are three
+ * words from passing.
+ */
+function Meter({
+  label,
+  bar,
+  value,
+  target,
+}: {
+  label: string;
+  bar: Bar;
+  /** The reading, in this bar's own units. */
+  value: string;
+  /** What it has to reach, in the same units. */
+  target: string;
+}) {
+  // Belt and braces against a criterion that asks for nothing. The storm arm
+  // is the one that carries `need: 0` and it no longer reaches this function,
+  // but a bar is a division and a division wants a floor under it.
+  const filled = bar.need <= 0 ? 1 : Math.min(1, bar.got / bar.need);
+
+  return (
+    <div className={`passbar${bar.ok ? " is-ok" : ""}`}>
+      <span className="passbar__label">{label}</span>
+      {/* The picture of a number the text beside it already gives, so a screen
+          reader is handed the number once rather than a bar it cannot see. */}
+      <span className="passbar__track" aria-hidden="true">
+        <span className="passbar__fill" style={{ width: `${filled * 100}%` }} />
+      </span>
+      <span className="passbar__value u-mono">
+        {value}
+        <span className="passbar__need"> / {target}</span>
+      </span>
+    </div>
+  );
+}

--- a/src/games/typing/TypingResults.tsx
+++ b/src/games/typing/TypingResults.tsx
@@ -8,9 +8,11 @@ import { levelCredit, wordsPerMinute } from "@/engine/decks/typing";
 import { clock, delta, percent } from "@/engine/format";
 import { cumulativeSplits, raceTimeMs } from "@/engine/records";
 import { randomSeed } from "@/engine/random";
+import { lessonById } from "@/engine/typing/lessons";
 import { Rewards } from "@/games/race";
 import { SplitsTable } from "@/games/flashcards/results/SplitsTable";
 import { sfx } from "@/services/sound";
+import LessonResults from "./LessonResults";
 
 /**
  * What the run was worth.
@@ -19,6 +21,11 @@ import { sfx } from "@/services/sound";
  * accuracy sits beside it rather than being folded into a single "net WPM".
  * A child who types fast and gets half of it wrong should see both, not one
  * blended figure that hides which half is the problem.
+ *
+ * That is **free play**, which is a race. A run from the ladder is marked
+ * against three criteria rather than ranked against a rival, so it gets a
+ * screen of its own (`LessonResults`, docs/typing.md §6.1) and this one is
+ * left exactly as it was — the wpm, the accuracy, the splits and the ghost.
  */
 export default function TypingResults() {
   const { profileId } = useParams();
@@ -44,6 +51,28 @@ export default function TypingResults() {
 
   const { session, ghost, personalRecord, previousBest, newBadges, bonuses } =
     outcome;
+
+  /**
+   * Which of the two screens this run gets, decided by the run itself.
+   *
+   * Off `config.lessonId` and not off a route or a prop, for the same reason
+   * `TypingTrack` reads it there: what a run IS travels with the run, and a
+   * second source for "is this a lesson" is a second thing to get out of step
+   * with `modeOf`, which files it under this same id. Below every guard above,
+   * so the two navigation races those guards were written for are settled
+   * before either screen renders — `LessonResults` starts runs and clears
+   * outcomes exactly as this one does, and it is this component's guards that
+   * catch it when it does.
+   */
+  const lesson = isTyping(session.config)
+    ? lessonById(session.config.lessonId)
+    : null;
+  if (lesson) {
+    return (
+      <LessonResults lesson={lesson} outcome={outcome} profile={profile} />
+    );
+  }
+
   const wpm = wordsPerMinute(session.cards, session.durationMs);
   // Through the deck registry's own guard rather than reading `kind` here:
   // narrowing the config union is `decks/index.ts`'s job and nowhere else's.
@@ -110,6 +139,12 @@ export default function TypingResults() {
         </div>
         <div className="stat">
           <span className="stat__value">{clock(raceTimeMs(session))}</span>
+          {/* `raceTimeMs` is the clock plus three seconds a miss, and that is
+              the truth about a free-play run: it is a race, the penalty is
+              what stops "guess fast" beating "know it", and it is the number
+              the personal best and the ghost are decided on. A lesson has no
+              penalty at all (§7) and says so with a plain "Time" — the label
+              is per-screen because the thing it names is. */}
           <span className="stat__label">
             {session.incorrect > 0 ? "Time + penalties" : "Time"}
           </span>

--- a/src/games/typing/lessonNotes.test.ts
+++ b/src/games/typing/lessonNotes.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import type { LadderProgress } from "@/engine/typing/ladder";
+import { lessonById, lessonNumbered } from "@/engine/typing/lessons";
+import type { Verdict } from "@/engine/typing/verdict";
+
+import { missNote, nextNote, weakestKey } from "./lessonNotes";
+
+/**
+ * The sentence a results screen says (docs/typing.md §6.1).
+ *
+ * What the numbers mean is `verdict.test.ts`'s, and which door a set of runs
+ * opens is `ladder.test.ts`'s. What is only true here is the reading: given
+ * three bars and a pass, which one is worth naming, which is worth praising,
+ * and what a Hailstorm level says instead of a speed it was never asked for.
+ *
+ * The verdicts are built by hand rather than run through `verdictFor`, because
+ * the point is the copy and not the arithmetic — a hand-built verdict can sit
+ * a run exactly on the two-bars-met case that the wording turns on.
+ */
+
+/** Lesson 1: `f` and `j`, at 95% accuracy and 8 wpm. */
+const L01 = lessonById("L01")!;
+/** Lesson 4 is a Hailstorm level — the arm with no passage and no wpm. */
+const STORM = lessonById("L04")!;
+
+const bar = (got: number, need: number) => ({ got, need, ok: got >= need });
+
+const verdict = (parts: Partial<Verdict> = {}): Verdict => ({
+  passed: false,
+  accuracy: bar(1, 0.95),
+  wpm: bar(20, 8),
+  keys: [],
+  ...parts,
+});
+
+const key = (id: string, got: number, ok = got >= 0.9) => ({
+  key: id,
+  got,
+  need: 0.9,
+  ok,
+});
+
+describe("weakestKey", () => {
+  it("prefers a key that has not passed over a lower fraction", () => {
+    // A key struck right three times reads 100% and is still not `ok`: the
+    // strike floor is the half of the gate a fraction cannot carry (§6.4). So
+    // the bar worth naming is the failing one, however full it looks.
+    const chosen = weakestKey([key("f", 0.95), key("j", 1, false)]);
+    expect(chosen?.key).toBe("j");
+  });
+
+  it("takes the lowest of several that have all passed", () => {
+    expect(weakestKey([key("f", 1), key("j", 0.95)])?.key).toBe("j");
+  });
+
+  it("has nothing to say about a lesson that introduces nothing", () => {
+    expect(weakestKey([])).toBeNull();
+  });
+});
+
+describe("missNote", () => {
+  /**
+   * The one the whole screen exists for. Three bars, one of them short, and
+   * the sentence says which — plus the half that says *don't change that*,
+   * without which a child fixes `j` by slowing under the speed bar.
+   */
+  it("names the key holding the run up, and says the speed was fine", () => {
+    const note = missNote(
+      L01,
+      verdict({ keys: [key("f", 1), key("j", 0.75)] }),
+    );
+    expect(note).toBe("You were fast enough; the j key needs more practice.");
+  });
+
+  it("names accuracy first when accuracy and a key both missed", () => {
+    // §6.1's order is the order they matter, which is also the order to fix
+    // them in: a child failing accuracy is not helped by being sent after `j`.
+    const note = missNote(
+      L01,
+      verdict({ accuracy: bar(0.5, 0.95), keys: [key("j", 0.4)] }),
+    );
+    expect(note).toBe(
+      "You were fast enough; slow down — 95% of your words have to be right, and you were at 50%.",
+    );
+  });
+
+  it("asks for speed when speed is all that is left, and praises the keys", () => {
+    const note = missNote(
+      L01,
+      verdict({ wpm: bar(5, 8), keys: [key("f", 1), key("j", 1)] }),
+    );
+    expect(note).toBe(
+      "Your new keys are there; a bit faster — 8 words a minute, and you were at 5.",
+    );
+  });
+
+  it("praises accuracy when there are no new keys to praise", () => {
+    // Every review lesson and every checkpoint: two bars, one of them short.
+    const note = missNote(L01, verdict({ wpm: bar(5, 8) }));
+    expect(note).toBe(
+      "Your accuracy is there; a bit faster — 8 words a minute, and you were at 5.",
+    );
+  });
+
+  it("praises nothing when nothing was met", () => {
+    const note = missNote(
+      L01,
+      verdict({ accuracy: bar(0.4, 0.95), wpm: bar(3, 8) }),
+    );
+    expect(note).toBe(
+      "Slow down — 95% of your words have to be right, and you were at 40%.",
+    );
+  });
+
+  /**
+   * The storm arm, and the reason it needed handling at all: §6.1's verdict
+   * gives a dead wave a full speed bar and no key bars, so the bars alone say
+   * "all met" over the word the child has just been told. Surviving is not a
+   * bar, so it is a sentence.
+   */
+  it("says the wave got through when a storm run met its accuracy", () => {
+    expect(
+      missNote(STORM, verdict({ wpm: { got: 0, need: 0, ok: true } })),
+    ).toBe("The wave got through — you have to face the whole storm.");
+  });
+
+  it("names the accuracy a storm wanted when that is what missed", () => {
+    const note = missNote(
+      STORM,
+      verdict({
+        accuracy: bar(0.6, 0.9),
+        wpm: { got: 0, need: 0, ok: true },
+      }),
+    );
+    expect(note).toBe("The storm wants 90% of the letters, and you hit 60%.");
+  });
+});
+
+describe("nextNote", () => {
+  const progress = (best: number, next: number): LadderProgress => ({
+    cleared: new Set([best]),
+    best,
+    next,
+  });
+
+  it("says which lesson just opened when the run cleared the frontier", () => {
+    const seven = lessonNumbered(7)!;
+    const eight = lessonNumbered(8)!;
+    const { next, text } = nextNote(seven, progress(7, 8));
+
+    expect(next).toBe(eight);
+    expect(text).toBe(`Lesson 8 just opened: ${eight.title}.`);
+  });
+
+  it("points at the pointer, and claims nothing, on a replayed lesson", () => {
+    // A child at lesson 41 doing lesson 3 again opens nothing. Telling them it
+    // did would be the one thing this screen must not do.
+    const three = lessonNumbered(3)!;
+    const forty = lessonNumbered(41)!;
+    const { next, text } = nextNote(three, progress(40, 41));
+
+    expect(next).toBe(forty);
+    expect(text).toBe(`Next up is lesson 41: ${forty.title}.`);
+  });
+
+  it("has no next lesson at the top of the ladder", () => {
+    // `next` is capped at the last rung, so clearing it points at itself.
+    const hundred = lessonNumbered(100)!;
+    const { next, text } = nextNote(hundred, progress(100, 100));
+
+    expect(next).toBeNull();
+    expect(text).toBe("That is the top of the ladder. Every lesson done.");
+  });
+});

--- a/src/games/typing/lessonNotes.ts
+++ b/src/games/typing/lessonNotes.ts
@@ -1,0 +1,139 @@
+import { percent } from "@/engine/format";
+import { lessonNumbered, type Lesson } from "@/engine/typing/lessons";
+import type { LadderProgress } from "@/engine/typing/ladder";
+import type { KeyBar, Verdict } from "@/engine/typing/verdict";
+
+/**
+ * A verdict, in a sentence a seven-year-old reads once (docs/typing.md §6.1).
+ *
+ * The whole reason there are three bars rather than one score is that **a
+ * single number tells you that you failed and not what to do**. Bars alone are
+ * only most of the way there: a child who has just missed something has to
+ * read three of them, compare each against its mark and work out which one
+ * cost them the lesson. This file does that reading for them and says it in
+ * words — "you were fast enough; the `z` key needs more practice" — which is
+ * the difference between a score and an instruction.
+ *
+ * Strings rather than JSX on purpose. What is hard here is the *choice* — which
+ * bar to name, which to praise, and what a storm says instead — and keeping it
+ * as text in, text out is what lets that choice be pinned by a test without a
+ * results screen, a router and a hub around it.
+ */
+
+/**
+ * The new keys, as one bar.
+ *
+ * A lesson introduces two characters as a rule, six at lesson 67 and fifteen at
+ * lesson 31 — and fifteen bars is a wall rather than a signal. So the bar shown
+ * is the key that is holding you up, because the gate is every key at once
+ * (§6.4): the run is only through when the weakest one is, and naming it is the
+ * instruction the child needs.
+ *
+ * "Weakest" is a not-yet-passed key before a lower fraction, which is not the
+ * same ordering. A key struck right three times reads 100% and is still not
+ * `ok`, because the strike floor is the half of the gate a fraction cannot
+ * carry — so a bar that looks full and one that looks nearly full can be the
+ * failing one and the passing one respectively.
+ */
+export function weakestKey(keys: KeyBar[]): KeyBar | null {
+  return keys.reduce<KeyBar | null>((worst, key) => {
+    if (!worst) return key;
+    if (worst.ok !== key.ok) return worst.ok ? key : worst;
+    return key.got < worst.got ? key : worst;
+  }, null);
+}
+
+/** Sentence case and a full stop, so the clauses below can be written plain. */
+const sentence = (text: string) =>
+  `${text.charAt(0).toUpperCase()}${text.slice(1)}.`;
+
+/**
+ * Why this run did not pass, and what was already there.
+ *
+ * Two clauses, and the order of the first is §6.1's order — accuracy, then the
+ * new keys, then speed — because that is the order the criteria matter in and
+ * therefore the order to fix them in. A child failing accuracy *and* speed is
+ * told about accuracy: speeding up would only make it worse.
+ *
+ * The praise is the last bar that was met, read the other way down the same
+ * list, which is why it can never name the bar the fix just named. It is not
+ * decoration. "You were fast enough" is the half of the instruction that says
+ * *don't change that* — without it, a child who slows down to fix `z` and
+ * drops under the speed bar has been taught the wrong lesson by a screen that
+ * only ever said no.
+ *
+ * Only ever called on a run that did not pass.
+ */
+export function missNote(lesson: Lesson, verdict: Verdict): string {
+  // ── The storm arm (§6.1, §8.7) ────────────────────────────────────────────
+  // A Hailstorm level is marked on surviving the wave and on accuracy, and
+  // `Verdict` carries no bar for the first of them — surviving is a fact about
+  // the run's length, so §6.1's type leaves `wpm` full and `keys` empty and
+  // lets `passed` carry it. That is right for the model and wrong on a screen:
+  // full bars over the word "failed" read as a bug at seven. So the storm's
+  // reason is stated in words here, and `PassBars` draws no bar a storm was
+  // never asked for.
+  //
+  // Which reason is decidable from the verdict alone: `passed` is accuracy AND
+  // survival, so a failed run with its accuracy bar met can only have died in
+  // the wave. Nothing about how a wave works is invented here — that is #159's
+  // to build, and this is what the screen says until it does.
+  if (lesson.pass.kind === "storm") {
+    return verdict.accuracy.ok
+      ? sentence("the wave got through — you have to face the whole storm")
+      : sentence(
+          `the storm wants ${percent(verdict.accuracy.need)} of the letters, and you hit ${percent(verdict.accuracy.got)}`,
+        );
+  }
+
+  const key = weakestKey(verdict.keys);
+  const fix = !verdict.accuracy.ok
+    ? `slow down — ${percent(verdict.accuracy.need)} of your words have to be right, and you were at ${percent(verdict.accuracy.got)}`
+    : key && !key.ok
+      ? `the ${key.key} key needs more practice`
+      : `a bit faster — ${verdict.wpm.need} words a minute, and you were at ${Math.round(verdict.wpm.got)}`;
+
+  const praise = verdict.wpm.ok
+    ? "you were fast enough"
+    : verdict.keys.length > 0 && verdict.keys.every((bar) => bar.ok)
+      ? "your new keys are there"
+      : verdict.accuracy.ok
+        ? "your accuracy is there"
+        : null;
+
+  return praise ? sentence(`${praise}; ${fix}`) : sentence(fix);
+}
+
+/**
+ * Which lesson a pass just opened, and the line that says so (§6.5, §6.6).
+ *
+ * Unlock is `max(cleared) + 1`, so the run that just cleared the frontier is
+ * the one whose number `best` now IS — which is the whole test for "did this
+ * open anything". A child at lesson 41 replaying lesson 3 opens nothing, and
+ * is told where they are up to instead of being told a lie; passing checkpoint
+ * 40 from a standing start opens 41, because clearing a checkpoint clears
+ * everything below it by that same `max`.
+ *
+ * `next` is the ladder's own pointer, already carried over any Hailstorm level
+ * standing in the way (§8.8) — so the lesson this hands back is never a storm,
+ * and the button built on it never sends a child to a wave they did not ask
+ * for. At the top of the hundred it is `null`, and there is no next lesson to
+ * offer.
+ */
+export function nextNote(
+  lesson: Lesson,
+  progress: LadderProgress,
+): { next: Lesson | null; text: string } {
+  const next = progress.next > lesson.n ? lessonNumbered(progress.next) : null;
+
+  if (!next) {
+    return { next, text: "That is the top of the ladder. Every lesson done." };
+  }
+  return {
+    next,
+    text:
+      progress.best === lesson.n
+        ? `Lesson ${next.n} just opened: ${next.title}.`
+        : `Next up is lesson ${next.n}: ${next.title}.`,
+  };
+}

--- a/src/games/typing/lessonRun.test.ts
+++ b/src/games/typing/lessonRun.test.ts
@@ -15,7 +15,7 @@ import { lessonConfig } from "./lessonRun";
  * must be able to build the run without ever meeting the generator.
  */
 
-/** Lesson 1: `f` and `j`, 24 words. */
+/** Lesson 1: `f` and `j`. Its word count is read off the lesson, not here. */
 const L01 = lessonById("L01")!;
 
 describe("lessonConfig", () => {

--- a/src/games/typing/lessonRun.test.ts
+++ b/src/games/typing/lessonRun.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDeck, configKey, modeOf } from "@/engine/decks";
+import { canType } from "@/engine/typing/keys";
+import { lessonById } from "@/engine/typing/lessons";
+
+import { lessonConfig } from "./lessonRun";
+
+/**
+ * Starting a lesson from inside the island (docs/typing.md §5.3, §5.4).
+ *
+ * Two things have to hold of the config this hands back, and both of them are
+ * about runs that already exist rather than about the one about to start: the
+ * key a run is filed under must not move with its passage, and the deck layer
+ * must be able to build the run without ever meeting the generator.
+ */
+
+/** Lesson 1: `f` and `j`, 24 words. */
+const L01 = lessonById("L01")!;
+
+describe("lessonConfig", () => {
+  it("files every attempt under one key, whatever the passage", () => {
+    // §5.4, and the reason `configKey` leaves the words out when a lesson id
+    // is there to stand in for them: lesson 7 generates a fresh passage every
+    // run, so folding them in would put each attempt in a bucket of one and a
+    // child would never be shown their own best.
+    const first = lessonConfig(L01, 1);
+    const second = lessonConfig(L01, 2);
+
+    expect(first.words).not.toEqual(second.words);
+    expect(configKey(first)).toBe(configKey(second));
+    expect(configKey(first)).toBe(`typing|L01|${L01.wordCount}`);
+    // And the run names the lesson, not the level field beside it.
+    expect(modeOf(first)).toBe("typing:L01");
+  });
+
+  it("carries the whole passage, so the deck never meets the generator", () => {
+    const config = lessonConfig(L01, 7);
+    const deck = buildDeck(config, 7);
+
+    expect(deck).toHaveLength(L01.wordCount);
+    // Every character reachable at lesson 1, which is the generator's first
+    // invariant (§5.2) and the thing a config that lost its words would break
+    // silently — `passageFor` would fall through to a level id that is really
+    // a lesson id and hand back nothing at all.
+    expect(deck.every((card) => canType(card.answer, L01.n))).toBe(true);
+  });
+});

--- a/src/games/typing/lessonRun.ts
+++ b/src/games/typing/lessonRun.ts
@@ -1,0 +1,37 @@
+import { generate } from "@/engine/typing/generate";
+import type { Lesson } from "@/engine/typing/lessons";
+import type { TypingConfig } from "@/engine/types";
+
+/**
+ * A lesson, as a config the race loop can be handed
+ * (docs/typing.md §5.3, §5.4).
+ *
+ * The passage is generated **here, inside the island**, and travels in
+ * `config.words`. That is the whole of §5.3's bargain: `decks/index.ts` is the
+ * front door for every island on the site, so a corpus reachable from it is a
+ * corpus every island downloads — 222 KB, the last time it was got wrong. The
+ * deck layer builds the run from the words it is given and never learns where
+ * they came from, and `local/no-corpus-in-decks` is what keeps that true.
+ *
+ * `levelId` carries the lesson's own id, exactly as §5.4 says: `modeOf` and
+ * `configKey` both prefer `lessonId`, so the level field is inert on a ladder
+ * run and setting it to anything else would only invite a screen to read it.
+ *
+ * `wordCount` is the lesson's, not the generated array's — it is half of
+ * `configKey` (`typing|L07|24`), and a key that moved with the passage would
+ * file every attempt in a bucket of one and never show a child their own best.
+ *
+ * Fresh words every time, which is why this takes a seed rather than caching:
+ * lesson 7 is a lesson, not a passage, and retyping the same forty words would
+ * be a memory test by the third attempt. The seed is saved with the run, so
+ * the passage is still reproducible after the fact.
+ */
+export function lessonConfig(lesson: Lesson, seed: number): TypingConfig {
+  return {
+    kind: "typing",
+    levelId: lesson.id,
+    lessonId: lesson.id,
+    words: generate(lesson, seed),
+    wordCount: lesson.wordCount,
+  };
+}

--- a/src/games/typing/lessonRun.ts
+++ b/src/games/typing/lessonRun.ts
@@ -18,13 +18,13 @@ import type { TypingConfig } from "@/engine/types";
  * run and setting it to anything else would only invite a screen to read it.
  *
  * `wordCount` is the lesson's, not the generated array's — it is half of
- * `configKey` (`typing|L07|24`), and a key that moved with the passage would
+ * `configKey` (`typing|L07|25`), and a key that moved with the passage would
  * file every attempt in a bucket of one and never show a child their own best.
  *
  * Fresh words every time, which is why this takes a seed rather than caching:
- * lesson 7 is a lesson, not a passage, and retyping the same forty words would
- * be a memory test by the third attempt. The seed is saved with the run, so
- * the passage is still reproducible after the fact.
+ * lesson 7 is a lesson, not a passage, and a child handed the same words back
+ * on every attempt would be sitting a memory test by the third one. The seed
+ * is saved with the run, so the passage is still reproducible after the fact.
  */
 export function lessonConfig(lesson: Lesson, seed: number): TypingConfig {
   return {

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1486,6 +1486,17 @@ label.segmented__btn {
   text-align: center;
 }
 
+/* The one sentence on a lesson's results screen that says what to do next
+   (docs/typing.md §6.1). Same voice as `.results__note` and deliberately not
+   the same alignment: it belongs to the headline above it rather than standing
+   on its own between two panels, and a line that names the key you missed is
+   read after the words "not yet" rather than beside them. */
+.results__lede {
+  font-size: var(--step-0);
+  color: var(--accent);
+  max-width: 60ch;
+}
+
 /* ── Typing: the keyboard on screen ──────────────────────────────────────
    A picture of the board, drawn from the layout in engine/keyboard.ts so a
    child never has to look down at the real one (docs/typing.md §4).


### PR DESCRIPTION
`docs/typing.md` §6.1 says why there are three bars rather than one score, and
§9 gives the results route two shapes. This story is the second shape.
Closes #143. Design: `docs/typing.md` §6.1, §9.

#142 gave a lesson a run. Finishing one landed on the free-play scoreline — a
wpm, an accuracy, a clock and a rival — which is the right screen for a race and
the wrong one for a lesson, because it answers a question the ladder never
asked. This is the screen that answers the one it did.

## The job is to turn a failure into an instruction

A single number tells a seven-year-old that they failed and not what to do.
That is §6.1's whole argument for three bars, and bars alone only get most of
the way there: a child who has just missed something still has to read three of
them, compare each against its mark and work out which one cost them the lesson.

So the bars lead — **accuracy, then the new keys, then speed**, §6.1's order,
which is the order they matter and therefore the order to fix them in — and one
sentence under the headline does that reading for the child:

> You were fast enough; the `z` key needs more practice.

Never a bare score. `missNote` picks the clause, and two decisions inside it are
the ones worth the words:

- **The fix names the first bar that is short, in §6.1's order.** A child
  failing accuracy *and* speed is told about accuracy, because speeding up
  would only make it worse.
- **The praise is not decoration.** It is the last bar that was met, read the
  other way down the same list, so it can never name the bar the fix just
  named. "You were fast enough" is the half of the instruction that says *don't
  change that* — without it, a child who slows down to fix `z`, drops under the
  speed bar and is told no a second time has been taught the wrong lesson by a
  screen that only ever said no.

A passed run says which lesson it just opened, and that is a real test rather
than a sentence: unlock is `max(cleared) + 1` (§6.6), so the run that cleared
the frontier is the one whose number `best` now *is*. A child at lesson 41
replaying lesson 3 opens nothing and is told where they are up to, instead of
being told a lie.

The headline is "Not yet", not "Failed". The line below it says what to change,
and nothing on this screen has taken anything away — **retries are unlimited and
unpenalised**, which is not a feature so much as the absence of one. There is no
attempt counter here and nothing anywhere that stores one, because a lesson is
passed if a session exists that meets its criteria (§6.5). Trying a checkpoint
you are nowhere near is the whole of the levelling advice in §6.6, and it is
only good advice because failing is free.

## The bars a child watched fill are the bars they are marked against

`PassBars` came out of `LessonBars` whole, and both screens now draw the same
lines from the same `Verdict`. The HUD's remaining job is the run-so-far half —
the run being marked is still going, so it builds the verdict and `PassBars`
never learns whether the clock has stopped.

That is not tidying. A results screen that re-drew the bars its own way would
drift from the live ones by a rounding rule, and tell a child they had it a word
before they did.

## "Time + penalties" is now true on both screens, because it is on neither by default

Free play charges `+3s` a miss, and its clock is labelled "Time + penalties"
when there were any. A lesson charges nothing (§7) — charging for a miss would
double-count the accuracy bar sitting directly above it — so its clock is a
plain "Time" and always was, and now the label says so.

The label is per-screen because the thing it names is. Both files carry the
comment saying which of the two they are and why, so the next person to touch
one does not helpfully make them match.

## A dead Hailstorm run, handled before there is one

A storm level is marked on surviving the wave and on accuracy. `Verdict` carries
no bar for surviving — it is a fact about the run's length, so §6.1's type
leaves `wpm` full, `keys` empty, and lets `passed` carry it. Correct for the
model, and a bug on a screen: drawn, that is **three full bars sitting over the
word "failed"**, which at seven reads as the computer being broken rather than
as "we didn't ask for that".

So the speed column is simply not there on a storm, and `missNote` says in words
what the bars can't — and which of the two reasons applies is decidable from the
verdict alone, since `passed` is accuracy AND survival, so a failed run with its
accuracy bar met can only have died in the wave. The two run actions stand down
as well, rather than offering a child a lesson-shaped run of a level that has no
passage.

None of this invents how a wave works. **Storm runs arrive in #159**; until then
nothing on this branch can start one, and this is what the screen says if
something ever does. It is defence against a route that already exists, not a
feature landing early.

## Free play, unchanged — checked rather than asserted

The claim that matters most here is a negative one. `TypingResults` picks the
screen off `config.lessonId` and does it **below every guard it already had**,
so the two navigation races those guards were written for are settled before
either screen renders. Everything past that point is the file it was.

Driven in Chromium against the built site, Verses level, twenty words: the
scoreline reads `299 wpm · 95% · 19/20 · Time + penalties 7.05 · +793 XP`, a
clean run flips that label back to a plain `Time`, twenty split rows, and the
Scripture credit line is under them. A second run offers "Your best · 6.74 ·
95%" as a rival, and racing it puts **Rival** and **Gap** back on the splits
table. No pass bars anywhere near it, no console errors.

The lesson side was driven the same way, through a temporary local hook (the
ladder is #144 and is not in this branch; the hook was reverted before the push
and the diff contains no route to a lesson). Lesson 6 passed shows three full
bars, "You passed", "Lesson 7 just opened: Home-row words.", a plain `Time`
of 3.13, and Try again / Next lesson / Back to the ladder. The same lesson
failed on purpose shows `50% / 95%` accuracy, `53% / 90%` on `g`, a full speed
bar, "Not yet", and — the sentence this story exists for — "You were fast
enough; slow down — 95% of your words have to be right, and you were at 50%.";
Next lesson is gone. Lesson 7 is a review, so it shows **two** bars and no key
column. XP, levels and badges pay out through the same `Rewards` a race uses.

## Scope

No ladder (#144), no brief (#145), no storm (#159). Every way off this screen
points at `#/p/:id` — the route the ladder will be — rather than at today's
setup screen, which makes #144 a swap rather than a hunt for the links that
guessed. No storage change, no `DB_VERSION` bump, no migration, no new
`Session` field. `lessonNumbered` moved from a private map in `ladder.ts` into
`lessons.ts` beside `lessonById`, since a second caller now asks the same
question. Everything is inside the 300-line cap and the allowlist stays deleted.

`type-check` 0 errors · `lint` clean · `test:unit` **1797 passed** · `build`
static, 200 pages · `test:smoke` all checks passed, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
