### PR TITLE
Lay the hundred lessons out as a map, with a place on it

### DIFF
--- a/src/games/typing/LessonLadder.test.tsx
+++ b/src/games/typing/LessonLadder.test.tsx
@@ -1,0 +1,163 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ladderProgress, type LadderProgress } from "@/engine/typing/ladder";
+import { LESSONS, lessonNumbered } from "@/engine/typing/lessons";
+
+import { LessonLadder } from "./LessonLadder";
+import { tileState } from "./LessonTile";
+
+/**
+ * The map, and which of its hundred doors are open (docs/typing.md §6.6, §9).
+ *
+ * What progress *is* is pinned next door in `ladder.test.ts`; what this file
+ * is for is the half of the unlock rule that lives on the screen. `next` is a
+ * pointer and not the rule (its own docstring says so), and a ladder that
+ * opened a tile on `n <= next` alone would pass a suite that only ever checked
+ * the frontier — while silently deleting the placement test, because the thing
+ * it removes is not on screen to look broken. So the checkpoints are asserted
+ * on a profile with no runs at all, which is exactly where a `next`-only rule
+ * would lock all ten.
+ */
+
+/** A profile that has never run anything: `{ cleared: {}, best: 0, next: 1 }`. */
+const FRESH = ladderProgress([]);
+
+/**
+ * Progress as the engine would derive it, without a hundred sessions to build.
+ *
+ * `next` is passed in rather than computed, because carrying the pointer over
+ * a Hailstorm level is `ladder.ts`'s rule and is pinned there — what is under
+ * test here is what the ladder draws for a given pointer, storms included.
+ */
+const at = (best: number, next: number): LadderProgress => ({
+  cleared: new Set(Array.from({ length: best }, (_, i) => i + 1)),
+  best,
+  next,
+});
+
+const CHECKPOINTS = LESSONS.filter((lesson) => lesson.checkpoint);
+const STORMS = LESSONS.filter((lesson) => lesson.kind.type === "storm");
+
+type Tile = { classes: string; label: string; shut: boolean };
+
+/** Every tile the ladder drew, in the order it drew them. */
+const tiles = (progress: LadderProgress): Tile[] =>
+  renderToStaticMarkup(<LessonLadder progress={progress} onOpen={() => {}} />)
+    .split("<button")
+    .slice(1)
+    .map((chunk) => ({
+      classes: /class="([^"]*)"/.exec(chunk)![1],
+      label: /<span class="u-sr">([^<]*)</.exec(chunk)![1],
+      shut: /aria-disabled="true"/.test(chunk),
+    }));
+
+describe("tileState", () => {
+  it("points at the first lesson on a profile with no runs", () => {
+    expect(tileState(lessonNumbered(1)!, FRESH)).toBe("next");
+    expect(tileState(lessonNumbered(2)!, FRESH)).toBe("locked");
+  });
+
+  /**
+   * Decision 16, and the one this whole file exists for. All ten, at `next`
+   * of 1 — a nine-year-old who already types opens checkpoint 40, passes it,
+   * and starts at 41 rather than spending a week on `fff jjj`.
+   */
+  it("opens every checkpoint on a brand-new profile", () => {
+    expect(CHECKPOINTS).toHaveLength(10);
+    for (const checkpoint of CHECKPOINTS)
+      expect(tileState(checkpoint, FRESH)).toBe("open");
+  });
+
+  it("fills what has been cleared and lights what is next", () => {
+    const progress = at(7, 8);
+    expect(tileState(lessonNumbered(7)!, progress)).toBe("cleared");
+    expect(tileState(lessonNumbered(8)!, progress)).toBe("next");
+    expect(tileState(lessonNumbered(9)!, progress)).toBe("locked");
+  });
+
+  /**
+   * §8.8: the pointer is carried over a storm rather than made to jump it, so
+   * the storm it stepped past stays at or below `next` and stays open.
+   * Skippable is not the same as skipped.
+   */
+  it("leaves a skipped storm open behind the pointer", () => {
+    // Lessons 1–3 cleared; 4 is a storm, so the pointer is carried to 5.
+    const progress = at(3, 5);
+    expect(tileState(lessonNumbered(4)!, progress)).toBe("open");
+    expect(tileState(lessonNumbered(5)!, progress)).toBe("next");
+  });
+
+  it("counts a cleared checkpoint as cleared, not as an open one", () => {
+    // Passing checkpoint 10 clears 1–10 with it, by `max`.
+    expect(tileState(lessonNumbered(10)!, at(10, 11))).toBe("cleared");
+  });
+});
+
+describe("LessonLadder", () => {
+  it("draws the hundred as ten rows of ten, named", () => {
+    const html = renderToStaticMarkup(
+      <LessonLadder progress={FRESH} onOpen={() => {}} />,
+    );
+    expect(tiles(FRESH)).toHaveLength(LESSONS.length);
+    expect(html.match(/class="ladder__row"/g)).toHaveLength(10);
+    // The first block and the last, so the names are read off §5.5 in order.
+    expect(html).toContain("Home row");
+    expect(html).toContain("Everything");
+  });
+
+  /**
+   * The state has to be in the accessible name and not only in the colour.
+   * Some of the children reading this screen are five and using a screen
+   * reader, and a hundred buttons called "7" is not a map.
+   */
+  it("says every tile's state out loud", () => {
+    const drawn = tiles(at(7, 8));
+    expect(drawn[0].label).toBe("Lesson 1, Two keys. Passed.");
+    expect(drawn[7].label).toBe("Lesson 8, Pairs that repeat. Start here.");
+    expect(drawn[9].label).toBe(
+      "Lesson 10, Checkpoint · Home row. Checkpoint — always open, whatever you have passed. Open.",
+    );
+    expect(drawn[8].label).toBe(
+      "Lesson 9, Hailstorm · Home row. Hailstorm — worth playing, never required. Coming soon.",
+    );
+  });
+
+  it("says a checkpoint is always open, on the tile and in the copy", () => {
+    const html = renderToStaticMarkup(
+      <LessonLadder progress={FRESH} onOpen={() => {}} />,
+    );
+    expect(html).toContain("every checkpoint is open from the start");
+    for (const tile of tiles(FRESH).filter((t) =>
+      t.classes.includes("is-checkpoint"),
+    )) {
+      expect(tile.label).toContain("always open");
+      expect(tile.shut).toBe(false);
+    }
+  });
+
+  /**
+   * `aria-disabled`, never `disabled`: a disabled button leaves the tab order,
+   * and a child moving through the ladder on a keyboard would hear the rungs
+   * they have reached and nothing about the ninety they have not.
+   */
+  it("keeps every tile in the tab order, locked ones included", () => {
+    const html = renderToStaticMarkup(
+      <LessonLadder progress={FRESH} onOpen={() => {}} />,
+    );
+    expect(html).not.toContain('disabled=""');
+    expect(tiles(FRESH).filter((tile) => tile.shut).length).toBeGreaterThan(0);
+  });
+
+  /**
+   * A storm level has no passage and no wave until #159 builds one, so its
+   * tile is drawn — the map is wrong without lesson 4 on it — and cannot be
+   * entered. Same stand-down the lesson results screen makes.
+   */
+  it("draws the storms as diamonds that cannot be entered yet", () => {
+    const drawn = tiles(at(99, 100));
+    const storms = drawn.filter((tile) => tile.classes.includes("is-storm"));
+    expect(storms).toHaveLength(STORMS.length);
+    for (const storm of storms) expect(storm.shut).toBe(true);
+  });
+});

--- a/src/games/typing/LessonLadder.tsx
+++ b/src/games/typing/LessonLadder.tsx
@@ -1,0 +1,137 @@
+import type { LadderProgress } from "@/engine/typing/ladder";
+import { LESSONS, type Lesson } from "@/engine/typing/lessons";
+import { LessonTile } from "./LessonTile";
+
+/**
+ * The hundred lessons, as the ice world's own overworld (docs/typing.md §9).
+ *
+ * Ten rows of ten with the blocks named down the side, because that is what
+ * turns a syllabus into a map: a child can see the whole course, see the two
+ * rows they have finished, and see that the row they are on ends in a
+ * checkpoint. A list of a hundred titles is the same data and none of that.
+ *
+ * Everything on it is **derived** — `LESSONS` for the shape of the ladder and
+ * `ladderProgress` for where this child is on it (§6.5). There is no stored
+ * "unlocked" flag anywhere behind this screen, which is why re-tuning a
+ * lesson's criteria re-draws the map for every child with no backfill.
+ *
+ * Choosing a tile opens the lesson. §9's `LessonBrief` — what it teaches, the
+ * three bars, your best — goes between the two later (LES11); until then the
+ * tile is the door, and a lesson that turns out to be too hard costs a child
+ * nothing but the run (§6.6).
+ */
+
+/**
+ * The ten blocks by name (§5.5), in the order the ladder walks them.
+ *
+ * The same names `lessons.ts` carries as section comments over its own table,
+ * because a block is a stretch of that table and the two would look wrong side
+ * by side if they disagreed. Written here rather than in the engine on
+ * purpose: `lessons.ts` is imported by `decks/index.ts`, which is the front
+ * door for every island on the site (§5.3), and a label only this screen draws
+ * has no business being shipped to the flash cards.
+ */
+const BLOCK_NAMES = [
+  "Home row",
+  "Reaching up",
+  "Reaching down",
+  "Capitals",
+  "Fluency",
+  "Numbers",
+  "Punctuation",
+  "Endurance",
+  "Speed",
+  "Everything",
+];
+
+/**
+ * The ladder cut into its blocks, once, at module load.
+ *
+ * Grouped off `lesson.block` rather than sliced ten at a time: the block is
+ * data on the lesson, and a `slice(0, 10)` would be a second opinion about
+ * where a block ends that quietly disagrees the day the ladder is re-cut.
+ */
+const BLOCKS = BLOCK_NAMES.map((name, i) => ({
+  n: i + 1,
+  name,
+  lessons: LESSONS.filter((lesson) => lesson.block === i + 1),
+}));
+
+export function LessonLadder({
+  progress,
+  onOpen,
+}: {
+  progress: LadderProgress;
+  onOpen: (lesson: Lesson) => void;
+}) {
+  return (
+    <section className="panel ladder anim-rise">
+      <div className="panel__head">
+        <h2 className="panel__title">Frost Keys</h2>
+        <span className="chip u-mono">
+          {progress.cleared.size}/{LESSONS.length}
+        </span>
+      </div>
+
+      {/* The rule of the ladder in two sentences, and the second is the one
+          that matters: the express lane is invisible unless it is said. A
+          child who can already type has no reason to guess that the tile forty
+          rungs up is one they are allowed to press (§6.6, decision 16). */}
+      <p className="muted ladder__lede">
+        A hundred lessons, ten to a block. Pass one and the next opens — and
+        every checkpoint is open from the start, so if you can already type, try
+        one. Getting it wrong costs you nothing.
+      </p>
+
+      <ol className="ladder__blocks">
+        {BLOCKS.map((block) => (
+          <li key={block.n} className="ladder__block">
+            {/* A heading rather than a caption, so the ten blocks are ten
+                stops for anyone moving through the page by heading — which is
+                how a hundred tiles stay navigable without a skip link. */}
+            <h3 className="ladder__name">
+              <span className="ladder__blocknum u-mono">{block.n}</span>
+              {block.name}
+            </h3>
+            <ol className="ladder__row">
+              {block.lessons.map((lesson) => (
+                <li key={lesson.id}>
+                  <LessonTile
+                    lesson={lesson}
+                    progress={progress}
+                    onOpen={onOpen}
+                  />
+                </li>
+              ))}
+            </ol>
+          </li>
+        ))}
+      </ol>
+
+      {/* The legend says what the shapes mean, because the shapes are the only
+          place two of these facts are written. Each swatch is scenery — the
+          words carry it, and every tile says its own state out loud. */}
+      <ul className="ladder__key">
+        <li className="ladder__keyitem">
+          <span className="ladder__tile is-cleared" aria-hidden="true" />
+          Passed
+        </li>
+        <li className="ladder__keyitem">
+          <span className="ladder__tile is-next" aria-hidden="true" />
+          Start here
+        </li>
+        <li className="ladder__keyitem">
+          <span
+            className="ladder__tile is-open is-checkpoint"
+            aria-hidden="true"
+          />
+          Checkpoint — open from the start, whatever you have passed
+        </li>
+        <li className="ladder__keyitem">
+          <span className="ladder__tile is-open is-storm" aria-hidden="true" />
+          Hailstorm — worth playing, never required. Coming soon
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/src/games/typing/LessonResults.tsx
+++ b/src/games/typing/LessonResults.tsx
@@ -84,12 +84,12 @@ export default function LessonResults({
   const storm = lesson.pass.kind === "storm";
 
   /**
-   * Where the ladder will live (§9).
+   * Where the ladder lives (§9).
    *
-   * `#/p/:id` is the setup screen until #144 turns it into the hundred tiles.
-   * Every way off this screen points at the route rather than at today's
-   * screen, which is what makes that story a swap rather than a hunt for the
-   * links that guessed.
+   * `#/p/:id` is the hundred tiles, with free play under them. Every way off
+   * this screen points at the route rather than at the screen behind it, which
+   * is what made turning the setup screen into the ladder a swap rather than a
+   * hunt for the links that had guessed.
    */
   const ladder = `/p/${profile.id}`;
 

--- a/src/games/typing/LessonTile.tsx
+++ b/src/games/typing/LessonTile.tsx
@@ -1,0 +1,143 @@
+import { Button } from "@/components/ui/kit";
+import type { LadderProgress } from "@/engine/typing/ladder";
+import type { Lesson } from "@/engine/typing/lessons";
+
+/**
+ * One rung of the ladder, as a square on a map (docs/typing.md §9).
+ *
+ * A tile carries three things and only three: which lesson it is, what state
+ * that lesson is in for this child, and what happens when it is pressed. The
+ * shape of the map — ten rows, blocks named down the side — is `LessonLadder`'s
+ * problem; a tile does not know it has ninety-nine neighbours.
+ *
+ * **Every state is in the accessible name, not only in the colour.** The number
+ * is the visible label and the sentence beside it is the spoken one, which is
+ * the same split `TopBar` uses for its icons. A ladder that said "passed" in
+ * cyan and "locked" in grey and nothing else would be a hundred unlabelled
+ * buttons to a child using a screen reader, and some of them do.
+ */
+
+/**
+ * What a tile is, in the order the states are decided.
+ *
+ * Four rather than a pair of booleans because they are exclusive on screen —
+ * a tile is filled, or lit, or outlined, or dim — and a component that took
+ * `cleared` and `open` separately would have to answer what a cleared-but-
+ * locked tile looks like, which is not a thing.
+ */
+export type TileState = "cleared" | "next" | "open" | "locked";
+
+/**
+ * Which of the four this lesson is, for this child — **the whole unlock rule**
+ * (docs/typing.md §6.6, decision 16).
+ *
+ * `LadderProgress.next` is the pointer and NOT the rule, and its own docstring
+ * says so at length. A screen that opened a tile on `n <= next` alone would
+ * pass every test anyone thought to write and quietly delete the placement
+ * test, because the thing it removes is not on screen to look broken. So, in
+ * full:
+ *
+ *   - **Everything up to and including `next` is open.** The pointer is
+ *     carried over Hailstorm levels rather than made to jump them (§8.8), so
+ *     the storm it stepped past is at or below `next` and stays playable —
+ *     skippable is not the same as skipped, and no storm ever gates the
+ *     lesson after it.
+ *   - **Every checkpoint is open, always.** All ten, at every value of `next`,
+ *     including on a profile that has never run anything. That is the express
+ *     lane: a nine-year-old who already types opens checkpoint 40, passes it,
+ *     and starts at 41 rather than spending a week on `fff jjj`. Passing one
+ *     clears everything below it by the same `max` rule that opens the next
+ *     lesson, so it is a placement test without a placement test existing.
+ *
+ * Nothing else gates, and a failed attempt costs nothing (§6.6) — which is
+ * what makes "just try one" the whole of the levelling advice.
+ */
+export function tileState(lesson: Lesson, progress: LadderProgress): TileState {
+  if (progress.cleared.has(lesson.n)) return "cleared";
+  if (lesson.n === progress.next) return "next";
+  if (lesson.n < progress.next || lesson.checkpoint) return "open";
+  return "locked";
+}
+
+/** The state, said out loud. Read after the lesson's number and title. */
+const SAID: Record<TileState, string> = {
+  cleared: "Passed",
+  next: "Start here",
+  open: "Open",
+  locked: "Locked",
+};
+
+/**
+ * The tile's accessible name: which lesson, what it is called, where you are
+ * with it, and — where it is true — why it is open when the one before it is
+ * not.
+ *
+ * The checkpoint clause is the copy half of decision 16. A child who cannot
+ * see the ring around a checkpoint has no other way to learn that the tile
+ * forty rungs above their own is one they are allowed to press.
+ */
+function tileLabel(lesson: Lesson, state: TileState): string {
+  const what = `Lesson ${lesson.n}, ${lesson.title}`;
+
+  // A storm level has no passage and no wave yet (#159 builds it), so its tile
+  // says what it is and that it cannot be entered — the same stand-down the
+  // lesson results screen makes for the same reason, rather than a run of
+  // nothing. Its place on the map is still worth drawing: it is what makes
+  // lesson 4 arriving before the first word look deliberate.
+  if (lesson.kind.type === "storm")
+    return `${what}. Hailstorm — worth playing, never required. Coming soon.`;
+
+  // Only worth saying while it is ahead of the child: a checkpoint they have
+  // already passed is just a lesson they passed, and "always open" on it would
+  // be a sentence about a door they walked through.
+  const note =
+    lesson.checkpoint && state !== "cleared"
+      ? " Checkpoint — always open, whatever you have passed."
+      : "";
+
+  return `${what}.${note} ${SAID[state]}.`;
+}
+
+export function LessonTile({
+  lesson,
+  progress,
+  onOpen,
+}: {
+  lesson: Lesson;
+  progress: LadderProgress;
+  onOpen: (lesson: Lesson) => void;
+}) {
+  const state = tileState(lesson, progress);
+  const storm = lesson.kind.type === "storm";
+  const openable = state !== "locked" && !storm;
+
+  const classes = [
+    "ladder__tile",
+    `is-${state}`,
+    lesson.checkpoint ? "is-checkpoint" : "",
+    storm ? "is-storm" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Button
+      variant="bare"
+      className={classes}
+      /* `aria-disabled` rather than `disabled`: a disabled button drops out of
+         the tab order, and a child moving through the ladder on a keyboard
+         would then hear the lessons they have reached and nothing about the
+         ninety they have not. The map is the information; being told a rung is
+         locked is half of it. */
+      aria-disabled={openable ? undefined : true}
+      onClick={() => {
+        if (openable) onOpen(lesson);
+      }}
+    >
+      <span className="ladder__n u-mono" aria-hidden="true">
+        {lesson.n}
+      </span>
+      <span className="u-sr">{tileLabel(lesson, state)}</span>
+    </Button>
+  );
+}

--- a/src/games/typing/TypingSetup.tsx
+++ b/src/games/typing/TypingSetup.tsx
@@ -13,19 +13,34 @@ import {
 } from "@/engine/decks/typing";
 import { bestRun, ghostsFor, sessionsFor } from "@/engine/records";
 import { randomSeed } from "@/engine/random";
+import { ladderProgress } from "@/engine/typing/ladder";
 import { RivalList } from "@/games/race";
 import { sfx } from "@/services/sound";
 import { KeyboardSetting } from "./keyboard/KeyboardSetting";
+import { LessonLadder } from "./LessonLadder";
+import { lessonConfig } from "./lessonRun";
+import type { Lesson } from "@/engine/typing/lessons";
 import type { KeyboardMode, TypingConfig } from "@/engine/types";
 
 const LENGTHS = [20, 30, 50, 80];
 
 /**
- * Picking a level and a length.
+ * The ladder, and free play under it (docs/typing.md §9).
  *
- * Shorter than the flash-card setup on purpose: there is no operation, no
- * number grid, no input mode and no per-word clock to choose. A typing run is
- * a level and a length, and everything else about it is the same for everyone.
+ * `#/p/:id` is the way into the typing world, and after LES10 that means the
+ * hundred lessons first: `LessonLadder` is the screen's subject and the panel
+ * below it is the game that was here before the course existed.
+ *
+ * **Free play stays, and stays whole** — the five levels, the four lengths,
+ * the keyboard setting and the rival list, unchanged. A hundred lessons is a
+ * course, and a child who has come here to type a psalm and race their brother
+ * has not asked to be enrolled in one. Nothing on the ladder gates it, and
+ * nothing about it is worse than it was the day before the ladder landed.
+ *
+ * The two halves share this screen and nothing else. A lesson is not a race
+ * (§7): it carries its own words, no ghost and no rival, which is why the
+ * ladder starts a run through `lessonConfig` rather than through the level and
+ * length held in this component's state.
  */
 export default function TypingSetup() {
   const { profileId } = useParams();
@@ -53,6 +68,21 @@ export default function TypingSetup() {
       setRivalId(null);
   }, [rivalId, rivals]);
 
+  /**
+   * Where this child is on the ladder, from the runs the hub has already
+   * loaded (§6.5). Nothing is stored: pass a lesson and the tile fills because
+   * the session it was passed in is in this array.
+   *
+   * Memoised over the slice as well as the derivation, because `sessionsFor`
+   * builds a fresh array every call and `ladderProgress` remembers its answer
+   * against the array it was handed — so an unmemoised slice would pay for a
+   * pass over every saved run on every keystroke of the free-play panel below.
+   */
+  const progress = useMemo(
+    () => ladderProgress(sessionsFor(sessions, profile?.id ?? "")),
+    [sessions, profile?.id],
+  );
+
   if (!profile) return <Navigate to="/" replace />;
 
   const credit = levelCredit(config.levelId);
@@ -77,6 +107,26 @@ export default function TypingSetup() {
     }
   }
 
+  /**
+   * Open a lesson: fresh words, no ghost, no rival (§7).
+   *
+   * The same three lines the results screen's "Try again" runs, and
+   * deliberately so — a lesson started from a tile and a lesson started from
+   * its own results are the same run, filed under the same `configKey`, or a
+   * child's best would depend on which button they reached it by.
+   */
+  function openLesson(lesson: Lesson) {
+    sfx.whoosh();
+    const seed = randomSeed();
+    start({
+      profileId: profile!.id,
+      config: lessonConfig(lesson, seed),
+      seed,
+      ghost: null,
+    });
+    navigate(`/p/${profile!.id}/go`);
+  }
+
   function launch() {
     const ghost = rivals.find((g) => g.session.id === rivalId) ?? null;
     sfx.whoosh();
@@ -99,12 +149,23 @@ export default function TypingSetup() {
         </Link>
       </TopBar>
 
+      <LessonLadder progress={progress} onOpen={openLesson} />
+
       <div className="setup__grid">
         <section className="panel anim-rise">
           <div className="panel__head">
-            <h2 className="panel__title">Typing</h2>
+            <h2 className="panel__title">Free play</h2>
             <span className="chip">{describeConfig(config)}</span>
           </div>
+
+          {/* Said once, under the ladder, because a screen that led with a
+              hundred lessons and then showed a level picker without a word
+              would read as the course being over. Free play is the other
+              game here, not the leftovers of this one. */}
+          <p className="muted">
+            No lesson, no bars to meet — a passage, a clock, and anyone
+            you&apos;ve raced before.
+          </p>
 
           <div className="control">
             <span className="control__label">Level</span>

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1346,6 +1346,250 @@ label.segmented__btn {
   color: var(--flare);
 }
 
+/* ── Typing: the ladder ─────────────────────────────────────────────────
+   The ice world's own overworld (docs/typing.md §9). A hundred lessons as
+   ten rows of ten, so a course reads as a map rather than a syllabus: what
+   is behind you, the rung you are on, and the checkpoint at the end of the
+   row you are in, all at one glance.
+
+   Every colour here is a world token — `--accent` for ground already
+   covered, `--go` for "press this" — so the map re-skins with `data-world`
+   and not one rule borrows from the telemetry five (tokens.css). Shape does
+   the work colour cannot: a checkpoint is a circle and a Hailstorm level a
+   diamond, because a child who cannot tell cyan from gold still has to be
+   able to tell an exam from a lesson.                                    */
+
+.ladder__lede {
+  max-width: 46rem;
+}
+
+.ladder__blocks {
+  display: grid;
+  gap: var(--gap-2);
+  margin-top: var(--gap-3);
+}
+
+/* The name down the side and ten tiles across it. A fixed name column rather
+   than `auto`, so all ten rows start at the same x and the hundred read as
+   one grid instead of ten ragged rows. */
+.ladder__block {
+  display: grid;
+  grid-template-columns: 8.5rem minmax(0, 1fr);
+  align-items: center;
+  gap: var(--gap-2);
+}
+
+.ladder__name {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: var(--step--1);
+  font-weight: 700;
+  color: var(--chalk-soft);
+  line-height: 1.2;
+}
+
+.ladder__blocknum {
+  font-size: var(--step--2);
+  color: var(--chalk-dim);
+}
+
+.ladder__row {
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+  gap: 0.3rem;
+  /* Capped, because a tile that grows with the panel stops being a map: at
+     1180px the ten would be 86px apiece and the hundred a page and a half of
+     scrolling. Held to a size a child can take in at a glance, and left to
+     fill the width on a phone, where the cap never binds. */
+  max-width: 32rem;
+}
+
+.ladder__tile {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  aspect-ratio: 1;
+  /* A floor under the tap target. Ten across is the shape of the ladder and
+     is not negotiable, and ten 44px tiles do not fit across a 390px phone —
+     so what gives is the square: below `560px` the tiles stop shrinking and
+     grow taller than they are wide, which buys back the height of the target
+     without either scrolling the map sideways or breaking the row. */
+  min-height: 2.1rem;
+  border-radius: 9px;
+  border: 1.5px solid var(--hairline);
+  background: rgb(255 255 255 / 3%);
+  color: var(--chalk-soft);
+  font-size: var(--step--2);
+  font-weight: 700;
+  transition:
+    transform 0.14s var(--ease-spring),
+    background-color 0.14s ease,
+    border-color 0.14s ease;
+}
+
+.ladder__tile:not([aria-disabled]):hover {
+  transform: scale(1.12);
+}
+
+/* Locked, and the storms until #159 gives them a wave to be. Dim rather than
+   hidden: the point of a map is that it shows you the ground you have not
+   walked yet. */
+.ladder__tile[aria-disabled] {
+  cursor: default;
+}
+
+.ladder__tile.is-locked {
+  color: var(--chalk-dim);
+  opacity: 0.45;
+}
+
+.ladder__tile.is-open {
+  color: var(--chalk);
+  border-color: color-mix(in oklab, var(--chalk) 20%, transparent);
+}
+
+/* Filled: this one is behind you. */
+.ladder__tile.is-cleared {
+  background: color-mix(in oklab, var(--accent) 85%, transparent);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+
+/* Lit: this one is next. `--go` is the world's "press this", so the one tile
+   a child is being pointed at is the same colour as every other button on the
+   site that means go. */
+.ladder__tile.is-next {
+  background: var(--go);
+  border-color: var(--go);
+  color: var(--go-ink);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--go) 32%, transparent);
+  /* A slow breath, and the keyframe ends where it starts — so
+     `prefers-reduced-motion`, which clamps every animation to one 0.001ms
+     pass (base.css), leaves the static ring above untouched and the hint
+     survives with only its motion gone. Same trick as the keyboard's. */
+  animation: tile-hint 1.9s var(--ease-out) infinite;
+}
+
+@keyframes tile-hint {
+  50% {
+    box-shadow: 0 0 0 7px color-mix(in oklab, var(--go) 5%, transparent);
+  }
+}
+
+/* A checkpoint is a different rung, so it is a different shape: the tenth of
+   every block, and the only tile a child may press forty rungs above their
+   own (§6.6). The ring is on it in every state, because "always open" is the
+   fact about it that has to be legible from across the room. */
+.ladder__tile.is-checkpoint {
+  border-radius: 50%;
+  border-width: 2px;
+  border-color: color-mix(in oklab, var(--accent) 60%, transparent);
+}
+
+.ladder__tile.is-checkpoint.is-cleared,
+.ladder__tile.is-checkpoint.is-next {
+  border-color: currentcolor;
+}
+
+/* A Hailstorm level is not on the ladder so much as beside it (§8.8), and a
+   diamond is what says so without a word. Rotated rather than clipped, so the
+   tile keeps its border and its focus ring; the number inside turns back. */
+.ladder__tile.is-storm {
+  transform: rotate(45deg) scale(0.82);
+  border-radius: 5px;
+  color: var(--chalk-dim);
+}
+
+.ladder__tile.is-storm .ladder__n {
+  transform: rotate(-45deg);
+}
+
+.ladder__tile.is-storm:not([aria-disabled]):hover {
+  transform: rotate(45deg) scale(0.9);
+}
+
+.ladder__key {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  gap: 0.5rem var(--gap-3);
+  margin-top: var(--gap-3);
+  padding-top: var(--gap-3);
+  border-top: 1px dashed var(--hairline);
+  font-size: var(--step--2);
+  color: var(--chalk-dim);
+  line-height: 1.35;
+}
+
+.ladder__keyitem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* The swatches are the same tiles at a fixed size — one set of rules for what
+   a state looks like, so a legend cannot drift from the map above it. */
+.ladder__keyitem .ladder__tile {
+  flex: none;
+  width: 1.4rem;
+  min-height: 0;
+  animation: none;
+}
+
+/* Wide enough for the map and its key side by side: the row is capped, so on
+   a laptop the panel would otherwise be half ladder and half nothing. */
+@media (width >= 1000px) {
+  .ladder {
+    display: grid;
+    grid-template-columns: minmax(0, auto) minmax(13rem, 1fr);
+    column-gap: var(--gap-5);
+    align-items: start;
+  }
+
+  .ladder .panel__head,
+  .ladder__lede {
+    grid-column: 1 / -1;
+  }
+
+  .ladder__blocks {
+    grid-column: 1;
+    grid-row: 3;
+  }
+
+  .ladder__key {
+    grid-column: 2;
+    grid-row: 3;
+    grid-template-columns: minmax(0, 1fr);
+    align-self: center;
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
+  }
+}
+
+@media (width < 760px) {
+  .ladder__block {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.35rem;
+  }
+}
+
+/* The panel's own padding is worth more as tile than as margin once ten
+   across is the constraint. */
+@media (width < 560px) {
+  .ladder {
+    padding-inline: var(--gap-2);
+  }
+
+  .ladder__row {
+    gap: 0.18rem;
+  }
+
+  .ladder__tile {
+    min-height: 2.4rem;
+  }
+}
+
 /* ── Typing: the passage and the line you type on ──────────────────────── */
 
 .typing .passage {


### PR DESCRIPTION
`docs/typing.md` §9 gives `#/p/:id` to the ladder — a hundred tiles with a Free
play section under them — and calls it the one piece of UI in this epic worth
spending real design time on. This is that screen.

Closes #144

Design: `docs/typing.md` §9, §6.6, §5.5.

Nine stories built the course and none of them could be reached. `LESSONS` had
a hundred entries, `ladderProgress` knew which were cleared, `lessonConfig`
could start one and `LessonResults` could mark it — and the only door into any
of it was a "Try again" button on a screen a child had no way to arrive at.
**This is the story that makes the epic playable**, and most of what it adds is
a way in rather than a new idea.

## Ten rows of ten, because that is what makes it a map

Everything on the ladder is derived: `LESSONS` for the shape, `ladderProgress`
for where this child is on it (§6.5). There is no stored `unlocked` flag behind
this screen, which is why re-tuning a lesson's criteria re-draws the map for
every child with no backfill.

The blocks are named down the side (§5.5) and grouped off `lesson.block` rather
than sliced ten at a time — the block is data on the lesson, and a `slice(0,10)`
would be a second opinion about where a block ends that disagrees the day the
ladder is re-cut. A child can see the whole course, see the rows they have
finished, and see that the row they are on ends in a checkpoint. A list of a
hundred titles is the same data and none of that.

## The tile carries the *whole* unlock rule, not the half that shows

This is the part worth reading twice. `LadderProgress.next` is a **pointer, not
the rule**, and a screen that opened a tile on `n <= next` alone would pass
every test anyone thought to write while quietly deleting the placement test —
because the thing it removes is not on screen to look broken. So `tileState` is
the rule in full:

- **Everything up to and including `next` is open.**
- **Every checkpoint is open, always** — all ten, at every value of `next`,
  **including on a profile that has never run anything.** That is the express
  lane (§6.6, decision 16): a nine-year-old who already types opens checkpoint
  40, passes it, and starts at 41 rather than spending a week on `fff jjj`.
  Passing one clears everything below it by the same `max` rule that opens the
  next lesson — a placement test without a placement test existing.

The test asserts the checkpoints on a *fresh* profile specifically, since that
is exactly where a `next`-only rule would lock all ten and look fine.

And **storms never gate.** The pointer is carried over a Hailstorm level rather
than made to jump it (§8.8), so a storm the child stepped past sits at or below
`next` and stays playable behind them. Skippable is not the same as skipped, and
no storm ever blocks the lesson after it.

## The express lane is invisible unless it is said

So it is said, in the lede, in words a seven-year-old can act on:

> every checkpoint is open from the start, so if you can already type, try one.
> Getting it wrong costs you nothing.

That second sentence is load-bearing. Retries are unlimited and unpenalised
(§6.6), which is the only reason "just try one" is good advice.

## Keyboard-reachable, with the state in the name

Every tile is a real button and **says its own state out loud**, because colour
cannot be the only copy of it:

> Lesson 40, Checkpoint · Real sentences. Checkpoint — always open, whatever
> you have passed. Open.

The number is the visible label, the sentence beside it is the spoken one —
"Passed" / "Start here" / "Open" / "Locked" / "Coming soon". Locked tiles use
`aria-disabled` rather than `disabled` so they **stay in the tab order**: a
disabled button drops out of it, and a child moving through the ladder on a
keyboard would then hear the lessons they have reached and nothing about the
ninety ahead of them. The map is the information; being told a rung is locked is
half of it. The ten block names are `<h3>`s rather than captions, so the ladder
is ten stops for anyone navigating by heading and stays usable without a skip
link.

Shape does what colour cannot: checkpoints are circles, storms diamonds, and the
legend says what both mean.

## Free play is unchanged, and still here

The claim that matters most is a negative one. The five levels, the four
lengths, the keyboard setting and the **rival list** are the panel they were —
it gains a name ("Free play") and one line saying what it is, and nothing else.
A hundred lessons is a course, and a child who came to type a psalm and race
their brother has not asked to be enrolled in one.

The two halves share the screen and nothing else. A lesson is not a race (§7),
so the ladder starts a run through `lessonConfig` — fresh words, no ghost, no
rival — the same three lines the results screen's "Try again" runs, so a run is
filed under the same `configKey` whichever door it came through. Otherwise a
child's best would depend on which button they reached it by.

## Notes

- Split into `LessonLadder` / `LessonTile` per §9's component budget; nothing
  is near the 300-line cap.
- All ice-world tokens, no hard-coded colours, and nothing borrowed from the
  telemetry five.
- The row is capped at 32rem so the map stays a map on a laptop; on a phone the
  tiles grow taller rather than the ladder scrolling sideways — ten across is
  the shape of the course, and ten 44px targets do not fit on 390px.
- Storm tiles are drawn but cannot be entered until #159 gives them a wave —
  the same stand-down `LessonResults` already makes, for the same reason.
- The per-lesson brief (§9's `LessonBrief`) goes between tile and run in LES11;
  until then the tile is the door.

## Verified

Full gate green: `type-check`, `lint`, `test:unit` (1807 passing),
`build` (static, 200 pages), and the browser smoke test with no console errors.

Driven in a browser at 1440×900 and 390×844: **a checkpoint opens from a
standing start on a brand-new profile**, lesson 1 passes and fills its tile, the
locked ones do nothing, and free play still races a ghost.
