### PR TITLE
STM01 · The wave, from a seed (#147)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -167,10 +167,13 @@ in, row 2 a little further, row 3 further still. Storing it means one number
 per key and no arithmetic anybody has to trust.
 
 `keyX(code)` is `x` plus half the key's width — the **middle** of the key, which
-is the lane its letter falls down (§8.2). One function rather than the same
-arithmetic in the field and in the drawn board, because a lane half a unit out
-is a spatial hint that teaches the wrong thing, and two copies of a sum are how
-that happens. It returns `null` for a code this board does not carry.
+is the lane its letter falls down (§8.2). The field and the drawn board cannot
+disagree about where a key is because both read this same table and both measure
+in key units off the same `--key` — one _table_, not one function. `keyX` is the
+field's convenience for the centre of a key's slot; the board wants a left edge
+and a width, and takes `x` and `width` directly. A lane half a unit out is a
+spatial hint that teaches the wrong thing, and the shared table is what rules
+that out. It returns `null` for a code this board does not carry.
 
 ### 3.3 · `keyFor`, and why shift is two keys
 
@@ -959,6 +962,19 @@ The keyboard component sits at the bottom of the field, lit by the same
 
 Lanes are key units, not pixels, so the field and the board scale together off
 one `--key` custom property.
+
+They scale off it differently, though, and the difference is worth writing down
+before the field is built. `keyX` returns the centre of a key's **slot**, while
+the drawn keycap is inset inside that slot: `game.css` gives it
+`width: calc(var(--w) * var(--key) - var(--key-gap))`, with `--key-gap` set to
+`calc(var(--key) * 0.09)`. So a cap's visual centre is `--key * (x + w/2 -
+0.045)` while its lane is `--key * (x + w/2)` — a letter placed at
+`left: calc(var(--lane) * var(--key))` and centred with `translateX(-50%)` sits
+**0.045 key units right of the centre of the cap it names**, about 1.7px at the
+2.4rem ceiling of `--key` and about 0.8px at the 1.05rem floor. Whether the
+field subtracts that half-gap is the field's own call to make deliberately
+(§13, item 18); it is recorded here so that it is neither inherited unknowingly
+nor "corrected" into a real misalignment.
 
 ### 8.3 · A wave, from a seed
 

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -166,6 +166,12 @@ from anything — it is a fact about the plastic. Row 1 starts a third of a unit
 in, row 2 a little further, row 3 further still. Storing it means one number
 per key and no arithmetic anybody has to trust.
 
+`keyX(code)` is `x` plus half the key's width — the **middle** of the key, which
+is the lane its letter falls down (§8.2). One function rather than the same
+arithmetic in the field and in the drawn board, because a lane half a unit out
+is a spatial hint that teaches the wrong thing, and two copies of a sum are how
+that happens. It returns `null` for a code this board does not carry.
+
 ### 3.3 · `keyFor`, and why shift is two keys
 
 ```ts
@@ -985,6 +991,52 @@ never more than one letter on screen and the game is pure reaction. Later
 levels overlap them, so two or three are falling at once and you have to work
 bottom-up — which is reading ahead, which is the thing that makes a fast typist.
 
+What it emits is the storm, decided:
+
+```ts
+export function buildWave(spec: WaveSpec, seed: number): Wave;
+
+export type StormLetter = {
+  /** The character, as it is drawn. */
+  ch: string;
+  /** The key that produces it — what a press is matched against. */
+  code: string;
+  /** The finger that types it: the shield segment it lands on (§8.5). */
+  finger: ShieldFinger;
+  /** `keyX(code)` — the column it falls down, in key units (§8.2). */
+  lane: number;
+  /** ms from the start of the wave. */
+  spawnMs: number;
+  /** ms to cross the field. */
+  fallMs: number;
+  /** `spawnMs + fallMs` — when it reaches the shield. */
+  landMs: number;
+};
+```
+
+Every letter is resolved against the keyboard **once, up front**: `strokeFor`
+gives the key and the finger, `keyX` gives the lane. So the reducer never asks
+the layout a question mid-run, the renderer does no arithmetic to place a
+letter, and the finger the death screen names cannot disagree with the column
+the letter fell down. `letters` is in spawn order and the index is a letter's
+identity — the wave is built once and never grows, so nothing can shift under a
+reducer's "which are in the air" or under a React key.
+
+A letter is on the field over the **half-open** interval `[spawnMs, landMs)`:
+there the instant it spawns, gone the instant it lands, because landing is the
+tick that turns it into shield damage. That is what makes the early levels'
+guarantee `gap[0] >= fall[1]` rather than `>` — at exactly equal, the outgoing
+letter lands on the same millisecond the next one spawns, which is a handover
+and not two letters on screen.
+
+Two characters never fall, whatever `spec.keys` says: one this board cannot
+produce (§3.3's null), because it could never be shot, and one typed with a
+thumb — the unlocked alphabet always carries a space and the shield has no
+thumb segment for it to damage (§8.5). A spec left with nothing to draw from
+builds an **empty wave rather than throwing**, the same habit as `deckSpec`
+never throwing: a storm with nothing in it is a screen that ends, and a throw
+is a game loop that dies holding a child's run.
+
 ### 8.4 · The lowest letter is the target
 
 **Only the lowest letter on screen can be shot.** Any other key is a miss.
@@ -1196,6 +1248,8 @@ first when either optional field is added.
 | 27  | A lesson's keyboard seeds; it does not overrule         | All hundred name a mode, so an override beats the player's own setting on every rung                     |
 | 28  | `eyes-up` reads the board the run was typed under       | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory       |
 | 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete  |
+| 30  | A falling letter is on the field on `[spawn, land)`     | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two      |
+| 31  | A letter carries its key, finger and lane               | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift       |
 
 ---
 

--- a/src/engine/keyboard.test.ts
+++ b/src/engine/keyboard.test.ts
@@ -221,10 +221,12 @@ describe("the board", () => {
   });
 
   it("puts a key's lane in the middle of it", () => {
-    // `keyX` is Hailstorm's lane (§8.2): the letter and the picture of the key
-    // it falls onto read the same number, so a field drawn from it cannot
-    // disagree with the board about where a key is. Middle rather than left
-    // edge, which is only visible on the keys that are not one unit wide.
+    // `keyX` is Hailstorm's lane (§8.2), and what this pins is its agreement
+    // with the layout table: every lane is `x` plus half the key's width, so a
+    // field drawn from it and a board drawn from `KEY_ROWS` are reading the
+    // same rows. Nothing here reads the board's CSS, so nothing here is a
+    // claim about the drawn keycaps. Middle rather than left edge, which is
+    // only visible on the keys that are not one unit wide.
     expect(keyX("KeyF")).toBe(5.25);
     expect(
       keyX("Space"),

--- a/src/engine/keyboard.test.ts
+++ b/src/engine/keyboard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { KEYS, KEY_ROWS, reachable, strokeFor } from "./keyboard";
+import { KEYS, KEY_ROWS, keyX, reachable, strokeFor } from "./keyboard";
 import type { Finger, KeyDef } from "./keyboard";
 import { TYPING_LEVELS } from "./decks/typing";
 
@@ -218,6 +218,40 @@ describe("the board", () => {
       }
       expect(edge, `row ${row[0].row}`).toBe(15);
     }
+  });
+
+  it("puts a key's lane in the middle of it", () => {
+    // `keyX` is Hailstorm's lane (§8.2): the letter and the picture of the key
+    // it falls onto read the same number, so a field drawn from it cannot
+    // disagree with the board about where a key is. Middle rather than left
+    // edge, which is only visible on the keys that are not one unit wide.
+    expect(keyX("KeyF")).toBe(5.25);
+    expect(
+      keyX("Space"),
+      "6.25 units wide, so its edge is not its middle",
+    ).toBe(6.875);
+
+    // The example the design is written in: `y` is not above a home key, it is
+    // between two of them, and that is what a child is being shown.
+    expect(keyX("KeyY")).toBeGreaterThan(keyX("KeyG")!);
+    expect(keyX("KeyY")).toBeLessThan(keyX("KeyH")!);
+
+    for (const key of KEYS) {
+      const x = keyX(key.code);
+      expect(x, key.code).toBe(key.x + (key.width ?? 1) / 2);
+      // The board is 15 units wide, so every lane is inside it — which is what
+      // the field's `--key` arithmetic assumes and never checks.
+      expect(x, key.code).toBeGreaterThan(0);
+      expect(x, key.code).toBeLessThan(15);
+    }
+  });
+
+  it("has no lane for a key it does not carry", () => {
+    // A numpad key, a media key, or a `code` from a layout that is not US ANSI
+    // (§3.4). Null rather than 0, which would be a lane on the far left.
+    expect(keyX("Numpad7")).toBeNull();
+    expect(keyX("AudioVolumeUp")).toBeNull();
+    expect(keyX("IntlBackslash")).toBeNull();
   });
 
   it("keeps each row on one row number", () => {

--- a/src/engine/keyboard.ts
+++ b/src/engine/keyboard.ts
@@ -197,9 +197,17 @@ const BY_CODE = new Map(KEYS.map((k) => [k.code, k]));
  * which is the point. Hailstorm's lanes are this function (docs/typing.md §8.2,
  * decision 19): a letter falls down the column of the key that produces it, so
  * `keyX("KeyF")` is where `f` falls and `keyX("KeyY")` lands between `g` and
- * `h` because that is where `y` is. The field and the drawn board reading one
- * number is what stops them disagreeing about where a key is, and a lane half a
- * unit out is a spatial hint that teaches the wrong thing.
+ * `h` because that is where `y` is.
+ *
+ * The field and the drawn board cannot disagree about where a key is because
+ * both read the same `KEY_ROWS` table and both measure in key units off that
+ * one `--key`. It is one *table*, not one function: `keyX` is the field's
+ * convenience for the centre of a key's slot, while the board wants a left
+ * edge and a width and takes `KeyDef.x` / `KeyDef.width` straight from the
+ * same rows without calling this. A lane half a unit out would be a spatial
+ * hint that teaches the wrong thing, and the shared table is what rules that
+ * out. The keycap drawn inside a slot is inset by `--key-gap`, so a slot's
+ * centre and a cap's centre are 0.045 units apart — §8.2 has that number.
  *
  * The **middle** rather than the left edge, because a falling glyph is centred
  * on its column and the wide keys are where the difference shows: the space bar

--- a/src/engine/keyboard.ts
+++ b/src/engine/keyboard.ts
@@ -186,6 +186,33 @@ export const KEY_ROWS: KeyDef[][] = [
 /** Every key on the board, rows flattened. Row order is left-to-right, top-down. */
 export const KEYS: KeyDef[] = KEY_ROWS.flat();
 
+/** `code` → its key. Built once; the table above is a constant. */
+const BY_CODE = new Map(KEYS.map((k) => [k.code, k]));
+
+/**
+ * Where a key sits across the board: the middle of it, in key units.
+ *
+ * The board is 15 units wide, so this is a number from 0 to 15 that scales off
+ * the same single `--key` custom property the picture of the keyboard does —
+ * which is the point. Hailstorm's lanes are this function (docs/typing.md §8.2,
+ * decision 19): a letter falls down the column of the key that produces it, so
+ * `keyX("KeyF")` is where `f` falls and `keyX("KeyY")` lands between `g` and
+ * `h` because that is where `y` is. The field and the drawn board reading one
+ * number is what stops them disagreeing about where a key is, and a lane half a
+ * unit out is a spatial hint that teaches the wrong thing.
+ *
+ * The **middle** rather than the left edge, because a falling glyph is centred
+ * on its column and the wide keys are where the difference shows: the space bar
+ * is 6.25 units, so its edge and its middle are three keys apart.
+ *
+ * `null` for a code this board does not carry — a numpad key, a media key, or
+ * anything from a layout that is not US ANSI (§3.4).
+ */
+export function keyX(code: string): number | null {
+  const key = BY_CODE.get(code);
+  return key ? key.x + (key.width ?? 1) / 2 : null;
+}
+
 export type Stroke = {
   /** The letter key. */
   code: string;

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, it } from "vitest";
+
+import { keyX, strokeFor } from "@/engine/keyboard";
+import { unlockedAt } from "./keys";
+import { buildWave } from "./storm";
+import type { Wave, WaveSpec } from "./storm";
+
+/**
+ * The wave's properties, proved rather than sampled (docs/typing.md §8.3).
+ *
+ * Every interesting claim this module makes is universally quantified — "the
+ * same seed is the same storm", "every character is one the child can type",
+ * "an early level never puts two letters on screen" — so each is asserted over
+ * a spread of seeds crossed with a spread of specs, not over one hand-picked
+ * wave. A generator is a distribution and one seed is an anecdote.
+ *
+ * Two of them are also load-bearing beyond this file. The first is the story:
+ * a child who just lost retries and meets the storm that beat them, which is
+ * only true while `(spec, seed)` decides everything. The second is the one that
+ * gives the early levels their shape — `gap` above `fall` means pure reaction —
+ * and it is arithmetic, so the boundary case is tested at the boundary and one
+ * millisecond the other side of it.
+ */
+
+/**
+ * Enough seeds that a rare draw is not a lucky pass.
+ *
+ * Spread rather than 0–15, for the same reason `generate.test.ts` spreads
+ * its: `mulberry32` is well-behaved over neighbouring seeds, but the numbers a
+ * run actually uses come from `randomSeed()` and look nothing like a counter.
+ */
+const SEEDS = [
+  0, 1, 2, 7, 42, 99, 128, 1000, 4242, 65535, 123456, 999983, 2147483647,
+  16777216, 31337, 8675309,
+];
+
+const HOME = ["a", "s", "d", "f", "g", "h", "j", "k", "l", ";"];
+
+const spec = (over: Partial<WaveSpec>): WaveSpec => ({
+  keys: HOME,
+  count: 24,
+  gap: [900, 1300],
+  fall: [1000, 1600],
+  shield: 3,
+  repairAt: 0,
+  ...over,
+});
+
+/**
+ * The shapes the twenty levels will be built out of (§8.3, §5.6's storm rows).
+ *
+ * Written as levels rather than as fixtures so that a property which only
+ * holds for tidy specs fails here: two of them draw from the alphabet a real
+ * lesson unlocks, which is where the space bar and the capitals come from.
+ */
+const SPECS: [name: string, spec: WaveSpec][] = [
+  // Lesson 4. Two keys, one at a time — `gap` clear of `fall`.
+  [
+    "first ice",
+    spec({ keys: ["f", "j"], count: 12, gap: [1400, 1800], fall: [900, 1200] }),
+  ],
+  // Lesson 9. The home row, still one at a time, but only just.
+  [
+    "home row",
+    spec({
+      keys: [...unlockedAt(13)],
+      count: 20,
+      gap: [1200, 1500],
+      fall: [800, 1200],
+    }),
+  ],
+  // Lesson 13 onwards. Overlapping, so the child has to work bottom-up.
+  ["eight lanes", spec({ keys: HOME, count: 24 })],
+  // Lesson 34. Capitals fall too — `A` and `a` are one key and two letters.
+  [
+    "capitals",
+    spec({
+      keys: ["a", "A", "s", "S", "l", "L", ";", ":"],
+      count: 30,
+      gap: [600, 1000],
+      fall: [1200, 2000],
+    }),
+  ],
+  // Lesson 59. Digits, which live on a row of their own.
+  [
+    "numbers falling",
+    spec({
+      keys: ["1", "2", "3", "8", "9", "0"],
+      count: 30,
+      gap: [700, 1100],
+      fall: [1300, 1900],
+    }),
+  ],
+  // Lesson 93. Everything the ladder ever hands over, including the space it
+  // always carries, at speed and with no repairs.
+  [
+    "everything falls",
+    spec({
+      keys: [...unlockedAt(100)],
+      count: 40,
+      gap: [200, 400],
+      fall: [1400, 2400],
+      shield: 2,
+      repairAt: 6,
+    }),
+  ],
+  // Lesson 73. Long, so a schedule that drifts has room to show it.
+  ["the long wave", spec({ keys: [...unlockedAt(100)], count: 60 })],
+];
+
+/** The specs whose `gap` clears their `fall` — the levels that are pure reaction. */
+const REACTION = SPECS.filter(([, s]) => s.gap[0] >= s.fall[1]);
+
+/** The specs whose ranges overlap — the levels that stack letters up. */
+const STACKING = SPECS.filter(([, s]) => s.gap[1] < s.fall[0]);
+
+/**
+ * The most letters on the field at any one moment.
+ *
+ * A letter occupies the field on the half-open interval `[spawnMs, landMs)` —
+ * present the instant it spawns, gone the instant it lands, because landing is
+ * the tick that resolves it into shield damage. That is why departures are
+ * processed before arrivals at an equal timestamp: a letter landing on the same
+ * millisecond as the next one spawns is a handover, not an overlap.
+ */
+const maxOnScreen = (wave: Wave): number => {
+  const events = wave.letters.flatMap((l) => [
+    { at: l.spawnMs, delta: 1 },
+    { at: l.landMs, delta: -1 },
+  ]);
+  events.sort((a, b) => a.at - b.at || a.delta - b.delta);
+
+  let live = 0;
+  let most = 0;
+  for (const event of events) {
+    live += event.delta;
+    most = Math.max(most, live);
+  }
+  return most;
+};
+
+/** The gaps between one spawn and the next, which is what `spec.gap` samples. */
+const gapsOf = (wave: Wave) =>
+  wave.letters.slice(1).map((l, i) => l.spawnMs - wave.letters[i].spawnMs);
+
+describe("a wave is deterministic in (spec, seed)", () => {
+  it("builds the same storm twice, for every spec and every seed", () => {
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS)
+        expect(buildWave(s, seed), `${name} @ ${seed}`).toEqual(
+          buildWave(s, seed),
+        );
+  });
+
+  it("meets the storm that beat you when you retry it", () => {
+    // The story, spelled out: a retry has nothing but the wave in hand, and
+    // rebuilding from what the wave carries has to produce the wave back.
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS) {
+        const wave = buildWave(s, seed);
+        expect(buildWave(wave.spec, wave.seed), `${name} @ ${seed}`).toEqual(
+          wave,
+        );
+      }
+  });
+
+  it("builds a different storm from a different seed", () => {
+    // Otherwise "deterministic" would be satisfied by a generator that ignored
+    // the seed entirely, and every level would be the same storm forever.
+    for (const [name, s] of SPECS.filter(([, s]) => s.keys.length > 4)) {
+      const storms = new Set(
+        SEEDS.map((seed) => JSON.stringify(buildWave(s, seed).letters)),
+      );
+      expect(storms.size, name).toBe(SEEDS.length);
+    }
+  });
+
+  it("reads no randomness of its own", () => {
+    // `Math.random()` anywhere in here would make a wave unrepeatable while
+    // every other assertion in this file still passed — the two calls would
+    // simply differ from each other, and only a child pressing "again" would
+    // ever find out. So the global is taken away for the length of one build.
+    const real = Math.random;
+    Math.random = () => {
+      throw new Error("buildWave must draw only from mulberry32(seed)");
+    };
+    try {
+      for (const [, s] of SPECS) expect(() => buildWave(s, 42)).not.toThrow();
+    } finally {
+      Math.random = real;
+    }
+  });
+});
+
+describe("every letter in a wave is one the child can shoot", () => {
+  it("falls only characters that are in spec.keys and on this board", () => {
+    for (const [name, s] of SPECS) {
+      const allowed = new Set(s.keys);
+      for (const seed of SEEDS)
+        for (const letter of buildWave(s, seed).letters) {
+          const where = `${name} @ ${seed}: ${letter.ch}`;
+          expect(allowed.has(letter.ch), where).toBe(true);
+          // The same null `reachable()` is built out of (§5.2). A letter this
+          // layout cannot produce is a letter that can never be shot.
+          expect(strokeFor(letter.ch), where).not.toBeNull();
+        }
+    }
+  });
+
+  it("carries the key, the finger and the lane the layout gives it", () => {
+    // Restating any of the three inside the game would be a second copy of the
+    // layout, and a lane half a unit out is a spatial hint that teaches the
+    // wrong thing. So each is checked against `engine/keyboard.ts` itself.
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS)
+        for (const letter of buildWave(s, seed).letters) {
+          const where = `${name} @ ${seed}: ${letter.ch}`;
+          const stroke = strokeFor(letter.ch);
+          expect(letter.code, where).toBe(stroke?.code);
+          expect(letter.finger, where).toBe(stroke?.finger);
+          expect(letter.lane, where).toBe(keyX(letter.code));
+        }
+  });
+
+  it("never drops anything onto a thumb", () => {
+    // The shield has eight segments, one per finger, and none for the thumbs
+    // (§8.5) — so a falling space would have nothing above it to damage. The
+    // unlocked alphabet always contains one, which is why this is a filter and
+    // not a note in the docs.
+    const alphabet = SPECS.find(([name]) => name === "everything falls")![1];
+    expect(
+      alphabet.keys,
+      "the premise: the alphabet carries a space",
+    ).toContain(" ");
+
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS)
+        for (const letter of buildWave(s, seed).letters)
+          expect(letter.finger, `${name} @ ${seed}`).not.toBe("thumb");
+  });
+
+  it("falls each letter down the column of its own key", () => {
+    // §8.2, in one assertion each: the two examples the design is written in.
+    const f = buildWave(spec({ keys: ["f"], count: 1 }), 1).letters[0];
+    expect(f.lane).toBe(keyX("KeyF"));
+
+    const y = buildWave(spec({ keys: ["y"], count: 1 }), 1).letters[0];
+    expect(y.lane).toBe(keyX("KeyY"));
+    expect(y.lane).toBeGreaterThan(keyX("KeyG")!);
+    expect(y.lane).toBeLessThan(keyX("KeyH")!);
+  });
+
+  it("drops a character this board cannot produce, and keeps the rest", () => {
+    // Curly quotes and em dashes are what prose pulled from a library carries,
+    // and the level that let one through would be unbeatable rather than hard.
+    const wave = buildWave(spec({ keys: ["“", "—", "f"] }), 7);
+    expect(wave.letters).toHaveLength(24);
+    expect(new Set(wave.letters.map((l) => l.ch))).toEqual(new Set(["f"]));
+  });
+
+  it("is an empty storm rather than a throw when nothing can fall", () => {
+    // The engine's habit: a mode that no longer makes sense still opens
+    // (`deckSpec` never throws). A wave with nothing in it is a screen that
+    // ends; a throw is a game loop that dies holding a child's run.
+    const wave = buildWave(spec({ keys: [" ", "“"], count: 20 }), 3);
+    expect(wave.letters).toEqual([]);
+    expect(wave.durationMs).toBe(0);
+    expect(wave.spec.count, "the spec is echoed as written").toBe(20);
+  });
+
+  it("falls exactly as many letters as the spec asks for", () => {
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS)
+        expect(buildWave(s, seed).letters, `${name} @ ${seed}`).toHaveLength(
+          s.count,
+        );
+  });
+});
+
+describe("gap and fall are sampled per letter", () => {
+  it("keeps every draw inside the spec's ranges", () => {
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS) {
+        const wave = buildWave(s, seed);
+        const where = `${name} @ ${seed}`;
+
+        expect(wave.letters[0].spawnMs, `${where}: the wave starts at 0`).toBe(
+          0,
+        );
+        for (const gap of gapsOf(wave)) {
+          expect(gap, `${where}: gap`).toBeGreaterThanOrEqual(s.gap[0]);
+          expect(gap, `${where}: gap`).toBeLessThanOrEqual(s.gap[1]);
+        }
+        for (const letter of wave.letters) {
+          expect(letter.fallMs, `${where}: fall`).toBeGreaterThanOrEqual(
+            s.fall[0],
+          );
+          expect(letter.fallMs, `${where}: fall`).toBeLessThanOrEqual(
+            s.fall[1],
+          );
+        }
+      }
+  });
+
+  it("draws a fresh number for each letter, not one for the wave", () => {
+    // "Sometimes random within the level" (§8.3) is the whole difference
+    // between a storm and a metronome, and a generator that sampled once per
+    // wave would satisfy every range assertion above.
+    for (const [name, s] of SPECS.filter(([, s]) => s.count >= 20))
+      for (const seed of SEEDS) {
+        const wave = buildWave(s, seed);
+        const where = `${name} @ ${seed}`;
+        expect(new Set(gapsOf(wave)).size, `${where}: gaps`).toBeGreaterThan(5);
+        expect(
+          new Set(wave.letters.map((l) => l.fallMs)).size,
+          `${where}: falls`,
+        ).toBeGreaterThan(5);
+      }
+  });
+
+  it("can draw either end of a range", () => {
+    // A range of three, so every value in it must turn up across the sweep.
+    // This is the assertion an exclusive bound fails: a generator that never
+    // reached `max` would make every level fractionally easier than written,
+    // and nothing else here would notice.
+    const s = spec({ keys: HOME, count: 40, gap: [10, 12], fall: [5, 7] });
+    const gaps = new Set<number>();
+    const falls = new Set<number>();
+    for (const seed of SEEDS) {
+      const wave = buildWave(s, seed);
+      for (const gap of gapsOf(wave)) gaps.add(gap);
+      for (const letter of wave.letters) falls.add(letter.fallMs);
+    }
+    expect([...gaps].sort()).toEqual([10, 11, 12]);
+    expect([...falls].sort()).toEqual([5, 6, 7]);
+  });
+});
+
+describe("the schedule the wave hands the reducer", () => {
+  it("spawns in order and lands a fall later", () => {
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS) {
+        const wave = buildWave(s, seed);
+        wave.letters.forEach((letter, i) => {
+          const where = `${name} @ ${seed}: letter ${i}`;
+          expect(letter.landMs, where).toBe(letter.spawnMs + letter.fallMs);
+          if (i > 0)
+            expect(letter.spawnMs, where).toBeGreaterThanOrEqual(
+              wave.letters[i - 1].spawnMs,
+            );
+        });
+      }
+  });
+
+  it("runs until the last letter lands, which is not the last letter", () => {
+    // A slow letter spawned early can land after a fast one spawned later, so
+    // the wave's length is a max and not the final element. Sixteen seeds of a
+    // spec with a wide `fall` and a tight `gap` is enough to make it happen.
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS) {
+        const wave = buildWave(s, seed);
+        expect(wave.durationMs, `${name} @ ${seed}`).toBe(
+          Math.max(...wave.letters.map((l) => l.landMs)),
+        );
+      }
+
+    const overtaking = spec({ count: 20, gap: [10, 10], fall: [100, 2000] });
+    const waves = SEEDS.map((seed) => buildWave(overtaking, seed));
+    expect(
+      waves.some((w) => w.durationMs !== w.letters.at(-1)!.landMs),
+      "the premise: a slow letter is sometimes overtaken",
+    ).toBe(true);
+  });
+});
+
+describe("when gap clears fall, one letter falls at a time", () => {
+  /*
+   * The invariant the early levels are made of (§8.3), and it is arithmetic
+   * rather than luck. Letter i is on the field over `[spawn_i, spawn_i +
+   * fall_i)` and letter i+1 spawns at `spawn_i + gap_{i+1}`, so the two share
+   * the screen exactly when `gap_{i+1} < fall_i`. If every gap the spec can
+   * draw is at least every fall it can draw, that is never true — and because
+   * spawn times only increase, no later letter can overlap letter i either.
+   *
+   * The boundary goes to safety: `gap` exactly equal to `fall` still leaves one
+   * letter on screen, because a letter occupies `[spawnMs, landMs)` — it is
+   * gone the instant it lands, and landing is the tick that turns it into
+   * shield damage. So the guarantee is `gap[0] >= fall[1]`, not `>`.
+   */
+
+  it("puts nothing beside a letter on the reaction levels", () => {
+    expect(
+      REACTION.length,
+      "the premise: some levels are reaction",
+    ).toBeGreaterThan(0);
+
+    for (const [name, s] of REACTION) {
+      expect(s.gap[0], `${name} is a reaction level`).toBeGreaterThanOrEqual(
+        s.fall[1],
+      );
+      for (const seed of SEEDS)
+        expect(maxOnScreen(buildWave(s, seed)), `${name} @ ${seed}`).toBe(1);
+    }
+  });
+
+  it("holds when a gap is exactly a fall", () => {
+    // The boundary itself. The outgoing letter lands on the same millisecond
+    // the next one spawns, which is a handover and not an overlap.
+    const s = spec({ count: 30, gap: [900, 900], fall: [900, 900] });
+    for (const seed of SEEDS)
+      expect(maxOnScreen(buildWave(s, seed)), `@ ${seed}`).toBe(1);
+  });
+
+  it("stops holding one millisecond the other side of it", () => {
+    // And this is the assertion that makes the one above mean something: move
+    // the boundary by a millisecond in the direction that overlaps, and two
+    // letters share the screen. An off-by-one in either direction fails one of
+    // this pair.
+    const s = spec({ count: 30, gap: [899, 899], fall: [900, 900] });
+    for (const seed of SEEDS)
+      expect(maxOnScreen(buildWave(s, seed)), `@ ${seed}`).toBe(2);
+  });
+
+  it("stacks letters up on the levels that mean to", () => {
+    // The other half of the shape: later levels overlap the ranges so that two
+    // or three are in the air and the child has to work bottom-up. Without
+    // this the invariant above could be satisfied by a generator that never
+    // put two letters on screen at all.
+    expect(STACKING.length, "the premise: some levels stack").toBeGreaterThan(
+      0,
+    );
+
+    for (const [name, s] of STACKING)
+      for (const seed of SEEDS)
+        expect(
+          maxOnScreen(buildWave(s, seed)),
+          `${name} @ ${seed}`,
+        ).toBeGreaterThan(1);
+  });
+});

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -1,0 +1,259 @@
+/**
+ * Hailstorm's rules. This half of them is the wave: what falls, where, and when
+ * (docs/typing.md §8.3).
+ *
+ * A wave is generated **whole, up front, from a seed**, exactly as every deck
+ * on this site is. That is not a stylistic echo — it is the story this module
+ * exists for. A child who has just lost wants to retry *the storm that beat
+ * them*, and a game that rolled its next letter as it went could only ever
+ * offer them a different one. Beating a wave you have met before means you got
+ * better; beating a fresh one means you got luckier, and a five-year-old can
+ * tell the difference even when they cannot say it.
+ *
+ * The second thing it buys is this file being testable at all. Spawn schedule,
+ * lanes and fall speeds are plain arithmetic over plain data here, so "is there
+ * ever more than one letter on screen at this level" is a question a unit test
+ * asks in a millisecond rather than a thing somebody watches for and hopes.
+ *
+ * ── Model, and it has to stay model ──────────────────────────────────────────
+ * No React, no rAF, no DOM, no clock (§8.9). The loop calls this; the tests
+ * call it too. The only reason the loop is allowed to be dumb — write a
+ * transform, do nothing else — is that everything it would otherwise have to
+ * decide was decided here, before the first frame.
+ *
+ * ── And it has to stay small ─────────────────────────────────────────────────
+ * `lessons.ts` is importable from the deck layer, and STM10 puts a `WaveSpec`
+ * on each of the twenty storm lessons — which will make this module reachable
+ * from `decks/index.ts`, the front door every island on the site downloads
+ * (§5.3, decision 7). So it must never grow a table. There is nothing here but
+ * the spec, the RNG, and the keyboard: the characters a wave draws from arrive
+ * as `spec.keys`, from a caller that already knows them.
+ */
+import { keyX, strokeFor } from "@/engine/keyboard";
+import type { Finger } from "@/engine/keyboard";
+import { between, mulberry32 } from "@/engine/random";
+
+/**
+ * The eight fingers the shield is divided into — every finger but the thumbs.
+ *
+ * The shield spans the bottom of the field in one segment per finger (§8.5),
+ * and thumbs are excluded because nothing falls on the space bar. Stating that
+ * as a type rather than as a convention is what makes it one rule instead of
+ * two: the pool filter below drops any character typed with a thumb, so a wave
+ * can never carry a letter with no segment above it — which is the case the
+ * reducer would otherwise have to invent an answer for at the worst moment.
+ */
+export type ShieldFinger = Exclude<Finger, "thumb">;
+
+/**
+ * One level of Hailstorm, as declared by the lesson that hosts it.
+ *
+ * `gap` and `fall` are **ranges rather than numbers**, and that is what "the
+ * storm is sometimes random within the level" means: each letter draws its own
+ * spawn delay and its own fall time. The relationship between the two ranges is
+ * the level's whole difficulty shape:
+ *
+ *   - `gap` at or above `fall` → a letter lands before the next one spawns, so
+ *     there is never more than one on screen and the game is pure reaction.
+ *     That is what the early levels are (see `buildWave` for the arithmetic).
+ *   - `gap` below `fall` → two or three in the air at once, and the child has
+ *     to work bottom-up. Which is reading ahead, which is the thing that makes
+ *     a fast typist.
+ */
+export type WaveSpec = {
+  /**
+   * Which characters can fall. Usually "everything unlocked by lesson n".
+   *
+   * Order and repeats are the caller's to use: a character listed twice falls
+   * about twice as often, which is how a level built around six new symbols
+   * weights them above the forty a child already has. Anything this board
+   * cannot produce, and anything typed with a thumb, is dropped rather than
+   * refused — see `buildWave`.
+   */
+  keys: string[];
+  /** How many letters in the wave. */
+  count: number;
+  /** ms between spawns — sampled per letter from this range. */
+  gap: [number, number];
+  /** ms for a letter to cross the field — sampled per letter. */
+  fall: [number, number];
+  /** Shield hit points per finger zone. */
+  shield: number;
+  /** Combo needed to repair a zone. 0 = no repairs. */
+  repairAt: number;
+};
+
+/**
+ * One falling letter, decided before the wave starts.
+ *
+ * Everything a frame, a hit or a death needs to know about it is here, so that
+ * the reducer never has to ask the keyboard a question mid-run and the renderer
+ * never has to do arithmetic: `lane` is where to draw it, `spawnMs`/`fallMs`
+ * are where it is at time _t_, `code` is what shoots it and `finger` is the
+ * shield segment it breaks if nothing does.
+ */
+export type StormLetter = {
+  /** The character, as it is drawn: `f`, `A`, `7`, `?`. */
+  ch: string;
+  /**
+   * `KeyboardEvent.code` of the key that produces it — what a press is
+   * compared against.
+   *
+   * `code`, not the character (decision 2): a shifted legend and its base
+   * share a key, so `A` and `a` are both fired by `KeyA` and the shift a child
+   * is holding cannot make the shot miss. It is also the code the lane is a
+   * column of, so the thing you press and the place it falls are one fact.
+   */
+  code: string;
+  /**
+   * The finger that types it, which is the shield segment above where it
+   * lands (§8.5).
+   *
+   * Carried rather than looked up so that the reducer, the death screen and
+   * the drill it offers all read the same value. A hole under the right ring
+   * finger is the best thing this game tells a child about their own hands,
+   * and it must not be able to disagree with where the letter actually fell.
+   */
+  finger: ShieldFinger;
+  /**
+   * The column it falls down: the middle of its key, in key units from the
+   * left edge of the board (§8.2, decision 19).
+   *
+   * The board is 15 units wide, so this is a number from 0 to 15 that the
+   * field scales by the same `--key` custom property the drawn keyboard uses.
+   * `f` falls onto `f`; `y` falls between `g` and `h`, because that is where
+   * `y` is.
+   */
+  lane: number;
+  /** ms from the start of the wave to this letter appearing at the top. */
+  spawnMs: number;
+  /** ms it takes to cross the field, drawn from `spec.fall`. */
+  fallMs: number;
+  /**
+   * `spawnMs + fallMs` — when it reaches the shield.
+   *
+   * A letter occupies the field on the **half-open** interval
+   * `[spawnMs, landMs)`: it is there the instant it spawns and gone the instant
+   * it lands, because landing is the tick that resolves it into damage. That
+   * convention is what makes `gap === fall` the safe side of the boundary in
+   * `buildWave`'s no-overlap guarantee, so it is written down here rather than
+   * left for the reducer to pick again.
+   *
+   * Derived, and stored anyway, because it is read on every tick. One warning
+   * belongs with it: the *lowest* letter on screen is the one with the greatest
+   * `(t - spawnMs) / fallMs`, which is not the same order as `landMs` once two
+   * letters fall at different speeds. Two orderings that look interchangeable
+   * and part company exactly where it matters are worth a sentence.
+   */
+  landMs: number;
+};
+
+/**
+ * A whole storm, replayable from `(spec, seed)`.
+ *
+ * Both are carried on it so that everything downstream takes one argument: the
+ * reducer needs `shield` and `repairAt`, the results screen needs `count`, and
+ * the retry button needs the seed — which is this story's whole point.
+ *
+ * `letters` is in spawn order, and **the index is the letter's identity** —
+ * for the reducer's "which are in the air", and for a React key. The wave is
+ * built once and never grows, so nothing can shift under either of them.
+ */
+export type Wave = {
+  spec: WaveSpec;
+  seed: number;
+  letters: StormLetter[];
+  /**
+   * ms from the start of the wave until the last letter lands, or 0 if nothing
+   * falls. The max rather than the last letter's, because a slow letter
+   * spawned early can land after a fast one spawned later.
+   */
+  durationMs: number;
+};
+
+/** A character the board can drop, with everything fixed about it resolved. */
+type Fallable = Pick<StormLetter, "ch" | "code" | "finger" | "lane">;
+
+/**
+ * A character as a thing that could fall, or `null` if it cannot.
+ *
+ * Everything here is read off `engine/keyboard.ts` and nothing is restated:
+ * the layout knows which key produces a character, which finger presses it and
+ * where that key sits. Two characters get dropped, for different reasons:
+ *
+ *   - **This board cannot produce it.** A curly quote, an em dash, a letter
+ *     from another layout. Same null `strokeFor` that `reachable()` is built
+ *     out of (§5.2) — a wave that dropped one would be unshootable.
+ *   - **A thumb types it.** The space bar, and nothing else that types a
+ *     character. The shield has no thumb segment (§8.5), so a falling space
+ *     would have nothing above it to damage. Spaces matter here because the
+ *     unlocked alphabet a caller passes as `spec.keys` always contains one.
+ */
+function fallable(ch: string): Fallable | null {
+  const stroke = strokeFor(ch);
+  if (!stroke) return null;
+  if (stroke.finger === "thumb") return null;
+  const lane = keyX(stroke.code);
+  // Unreachable: every stroke names a key on this board, because `strokeFor`
+  // was built from the same table `keyX` reads. Skipping the character is
+  // still cheaper than asserting the null away, and it cannot hide a bug — a
+  // wave short of a character it should have had is what the pool test sees.
+  if (lane === null) return null;
+  return { ch, code: stroke.code, finger: stroke.finger, lane };
+}
+
+/**
+ * The whole wave, from a seed.
+ *
+ * Deterministic in `(spec, seed)` and in nothing else: no clock is read and
+ * `Math.random` is never called, here or below. The **draw order** — the gap in
+ * front of a letter, then which letter, then how fast it falls — is therefore
+ * part of what a seed means. Reordering those three lines re-rolls every storm,
+ * which is free today and is not free the moment a level's seed is written down
+ * beside a saved run (STM08).
+ *
+ * ── Why `gap ≥ fall` means one letter at a time ──────────────────────────────
+ * Letter _i_ is on the field over `[spawn_i, spawn_i + fall_i)` and letter
+ * _i+1_ spawns at `spawn_i + gap_{i+1}`, so the two share the screen exactly
+ * when `gap_{i+1} < fall_i`. If every gap a spec can draw is at least every
+ * fall it can draw — `gap[0] ≥ fall[1]` — that is never true, and since spawn
+ * times only increase, no *later* letter can overlap letter _i_ either. So the
+ * early levels' "never more than one on screen" is a property of the spec, not
+ * a hope about the draw.
+ *
+ * The boundary goes to safety: `gap` exactly equal to `fall` still leaves one
+ * letter on screen, because the interval is half-open — the outgoing letter
+ * lands on the same millisecond the next one spawns, and landing is the tick
+ * that takes it off the field.
+ */
+export function buildWave(spec: WaveSpec, seed: number): Wave {
+  const rand = mulberry32(seed);
+
+  // Filtered once, up front. An empty pool — a spec naming only characters
+  // this board cannot type — yields an empty wave rather than an exception:
+  // the engine's habit is that a mode which no longer makes sense still opens
+  // (`deckSpec` never throws), and a storm with nothing in it is a screen that
+  // ends, where a throw is a game loop that dies holding a child's run.
+  const pool = spec.keys
+    .map(fallable)
+    .filter((entry): entry is Fallable => entry !== null);
+
+  const letters: StormLetter[] = [];
+  let spawnMs = 0;
+  for (let i = 0; i < spec.count && pool.length > 0; i++) {
+    // The gap is the time since the previous spawn, so the first letter has
+    // none — the wave starts with it. Not sampled-and-discarded for i = 0,
+    // because a draw nobody uses is still part of what the seed means.
+    if (i > 0) spawnMs += between(spec.gap[0], spec.gap[1], rand);
+    const from = pool[between(0, pool.length - 1, rand)];
+    const fallMs = between(spec.fall[0], spec.fall[1], rand);
+    letters.push({ ...from, spawnMs, fallMs, landMs: spawnMs + fallMs });
+  }
+
+  return {
+    spec,
+    seed,
+    letters,
+    durationMs: letters.reduce((last, l) => Math.max(last, l.landMs), 0),
+  };
+}


### PR DESCRIPTION
Closes #147

First story of epic #159 (Hailstorm). Adds the wave generator — the model half of the storm, with nothing on screen yet.

## `src/engine/typing/storm.ts`

`WaveSpec` declares one level: `keys`, `count`, `gap: [min,max]`, `fall: [min,max]`, `shield`, `repairAt`. `buildWave(spec, seed)` generates the **whole wave up front** from `mulberry32(seed)` — which character, which lane, when it spawns, how fast it falls — so it is deterministic in `(spec, seed)` and nothing else. No clock is read and `Math.random` is never called. That is the same rule every deck on this site already follows, and it is what lets a child who just lost retry *the storm that beat them*: beating a wave you have met before means you got better, not luckier.

`gap` and `fall` are sampled **per letter** from their ranges, which is what "sometimes random within the level" means. The draw order (gap, then which letter, then fall) is part of what a seed means, so reordering those lines re-rolls every storm — free today, not free once a seed is written down beside a saved run (STM08).

### The emitted `StormLetter`, and why it suits the reducer

```ts
type StormLetter = {
  ch: string;       // the character as drawn
  code: string;     // KeyboardEvent.code — what a press is compared against
  finger: Exclude<Finger, "thumb">;
  lane: number;     // keyX(code) — the column it falls down, in key units
  spawnMs: number;
  fallMs: number;
  landMs: number;   // spawnMs + fallMs
};
```

Every letter is resolved against the keyboard **once, up front**, so the reducer never asks the layout a question mid-run and the renderer does no arithmetic to place a letter. Two details carry their weight:

- **`code` is what firing compares**, not the character. A shifted legend and its base share a key, so `A` and `a` are both fired by `KeyA` and the shift a child is holding cannot make the shot miss. It is also the code the lane is a column of, so the thing you press and the place it falls are one fact.
- **`finger` is typed `Exclude<Finger, "thumb">`** (exported as `ShieldFinger`). The shield spans the field in one segment per finger and has no thumb segment, so a falling letter always has a shield segment above it — stated as a type rather than a convention, which makes it one rule instead of two. The pool filter drops thumb-typed characters, and the unlocked alphabet a caller passes always contains a space.

`letters` is in spawn order and the index is a letter's identity — for the reducer's "which are in the air" and for a React key. The wave is built once and never grows, so nothing shifts under either.

### The half-open interval, and why the guarantee is `>=`

A letter occupies the field on `[spawnMs, landMs)` — there the instant it spawns, gone the instant it lands, because landing is the tick that resolves it into shield damage. Letter *i* is on the field over `[spawn_i, spawn_i + fall_i)` and letter *i+1* spawns at `spawn_i + gap_{i+1}`, so the two share the screen exactly when `gap_{i+1} < fall_i`. If every gap the spec can draw is at least every fall it can draw — **`gap[0] >= fall[1]`, not `>`** — that is never true, and since spawn times only increase no later letter can overlap letter *i* either. At exact equality the outgoing letter lands as the next one spawns: a handover, not two letters on screen. So "never more than one letter on screen" on the early reaction levels is a property of the spec, not a hope about the draw.

Verified by brute force over **121 spec shapes x 16 seeds**: all **66** shapes satisfying `gap[0] >= fall[1]` gave max-on-screen exactly 1, and all **55** others stacked. The test suite pins the boundary from both sides — `gap: [900,900] / fall: [900,900]` holds at 1, and `gap: [899,899]` moves it to 2, so an off-by-one in either direction fails one of the pair.

### The lowest letter is not `landMs` order

The *lowest* letter on screen is the one with the greatest `(t - spawnMs) / fallMs`, which is **not** the same ordering as `landMs` once two letters fall at different speeds. Two orderings that look interchangeable and part company exactly where it matters are worth writing down, so it is a doc block on `landMs`. This is a real disagreement, not a theoretical one — it shows up at **seed 42** (in the capitals spec at t=15978, and in the everything-falls spec at t=1945). #152 resolves the lowest target and will depend on it.

## `keyX(code)` in `keyboard.ts`

Added for the field's lanes: `x + width/2`, the **middle** of a key in key units, or `null` for a code this board does not carry. The middle rather than the left edge because a falling glyph is centred on its column and the wide keys are where the difference shows — the space bar is 6.25 units, so its edge and its middle are three keys apart.

## Empty waves

A spec naming only characters this board cannot produce, or an empty `keys`, yields an **empty wave rather than an exception** — the same habit as `deckSpec` never throwing. A storm with nothing in it is a screen that ends; a throw is a game loop that dies holding a child's run.

## Review fix

The `keyX` doc claimed the drawn board shared the function. That was false — the board reads `KeyDef.x` / `KeyDef.width` and lets CSS do the `calc()`. It is one **table**, not one function. Corrected in `keyboard.ts`, `docs/typing.md` §3.2 and `keyboard.test.ts`.

Chasing that down surfaced a real number worth recording: `keyX` returns the centre of a key's **slot**, while the drawn keycap is inset inside that slot by `--key-gap` (`calc(var(--key) * 0.09)`). So a lane sits **0.045 key units** right of the visual centre of the cap it names — about **1.7px** at the 2.4rem ceiling of `--key` and about **0.8px** at the 1.05rem floor. Whether the field subtracts that half-gap is the field's own call, so it is recorded in §8.2 for #149 to decide about deliberately, rather than being inherited unknowingly or "corrected" into a real misalignment.

## Bundle impact

`storm.ts` is reachable from the deck layer once STM10 puts a `WaveSpec` on each storm lesson, so this module must not grow a table — the characters a wave draws from arrive as `spec.keys` from a caller that already knows them.

| Chunk | develop | this branch | delta |
| --- | --- | --- | --- |
| deck chunk (`records.Clx2fslG.js`) | 55,608 B | 55,608 B | **0** — byte-identical, same content hash |
| typing island (`App.*.js`) | 63,010 B | 63,045 B | **+35 B** |

## Docs

`docs/typing.md` §3.2 (the `keyX` correction), §8.2 (the 0.045-unit offset) and §8.3 (what `buildWave` emits), plus decisions **30** (a falling letter is on the field on `[spawn, land)`) and **31** (a letter carries its key, finger and lane).

## Out of scope

The reducer (STM02) and anything on screen. No React, no rAF, no DOM.

## Validation

`npm run type-check`, `npm run lint`, `npm run test:unit` (1881 passing across 92 files), `npm run build`, and the browser smoke test against the built output — all green, no console errors.
