### PR TITLE
LES11 · The lesson brief, and the keyboard lock (#145)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -250,6 +250,22 @@ never seen a keyboard cannot be asked to guess, and every checkpoint forces
 `off` because a checkpoint that can be passed while reading the answer off the
 screen measures nothing.
 
+**A lesson's mode seeds the run; it does not overrule the player** (#145).
+Read as a plain override the line above is a trap, and the ladder walks
+straight into it: **every one of the hundred names a mode**, so the `??` never
+falls through, the player's setting is beaten on all hundred rungs, and
+`keyboardLocked` marks no difference between the lessons that insist and the
+ninety-odd that were only suggesting. So the lesson's mode is what the brief's
+control **opens on**; an unlocked lesson may be changed before Start and the
+choice governs that run; a locked one is shown, disabled, with the reason.
+
+The choice lives in `TypingConfig.keyboard` and lasts exactly as long as the
+run it was made for. It is deliberately not written back to the profile: the
+control opens on the _lesson's_ suggestion, so saving what came out of it would
+let the ladder quietly overwrite a setting the child chose for themselves in
+free play. `games/typing/keyboard/lessonKeyboard.ts` is the one resolver, and
+both the brief and the track read it.
+
 Default `guide` rather than `off` for a new profile: the cost of showing it to
 a child who didn't need it is a glance; the cost of hiding it from one who did
 is a downward glance that becomes a habit.
@@ -1091,6 +1107,7 @@ Almost nothing, and that is the design working.
 | `Session`         | unchanged                                                             |
 | `Profile`         | `keyboard?: KeyboardMode` — optional, defaulted on read, no migration |
 | `TypingConfig`    | `lessonId?: string` — optional, and the ghost-key discriminator       |
+| `TypingConfig`    | `keyboard?: KeyboardMode` — the brief's choice; inert in `configKey`  |
 | `configKey`       | unchanged for every config already saved (§5.4)                       |
 | Lesson progress   | derived from sessions; stored nowhere (§6.5)                          |
 
@@ -1130,6 +1147,7 @@ first when either optional field is added.
 | 24  | Hailstorm never gates the ladder                        | A tablet has no keys, and a reward that blocks you is not a reward                                       |
 | 25  | DOM, not canvas                                         | Eleven custom properties change the whole app's biome; a canvas is a hole in that                        |
 | 26  | US ANSI only, and say so                                | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                            |
+| 27  | A lesson's keyboard seeds; it does not overrule         | All hundred name a mode, so an override beats the player's own setting on every rung                     |
 
 ---
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -124,6 +124,29 @@ export type TypingConfig = {
    * ladder existed is a level and must key exactly as it always has.
    */
   lessonId?: string;
+  /**
+   * How much of the board this run puts on screen, when the child chose it
+   * (docs/typing.md §4.2).
+   *
+   * Absent is the ordinary case and means "nobody chose": free play never sets
+   * it, and a lesson whose keyboard is locked has nothing to record. It is set
+   * by the lesson brief, which seeds its control from `lesson.keyboard` and
+   * lets an unlocked lesson be run with the board turned down — the choice
+   * belongs to the run it was made for, so it travels with the run's config
+   * rather than being written back over the player's own setting.
+   *
+   * Carried in the config rather than in `PendingRace` because the run outlives
+   * the navigation: a lesson passed with the board off is a different thing
+   * from one passed reading the answers, and `eyes-up` (§6.7) is a badge for
+   * exactly that choice. A mode kept in memory would be gone by the time
+   * anything could award it.
+   *
+   * Inert in `configKey` on purpose (`decks/typing.ts#typingConfigKey`) — a
+   * child's best at lesson 7 is their best at lesson 7, and splitting the
+   * record book by how much help was on screen would hide their own record
+   * from them the first time they turned the guide off.
+   */
+  keyboard?: KeyboardMode;
   /** An explicit set, for a drill of the words a player keeps fumbling. */
   words?: string[];
   wordCount: number;

--- a/src/games/typing/LessonBrief.test.tsx
+++ b/src/games/typing/LessonBrief.test.tsx
@@ -1,0 +1,198 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ladderProgress, type LadderProgress } from "@/engine/typing/ladder";
+import { lessonById } from "@/engine/typing/lessons";
+import type { Run } from "@/engine/typing/verdict";
+import type { CardResult, KeyboardMode } from "@/engine/types";
+
+import { LessonBrief } from "./LessonBrief";
+
+/**
+ * What is written on the door (docs/typing.md §9, §4.2).
+ *
+ * Three things are on trial here and only one of them is copy:
+ *
+ *   - **The keyboard is seeded, not imposed.** An unlocked lesson opens on its
+ *     own suggestion with three pills a child may press; a locked one shows the
+ *     same three, disabled, with the reason. That distinction is the whole of
+ *     #145's folded-in half, and before it `keyboardLocked` marked nothing.
+ *   - **What starts, and what cannot.** A locked lesson has no Start, and
+ *     **every checkpoint is startable at any time** — the express lane (§6.6)
+ *     runs through this screen now, and a brief that gated on `n <= next` would
+ *     take it out with nothing on the ladder looking broken.
+ *   - **What it says it wants**, which is the three bars, in §6.1's order.
+ */
+
+/** Lesson 1: `f` and `j`, `guide` and locked. Open on a fresh profile. */
+const L01 = lessonById("L01")!;
+/** Lesson 7: home-row words, `guide` and only suggesting it. */
+const L07 = lessonById("L07")!;
+/** Checkpoint 10: `off`, locked, and open at every value of `next`. */
+const L10 = lessonById("L10")!;
+
+/** A profile that has never run anything: `{ cleared: {}, best: 0, next: 1 }`. */
+const FRESH = ladderProgress([]);
+
+const render = (
+  lesson = L07,
+  {
+    progress = FRESH,
+    best = null,
+    profileKeyboard,
+  }: {
+    progress?: LadderProgress;
+    best?: Run | null;
+    profileKeyboard?: KeyboardMode;
+  } = {},
+) =>
+  renderToStaticMarkup(
+    <LessonBrief
+      lesson={lesson}
+      progress={progress}
+      best={best}
+      profileKeyboard={profileKeyboard}
+      onStart={() => {}}
+      onClose={() => {}}
+    />,
+  );
+
+/** Which pill is selected, and whether the row can be pressed at all. */
+const pills = (html: string) =>
+  html
+    .split("<input")
+    .slice(1)
+    .map((chunk) => ({
+      value: /value="([^"]+)"/.exec(chunk)![1],
+      on: chunk.includes("checked"),
+      shut: chunk.includes("disabled"),
+    }));
+
+const started = (html: string) => html.includes(">Start</button>");
+
+describe("LessonBrief", () => {
+  it("says what the lesson is and which keys are new", () => {
+    const html = render(L01);
+
+    expect(html).toContain("Lesson 1");
+    expect(html).toContain("Two keys");
+    expect(html).toContain("New keys");
+    // Its own two, as keys rather than as a list in a sentence.
+    expect(html).toContain(">f</kbd>");
+    expect(html).toContain(">j</kbd>");
+  });
+
+  it("says a review lesson has nothing new, rather than saying nothing", () => {
+    expect(L07.introduces).toHaveLength(0);
+    expect(render(L07)).toContain("No new keys");
+  });
+
+  /**
+   * The three bars as targets. In §6.1's order, and the new-key row absent
+   * exactly where its bar is — a lesson that introduces nothing is not being
+   * asked a third thing, and a row for it could never be met or missed.
+   */
+  it("asks for the three bars, in the order they matter", () => {
+    const html = render(L01);
+
+    expect(html).toContain("Accuracy");
+    expect(html).toContain("New keys</b>");
+    expect(html).toContain("Speed");
+    expect(html.indexOf("Accuracy")).toBeLessThan(html.indexOf("Speed"));
+    // Lesson 1's own row of §5.6: 95%, 8 wpm, 12 strikes a key.
+    expect(html).toContain("95%");
+    expect(html).toContain("8 words a minute");
+    expect(html).toContain("12 goes");
+
+    // No new keys, no third ask.
+    expect(render(L07)).not.toContain("New keys</b>");
+  });
+
+  it("says there is no best yet, and quotes one when there is", () => {
+    expect(render(L07)).toContain("run this one yet");
+
+    const html = render(L07, { best: run(L07.wordCount, 60000) });
+    expect(html).toContain("Your best here");
+    expect(html).toContain("100% right");
+  });
+
+  // ── The keyboard (§4.2) ────────────────────────────────────────────────────
+
+  it("opens on the lesson's mode, with the choice left open", () => {
+    // The lesson suggests `guide`; the child's own setting is `off`. Seeded
+    // from the lesson, and every pill still pressable — which is the half that
+    // was missing: before #145 the lesson's mode was simply imposed.
+    const html = render(L07, { profileKeyboard: "off" });
+
+    expect(pills(html).filter((pill) => pill.on)).toEqual([
+      { value: "guide", on: true, shut: false },
+    ]);
+    expect(pills(html).some((pill) => pill.shut)).toBe(false);
+  });
+
+  it("shows a locked keyboard disabled, and says why", () => {
+    const html = render(L01);
+
+    expect(pills(html)).toHaveLength(3);
+    expect(pills(html).every((pill) => pill.shut)).toBe(true);
+    expect(html).toContain("new keys");
+
+    // The checkpoint's reason is the other one worth giving, and it is why a
+    // checkpoint means anything at all.
+    expect(render(L10)).toContain("Checkpoints are typed without the keyboard");
+  });
+
+  it("falls through to the player's own setting where a lesson defers", () => {
+    // No lesson in the shipped hundred defers, which is exactly why the chain
+    // read as an override for so long. Free play is the live caller of this
+    // arm; this pins that the arm still exists for a lesson that ever does.
+    const html = render({ ...L07, keyboard: null }, { profileKeyboard: "off" });
+
+    expect(pills(html).find((pill) => pill.on)?.value).toBe("off");
+  });
+
+  // ── What may be started (§6.6) ────────────────────────────────────────────
+
+  it("starts an open lesson", () => {
+    expect(started(render(L01))).toBe(true);
+  });
+
+  it("will not start a locked lesson, and says what would open it", () => {
+    // Lesson 7 on a profile that has never run anything: locked, and the rung
+    // below it is 6 — not 5, and the storm at 4 is not in the way of either.
+    const html = render(L07);
+
+    expect(started(html)).toBe(false);
+    expect(html).toContain("Pass lesson 6 to open this one.");
+    expect(html).toContain("try a checkpoint");
+  });
+
+  /**
+   * Decision 16, through the brief. A nine-year-old who already types opens
+   * checkpoint 40 from a standing start, passes it, and begins at 41 — and
+   * that only works if this screen offers them Start.
+   */
+  it("starts any checkpoint, on a profile with no runs at all", () => {
+    expect(started(render(L10))).toBe(true);
+  });
+});
+
+/** A run of `words` perfect words in `ms`, as the loop would have recorded it. */
+function run(words: number, ms: number): Run {
+  const cards: CardResult[] = Array.from({ length: words }, () => ({
+    prompt: "dad",
+    answer: "dad",
+    given: "dad",
+    ok: true,
+    ms: ms / words,
+    factId: "dad",
+  }));
+
+  return {
+    cards,
+    config: { kind: "typing", levelId: "L07", lessonId: "L07", wordCount: 25 },
+    correct: words,
+    incorrect: 0,
+    durationMs: ms,
+  };
+}

--- a/src/games/typing/LessonBrief.tsx
+++ b/src/games/typing/LessonBrief.tsx
@@ -1,0 +1,229 @@
+import { useId, useState } from "react";
+
+import { Button, Scrim } from "@/components/ui/kit";
+import { percent } from "@/engine/format";
+import type { Lesson } from "@/engine/typing/lessons";
+import type { LadderProgress } from "@/engine/typing/ladder";
+import { verdictFor, type Run } from "@/engine/typing/verdict";
+import type { KeyboardMode } from "@/engine/types";
+
+import { KeyboardSetting } from "./keyboard/KeyboardSetting";
+import { keyboardFor, keyboardLock } from "./keyboard/lessonKeyboard";
+import { lockNote } from "./lessonNotes";
+import { tileState } from "./LessonTile";
+
+/**
+ * What a lesson teaches and what it asks for, before the clock starts
+ * (docs/typing.md §9, §4.2).
+ *
+ * A tile is a door and a door is not an explanation. Between them goes this:
+ * which keys are new, the three bars that decide the run, your best if you
+ * have one, and how much of the keyboard will be on screen. A child who starts
+ * without any of that is guessing at the target while being timed, and the
+ * three bars are the one thing on the ladder they cannot work out from the map.
+ *
+ * ── The keyboard is seeded here, not decided here ──────────────────────────
+ * §4.2 resolves the board as `lesson.keyboard ?? profile.keyboard ?? "guide"`.
+ * Every one of the hundred lessons names a mode, so read as an override that
+ * chain silently beats the setting the child chose — which is the bug #142's
+ * review found, and the reason `keyboardLocked` had stopped distinguishing
+ * anything. So: the lesson's mode **seeds** this control, an unlocked lesson
+ * may be changed before Start, and a locked one shows its pills disabled with
+ * the reason on them. `lessonKeyboard.ts` owns both halves of that; this screen
+ * is where a child meets them.
+ *
+ * The choice lives in this component's state and dies with it. That is the
+ * lifetime it should have: it is a decision about *this run*, and writing it
+ * back to the profile would let a lesson's own suggestion — which is what the
+ * control opens on — overwrite a setting the child made for themselves in free
+ * play. It travels to the run in `config.keyboard`, the way the passage
+ * travels in `config.words`.
+ *
+ * ── It asks the ladder whether it may start ───────────────────────────────
+ * `tileState`, the same function the tiles are drawn from, so the express lane
+ * survives the trip: **every checkpoint is openable at any time** (§6.6), and a
+ * brief that gated on `n <= next` would delete the placement test while looking
+ * completely reasonable. Asking twice — once to draw the tile, once to offer
+ * Start — is deliberate. A screen that can say "locked" must not also be able
+ * to start the thing it just called locked.
+ */
+export function LessonBrief({
+  lesson,
+  progress,
+  best,
+  profileKeyboard,
+  onStart,
+  onClose,
+}: {
+  lesson: Lesson;
+  progress: LadderProgress;
+  /**
+   * This child's best run at this lesson, or `null` for one they have never
+   * tried. A run rather than a formatted line, so the numbers are read off the
+   * same `verdictFor` that marked it — a brief quoting a wpm the results screen
+   * rounds differently would be telling a child two things about one run.
+   */
+  best: Run | null;
+  /** `Profile.keyboard`, for the arm of §4.2 an unpinned lesson falls through to. */
+  profileKeyboard?: KeyboardMode;
+  /** The chosen mode is handed over; `undefined` when the lesson pinned it. */
+  onStart: (keyboard?: KeyboardMode) => void;
+  onClose: () => void;
+}) {
+  const titleId = useId();
+  const locked = tileState(lesson, progress) === "locked";
+  const why = keyboardLock(lesson);
+
+  /**
+   * Seeded from the lesson, resolved once, on mount.
+   *
+   * `LessonBrief` is mounted per lesson (`key={lesson.id}` at the call site),
+   * so opening a second brief seeds a second time rather than carrying the
+   * first one's choice onto a lesson that suggests something else.
+   */
+  const [keyboard, setKeyboard] = useState<KeyboardMode>(() =>
+    keyboardFor(lesson, profileKeyboard),
+  );
+
+  return (
+    <div
+      className="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <Scrim onClose={onClose} label="Close" />
+      <div className="modal__panel panel anim-pop brief">
+        <p className="u-eyebrow">Lesson {lesson.n}</p>
+        <h2 className="panel__title" id={titleId}>
+          {lesson.title}
+        </h2>
+
+        <NewKeys lesson={lesson} />
+        <Asks lesson={lesson} />
+
+        <p className="brief__best">
+          {best ? bestNote(best, lesson) : "You haven't run this one yet."}
+        </p>
+
+        <KeyboardSetting
+          mode={keyboard}
+          onChange={setKeyboard}
+          lockedBecause={why}
+        />
+
+        {/* Said where the Start button would be, because "why can't I press
+            it" is a question about the button and not about the lesson. The
+            second sentence is the express lane (§6.6): this is the one screen
+            where a child is stopped, and "climb" is only half the answer when
+            all ten checkpoints are open behind them. */}
+        {locked && (
+          <p className="brief__locked">
+            {lockNote(lesson)} Or try a checkpoint — every one of those is open
+            already, and getting one wrong costs you nothing.
+          </p>
+        )}
+
+        <div className="modal__actions">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Not now
+          </Button>
+          {!locked && (
+            <Button
+              variant="go"
+              onClick={() => onStart(why ? undefined : keyboard)}
+            >
+              Start
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The keys this lesson is for, as keys.
+ *
+ * Drawn as caps rather than listed in the sentence because they are what the
+ * child is about to look for: two glyphs, or fifteen at lesson 31, and a
+ * comma-separated list of fifteen is a paragraph. A lesson that introduces
+ * nothing says so — half the ladder is review, and silence there would read as
+ * a missing line rather than as "no new keys today".
+ */
+function NewKeys({ lesson }: { lesson: Lesson }) {
+  if (lesson.introduces.length === 0) {
+    return (
+      <p className="brief__new muted">
+        No new keys — this one is practice on what you have.
+      </p>
+    );
+  }
+
+  return (
+    <p className="brief__new">
+      <span className="brief__newlabel">New keys</span>
+      {lesson.introduces.map((key) => (
+        <kbd key={key} className="brief__key u-mono">
+          {key}
+        </kbd>
+      ))}
+    </p>
+  );
+}
+
+/**
+ * The three bars, as what they want rather than as how you are doing.
+ *
+ * Same three in §6.1's order — accuracy, the new keys, then speed — so the
+ * list a child reads before the run is the list that fills beside them during
+ * it (`LessonBars`) and the list they are marked against after it (`PassBars`).
+ * Empty bars would be the other way of showing this and a worse one: three
+ * troughs at zero over the word "Accuracy" reads as a score, and the score is
+ * nought.
+ *
+ * The new-key row is absent exactly where its bar is — a review lesson and
+ * every checkpoint introduce nothing, so there is no third thing being asked.
+ */
+function Asks({ lesson }: { lesson: Lesson }) {
+  // A Hailstorm level is marked on surviving a wave rather than on three bars,
+  // and has no passage to ask anything about (§6.1). Its tile cannot open this
+  // screen until #159 builds the wave; this is the arm that keeps that true
+  // rather than a promise that it is.
+  if (lesson.pass.kind !== "lesson") return null;
+  const { accuracy, wpm, keyAccuracy, keyStrikes } = lesson.pass;
+
+  return (
+    <section className="brief__asks" aria-label="What this lesson asks for">
+      <h3 className="brief__askshead">To pass, in {lesson.wordCount} words</h3>
+      <ul>
+        <li>
+          <b>Accuracy</b> — {percent(accuracy)} of your words right.
+        </li>
+        {lesson.introduces.length > 0 && (
+          <li>
+            <b>New keys</b> — each one right {percent(keyAccuracy)} of the time,
+            over at least {keyStrikes} goes.
+          </li>
+        )}
+        <li>
+          <b>Speed</b> — {wpm} words a minute.
+        </li>
+      </ul>
+    </section>
+  );
+}
+
+/**
+ * Your best here, in the units the bars above just asked in.
+ *
+ * Through `verdictFor` rather than through a wpm helper, so the two numbers
+ * are the ones this lesson was actually marked on — the accuracy a lesson
+ * counts is its own (§6.1), and a brief quoting a different one would be
+ * quietly arguing with the results screen that produced it.
+ */
+function bestNote(best: Run, lesson: Lesson): string {
+  const verdict = verdictFor(best, lesson);
+  const line = `Your best here: ${Math.round(verdict.wpm.got)} words a minute, ${percent(verdict.accuracy.got)} right.`;
+  return verdict.passed ? `${line} Passed.` : line;
+}

--- a/src/games/typing/LessonLadder.tsx
+++ b/src/games/typing/LessonLadder.tsx
@@ -15,10 +15,12 @@ import { LessonTile } from "./LessonTile";
  * "unlocked" flag anywhere behind this screen, which is why re-tuning a
  * lesson's criteria re-draws the map for every child with no backfill.
  *
- * Choosing a tile opens the lesson. §9's `LessonBrief` — what it teaches, the
- * three bars, your best — goes between the two later (LES11); until then the
- * tile is the door, and a lesson that turns out to be too hard costs a child
- * nothing but the run (§6.6).
+ * Choosing a tile opens the lesson's brief (§9, #145) — what it teaches, the
+ * three bars it wants, your best, and how much of the keyboard will be on
+ * screen. The tile is the door and the brief is what is written on it, which
+ * is why a locked tile still says what would open it: a lesson that turns out
+ * to be too hard costs a child nothing but the run (§6.6), and one they cannot
+ * reach yet should at least say so.
  */
 
 /**

--- a/src/games/typing/LessonResults.tsx
+++ b/src/games/typing/LessonResults.tsx
@@ -105,13 +105,25 @@ export default function LessonResults({
     ? levelCredit(session.config.levelId)
     : undefined;
 
+  /**
+   * What the child chose in the brief, if they chose anything (#145, §4.2).
+   *
+   * Carried onto "Try again" and onto nothing else. A retry is the same lesson
+   * with fresh words, and a child who turned the guide off to sit lesson 40
+   * properly should not have it switched back on by the button that means
+   * "again" — but the lesson after it is a different lesson, and it gets to
+   * make its own suggestion. Read through the deck registry's own guard, for
+   * the same reason `credit` above is.
+   */
+  const chosen = isTyping(session.config) ? session.config.keyboard : undefined;
+
   /** Fresh words, no ghost, no attempt counter. */
   function run(of: Lesson) {
     sfx.whoosh();
     const seed = randomSeed();
     start({
       profileId: profile.id,
-      config: lessonConfig(of, seed),
+      config: lessonConfig(of, seed, of.id === lesson.id ? chosen : undefined),
       seed,
       ghost: null,
     });

--- a/src/games/typing/LessonTile.tsx
+++ b/src/games/typing/LessonTile.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/kit";
 import type { LadderProgress } from "@/engine/typing/ladder";
 import type { Lesson } from "@/engine/typing/lessons";
+import { lockNote } from "./lessonNotes";
 
 /**
  * One rung of the ladder, as a square on a map (docs/typing.md §9).
@@ -70,7 +71,7 @@ const SAID: Record<TileState, string> = {
 /**
  * The tile's accessible name: which lesson, what it is called, where you are
  * with it, and — where it is true — why it is open when the one before it is
- * not.
+ * not, or what would open it when it isn't.
  *
  * The checkpoint clause is the copy half of decision 16. A child who cannot
  * see the ring around a checkpoint has no other way to learn that the tile
@@ -95,7 +96,12 @@ function tileLabel(lesson: Lesson, state: TileState): string {
       ? " Checkpoint — always open, whatever you have passed."
       : "";
 
-  return `${what}.${note} ${SAID[state]}.`;
+  // What unlocks it, on the tile as well as in the brief (#145). The tile is
+  // the only place a locked lesson is met by a child who never presses it, and
+  // "Locked" on its own is a state rather than a way out of one.
+  const how = state === "locked" ? ` ${lockNote(lesson)}` : "";
+
+  return `${what}.${note} ${SAID[state]}.${how}`;
 }
 
 export function LessonTile({

--- a/src/games/typing/TypingSetup.tsx
+++ b/src/games/typing/TypingSetup.tsx
@@ -17,8 +17,9 @@ import { ladderProgress } from "@/engine/typing/ladder";
 import { RivalList } from "@/games/race";
 import { sfx } from "@/services/sound";
 import { KeyboardSetting } from "./keyboard/KeyboardSetting";
+import { LessonBrief } from "./LessonBrief";
 import { LessonLadder } from "./LessonLadder";
-import { lessonConfig } from "./lessonRun";
+import { lessonConfig, lessonKey } from "./lessonRun";
 import type { Lesson } from "@/engine/typing/lessons";
 import type { KeyboardMode, TypingConfig } from "@/engine/types";
 
@@ -55,6 +56,17 @@ export default function TypingSetup() {
     wordCount: 30,
   }));
   const [rivalId, setRivalId] = useState<string | null>(null);
+
+  /**
+   * The lesson whose brief is up, or `null` for none (§9).
+   *
+   * A tile no longer starts a run — it opens the door and the brief is what is
+   * written on it. Holding the lesson rather than a boolean is what lets the
+   * brief be mounted per lesson below, which is how the keyboard control gets
+   * seeded afresh each time instead of carrying the last lesson's choice onto
+   * one that suggests something else.
+   */
+  const [briefing, setBriefing] = useState<Lesson | null>(null);
 
   const key = configKey(config);
   const rivals = useMemo(
@@ -108,19 +120,25 @@ export default function TypingSetup() {
   }
 
   /**
-   * Open a lesson: fresh words, no ghost, no rival (§7).
+   * Start the lesson the brief is showing: fresh words, no ghost, no rival
+   * (§7).
    *
    * The same three lines the results screen's "Try again" runs, and
    * deliberately so — a lesson started from a tile and a lesson started from
    * its own results are the same run, filed under the same `configKey`, or a
    * child's best would depend on which button they reached it by.
+   *
+   * `keyboard` is what the child chose in the brief, and it is absent when
+   * they were not offered a choice — a locked lesson hands back nothing rather
+   * than handing back the mode it insisted on, so what is saved with the run
+   * says "chosen" and not merely "shown" (§4.2).
    */
-  function openLesson(lesson: Lesson) {
+  function runLesson(lesson: Lesson, keyboard?: KeyboardMode) {
     sfx.whoosh();
     const seed = randomSeed();
     start({
       profileId: profile!.id,
-      config: lessonConfig(lesson, seed),
+      config: lessonConfig(lesson, seed, keyboard),
       seed,
       ghost: null,
     });
@@ -149,7 +167,23 @@ export default function TypingSetup() {
         </Link>
       </TopBar>
 
-      <LessonLadder progress={progress} onOpen={openLesson} />
+      <LessonLadder progress={progress} onOpen={setBriefing} />
+
+      {/* Keyed by the lesson, so a second brief is a second mount: the
+          keyboard control is seeded from the lesson on mount, and a component
+          held across two openings would show lesson 12's suggestion under
+          lesson 40's title. */}
+      {briefing && (
+        <LessonBrief
+          key={briefing.id}
+          lesson={briefing}
+          progress={progress}
+          best={bestRun(sessionsFor(sessions, profile.id, lessonKey(briefing)))}
+          profileKeyboard={profile.keyboard}
+          onStart={(keyboard) => runLesson(briefing, keyboard)}
+          onClose={() => setBriefing(null)}
+        />
+      )}
 
       <div className="setup__grid">
         <section className="panel anim-rise">

--- a/src/games/typing/TypingTrack.tsx
+++ b/src/games/typing/TypingTrack.tsx
@@ -26,7 +26,7 @@ import { sfx } from "@/services/sound";
 import { LessonBars } from "./LessonBars";
 import { Passage } from "./Passage";
 import { TypeField } from "./TypeField";
-import { keyboardMode } from "./keyboard/KeyboardSetting";
+import { keyboardFor } from "./keyboard/lessonKeyboard";
 import { LiveKeyboard } from "./keyboard/LiveKeyboard";
 import type {
   CardResult,
@@ -291,26 +291,22 @@ function Track({
   const next = live ? nextChar(deck[index]?.answer ?? "", entry) : null;
 
   /**
-   * How much of the board is on screen: `lesson.keyboard ?? profile.keyboard ??
-   * "guide"`, which is the one line §4.2 asks for.
+   * How much of the board is on screen — §4.2's one line, resolved in the one
+   * place that resolves it (`keyboardFor`).
    *
-   * On the ladder as it stands, the lesson always wins: every one of the
-   * hundred names a mode, so `?? keyboardMode(profile.keyboard)` is free play's
-   * arm — plus the defensive one, for a lesson that ever carries `null`. The
-   * pins run the ladder's whole length, not just its ends, and the reasoning is
-   * clearest there: lesson 1 forces `guide`, because a child who has never seen
-   * a keyboard cannot be asked to guess, and every checkpoint forces `off`,
-   * because a checkpoint that can be passed while reading the answer off the
-   * screen measures nothing. `keyboardLocked` consequently reads the same as
-   * unlocked here — #145, the lesson brief and its keyboard lock, is where an
-   * unlocked lesson seeds the control instead of overriding it and the player
-   * gets the choice back.
+   * Three inputs and the same three the brief showed before the run started: a
+   * locked lesson wins outright, then what the child chose in the brief
+   * (`config.keyboard`, travelling with the run exactly as its words do), then
+   * the lesson's own suggestion, the player's setting and `guide`. Free play
+   * has no lesson and makes no choice, so it lands on the profile's setting and
+   * is untouched by any of it.
    *
-   * The player's half is resolved by the same function that draws the pills on
-   * the setup screen, so the two can't disagree about a profile whose field is
-   * absent — which is every profile made before the setting shipped.
+   * Reading the choice off the config rather than off a prop is what makes it
+   * survive the navigation: `pending` is what the countdown, the save and the
+   * results screen all read, and a mode that lived anywhere else would be gone
+   * by the time this component mounted.
    */
-  const board = lesson?.keyboard ?? keyboardMode(profile.keyboard);
+  const board = keyboardFor(lesson, profile.keyboard, config.keyboard);
 
   if (saveError) {
     return (

--- a/src/games/typing/keyboard/KeyboardSetting.test.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.test.tsx
@@ -80,6 +80,36 @@ describe("KeyboardSetting", () => {
     expect(chosen(html)).toEqual(["off"]);
   });
 
+  /**
+   * The lessons that insist (docs/typing.md §4.2, #145). Shown rather than
+   * hidden, disabled rather than silently overridden, and with the reason on
+   * the panel — a control that ignores the setting a child chose and a control
+   * greyed out with no explanation are the same bug at different volumes.
+   */
+  it("shows a locked keyboard, disabled, with the reason", () => {
+    const html = renderToStaticMarkup(
+      <KeyboardSetting
+        mode="off"
+        onChange={() => {}}
+        lockedBecause="Checkpoints are typed without the keyboard."
+      />,
+    );
+
+    // Still three pills, still saying which one the run is in.
+    expect(chosen(html)).toEqual(["off"]);
+    expect(html.match(/disabled=""/g)?.length).toBe(3);
+    expect(html).toContain("Checkpoints are typed without the keyboard.");
+  });
+
+  it("leaves an unlocked control pressable and unexplained", () => {
+    const html = renderToStaticMarkup(
+      <KeyboardSetting mode="off" onChange={() => {}} />,
+    );
+
+    expect(html).not.toContain("disabled");
+    expect(html).not.toContain("control__why");
+  });
+
   it("is a named radio group, because this one is a control", () => {
     const html = renderToStaticMarkup(
       <KeyboardSetting mode="keys" onChange={() => {}} />,

--- a/src/games/typing/keyboard/KeyboardSetting.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.tsx
@@ -25,6 +25,14 @@ import type { KeyboardMode } from "@/engine/types";
  * `keyboard` key at all, and a restored backup can carry a value no version of
  * this app ever wrote. Either one must land on "guide" rather than on nothing
  * selected. `KeyboardSetting.test.tsx` is that test.
+ *
+ * ── Two homes, and only one of them saves ─────────────────────────────────
+ * On the free-play panel this writes straight through to the profile: how much
+ * of the keyboard you need is a fact about the child and should still be true
+ * next week. In the lesson brief it is seeded by the lesson and governs that
+ * run alone (`lessonKeyboard.ts`). The component does not know the difference —
+ * it renders a mode and reports a change — which is what keeps the two screens
+ * showing one control instead of two that look alike.
  */
 
 /**
@@ -47,6 +55,12 @@ const OPTIONS: SegmentedOption<KeyboardMode>[] = [
   { value: "keys", label: "Keys", hint: "Show the board" },
   { value: "guide", label: "Guide", hint: "Show the next key" },
 ];
+
+/** The same three pills with nothing to press, built once rather than per render. */
+const LOCKED: SegmentedOption<KeyboardMode>[] = OPTIONS.map((option) => ({
+  ...option,
+  disabled: true,
+}));
 
 /**
  * What a profile's `keyboard` field actually means, for a field that may hold
@@ -76,6 +90,7 @@ export const keyboardMode = (mode?: KeyboardMode): KeyboardMode =>
 export function KeyboardSetting({
   mode,
   onChange,
+  lockedBecause,
 }: {
   /**
    * `Profile.keyboard` as it comes out of storage — absent on every profile
@@ -85,7 +100,20 @@ export function KeyboardSetting({
    */
   mode?: KeyboardMode;
   onChange: (next: KeyboardMode) => void;
+  /**
+   * Why this run's keyboard cannot be changed, on the lessons that insist
+   * (docs/typing.md §4.2). Absent everywhere else, which is free play and
+   * every unlocked lesson.
+   *
+   * A sentence rather than a `disabled` flag, because a control that can be
+   * greyed out without saying why is a control that will be. The pills still
+   * show which mode the run is in — a lesson that hid them would be deciding
+   * for a child and not telling them what it decided.
+   */
+  lockedBecause?: string | null;
 }) {
+  const locked = Boolean(lockedBecause);
+
   return (
     <div className="control">
       {/* A span, not a `<label>`: the group's accessible name comes from
@@ -96,8 +124,14 @@ export function KeyboardSetting({
         label="Keyboard"
         value={keyboardMode(mode)}
         onChange={onChange}
-        options={OPTIONS}
+        options={locked ? LOCKED : OPTIONS}
       />
+      {/* Under the pills, in reading order, because a disabled radiogroup has
+          no focus stop left to hang a description on — every input in it is
+          `disabled`, so nothing in the group can be tabbed to and told. Plain
+          text after the thing it explains is what a screen reader meets on the
+          way past, and what everyone else reads without looking for it. */}
+      {lockedBecause && <p className="control__why muted">{lockedBecause}</p>}
     </div>
   );
 }

--- a/src/games/typing/keyboard/lessonKeyboard.test.ts
+++ b/src/games/typing/keyboard/lessonKeyboard.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { LESSONS, lessonById } from "@/engine/typing/lessons";
+
+import { keyboardFor, keyboardLock } from "./lessonKeyboard";
+
+/**
+ * Who wins the keyboard, and the bug this file exists to keep dead
+ * (docs/typing.md §4.2).
+ *
+ * §4.2 reads as `lesson.keyboard ?? profile.keyboard ?? "guide"`, which looks
+ * like a chain with three live arms. It is not: **every one of the hundred
+ * lessons names a mode**, so read as an override the lesson wins on all
+ * hundred rungs, the player's setting is ignored the length of the ladder, and
+ * `keyboardLocked` marks no difference between the lessons that insist and the
+ * ninety-odd that were only making a suggestion. #142's review reproduced it —
+ * profile on Off, lesson 7 unlocked, board still on.
+ *
+ * So the sweeps below are the point of the file rather than decoration. One
+ * asserts that every unlocked lesson hands the choice back; the other that
+ * every locked one keeps it and can say why. A regression that re-inverts the
+ * chain fails ninety-odd assertions at once instead of none.
+ */
+
+/** Lesson 1: `guide`, locked — a child who has never seen a keyboard. */
+const L01 = lessonById("L01")!;
+/** Lesson 7: `guide`, and only suggesting it. */
+const L07 = lessonById("L07")!;
+/** Checkpoint 10: `off`, locked — reading the answers measures nothing. */
+const L10 = lessonById("L10")!;
+
+describe("keyboardFor", () => {
+  it("reads the profile in free play, and defaults to guide", () => {
+    expect(keyboardFor(null, "off")).toBe("off");
+    expect(keyboardFor(null, "keys")).toBe("keys");
+    // A profile made before the setting shipped, which is most of them.
+    expect(keyboardFor(null, undefined)).toBe("guide");
+  });
+
+  it("seeds an unlocked lesson from the lesson", () => {
+    expect(keyboardFor(L07, "off")).toBe("guide");
+  });
+
+  /** The bug, exactly as #142's review found it. */
+  it("lets an unlocked lesson be run the way the child chose", () => {
+    expect(keyboardFor(L07, "off", "off")).toBe("off");
+    expect(keyboardFor(L07, undefined, "keys")).toBe("keys");
+  });
+
+  it("ignores a choice on a lesson that insists", () => {
+    expect(keyboardFor(L01, "off", "off")).toBe("guide");
+    expect(keyboardFor(L10, "guide", "guide")).toBe("off");
+  });
+
+  it("hands every unlocked lesson back to the player who chose", () => {
+    const unlocked = LESSONS.filter((lesson) => !lesson.keyboardLocked);
+
+    expect(unlocked.length).toBeGreaterThan(0);
+    for (const lesson of unlocked)
+      expect(keyboardFor(lesson, "guide", "off")).toBe("off");
+  });
+
+  it("keeps every locked lesson on its own mode", () => {
+    const locked = LESSONS.filter((lesson) => lesson.keyboardLocked);
+
+    expect(locked.length).toBeGreaterThan(0);
+    for (const lesson of locked)
+      expect(keyboardFor(lesson, "keys", "keys")).toBe(lesson.keyboard);
+  });
+});
+
+describe("keyboardLock", () => {
+  it("says nothing about a lesson that is only suggesting", () => {
+    expect(keyboardLock(L07)).toBeNull();
+  });
+
+  /**
+   * The two ends of the ladder, and the two reasons worth giving. A control
+   * greyed out with no reason is the same bug as one that silently ignores the
+   * setting; it just looks tidier.
+   */
+  it("gives the reason at both ends of the ladder", () => {
+    expect(keyboardLock(L01)).toContain("new keys");
+    expect(keyboardLock(L10)).toContain("Checkpoints");
+  });
+
+  it("has a reason for every lesson that insists", () => {
+    for (const lesson of LESSONS.filter((l) => l.keyboardLocked))
+      expect(keyboardLock(lesson)).toBeTruthy();
+  });
+});

--- a/src/games/typing/keyboard/lessonKeyboard.ts
+++ b/src/games/typing/keyboard/lessonKeyboard.ts
@@ -1,0 +1,82 @@
+import type { Lesson } from "@/engine/typing/lessons";
+import type { KeyboardMode } from "@/engine/types";
+import { keyboardMode } from "./KeyboardSetting";
+
+/**
+ * How much of the board a run puts on screen — the one resolution
+ * (docs/typing.md §4.2).
+ *
+ * §4.2 writes it as `lesson.keyboard ?? profile.keyboard ?? "guide"`, and that
+ * is still the chain. What it does not say, because it reads as an edge case
+ * until you count the table, is that **every one of the hundred lessons names
+ * a mode**: the `??` never falls through on the ladder, so a child who set
+ * their keyboard to Off had it turned back on by lesson 7 and `keyboardLocked`
+ * distinguished nothing at all. #142's review reproduced exactly that.
+ *
+ * So a lesson's mode **seeds** rather than overrides. The brief opens on the
+ * lesson's suggestion, an unlocked lesson may be changed before Start, and the
+ * choice travels with the run in `config.keyboard` — which is what `chosen` is
+ * here. Three arms, in the order they win:
+ *
+ *   - **A locked lesson.** The lesson insists and nothing overrules it, this
+ *     function included: the control is disabled in the brief, and this arm is
+ *     what makes that a rule rather than a piece of UI politeness. The two ends
+ *     of the ladder are why it exists — lesson 1 forces `guide`, because a
+ *     child who has never seen a keyboard cannot be asked to guess, and every
+ *     checkpoint forces `off`, because a checkpoint passed while reading the
+ *     answer off the screen measures nothing.
+ *   - **What the child chose**, for the run they chose it on.
+ *   - **The lesson's own mode, then the player's, then `guide`** — §4.2's line,
+ *     unchanged, and the arm free play takes. Free play has no lesson and makes
+ *     no choice, so it reads the profile exactly as it did before the ladder
+ *     existed.
+ *
+ * Called from the brief (to seed its control) and from the track (to draw the
+ * board). One function, so those two can't disagree about a run that is already
+ * on screen.
+ */
+export function keyboardFor(
+  lesson: Lesson | null,
+  /** `Profile.keyboard` raw, defaults and all — `keyboardMode` resolves it. */
+  profileMode?: KeyboardMode,
+  /** `TypingConfig.keyboard`: what the child chose in the brief, if anything. */
+  chosen?: KeyboardMode | null,
+): KeyboardMode {
+  if (lesson?.keyboardLocked && lesson.keyboard) return lesson.keyboard;
+  return chosen ?? lesson?.keyboard ?? keyboardMode(profileMode);
+}
+
+/**
+ * Why this lesson's keyboard cannot be changed, or `null` when it can.
+ *
+ * A sentence and not a boolean, because the disabled control has to **say what
+ * it is doing**. A toggle that silently ignores the setting a child chose is
+ * the bug #142's review found; a toggle greyed out with no reason is the same
+ * bug wearing a nicer suit. Both ends of the ladder have a reason worth giving,
+ * and giving it is the difference between "this is broken" and "this lesson is
+ * about something".
+ *
+ * Keyed on the mode the lesson insists on rather than on its number, so the
+ * copy follows the table: re-cut the ladder and the checkpoints move with it.
+ * The `keys` arm is unreachable today — no row is `keys!` — and is written
+ * anyway, because `Keyboard` in `lessons.ts` permits it and a missing arm would
+ * be an empty explanation rather than a type error.
+ *
+ * A lock over `keyboard: null` is not a lock, and says so by handing back
+ * `null` here: a lesson that names no mode is insisting on nothing, and
+ * `keyboardFor` above lets the player through for the same reason. The two have
+ * to agree — a control greyed out with a reason while the run honoured the
+ * child's setting anyway would be the first bug all over again, inverted.
+ */
+export function keyboardLock(lesson: Lesson): string | null {
+  if (!lesson.keyboardLocked || !lesson.keyboard) return null;
+
+  switch (lesson.keyboard) {
+    case "off":
+      return "Checkpoints are typed without the keyboard — that is what makes passing one worth something.";
+    case "guide":
+      return "The guide stays on while a lesson is teaching new keys.";
+    default:
+      return "This lesson sets the keyboard itself.";
+  }
+}

--- a/src/games/typing/lessonNotes.test.ts
+++ b/src/games/typing/lessonNotes.test.ts
@@ -4,7 +4,7 @@ import type { LadderProgress } from "@/engine/typing/ladder";
 import { lessonById, lessonNumbered } from "@/engine/typing/lessons";
 import type { Verdict } from "@/engine/typing/verdict";
 
-import { missNote, nextNote, weakestKey } from "./lessonNotes";
+import { lockNote, missNote, nextNote, weakestKey } from "./lessonNotes";
 
 /**
  * The sentence a results screen says (docs/typing.md §6.1).
@@ -171,5 +171,38 @@ describe("nextNote", () => {
 
     expect(next).toBeNull();
     expect(text).toBe("That is the top of the ladder. Every lesson done.");
+  });
+});
+
+describe("lockNote", () => {
+  it("names the rung below", () => {
+    expect(lockNote(lessonNumbered(8)!)).toBe(
+      "Pass lesson 7 to open this one.",
+    );
+  });
+
+  /**
+   * §8.8: a Hailstorm level never gates, so the lesson that opens 10 is 8 —
+   * and pointing a child at the storm at 9 would be sending them at a wave
+   * they cannot play at all on a tablet.
+   */
+  it("looks past a Hailstorm level to the lesson that really opens it", () => {
+    expect(lessonNumbered(9)!.kind.type).toBe("storm");
+    expect(lockNote(lessonNumbered(10)!)).toBe(
+      "Pass lesson 8 to open this one.",
+    );
+    // Two storms never sit together, but the loop walks rather than steps once
+    // so that a re-cut ladder cannot make this the sentence that lies.
+    expect(lessonNumbered(4)!.kind.type).toBe("storm");
+    expect(lockNote(lessonNumbered(5)!)).toBe(
+      "Pass lesson 3 to open this one.",
+    );
+  });
+
+  it("says something sensible at the bottom of the ladder", () => {
+    // Unreachable: lesson 1 is `next` on a profile with no runs at all, so it
+    // is never locked. A sentence rather than a throw, because the ladder is
+    // data and this is copy.
+    expect(lockNote(lessonNumbered(1)!)).toBe("This one opens as you climb.");
   });
 });

--- a/src/games/typing/lessonNotes.ts
+++ b/src/games/typing/lessonNotes.ts
@@ -137,3 +137,31 @@ export function nextNote(
         : `Next up is lesson ${next.n}: ${next.title}.`,
   };
 }
+
+/**
+ * What opens a lesson that is not open yet (§6.6).
+ *
+ * The rung below it — skipping any Hailstorm level in between, because the
+ * pointer is carried over a storm rather than made to jump it (§8.8), so
+ * clearing lesson 44 is what opens lesson 46 and saying "pass lesson 45" would
+ * send a child at a wave they cannot play on a tablet.
+ *
+ * One sentence, because it is read on a tile as well as in the brief and
+ * ninety tiles all offering the same advice about checkpoints is not advice,
+ * it is wallpaper. The nudge towards the express lane belongs on the screen
+ * where a child is actually stopped, which is the brief.
+ *
+ * A locked lesson always has a rung below it — lesson 1 is `next` on a profile
+ * with no runs at all and can never be locked — but the fallback is written
+ * rather than asserted, because a re-cut ladder is data and this is a sentence,
+ * not a place to throw.
+ */
+export function lockNote(lesson: Lesson): string {
+  let n = lesson.n - 1;
+  while (lessonNumbered(n)?.kind.type === "storm") n -= 1;
+  const below = lessonNumbered(n);
+
+  return below
+    ? `Pass lesson ${below.n} to open this one.`
+    : "This one opens as you climb.";
+}

--- a/src/games/typing/lessonRun.test.ts
+++ b/src/games/typing/lessonRun.test.ts
@@ -4,7 +4,7 @@ import { buildDeck, configKey, modeOf } from "@/engine/decks";
 import { canType } from "@/engine/typing/keys";
 import { lessonById } from "@/engine/typing/lessons";
 
-import { lessonConfig } from "./lessonRun";
+import { lessonConfig, lessonKey } from "./lessonRun";
 
 /**
  * Starting a lesson from inside the island (docs/typing.md §5.3, §5.4).
@@ -44,5 +44,38 @@ describe("lessonConfig", () => {
     // silently — `passageFor` would fall through to a level id that is really
     // a lesson id and hand back nothing at all.
     expect(deck.every((card) => canType(card.answer, L01.n))).toBe(true);
+  });
+
+  /**
+   * The choice made in the brief, travelling with the run (§4.2, #145).
+   *
+   * In the config rather than in memory because the run outlives the
+   * navigation that starts it — and because a lesson passed with the board off
+   * is a different thing from one passed reading the answers, which is what
+   * `eyes-up` (§6.7) is a badge for. Absent when nobody chose, which is a
+   * locked lesson and every route that starts a run without a brief.
+   */
+  it("carries the keyboard the child chose, and nothing when they didn't", () => {
+    expect(lessonConfig(L01, 1, "off").keyboard).toBe("off");
+    expect(lessonConfig(L01, 1).keyboard).toBeUndefined();
+  });
+
+  it("leaves the record book's key alone whatever was chosen", () => {
+    // `configKey` must not see it: a child's best at lesson 1 is their best at
+    // lesson 1, and splitting the book by how much help was on screen would
+    // hide their own record from them the moment they turned the guide off.
+    expect(configKey(lessonConfig(L01, 1, "off"))).toBe(
+      configKey(lessonConfig(L01, 1, "guide")),
+    );
+  });
+});
+
+describe("lessonKey", () => {
+  it("is the key a run of that lesson files under, without a passage", () => {
+    // The brief looks up a best on a lesson a child may never start, so it must
+    // not pay for a passage to ask — and the two must not drift, or the best
+    // shown would come from a different bucket than Start writes into.
+    expect(lessonKey(L01)).toBe(configKey(lessonConfig(L01, 3)));
+    expect(lessonKey(L01)).toBe(`typing|L01|${L01.wordCount}`);
   });
 });

--- a/src/games/typing/lessonRun.ts
+++ b/src/games/typing/lessonRun.ts
@@ -1,6 +1,7 @@
+import { configKey } from "@/engine/decks";
 import { generate } from "@/engine/typing/generate";
 import type { Lesson } from "@/engine/typing/lessons";
-import type { TypingConfig } from "@/engine/types";
+import type { KeyboardMode, TypingConfig } from "@/engine/types";
 
 /**
  * A lesson, as a config the race loop can be handed
@@ -26,12 +27,48 @@ import type { TypingConfig } from "@/engine/types";
  * on every attempt would be sitting a memory test by the third one. The seed
  * is saved with the run, so the passage is still reproducible after the fact.
  */
-export function lessonConfig(lesson: Lesson, seed: number): TypingConfig {
+export function lessonConfig(
+  lesson: Lesson,
+  seed: number,
+  /**
+   * What the child chose in the brief, when they chose anything (§4.2).
+   *
+   * Absent on a locked lesson and on every route that starts a run without a
+   * brief in front of it, and absent is the right answer for both: the run then
+   * reads the lesson's own mode, which is what it would have been shown.
+   */
+  keyboard?: KeyboardMode,
+): TypingConfig {
   return {
-    kind: "typing",
-    levelId: lesson.id,
-    lessonId: lesson.id,
+    ...identity(lesson),
     words: generate(lesson, seed),
-    wordCount: lesson.wordCount,
+    ...(keyboard ? { keyboard } : {}),
   };
 }
+
+/**
+ * Everything about a lesson's config that the record book keys on, which is
+ * everything except the passage and the choice made in the brief.
+ *
+ * Split out so that `lessonKey` below can be built from the same three fields
+ * `lessonConfig` sets rather than from a second opinion about them. The two
+ * drifting is the failure that matters: a brief showing a best from one bucket
+ * over a Start that files into another would be wrong in the direction nobody
+ * checks, because both halves look right on their own.
+ */
+const identity = (lesson: Lesson): TypingConfig => ({
+  kind: "typing",
+  levelId: lesson.id,
+  lessonId: lesson.id,
+  wordCount: lesson.wordCount,
+});
+
+/**
+ * Where this lesson's runs are filed, without generating a passage to ask.
+ *
+ * `configKey` leaves the words out whenever a `lessonId` is there to stand in
+ * for them (§5.4), so this is the same string `lessonConfig`'s output produces
+ * — and the brief can look up a child's best on a lesson they may never start
+ * without paying for a passage it would then throw away.
+ */
+export const lessonKey = (lesson: Lesson) => configKey(identity(lesson));

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1410,11 +1410,10 @@ label.segmented__btn {
   place-items: center;
   width: 100%;
   aspect-ratio: 1;
-  /* A floor under the tap target. Ten across is the shape of the ladder and
-     is not negotiable, and ten 44px tiles do not fit across a 390px phone —
-     so what gives is the square: below `560px` the tiles stop shrinking and
-     grow taller than they are wide, which buys back the height of the target
-     without either scrolling the map sideways or breaking the row. */
+  /* A floor under the tap target, for the widths where ten across still fits.
+     Ten 44px tiles do not fit across a 390px phone at all, and what gives
+     there is ten rather than the square — see the `560px` block at the end of
+     this section, which redraws a block as five and five. */
   min-height: 2.1rem;
   border-radius: 9px;
   border: 1.5px solid var(--hairline);
@@ -1574,20 +1573,134 @@ label.segmented__btn {
   }
 }
 
-/* The panel's own padding is worth more as tile than as margin once ten
-   across is the constraint. */
+/* ── The phone: five across, and the tile gets its 44px back ─────────────
+   Ten across is the shape of the ladder on a laptop and it does not survive a
+   390px phone: ten tiles across 336px of content is 31px apiece, and the
+   guidance — and CLAUDE.md, which is blunter about it, because the youngest
+   player is five — puts a tap target at 44. Growing the tiles taller than they
+   are wide bought some of that back and cost the shapes, which are the half of
+   the legend colour cannot carry: an ellipse is not a circle and a squashed
+   diamond is not a diamond.
+
+   So what gives at this width is TEN, not the square. A block is still ten
+   lessons; it is drawn five and five, and twenty rows of five is still a
+   ladder. The tiles come out square and around 65px, the checkpoint is a
+   circle again, and the map is taller — which on a phone is what scrolling is
+   for. `min-height` stays as a floor for the narrowest phones, where five
+   across is itself under 44. */
 @media (width < 560px) {
   .ladder {
     padding-inline: var(--gap-2);
   }
 
   .ladder__row {
-    gap: 0.18rem;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.3rem;
   }
 
   .ladder__tile {
-    min-height: 2.4rem;
+    min-height: 2.75rem;
   }
+}
+
+/* ── Typing: the lesson brief ──────────────────────────────────────────────
+   What is written on the door before a child goes through it (§9): the new
+   keys, the three bars, their best, and how much of the keyboard will be up.
+   Built out of the modal the quit sheet already uses, so there is one thing on
+   this site that means "read this, then choose". */
+
+.brief {
+  gap: var(--gap-2);
+}
+
+.brief .panel__title {
+  margin-top: -0.15rem;
+}
+
+/* The keys as keys, on one line with their label. They are what the child is
+   about to go looking for, and fifteen of them at lesson 31 is a row rather
+   than a sentence. */
+.brief__new {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0;
+}
+
+.brief__newlabel {
+  font-family: var(--font-mono);
+  font-size: var(--step--2);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--chalk-dim);
+  margin-right: 0.15rem;
+}
+
+.brief__key {
+  display: grid;
+  place-items: center;
+  min-width: 1.8rem;
+  padding: 0.25rem 0.4rem;
+  border: 1.5px solid var(--hairline);
+  border-bottom-width: 3px;
+  border-radius: 7px;
+  background: rgb(255 255 255 / 4%);
+  color: var(--chalk);
+  font-size: var(--step--1);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.brief__askshead {
+  font-family: var(--font-mono);
+  font-size: var(--step--2);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--chalk-dim);
+  margin-bottom: 0.4rem;
+}
+
+.brief__asks ul {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: var(--step--1);
+  color: var(--chalk-soft);
+  line-height: 1.4;
+}
+
+.brief__asks b {
+  color: var(--chalk);
+}
+
+.brief__best {
+  margin: 0;
+  font-size: var(--step--1);
+  color: var(--chalk-soft);
+}
+
+/* The one line on this panel that is answering "why can't I press Start". It
+   sits where the button would be, so it is read instead of it and not after
+   a hunt for it. */
+.brief__locked {
+  margin: 0;
+  padding-left: 0.7rem;
+  border-left: 3px solid var(--hairline);
+  font-size: var(--step--1);
+  color: var(--chalk-dim);
+  line-height: 1.4;
+}
+
+/* Why a disabled control is disabled — see `KeyboardSetting`. Quiet, because
+   it is an explanation and not a warning: nothing has gone wrong. */
+.control__why {
+  margin: 0;
+  font-size: var(--step--2);
+  line-height: 1.4;
 }
 
 /* ── Typing: the passage and the line you type on ──────────────────────── */


### PR DESCRIPTION
## What this adds

**LES11 — the lesson brief.** Choosing a tile no longer drops a child straight
into a running clock. It opens a brief that says what the lesson is: its title,
which keys are new, the three bars it wants, their best if they have one, and
Start. A locked lesson cannot be started from it; its tile says what unlocks it.

**The keyboard control lives on the brief**, showing the mode this lesson will
run in. When the lesson is locked the control is *shown, disabled, and gives the
reason* — "The guide stays on while a lesson is teaching new keys", "Checkpoints
are typed without the keyboard" — rather than silently ignoring what the player
chose.

## One resolver

`keyboardFor` in `src/games/typing/keyboard/lessonKeyboard.ts` is the only place
the mode is decided, read by both the brief (to seed its control) and the track
(to draw the board), so the two cannot disagree about a run already on screen:

1. a **locked** lesson's mode wins outright,
2. otherwise **what the child chose** for this run,
3. otherwise the **lesson's suggestion**,
4. otherwise the **profile's** setting,
5. otherwise `guide`.

The middle arm is the correction §4.2 needed. Read as a plain override, a
lesson's mode beats the player on all hundred rungs — every lesson names a mode,
so the `??` never falls through and `keyboardLocked` distinguishes nothing.
A lesson's mode therefore **seeds** the control; it does not overrule.

## Why the choice lives on the persisted config

New optional field `TypingConfig.keyboard`. It is on the run's saved config, not
in memory, because LES12's `eyes-up` badge has to read after the fact what was
actually on screen. `PendingRace` is memory-only and would be gone by the time
anything could award it, and `Profile.keyboard` is mutable — a later change in
free play would rewrite the history of a run already finished. It is also
deliberately not written back to the profile: the control opens on the lesson's
suggestion, so saving its result would let the ladder quietly overwrite a
setting the child chose for themselves.

**Inert in `configKey`.** A child's best at lesson 7 is their best at lesson 7;
splitting the record book by how much help was on screen would hide their own
record from them the first time they turned the guide off. Verified against a
clean `develop` checkout — `src/engine/decks/` is byte-identical, so no saved
run is orphaned.

## The phone

Ten 44px tiles do not fit across a 390px phone — ten across 336px of content is
31px apiece. What gives at this width is **ten, not the square**: below `560px`
a block is drawn five and five, which returns square **62.6 × 62.6px** tap
targets at 390×844 and gives the checkpoint back its circle (shape is the half
of the legend colour cannot carry). Ten across is unchanged at 1280px.

## Docs

`docs/typing.md` §4.2 and the type table, plus decision **27 — "A lesson's
keyboard seeds; it does not overrule"**.

## Validation

`npm run type-check`, `npm run lint`, `npm run test:unit` (1834 passing),
`npm run build`, and the browser smoke test against the built output all pass.

Closes #145
