### PR TITLE
LES12 · Badges for the course (#146)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -841,8 +841,8 @@ profile, so adding is safe and removing is not. Five, no more:
 | `unbroken`     | Unbroken     | 🛡️ Clear a Hailstorm wave with the shield untouched |
 
 `eyes-up` is the one that matters. It is the only badge on the site that
-rewards choosing to make something harder, and it exists because the whole
-course is an argument for doing that.
+rewards doing the work the harder way, and it exists because the whole course
+is an argument for doing that.
 
 **"Clear" means what the ladder means by it.** The three ladder badges are
 asked of `ladderProgress` and read `best`, not `cleared`: passing checkpoint 50
@@ -854,24 +854,37 @@ coat. They are asked on every finished run and not only on typing ones, because
 how a child who cleared checkpoint 10 before LES12 shipped is handed the badge
 by their next race, of anything.
 
-**`eyes-up` asks whose doing it was, not what was on screen.** Every checkpoint
-forces the board off, so a badge that read the resolved mode — or
-`config.keyboard` on its own — would fire on exactly the ten runs where being
-eyes-up was compulsory and on none of the runs where it was chosen, which is
-the inverse of the badge. What it asks instead is: the lesson left the choice
-open, the child made it, and they passed. Whether a lesson insists is
-`forcedKeyboard` in `engine/typing/lessons.ts` — one definition, read by the
-island's `keyboardFor` to draw the board and by the badge to decide whose
-choice it was (decision 28). A `keyboard` absent from the config means nobody
-chose, and absent is not a choice to reward.
+**`eyes-up` asks what the run was typed under, minus the lessons that left no
+choice.** Three things: the lesson did not force the board off, the run's own
+`config.keyboard` is `off`, and it passed. The exclusion is about compulsion,
+not authorship — every checkpoint forces the board off, so a badge that read
+the resolved mode, or `config.keyboard` on a lesson that insists, would fire on
+exactly the ten runs where being eyes-up was not optional, which is the inverse
+of the badge. Whether a lesson insists is `forcedKeyboard` in
+`engine/typing/lessons.ts` — one definition, read by the island's `keyboardFor`
+to draw the board and by the badge to exclude the forced ten (decision 28).
+
+**Hidden, not chosen, is where the line sits, and on purpose.** A lesson's mode
+only _seeds_ the brief's control (§4.2) and Start hands over whatever the
+control is showing, so on an unlocked lesson `config.keyboard` records the mode
+the run was actually typed under whether or not the child touched the pills —
+and twenty-three unlocked rows seed `off` themselves, so opening lesson 46,
+pressing Start and passing earns this. That is the badge working: they typed a
+lesson blind, which is what it says on the shelf ("Pass a lesson with the
+keyboard hidden"). Insisting on authorship would mean comparing the config
+against the lesson's seed and refusing a child for doing exactly what the ladder
+asked, while rewarding the one who flipped a pill the ladder had already
+flipped. A `keyboard` absent from the config is a different matter — free play,
+or a run started without a brief in front of it — and absent is not evidence of
+a hidden board, so `=== "off"` refuses it rather than guessing.
 
 **`unbroken` is waiting for the waves, and the guard says so.** A storm level's
-`wordCount` is its wave's `count` (§8.3) and every one of the ten is `0` until
-STM08 writes them — so `survived` is vacuously true and "cleared a wave" is a
-claim about a wave that does not exist. The badge requires the wave to have a
-length, which is a guard that retires itself the day the waves land rather than
-a line someone has to remember to delete (decision 29). "Shield untouched" is
-read as **no letter reached the bottom**, which is what takes a point off a
+`wordCount` is its wave's `count` (§8.3) and every one of the twenty is `0`
+until STM10 writes them — so `survived` is vacuously true and "cleared a wave"
+is a claim about a wave that does not exist. The badge requires the wave to have
+a length, which is a guard that retires itself the day the waves land rather
+than a line someone has to remember to delete (decision 29). "Shield untouched"
+is read as **no letter reached the bottom**, which is what takes a point off a
 segment (§8.5): a storm's cards are its falling letters (§8.7), so a run with
 nothing marked wrong is a run where nothing got through. That errs strict, and
 strict is the right direction for a badge that, once in `Profile.badges`, is
@@ -1181,8 +1194,8 @@ first when either optional field is added.
 | 25  | DOM, not canvas                                         | Eleven custom properties change the whole app's biome; a canvas is a hole in that                        |
 | 26  | US ANSI only, and say so                                | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                            |
 | 27  | A lesson's keyboard seeds; it does not overrule         | All hundred name a mode, so an override beats the player's own setting on every rung                     |
-| 28  | `eyes-up` reads whose doing the hidden board was        | Checkpoints force it off, so reading the mode alone awards it for the ten runs where it was compulsory   |
-| 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM08 lands; "no screen starts one" is a line someone must delete  |
+| 28  | `eyes-up` reads the board the run was typed under       | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory       |
+| 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete  |
 
 ---
 

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -844,6 +844,39 @@ profile, so adding is safe and removing is not. Five, no more:
 rewards choosing to make something harder, and it exists because the whole
 course is an argument for doing that.
 
+**"Clear" means what the ladder means by it.** The three ladder badges are
+asked of `ladderProgress` and read `best`, not `cleared`: passing checkpoint 50
+clears 1–49 with it (§6.6), so a nine-year-old who takes the express lane holds
+Home Keys as well as Touch Typist. A shelf that disagreed with the ladder next
+to it about the same child would be the stored-flag bug of §6.5 in another
+coat. They are asked on every finished run and not only on typing ones, because
+`evaluateBadges` returns what is _true_ rather than what is new — which is also
+how a child who cleared checkpoint 10 before LES12 shipped is handed the badge
+by their next race, of anything.
+
+**`eyes-up` asks whose doing it was, not what was on screen.** Every checkpoint
+forces the board off, so a badge that read the resolved mode — or
+`config.keyboard` on its own — would fire on exactly the ten runs where being
+eyes-up was compulsory and on none of the runs where it was chosen, which is
+the inverse of the badge. What it asks instead is: the lesson left the choice
+open, the child made it, and they passed. Whether a lesson insists is
+`forcedKeyboard` in `engine/typing/lessons.ts` — one definition, read by the
+island's `keyboardFor` to draw the board and by the badge to decide whose
+choice it was (decision 28). A `keyboard` absent from the config means nobody
+chose, and absent is not a choice to reward.
+
+**`unbroken` is waiting for the waves, and the guard says so.** A storm level's
+`wordCount` is its wave's `count` (§8.3) and every one of the ten is `0` until
+STM08 writes them — so `survived` is vacuously true and "cleared a wave" is a
+claim about a wave that does not exist. The badge requires the wave to have a
+length, which is a guard that retires itself the day the waves land rather than
+a line someone has to remember to delete (decision 29). "Shield untouched" is
+read as **no letter reached the bottom**, which is what takes a point off a
+segment (§8.5): a storm's cards are its falling letters (§8.7), so a run with
+nothing marked wrong is a run where nothing got through. That errs strict, and
+strict is the right direction for a badge that, once in `Profile.badges`, is
+never taken back.
+
 ---
 
 ## 7 · A lesson is not a race
@@ -1148,6 +1181,8 @@ first when either optional field is added.
 | 25  | DOM, not canvas                                         | Eleven custom properties change the whole app's biome; a canvas is a hole in that                        |
 | 26  | US ANSI only, and say so                                | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                            |
 | 27  | A lesson's keyboard seeds; it does not overrule         | All hundred name a mode, so an override beats the player's own setting on every rung                     |
+| 28  | `eyes-up` reads whose doing the hidden board was        | Checkpoints force it off, so reading the mode alone awards it for the ten runs where it was compulsory   |
+| 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM08 lands; "no screen starts one" is a line someone must delete  |
 
 ---
 

--- a/src/engine/progress.test.ts
+++ b/src/engine/progress.test.ts
@@ -1,0 +1,494 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardResult, KeyboardMode, Session } from "@/engine/types";
+
+import { typingMode } from "@/engine/decks/typing";
+import { BADGES, evaluateBadges } from "./progress";
+import { LESSONS, type Lesson } from "./typing/lessons";
+
+/**
+ * What the badge shelf has to prove (docs/typing.md §6.7).
+ *
+ * Two jobs, and the first one is the reason this file exists at all:
+ *
+ *   - **Nothing that shipped may move.** A badge id is written into
+ *     `Profile.badges` the moment it is earned, in IndexedDB on a child's own
+ *     device, and that is the only copy there is. Renaming `ghost-buster` does
+ *     not rename anyone's badge — it deletes it, silently, on a shelf nobody is
+ *     watching. So the whole table is frozen below, and the triggers that were
+ *     here before the typing course are re-run underneath it.
+ *   - **The five new ones fire on what they say they fire on.** `eyes-up`
+ *     carries the epic's argument — it is the only badge on the site that
+ *     rewards choosing to make something harder — and the way to get it wrong
+ *     is to award it for the ten checkpoints, which force the keyboard off
+ *     whatever the child wanted. That inversion has a test of its own.
+ */
+
+/* ── The runs ────────────────────────────────────────────────────────────── */
+
+const card = (answer: string, given: string | null, ms = 400): CardResult => ({
+  prompt: answer,
+  answer,
+  given,
+  ok: given === answer,
+  ms,
+  factId: answer,
+});
+
+let saved = 0;
+
+/** A flash-card race, filed as the flash-card island files one. */
+function race(
+  cards: CardResult[],
+  extra: Partial<Session> = {},
+): Omit<Session, "id" | "finishedAt"> {
+  const correct = cards.filter((c) => c.ok).length;
+  return {
+    profileId: "p1",
+    game: "flashcards",
+    mode: "multiply",
+    configKey: "multiply|2|1-12|type",
+    config: {
+      operation: "multiply",
+      tables: [2],
+      others: [1, 2, 3, 4, 5],
+      cardCount: cards.length,
+      inputMode: "type",
+    },
+    seed: 7,
+    durationMs: cards.reduce((sum, c) => sum + c.ms, 0),
+    correct,
+    incorrect: cards.length - correct,
+    bestStreak: correct,
+    xpEarned: 0,
+    ghostSessionId: null,
+    beatGhost: null,
+    cards,
+    ...extra,
+  };
+}
+
+/** The same, saved — history is sessions that already have an id and a date. */
+const asSaved = (draft: Omit<Session, "id" | "finishedAt">): Session => ({
+  ...draft,
+  id: `s${(saved += 1)}`,
+  finishedAt: "2026-08-19T10:00:00.000Z",
+});
+
+const byN = new Map(LESSONS.map((l) => [l.n, l]));
+const lesson = (n: number): Lesson => {
+  const found = byN.get(n);
+  if (!found) throw new Error(`no lesson ${n}`);
+  return found;
+};
+
+/**
+ * A run of a lesson, filed exactly as the typing island files one: `typing:L41`
+ * for its mode, the lesson's own `wordCount` in the config (that is half the
+ * ghost key, §5.4), and `keyboard` present only when the brief handed a choice
+ * over.
+ *
+ * `durationMs` is worked back from the words per minute wanted, so a test can
+ * sit a run exactly on a lesson's speed bar or exactly one under it.
+ */
+function lessonRun(
+  of: Lesson,
+  cards: CardResult[],
+  {
+    wpm,
+    keyboard,
+    wordCount = of.wordCount,
+  }: { wpm?: number; keyboard?: KeyboardMode; wordCount?: number } = {},
+): Omit<Session, "id" | "finishedAt"> {
+  const correct = cards.filter((c) => c.ok).length;
+  // Five characters is a word, plus the space that committed each one — the
+  // same count `wordsPerMinute` makes.
+  const characters = cards.reduce((sum, c) => sum + c.answer.length + 1, 0);
+  return {
+    profileId: "p1",
+    game: "flashcards",
+    mode: typingMode(of.id),
+    configKey: `typing|${of.id}|${of.wordCount}`,
+    config: {
+      kind: "typing",
+      levelId: of.id,
+      lessonId: of.id,
+      wordCount,
+      ...(keyboard ? { keyboard } : {}),
+    },
+    seed: 7,
+    durationMs: wpm ? (characters / 5) * (60_000 / wpm) : 60_000,
+    correct,
+    incorrect: cards.length - correct,
+    bestStreak: correct,
+    xpEarned: 0,
+    ghostSessionId: null,
+    beatGhost: null,
+    cards,
+  };
+}
+
+/** Every word right, at exactly the speed the lesson asks for. */
+const passing = (of: Lesson, keyboard?: KeyboardMode) =>
+  lessonRun(
+    of,
+    ["all", "flask", "glad", "shall", "gall"].map((w) => card(w, w)),
+    { wpm: of.pass.kind === "lesson" ? of.pass.wpm : undefined, keyboard },
+  );
+
+/** Fast enough and nowhere near accurate enough. */
+const failing = (of: Lesson, keyboard?: KeyboardMode) =>
+  lessonRun(
+    of,
+    ["all", "flask", "glad", "shall", "gall"].map((w, i) =>
+      card(w, i === 0 ? w : "xx"),
+    ),
+    { wpm: of.pass.kind === "lesson" ? of.pass.wpm : undefined, keyboard },
+  );
+
+/** `evaluateBadges` with the knobs no course badge reads held still. */
+const badgesFor = (
+  session: Omit<Session, "id" | "finishedAt">,
+  history: Session[] = [],
+) =>
+  evaluateBadges({
+    session,
+    history,
+    personalRecord: false,
+    maxDeficitMs: 0,
+    xpAfter: 0,
+  });
+
+/* ── The table ───────────────────────────────────────────────────────────── */
+
+/**
+ * Every badge that has ever shipped, written out rather than derived.
+ *
+ * Deliberately a second copy of `BADGES`, because a test that mapped over the
+ * real table would pass no matter what the real table said. This one is a
+ * promise to children who already hold these: change a row here and the diff
+ * makes you say out loud that you are taking a badge off a shelf.
+ *
+ * Adding to the end is the only edit this test is meant to permit, and it is
+ * the only edit that is safe (§6.7).
+ */
+const FROZEN = [
+  ["green-light", "Green Light", "🚦", "Finish your first race"],
+  ["clean-sheet", "Clean Sheet", "✨", "Finish a race with zero mistakes"],
+  ["record-setter", "Record Setter", "⏱️", "Set a personal best time"],
+  ["ghost-buster", "Ghost Buster", "👻", "Beat a rival ghost"],
+  ["comeback", "Comeback", "🔄", "Win after trailing by 3 seconds"],
+  ["hot-streak", "Hot Streak", "🔥", "15 correct in a row"],
+  ["inferno", "Inferno", "🌋", "30 correct in a row"],
+  ["quick-draw", "Quick Draw", "⚡", "Average under 3 seconds a card"],
+  ["lightning", "Lightning", "🌩️", "Average under 1.5 seconds a card"],
+  ["century", "Century", "💯", "Answer 100 cards"],
+  ["five-hundred", "Long Haul", "🎖️", "Answer 500 cards"],
+  ["gauntlet", "Gauntlet Runner", "🛡️", "Race every table at once"],
+  ["marathon", "Marathon", "🏃", "Finish a 30-card race"],
+  ["all-rounder", "All-Rounder", "🎛️", "Race all four operations"],
+  ["level-10", "Double Digits", "🌟", "Reach level 10"],
+  [
+    "beat-the-clock",
+    "Beat the Clock",
+    "⏳",
+    "Finish a timed race without running out once",
+  ],
+  [
+    "nemesis",
+    "Nemesis",
+    "🎯",
+    "Clear a drill of your tricky facts with no mistakes",
+  ],
+  // ── The typing course's five (LES12, §6.7) ─────────────────────────────────
+  ["home-keys", "Home Keys", "🏠", "Clear checkpoint 10"],
+  ["touch-typist", "Touch Typist", "✋", "Clear checkpoint 50"],
+  ["ice-exam", "Ice Exam", "🧊", "Clear lesson 100"],
+  ["eyes-up", "Eyes Up", "👀", "Pass a lesson with the keyboard hidden"],
+  [
+    "unbroken",
+    "Unbroken",
+    "🛡️",
+    "Clear a Hailstorm wave with the shield untouched",
+  ],
+];
+
+describe("the badge table", () => {
+  it("is exactly what has shipped, in order", () => {
+    expect(BADGES.map((b) => [b.id, b.name, b.icon, b.how])).toEqual(FROZEN);
+  });
+
+  it("has no two badges under one id", () => {
+    expect(new Set(BADGES.map((b) => b.id)).size).toBe(BADGES.length);
+  });
+});
+
+/* ── The seventeen that were here first ──────────────────────────────────── */
+
+/**
+ * The triggers, re-run through `evaluateBadges` rather than read off `how`.
+ *
+ * The table above pins what a badge *says*; these pin what it *does*, which is
+ * the half a refactor moves. The assertions are on the whole set and not on one
+ * id, so a course badge leaking onto a flash-card race fails here too — which
+ * is the direction LES12 could have got wrong.
+ */
+describe("the badges that shipped before the typing course", () => {
+  it("gives an ordinary first race the one badge for turning up", () => {
+    const ordinary = race([
+      card("14", "14", 5000),
+      card("16", "16", 5000),
+      card("18", "9", 5000),
+    ]);
+    expect(badgesFor(ordinary).sort()).toEqual(["green-light"]);
+  });
+
+  it("still reads perfect, and still reads fast", () => {
+    const flawless = race(
+      Array.from({ length: 12 }, (_, i) => card(`${i}`, `${i}`, 1200)),
+    );
+    expect(badgesFor(flawless).sort()).toEqual(
+      ["clean-sheet", "green-light", "lightning", "quick-draw"].sort(),
+    );
+  });
+
+  it("still counts a lifetime, a streak, a clock and a drill", () => {
+    const drill = race(
+      Array.from({ length: 30 }, (_, i) => card(`${i}`, `${i}`, 2000)),
+      {
+        bestStreak: 30,
+        config: {
+          operation: "multiply",
+          tables: [2],
+          others: [1, 2, 3],
+          cardCount: 30,
+          inputMode: "type",
+          timeLimitMs: 10_000,
+          facts: [[7, 8]],
+        },
+      },
+    );
+    const history = [
+      asSaved(
+        race(Array.from({ length: 80 }, (_, i) => card(`${i}`, `${i}`, 2000))),
+      ),
+    ];
+    expect(badgesFor(drill, history).sort()).toEqual(
+      [
+        "beat-the-clock",
+        "century",
+        "clean-sheet",
+        "green-light",
+        "hot-streak",
+        "inferno",
+        "marathon",
+        "nemesis",
+        "quick-draw",
+      ].sort(),
+    );
+  });
+});
+
+/* ── The three ladder badges ─────────────────────────────────────────────── */
+
+describe("clearing the course", () => {
+  it("gives Home Keys the moment checkpoint 10 goes down", () => {
+    expect(badgesFor(passing(lesson(10)))).toContain("home-keys");
+  });
+
+  it("gives it for the run that cleared it, not the run after", () => {
+    // The run has not been saved when badges are evaluated, so a reader that
+    // asked only the history would hold the badge back until the child's next
+    // race — and show it on a results screen for a lesson they were not on.
+    const before = badgesFor(failing(lesson(10)));
+    expect(before).not.toContain("home-keys");
+  });
+
+  it("does not give it for a checkpoint that was missed", () => {
+    const history = [asSaved(failing(lesson(10)))];
+    expect(badgesFor(race([card("2", "2")]), history)).not.toContain(
+      "home-keys",
+    );
+  });
+
+  /**
+   * The placement test, as a shelf (§6.6). Unlock is `max(cleared) + 1`, so a
+   * nine-year-old who opens checkpoint 50 cold has cleared 1–49 with it. A
+   * Touch Typist without Home Keys would be a badge shelf disagreeing with the
+   * ladder next to it about the same child.
+   */
+  it("carries the lower checkpoints with the higher one", () => {
+    const badges = badgesFor(passing(lesson(50)));
+    expect(badges).toContain("home-keys");
+    expect(badges).toContain("touch-typist");
+    expect(badges).not.toContain("ice-exam");
+  });
+
+  it("gives Ice Exam for lesson 100, and the two below it", () => {
+    const badges = badgesFor(passing(lesson(100)));
+    expect(badges).toContain("ice-exam");
+    expect(badges).toContain("touch-typist");
+    expect(badges).toContain("home-keys");
+  });
+
+  /**
+   * A child who cleared checkpoint 10 months before this story shipped has the
+   * runs and not the badge. `evaluateBadges` returns what is true rather than
+   * what is new, so the next run of anything at all hands it over.
+   */
+  it("is awarded retroactively, on a race that is not a lesson", () => {
+    const history = [asSaved(passing(lesson(10)))];
+    expect(badgesFor(race([card("2", "2")]), history)).toContain("home-keys");
+  });
+
+  it("is not awarded for runs that are not on the ladder", () => {
+    const notALesson = asSaved({
+      ...passing(lesson(10)),
+      mode: "typing:home-row",
+    });
+    expect(badgesFor(race([card("2", "2")]), [notALesson])).not.toContain(
+      "home-keys",
+    );
+  });
+});
+
+/* ── Eyes Up ─────────────────────────────────────────────────────────────── */
+
+/**
+ * Lesson 41 is the shape this badge is for: an ordinary rung, `keyboard: keys`
+ * and no lock on it, so the brief offers the choice and the run records what
+ * was chosen.
+ */
+describe("Eyes Up", () => {
+  it("is given for a lesson passed with the board turned off", () => {
+    expect(badgesFor(passing(lesson(41), "off"))).toContain("eyes-up");
+  });
+
+  it("is not given when the board was on", () => {
+    expect(badgesFor(passing(lesson(41), "keys"))).not.toContain("eyes-up");
+    expect(badgesFor(passing(lesson(41), "guide"))).not.toContain("eyes-up");
+  });
+
+  it("is not given when nobody chose anything", () => {
+    // No `keyboard` on the config is the ordinary case for free play and for
+    // any route that starts a run without a brief in front of it. Absent is
+    // not a choice, and this badge is for the choice.
+    expect(badgesFor(passing(lesson(41)))).not.toContain("eyes-up");
+  });
+
+  it("is not given for a lesson that was not passed", () => {
+    expect(badgesFor(failing(lesson(41), "off"))).not.toContain("eyes-up");
+  });
+
+  /**
+   * The inversion this badge exists to avoid.
+   *
+   * Every checkpoint forces the keyboard off (§4.2) — that is what makes
+   * passing one mean something. A badge that read the board on screen, or that
+   * trusted a `keyboard` field a future screen might write on a locked lesson,
+   * would fire on exactly the ten runs where being eyes-up was compulsory and
+   * on none of the runs where it was chosen. So the config below carries `off`
+   * and is still refused: the lesson forced it, so the child did not choose it.
+   */
+  it("is refused on a checkpoint, which forces the board off anyway", () => {
+    const badges = badgesFor(passing(lesson(10), "off"));
+    expect(badges).toContain("home-keys");
+    expect(badges).not.toContain("eyes-up");
+  });
+
+  it("is refused on every locked lesson the ladder has", () => {
+    for (const of of LESSONS) {
+      if (!of.keyboardLocked || of.pass.kind !== "lesson") continue;
+      expect(badgesFor(passing(of, "off"))).not.toContain("eyes-up");
+    }
+  });
+});
+
+/* ── Unbroken ────────────────────────────────────────────────────────────── */
+
+/**
+ * Give a storm level the wave it will get from STM08, for the length of one
+ * test, and take it back.
+ *
+ * `wordCount` is a storm's wave length (§8.3), and every one of the ten is `0`
+ * until the twenty `WaveSpec`s are written. Mutating it here is standing in for
+ * the deploy that writes them — nothing else about the world changes.
+ */
+function withWave(n: number, count: number, body: () => void) {
+  const of = lesson(n);
+  const was = of.wordCount;
+  of.wordCount = count;
+  try {
+    body();
+  } finally {
+    of.wordCount = was;
+  }
+}
+
+describe("Unbroken", () => {
+  /**
+   * The premise of the guard, pinned so that it cannot quietly stop being
+   * true: no storm level has a wave yet, so no run can have cleared one.
+   */
+  it("has nothing to fire on — no Hailstorm level has a wave yet", () => {
+    const storms = LESSONS.filter((l) => l.pass.kind === "storm");
+    expect(storms.length).toBeGreaterThan(0);
+    for (const of of storms) expect(of.wordCount).toBe(0);
+  });
+
+  it("is not awarded for a flawless run of a storm level with no wave", () => {
+    const of = lesson(4);
+    const flawless = lessonRun(
+      of,
+      ["a", "s", "d"].map((letter) => card(letter, letter)),
+    );
+    expect(badgesFor(flawless)).not.toContain("unbroken");
+  });
+
+  it("does not throw on a storm-shaped run", () => {
+    // A storm has no words per minute and introduces no keys, so a badge
+    // reader that reached for either would blow up on the first wave rather
+    // than on a test. It is checked with an empty run too: dying at the first
+    // letter saves a session with nothing in it (§8.7).
+    const of = lesson(4);
+    expect(() => badgesFor(lessonRun(of, []))).not.toThrow();
+    expect(() => badgesFor(lessonRun(of, [card("a", null)]))).not.toThrow();
+  });
+
+  it("is awarded once the wave exists and nothing got through", () => {
+    withWave(4, 3, () => {
+      const clean = lessonRun(
+        lesson(4),
+        ["a", "s", "d"].map((letter) => card(letter, letter)),
+        { wordCount: 3 },
+      );
+      expect(badgesFor(clean)).toContain("unbroken");
+    });
+  });
+
+  it("is refused when a letter got past the shield", () => {
+    withWave(4, 3, () => {
+      const holed = lessonRun(
+        lesson(4),
+        [card("a", "a"), card("s", "s"), card("d", null)],
+        { wordCount: 3 },
+      );
+      expect(badgesFor(holed)).not.toContain("unbroken");
+    });
+  });
+
+  it("is refused when the wave ended early, however clean it was", () => {
+    withWave(4, 40, () => {
+      const died = lessonRun(
+        lesson(4),
+        ["a", "s", "d"].map((letter) => card(letter, letter)),
+        { wordCount: 40 },
+      );
+      expect(badgesFor(died)).not.toContain("unbroken");
+    });
+  });
+
+  it("is not awarded for a flawless run of an ordinary lesson", () => {
+    expect(badgesFor(passing(lesson(41), "off"))).not.toContain("unbroken");
+  });
+});

--- a/src/engine/progress.test.ts
+++ b/src/engine/progress.test.ts
@@ -19,8 +19,8 @@ import { LESSONS, type Lesson } from "./typing/lessons";
  *     here before the typing course are re-run underneath it.
  *   - **The five new ones fire on what they say they fire on.** `eyes-up`
  *     carries the epic's argument — it is the only badge on the site that
- *     rewards choosing to make something harder — and the way to get it wrong
- *     is to award it for the ten checkpoints, which force the keyboard off
+ *     rewards doing the work the harder way — and the way to get it wrong is
+ *     to award it for the ten checkpoints, which force the keyboard off
  *     whatever the child wanted. That inversion has a test of its own.
  */
 
@@ -356,8 +356,14 @@ describe("clearing the course", () => {
 
 /**
  * Lesson 41 is the shape this badge is for: an ordinary rung, `keyboard: keys`
- * and no lock on it, so the brief offers the choice and the run records what
- * was chosen.
+ * and no lock on it, so the brief's control is live and the run records the
+ * mode it was actually typed under.
+ *
+ * That recorded mode is the whole question. The badge does not ask who set it:
+ * a lesson's mode seeds the control and Start hands over whatever it shows, so
+ * on the twenty-three unlocked rows that seed `off` themselves an untouched
+ * Start earns this too, once the run passes — which is right, because the
+ * child still typed the lesson blind (§6.7).
  */
 describe("Eyes Up", () => {
   it("is given for a lesson passed with the board turned off", () => {
@@ -369,10 +375,10 @@ describe("Eyes Up", () => {
     expect(badgesFor(passing(lesson(41), "guide"))).not.toContain("eyes-up");
   });
 
-  it("is not given when nobody chose anything", () => {
+  it("is not given when the run recorded no board at all", () => {
     // No `keyboard` on the config is the ordinary case for free play and for
     // any route that starts a run without a brief in front of it. Absent is
-    // not a choice, and this badge is for the choice.
+    // not evidence that the board was hidden, and hidden is what this reads.
     expect(badgesFor(passing(lesson(41)))).not.toContain("eyes-up");
   });
 
@@ -386,9 +392,10 @@ describe("Eyes Up", () => {
    * Every checkpoint forces the keyboard off (§4.2) — that is what makes
    * passing one mean something. A badge that read the board on screen, or that
    * trusted a `keyboard` field a future screen might write on a locked lesson,
-   * would fire on exactly the ten runs where being eyes-up was compulsory and
-   * on none of the runs where it was chosen. So the config below carries `off`
-   * and is still refused: the lesson forced it, so the child did not choose it.
+   * would fire on exactly the ten runs where being eyes-up was compulsory,
+   * which is the one distinction this badge does draw. So the config below
+   * carries `off` and is still refused: the lesson left no other way to play
+   * it, and a run that could not have been typed any other way proves nothing.
    */
   it("is refused on a checkpoint, which forces the board off anyway", () => {
     const badges = badgesFor(passing(lesson(10), "off"));
@@ -407,11 +414,11 @@ describe("Eyes Up", () => {
 /* ── Unbroken ────────────────────────────────────────────────────────────── */
 
 /**
- * Give a storm level the wave it will get from STM08, for the length of one
+ * Give a storm level the wave it will get from STM10, for the length of one
  * test, and take it back.
  *
- * `wordCount` is a storm's wave length (§8.3), and every one of the ten is `0`
- * until the twenty `WaveSpec`s are written. Mutating it here is standing in for
+ * `wordCount` is a storm's wave length (§8.3), and every one of the twenty is
+ * `0` until STM10 writes the `WaveSpec`s. Mutating it here is standing in for
  * the deploy that writes them — nothing else about the world changes.
  */
 function withWave(n: number, count: number, body: () => void) {

--- a/src/engine/progress.ts
+++ b/src/engine/progress.ts
@@ -1,5 +1,8 @@
 import { OPERATION_ORDER } from "@/engine/decks/flashcards";
 import { isFlash, isTyping, isWords } from "@/engine/decks";
+import { ladderProgress } from "@/engine/typing/ladder";
+import { forcedKeyboard, lessonById } from "@/engine/typing/lessons";
+import { verdictFor } from "@/engine/typing/verdict";
 import type { Session } from "@/engine/types";
 
 /* ── Levels ──────────────────────────────────────────────────────────────
@@ -170,6 +173,39 @@ export const BADGES: BadgeDef[] = [
     icon: "🎯",
     how: "Clear a drill of your tricky facts with no mistakes",
   },
+
+  /* ── Frost Keys, the typing course (docs/typing.md §6.7) ───────────────────
+     Appended, and only ever appended. A badge id is written into
+     `Profile.badges` the moment it is earned and that list is the only copy
+     there is, so adding to this table is free and renaming or removing an
+     entry takes a badge off a child who has it — the row would simply stop
+     resolving in `BADGES_BY_ID` and the tile would vanish from their shelf.
+     Five, and no more (§6.7). */
+  {
+    id: "home-keys",
+    name: "Home Keys",
+    icon: "🏠",
+    how: "Clear checkpoint 10",
+  },
+  {
+    id: "touch-typist",
+    name: "Touch Typist",
+    icon: "✋",
+    how: "Clear checkpoint 50",
+  },
+  { id: "ice-exam", name: "Ice Exam", icon: "🧊", how: "Clear lesson 100" },
+  {
+    id: "eyes-up",
+    name: "Eyes Up",
+    icon: "👀",
+    how: "Pass a lesson with the keyboard hidden",
+  },
+  {
+    id: "unbroken",
+    name: "Unbroken",
+    icon: "🛡️",
+    how: "Clear a Hailstorm wave with the shield untouched",
+  },
 ];
 
 export const BADGES_BY_ID = new Map(BADGES.map((b) => [b.id, b]));
@@ -233,5 +269,110 @@ export function evaluateBadges({
   const raced = new Set([session.mode, ...history.map((s) => s.mode)]);
   if (OPERATION_ORDER.every((op) => raced.has(op))) earned.add("all-rounder");
 
+  for (const id of courseBadges(session, history)) earned.add(id);
+
   return [...earned];
+}
+
+/* ── The typing course's five (docs/typing.md §6.7) ───────────────────────────
+   Split out rather than added to the list above because they are asked in a
+   different tense. The seventeen above are questions about *this race* —
+   perfect, fast, thirty cards, a streak of fifteen. Three of these five are
+   questions about a child's whole climb, and the climb is derived from every
+   run they have ever saved (§6.5). Keeping them apart is what stops the
+   history pass being paid for by a badge that only needed the card count.     */
+
+/**
+ * Whichever of the five this run has just earned, plus the ladder ones the
+ * child already had.
+ *
+ * Like `evaluateBadges` itself this returns what is *true*, not what is new —
+ * `summariseRun` diffs against `Profile.badges` to find the ones worth
+ * celebrating. Which is also how a child who cleared checkpoint 10 before this
+ * shipped is given Home Keys: the next run of anything at all re-asks the
+ * question, and the answer has been yes for months.
+ */
+function courseBadges(
+  session: BadgeContext["session"],
+  history: Session[],
+): string[] {
+  const earned: string[] = [];
+
+  /* ── The three ladder badges ───────────────────────────────────────────────
+     Asked of `ladderProgress` rather than of this run, because "clear
+     checkpoint 10" is a fact about a child and not about a race, and the
+     ladder is the only place that knows what clearing means. This run is
+     handed over beside the history because it is not saved yet: a checkpoint
+     cleared *by this run* has to award its badge on this run's results screen,
+     not on the next one's.
+
+     `best`, not `cleared.has(n)`, and that is the ladder's own rule rather
+     than a shortcut (§6.6). Passing checkpoint 50 clears 1–49 with it — that
+     is the whole of the placement test — so a nine-year-old who opens
+     checkpoint 50 cold has cleared checkpoint 10, and a Touch Typist without
+     Home Keys would be a shelf that disagreed with the ladder next to it.   */
+  const ladder = ladderProgress([...history, session]);
+  if (ladder.best >= 10) earned.push("home-keys");
+  if (ladder.best >= 50) earned.push("touch-typist");
+  if (ladder.best >= 100) earned.push("ice-exam");
+
+  // Through the deck registry's own guard, as everywhere else: narrowing the
+  // config union is `decks/index.ts`'s job. A run that is not a lesson — free
+  // play, a spelling race, a drill — has neither of the two below to earn.
+  const config = isTyping(session.config) ? session.config : null;
+  const lesson = lessonById(config?.lessonId);
+  if (!config || !lesson) return earned;
+
+  const verdict = verdictFor(session, lesson);
+
+  /* ── `eyes-up`, the one that matters ───────────────────────────────────────
+     The only badge on the site that rewards choosing to make something harder,
+     which is why it asks *whose doing* the hidden keyboard was rather than
+     what was on screen. Every checkpoint forces the board off (§4.2), so a
+     badge that read the resolved mode — or `config.keyboard` on its own, the
+     day a screen starts writing that field on a locked lesson — would fire on
+     exactly the ten runs where being eyes-up was compulsory. That is the
+     inverse of the badge.
+
+     So: the lesson must have left the choice open (`forcedKeyboard` is the one
+     definition of that, shared with the island's resolver), the child must
+     have made it, and they must have passed. A `keyboard` absent from the
+     config means nobody chose — free play, or a run started without a brief in
+     front of it — and absent is not a choice to reward.
+
+     Lessons only. A Hailstorm level's ⌨ column is about the *field*, which is
+     the keyboard (§8.2), so "hidden" does not mean there what it means here. */
+  if (
+    lesson.pass.kind === "lesson" &&
+    !forcedKeyboard(lesson) &&
+    config.keyboard === "off" &&
+    verdict.passed
+  )
+    earned.push("eyes-up");
+
+  /* ── `unbroken`, which is waiting for STM08 ────────────────────────────────
+     Guarded on the wave rather than on the absence of a screen that could
+     start one. A storm level's `wordCount` is its wave's `count` (§8.3) and
+     every one of the ten is `0` until the twenty `WaveSpec`s are written — so
+     `survived` is vacuously true, "cleared a wave" is a claim about a wave
+     that does not exist, and this badge must not be given for it. Stating the
+     guard as "the wave has a length" means it retires itself the day the waves
+     land, rather than being a line someone has to remember to delete.
+
+     "Shield untouched" is read as **no letter reached the bottom**, which is
+     what takes a point off a segment (§8.5). A storm's cards are its falling
+     letters (§8.7), so a run with nothing marked wrong is a run where nothing
+     got through. That errs strict — a letter fired at twice and then hit may
+     cost a card without costing the shield — and strict is the right direction
+     for a badge that, once in `Profile.badges`, is not taken back.           */
+  if (
+    lesson.pass.kind === "storm" &&
+    lesson.wordCount > 0 &&
+    verdict.passed &&
+    session.incorrect === 0 &&
+    session.correct > 0
+  )
+    earned.push("unbroken");
+
+  return earned;
 }

--- a/src/engine/progress.ts
+++ b/src/engine/progress.ts
@@ -326,19 +326,33 @@ function courseBadges(
   const verdict = verdictFor(session, lesson);
 
   /* ── `eyes-up`, the one that matters ───────────────────────────────────────
-     The only badge on the site that rewards choosing to make something harder,
-     which is why it asks *whose doing* the hidden keyboard was rather than
-     what was on screen. Every checkpoint forces the board off (§4.2), so a
-     badge that read the resolved mode — or `config.keyboard` on its own, the
-     day a screen starts writing that field on a locked lesson — would fire on
-     exactly the ten runs where being eyes-up was compulsory. That is the
-     inverse of the badge.
+     Three conditions, and "the child chose it" is deliberately not one of
+     them: the lesson must not have forced the board off (`forcedKeyboard` is
+     the one definition of that, shared with the island's resolver), the run
+     must have been typed with it off, and it must have passed.
 
-     So: the lesson must have left the choice open (`forcedKeyboard` is the one
-     definition of that, shared with the island's resolver), the child must
-     have made it, and they must have passed. A `keyboard` absent from the
-     config means nobody chose — free play, or a run started without a brief in
-     front of it — and absent is not a choice to reward.
+     What excluding the forced ones buys is *compulsion*, not authorship. Every
+     checkpoint forces the board off (§4.2), so a badge that read the resolved
+     mode — or `config.keyboard` on its own, the day a screen starts writing
+     that field on a locked lesson — would fire on exactly the ten runs where
+     being eyes-up was not optional. That is the inverse of the badge.
+
+     Hidden rather than chosen is where the line belongs, and it is worth being
+     plain about the difference. A lesson's mode only *seeds* the brief's
+     control (§4.2, #145) and Start hands over whatever that control is showing,
+     so on an unlocked lesson `config.keyboard` records the mode the run was
+     actually typed under — touched or untouched. Twenty-three unlocked rows
+     seed `off` themselves, so a child who opens lesson 46, presses Start and
+     passes earns this. That is right: they typed a lesson blind. Insisting on
+     authorship would mean comparing the config against the seed and refusing
+     that child for doing exactly what the ladder asked — same lesson, same
+     empty screen, same work — while rewarding a neighbour who flipped a pill
+     the ladder had already flipped for them. "Pass a lesson with the keyboard
+     hidden" is what the badge promises, and hidden is what this reads.
+
+     A `keyboard` absent from the config is not evidence of a hidden board —
+     free play, or a run started without a brief in front of it — so `=== "off"`
+     refuses it rather than guessing.
 
      Lessons only. A Hailstorm level's ⌨ column is about the *field*, which is
      the keyboard (§8.2), so "hidden" does not mean there what it means here. */
@@ -350,10 +364,10 @@ function courseBadges(
   )
     earned.push("eyes-up");
 
-  /* ── `unbroken`, which is waiting for STM08 ────────────────────────────────
+  /* ── `unbroken`, which is waiting for the waves (STM10) ─────────────────────
      Guarded on the wave rather than on the absence of a screen that could
      start one. A storm level's `wordCount` is its wave's `count` (§8.3) and
-     every one of the ten is `0` until the twenty `WaveSpec`s are written — so
+     every one of the twenty is `0` until STM10 writes the `WaveSpec`s — so
      `survived` is vacuously true, "cleared a wave" is a claim about a wave
      that does not exist, and this badge must not be given for it. Stating the
      guard as "the wave has a length" means it retires itself the day the waves
@@ -364,7 +378,17 @@ function courseBadges(
      letters (§8.7), so a run with nothing marked wrong is a run where nothing
      got through. That errs strict — a letter fired at twice and then hit may
      cost a card without costing the shield — and strict is the right direction
-     for a badge that, once in `Profile.badges`, is not taken back.           */
+     for a badge that, once in `Profile.badges`, is not taken back.
+
+     `correct > 0` cannot change the answer, and is kept on purpose. A run with
+     no cards at all has an accuracy of 0 (`accuracyOf` returns 0 rather than
+     NaN for an empty run), which is under every storm's 0.9 bar, so
+     `verdict.passed` has already refused it. It stays because it says the
+     second half of what "nothing got through" means — nothing wrong *and*
+     something faced — the same pair `perfect` is built from above, and because
+     the thing holding it up is a bar in the criteria table that a future
+     re-tune could lower. Redundant, deliberately; not a condition somebody
+     forgot to finish.                                                        */
   if (
     lesson.pass.kind === "storm" &&
     lesson.wordCount > 0 &&

--- a/src/engine/typing/ladder.ts
+++ b/src/engine/typing/ladder.ts
@@ -2,7 +2,7 @@ import type { Session } from "@/engine/types";
 
 import { typingMode } from "@/engine/decks/typing";
 import { LESSONS, lessonNumbered } from "./lessons";
-import { verdictFor } from "./verdict";
+import { verdictFor, type Run } from "./verdict";
 
 /**
  * How far up the ladder a child has got (docs/typing.md §6.5, §6.6).
@@ -24,6 +24,21 @@ import { verdictFor } from "./verdict";
  * down. Which sessions belong to which child is the caller's to say — hand it
  * `sessionsFor(sessions, profile.id)`, exactly as the progress screens do.
  */
+
+/**
+ * What the ladder needs of a run, which is less than a whole `Session`.
+ *
+ * `verdictFor`'s `Run` — what the child did — plus the string the run is filed
+ * under, which is what says *which* lesson they did it on. Nothing here wants
+ * an id or a `finishedAt`, and asking for them would cost something real: the
+ * badge evaluator (`engine/progress.ts`) asks this about the run that has just
+ * finished, before the session service has written it and given it either
+ * field. A ladder that insisted would have made that caller cast, and a cast
+ * is a promise nobody checks.
+ *
+ * Every other caller hands over real `Session`s, which are `LadderRun`s.
+ */
+export type LadderRun = Run & Pick<Session, "mode">;
 
 export type LadderProgress = {
   /** Every lesson number cleared. */
@@ -96,7 +111,7 @@ function carriedOverStorms(best: number): number {
   return Math.min(next, LAST);
 }
 
-function derive(sessions: Session[]): LadderProgress {
+function derive(sessions: readonly LadderRun[]): LadderProgress {
   const cleared = new Set<number>();
 
   for (const session of sessions) {
@@ -145,9 +160,9 @@ function derive(sessions: Session[]): LadderProgress {
  * still (a `useMemo`, as the progress screens already do), or every render
  * hands over a fresh array and pays for the pass again.
  */
-const MEMO = new WeakMap<Session[], LadderProgress>();
+const MEMO = new WeakMap<readonly LadderRun[], LadderProgress>();
 
-export function ladderProgress(sessions: Session[]): LadderProgress {
+export function ladderProgress(sessions: readonly LadderRun[]): LadderProgress {
   const known = MEMO.get(sessions);
   if (known) return known;
 

--- a/src/engine/typing/lessons.ts
+++ b/src/engine/typing/lessons.ts
@@ -540,3 +540,26 @@ const BY_NUMBER = new Map(LESSONS.map((lesson) => [lesson.n, lesson]));
  */
 export const lessonNumbered = (n: number): Lesson | null =>
   BY_NUMBER.get(n) ?? null;
+
+/**
+ * The mode this lesson insists on, or `null` when the choice is the child's
+ * (docs/typing.md §4.2).
+ *
+ * The one definition of "the lesson forced the board", and it lives here — in
+ * the engine, beside the rows it reads — because two layers need the same
+ * answer to two different questions. The island asks it to draw the board and
+ * to grey out the control (`keyboardFor`, `keyboardLock`); the engine asks it
+ * to award `eyes-up` (§6.7), and the engine may not import from `src/games/`.
+ *
+ * That badge is why the distinction is a function at all rather than a line
+ * inside the island's resolver. Every checkpoint forces the board `off`,
+ * because a checkpoint passed while reading the answer off the screen measures
+ * nothing — so a badge for "passed with the keyboard hidden" that asked only
+ * what was on screen would land on exactly the ten runs where being eyes-up
+ * was compulsory, which is the inverse of what it is for.
+ *
+ * A lock over `keyboard: null` is not a lock, and hands back `null` here: a
+ * lesson that names no mode is insisting on nothing.
+ */
+export const forcedKeyboard = (lesson: Lesson): KeyboardMode | null =>
+  lesson.keyboardLocked && lesson.keyboard ? lesson.keyboard : null;

--- a/src/games/typing/keyboard/lessonKeyboard.ts
+++ b/src/games/typing/keyboard/lessonKeyboard.ts
@@ -1,5 +1,5 @@
-import type { Lesson } from "@/engine/typing/lessons";
 import type { KeyboardMode } from "@/engine/types";
+import { forcedKeyboard, type Lesson } from "@/engine/typing/lessons";
 import { keyboardMode } from "./KeyboardSetting";
 
 /**
@@ -24,7 +24,10 @@ import { keyboardMode } from "./KeyboardSetting";
  *     of the ladder are why it exists — lesson 1 forces `guide`, because a
  *     child who has never seen a keyboard cannot be asked to guess, and every
  *     checkpoint forces `off`, because a checkpoint passed while reading the
- *     answer off the screen measures nothing.
+ *     answer off the screen measures nothing. Which lesson insists on what is
+ *     `forcedKeyboard`'s to say, in the engine: `eyes-up` (§6.7) has to tell a
+ *     board a child turned off from one the lesson turned off for them, and a
+ *     rule only this file knew would be a rule the badge had to guess at.
  *   - **What the child chose**, for the run they chose it on.
  *   - **The lesson's own mode, then the player's, then `guide`** — §4.2's line,
  *     unchanged, and the arm free play takes. Free play has no lesson and makes
@@ -42,7 +45,8 @@ export function keyboardFor(
   /** `TypingConfig.keyboard`: what the child chose in the brief, if anything. */
   chosen?: KeyboardMode | null,
 ): KeyboardMode {
-  if (lesson?.keyboardLocked && lesson.keyboard) return lesson.keyboard;
+  const forced = lesson ? forcedKeyboard(lesson) : null;
+  if (forced) return forced;
   return chosen ?? lesson?.keyboard ?? keyboardMode(profileMode);
 }
 
@@ -66,12 +70,14 @@ export function keyboardFor(
  * `null` here: a lesson that names no mode is insisting on nothing, and
  * `keyboardFor` above lets the player through for the same reason. The two have
  * to agree — a control greyed out with a reason while the run honoured the
- * child's setting anyway would be the first bug all over again, inverted.
+ * child's setting anyway would be the first bug all over again, inverted — so
+ * both ask `forcedKeyboard` rather than each reading the two fields itself.
  */
 export function keyboardLock(lesson: Lesson): string | null {
-  if (!lesson.keyboardLocked || !lesson.keyboard) return null;
+  const forced = forcedKeyboard(lesson);
+  if (!forced) return null;
 
-  switch (lesson.keyboard) {
+  switch (forced) {
     case "off":
       return "Checkpoints are typed without the keyboard — that is what makes passing one worth something.";
     case "guide":


### PR DESCRIPTION
## LES12 · Badges for the course

Five badges for the typing course, appended to `BADGES` in
`src/engine/progress.ts` and awarded by `evaluateBadges`:

| id             | name         | how                                              |
| -------------- | ------------ | ------------------------------------------------ |
| `home-keys`    | Home Keys    | 🏠 Clear checkpoint 10                           |
| `touch-typist` | Touch Typist | ✋ Clear checkpoint 50                            |
| `ice-exam`     | Ice Exam     | 🧊 Clear lesson 100                              |
| `eyes-up`      | Eyes Up      | 👀 Pass a lesson with the keyboard hidden        |
| `unbroken`     | Unbroken     | 🛡️ Clear a Hailstorm wave with the shield untouched |

The three ladder badges are asked of `ladderProgress` and read `best`, not
`cleared` — passing checkpoint 50 clears 1–49 with it, so a child who takes the
express lane holds Home Keys as well as Touch Typist, and the shelf never
disagrees with the ladder beside it. They are re-asked on every finished run of
anything, which is how a child who cleared checkpoint 10 before this shipped is
handed the badge by their next race.

### `eyes-up` is the point of the epic

It is the only badge on the site that rewards choosing to make something
harder. It fires when three things hold: **the lesson did not force the board
off, the run recorded `keyboard: "off"`, and it passed.**

Deliberately *not* a condition: that the child flipped the pill themselves.
A lesson's mode only seeds the brief's control, and Start hands over whatever
the control is showing — so on an unlocked lesson `config.keyboard` records the
mode the run was actually typed under, touched or untouched. Twenty-three
unlocked rows seed `off` themselves, so opening lesson 46, pressing Start and
passing earns this: they typed a lesson blind, which is exactly what the shelf
promises. Insisting on authorship would mean refusing that child for doing what
the ladder asked while rewarding a neighbour who flipped a pill the ladder had
already flipped for them.

What the exclusion buys is *compulsion*, not authorship: every checkpoint forces
the board off, so a badge reading the resolved mode would land on precisely the
ten runs where being eyes-up was not optional — the inverse of the badge.

### One rule for "the lesson forced the board" (decision 28)

`forcedKeyboard(lesson)` moved into `src/engine/typing/lessons.ts`, beside the
rows it reads. The island's `keyboardFor` / `keyboardLock` call it to draw the
board and grey out the control; the badge calls it to exclude the forced ten.
The board drawn and the badge awarded now read one rule — and the engine may not
import from `src/games/`, so this is the layer it has to live in.

### `unbroken` is gated on the wave existing (decision 29)

A storm level's `wordCount` is its wave's `count`, and every one of the twenty
storms is `0` until STM10 (#156) writes the `WaveSpec`s. Until then "cleared a
wave" is a claim about a wave that does not exist, so the badge requires
`wordCount > 0`. Stating the guard as "the wave has a length" means it **retires
itself** the day the waves land, rather than being a line someone has to
remember to delete.

**Caveat for #156's review:** badge awards are permanent — an id written into
`Profile.badges` is the only copy there is — so STM10 must re-check this mapping
when it sets the wave lengths, since that is the commit that turns the badge on.
"Shield untouched" is read as no letter reaching the bottom (`incorrect === 0`),
which errs strict, and strict is the right direction for something never taken
back.

### Additive only

Badge ids are persisted per profile, so appending is free and renaming or
removing takes a badge off a child who has it. `src/engine/progress.test.ts`
carries a pinning test over the seventeen badges that shipped before this — id,
name, icon, order and trigger — proving no shipped badge moved.

### Browser evidence

- Checkpoint 10 cleared → `home-keys`, and **not** `eyes-up` (the checkpoint
  forced the board off).
- A lesson passed with the keyboard **on** → nothing.
- The same lesson passed with it **off** → `eyes-up`.
- Checkpoint 50 cleared cold → `home-keys` **and** `touch-typist`.

### Validation

`npm run type-check`, `npm run lint`, `npm run test:unit` (1859 passing),
`npm run build`, and the browser smoke test against the built output — all green.

Design: `docs/typing.md` §6.7, decisions 28 and 29.

Closes #146
