### PR TITLE
STM02 · The storm reducer — hits, misses, shield, death (#148)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1062,6 +1062,19 @@ a wave with three letters in the air is a small exercise in prioritising, and
 "firing the wrong letter out of sequence" is a definable thing that can cost
 you something.
 
+Lowest is the greatest **fall progress** — `(t - spawnMs) / fallMs` — and not
+the earliest `landMs`. The two part company as soon as two letters fall at
+different speeds, which is most of the ladder: a slow letter spawned early is
+halfway down while a fast one spawned later has barely started, and yet the
+fast one lands first. Aiming by the schedule would point the gun at a letter
+that is visibly nearer the top of the screen, and the child is looking at the
+field. On an exact tie — the single instant two letters cross — the earlier
+spawn wins, because a letter's index is its identity (§8.3) and a replay has to
+resolve a dead heat the same way every time.
+
+Firing at an empty field is a miss too. It is the same spray by another route,
+and a streak that survived it would have found the strategy again.
+
 ### 8.5 · The shield is your fingers
 
 The shield spans the bottom of the field in **eight segments, one per finger**
@@ -1084,7 +1097,18 @@ percentage will ever tell them.
 
 `repairAt` gives it back: every _n_ consecutive hits restores a point to the
 weakest segment. It is the comeback path, and it rewards the exact behaviour
-the game exists to build.
+the game exists to build. The weakest segment rather than the last one damaged,
+because a segment at zero is simultaneously the one about to end the run and
+the one a single point is worth most in — "weakest" reaches it with no special
+case for holes.
+
+Two edges of that, both decided in the reducer. **Consecutive means
+consecutive**: a letter you let land breaks the streak exactly as a wrong key
+does, because the streak is "are you keeping up" and a letter that got through
+is the definition of not. And **a repair never lifts a segment above
+`shield`** — repairs that outran damage would hand a strong player a shield
+deeper than the level ever wrote down, and the eight-of-`shield` a run starts
+with is what "the shield came through untouched" is reported against.
 
 ### 8.6 · Score can fall; XP cannot
 
@@ -1159,6 +1183,16 @@ for reduced motion.
 The **rules** — spawn schedule, hit resolution, shield state, scoring — are in
 `engine/typing/storm.ts` as a pure reducer over a tick. No React, no rAF, no
 DOM. The loop calls it; the tests call it too.
+
+`tick(state, dtMs)` resolves **every** landing inside the interval it is given,
+however long that is — including letters that spawned and landed inside the
+same tick and were airborne at no instant anybody sampled. A backgrounded tab
+stops `requestAnimationFrame` and hands back seconds, and a dropped landing
+would leave the shield quietly disagreeing with the storm that damaged it.
+Whether a child should be held responsible for a tab they were not looking at
+is a separate question, and it is the loop's: clamping the delta, or pausing on
+`visibilitychange`, is a decision the clock can only make deliberately because
+the rules underneath it are honest about the whole interval.
 
 ### 8.10 · Motion, flashing and reduced motion
 
@@ -1266,6 +1300,10 @@ first when either optional field is added.
 | 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete  |
 | 30  | A falling letter is on the field on `[spawn, land)`     | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two      |
 | 31  | A letter carries its key, finger and lane               | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift       |
+| 32  | The target is the greatest fall progress, not `landMs`  | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen           |
+| 33  | An exact tie goes to the earlier spawn                  | The index is the letter's identity, so a replay resolves the same dead heat the same way                 |
+| 34  | A repair never lifts a zone above `spec.shield`         | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                 |
+| 35  | A tick resolves every landing inside it                 | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's            |
 
 ---
 

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -2,8 +2,18 @@ import { describe, expect, it } from "vitest";
 
 import { keyX, strokeFor } from "@/engine/keyboard";
 import { unlockedAt } from "./keys";
-import { buildWave } from "./storm";
-import type { Wave, WaveSpec } from "./storm";
+import {
+  SHIELD_FINGERS,
+  buildWave,
+  fire,
+  hasLanded,
+  isAirborne,
+  progressAt,
+  startStorm,
+  targetIndex,
+  tick,
+} from "./storm";
+import type { Shield, StormLetter, StormState, Wave, WaveSpec } from "./storm";
 
 /**
  * The wave's properties, proved rather than sampled (docs/typing.md §8.3).
@@ -117,27 +127,22 @@ const STACKING = SPECS.filter(([, s]) => s.gap[1] < s.fall[0]);
 /**
  * The most letters on the field at any one moment.
  *
- * A letter occupies the field on the half-open interval `[spawnMs, landMs)` —
- * present the instant it spawns, gone the instant it lands, because landing is
- * the tick that resolves it into shield damage. That is why departures are
- * processed before arrivals at an equal timestamp: a letter landing on the same
- * millisecond as the next one spawns is a handover, not an overlap.
+ * The count on screen only ever goes up at a spawn, so asking `isAirborne` at
+ * every spawn instant finds the maximum without a sweep. Reading the half-open
+ * interval out of the engine rather than restating it here is what makes the
+ * boundary pair at the bottom of this file — `gap` exactly `fall`, and one
+ * millisecond the other side — a test of the rule the reducer actually fires
+ * and damages by, instead of a test of a second copy of it that happens to
+ * live in the test file.
  */
-const maxOnScreen = (wave: Wave): number => {
-  const events = wave.letters.flatMap((l) => [
-    { at: l.spawnMs, delta: 1 },
-    { at: l.landMs, delta: -1 },
-  ]);
-  events.sort((a, b) => a.at - b.at || a.delta - b.delta);
-
-  let live = 0;
-  let most = 0;
-  for (const event of events) {
-    live += event.delta;
-    most = Math.max(most, live);
-  }
-  return most;
-};
+const maxOnScreen = (wave: Wave): number =>
+  Math.max(
+    0,
+    ...wave.letters.map(
+      (l) =>
+        wave.letters.filter((other) => isAirborne(other, l.spawnMs)).length,
+    ),
+  );
 
 /** The gaps between one spawn and the next, which is what `spec.gap` samples. */
 const gapsOf = (wave: Wave) =>
@@ -436,5 +441,549 @@ describe("when gap clears fall, one letter falls at a time", () => {
           maxOnScreen(buildWave(s, seed)),
           `${name} @ ${seed}`,
         ).toBeGreaterThan(1);
+  });
+});
+
+/* ═══ The reducer (§8.4, §8.5) ═══════════════════════════════════════════════
+ *
+ * The wave above is tested as a distribution, because that is what a generator
+ * is. The rules below are tested at the millisecond instead, on waves written
+ * by hand: "the second-lowest letter is a miss" and "a letter landing in a hole
+ * ends the run" are claims about single instants, and a generated schedule
+ * would only ever reach them by luck.
+ */
+
+/**
+ * One letter, placed by hand.
+ *
+ * Built through `strokeFor`/`keyX` rather than with literal codes and fingers
+ * so that a fixture cannot quietly disagree with the board the game is played
+ * on: `at("f", …)` really is the left index finger's zone, and a change to the
+ * layout breaks these tests where it should.
+ */
+const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
+  const stroke = strokeFor(ch);
+  if (!stroke || stroke.finger === "thumb")
+    throw new Error(`${ch} is not a letter that can fall`);
+  return {
+    ch,
+    code: stroke.code,
+    finger: stroke.finger,
+    lane: keyX(stroke.code) ?? 0,
+    spawnMs,
+    fallMs,
+    landMs: spawnMs + fallMs,
+  };
+};
+
+/** A run over exactly these letters, at time zero. */
+const runOf = (letters: StormLetter[], over: Partial<WaveSpec> = {}) =>
+  startStorm({
+    spec: spec({ count: letters.length, shield: 1, ...over }),
+    seed: 0,
+    letters,
+    durationMs: letters.reduce((last, l) => Math.max(last, l.landMs), 0),
+  });
+
+/** Advance the run to an absolute moment, which is how a test thinks. */
+const to = (state: StormState, ms: number) => tick(state, ms - state.timeMs);
+
+/** Eight zones, all at `points` — what an undamaged shield looks like. */
+const evenShield = (points: number): Shield =>
+  Object.fromEntries(SHIELD_FINGERS.map((f) => [f, points])) as Shield;
+
+/** Which letters got through, by index — the shape STM07's death screen counts. */
+const landed = (state: StormState) =>
+  state.resolved.flatMap((outcome, index) =>
+    outcome?.outcome === "landed" ? [index] : [],
+  );
+
+describe("where a letter is at time t", () => {
+  const letter = at("f", 1000, 500);
+
+  it("is on the field over [spawn, land), and not one millisecond either side", () => {
+    // Decision 30, as a boundary rather than as prose. The instant it lands is
+    // the tick that turns it into shield damage, so it cannot still be
+    // shootable there — a letter that was both would be a free hit that also
+    // took a hit point off.
+    expect(isAirborne(letter, 999)).toBe(false);
+    expect(isAirborne(letter, 1000)).toBe(true);
+    expect(isAirborne(letter, 1499)).toBe(true);
+    expect(isAirborne(letter, 1500)).toBe(false);
+
+    expect(hasLanded(letter, 1499)).toBe(false);
+    expect(hasLanded(letter, 1500)).toBe(true);
+  });
+
+  it("has not landed before it has spawned", () => {
+    // `hasLanded` is not `!isAirborne`: a letter still to come is neither, and
+    // a reducer that read it as "landed" would charge the shield for letters
+    // that never fell.
+    expect(isAirborne(letter, 0)).toBe(false);
+    expect(hasLanded(letter, 0)).toBe(false);
+  });
+
+  it("falls from 0 at the top to 1 at the shield", () => {
+    expect(progressAt(letter, 1000)).toBe(0);
+    expect(progressAt(letter, 1250)).toBe(0.5);
+    expect(progressAt(letter, 1500)).toBe(1);
+  });
+});
+
+describe("the lowest letter is the target", () => {
+  it("is the greatest fall progress, not the earliest landing", () => {
+    // The disagreement STM01 wrote down, built to order: a slow letter spawned
+    // first is more than halfway down while a fast one spawned later has
+    // barely started — and yet the fast one lands first. `landMs` order would
+    // aim the gun at the letter that is visibly nearer the top of the screen.
+    const slow = at("f", 0, 5000); // lands at 5000
+    const fast = at("j", 3000, 1000); // lands at 4000
+    const state = to(runOf([slow, fast], { shield: 3 }), 3100);
+
+    expect(progressAt(slow, 3100)).toBeGreaterThan(progressAt(fast, 3100));
+    expect(slow.landMs).toBeGreaterThan(fast.landMs);
+    expect(targetIndex(state)).toBe(0);
+  });
+
+  it("hands the target over as the two letters cross", () => {
+    // Different fall speeds means the orderings really do swap, once, at a
+    // crossing — so the target before it, at it, and after it are three
+    // different answers and all three are tested.
+    const first = at("f", 0, 2000);
+    const second = at("j", 500, 1000);
+    const state = runOf([first, second], { shield: 3 });
+
+    expect(targetIndex(to(state, 900))).toBe(0);
+    expect(progressAt(first, 1000)).toBe(progressAt(second, 1000));
+    expect(targetIndex(to(state, 1000))).toBe(0);
+    expect(targetIndex(to(state, 1100))).toBe(1);
+  });
+
+  it("gives an exact tie to the earlier spawn", () => {
+    // Two letters at the same height are the same shot to a child, so the tie
+    // goes to the letter's identity — the index — and a replay of the same
+    // wave resolves the dead heat the same way every time.
+    const state = to(runOf([at("f", 0, 1000), at("j", 0, 1000)]), 400);
+    expect(targetIndex(state)).toBe(0);
+  });
+
+  it("has no target when the field is empty", () => {
+    const state = runOf([at("f", 1000, 500)], { shield: 3 });
+    expect(targetIndex(state), "before the first spawn").toBeNull();
+    expect(targetIndex(to(state, 1500)), "after it has landed").toBeNull();
+  });
+
+  it("stops targeting a letter that has been shot", () => {
+    const state = to(runOf([at("f", 0, 1000), at("j", 100, 1000)]), 200);
+    expect(targetIndex(state)).toBe(0);
+    expect(targetIndex(fire(state, "KeyF"))).toBe(1);
+  });
+});
+
+describe("firing resolves the lowest letter, and nothing else", () => {
+  const two = () => to(runOf([at("f", 0, 1000), at("j", 300, 1000)]), 500);
+
+  it("shoots the lowest letter with its own key", () => {
+    const state = fire(two(), "KeyF");
+    expect(state.resolved[0]).toEqual({ outcome: "shot", atMs: 500 });
+    expect(state.resolved[1], "the letter above it is untouched").toBeNull();
+    expect(state.combo).toBe(1);
+    expect(state.shield, "a hit costs the shield nothing").toEqual(
+      evenShield(1),
+    );
+  });
+
+  it("counts the second-lowest letter as a miss", () => {
+    // The rule the whole game is balanced on. `KeyJ` is a real letter on a
+    // real lane and it is the wrong shot, because it is not the one about to
+    // cost a shield point.
+    const before = two();
+    const state = fire(before, "KeyJ");
+
+    expect(targetIndex(before), "the premise: KeyJ is not the target").toBe(0);
+    expect(isAirborne(before.wave.letters[1], 500)).toBe(true);
+    expect(state.resolved, "nothing was resolved").toEqual([null, null]);
+    expect(state.combo).toBe(0);
+    expect(state.shield).toEqual(evenShield(1));
+  });
+
+  it("counts a key nothing on screen uses as a miss", () => {
+    const state = fire(two(), "KeyZ");
+    expect(state.resolved).toEqual([null, null]);
+    expect(state.combo).toBe(0);
+  });
+
+  it("counts a shot at an empty field as a miss", () => {
+    // Spraying between letters is the same strategy by another route, so it
+    // costs the streak the same way.
+    const state = fire(runOf([at("f", 1000, 500)]), "KeyF");
+    expect(targetIndex(state), "the premise: nothing is falling").toBeNull();
+    expect(state.resolved).toEqual([null]);
+    expect(state.combo).toBe(0);
+  });
+
+  it("shoots a capital with the key that types it", () => {
+    // `A` and `a` are one key and two letters (decision 2), so the shift a
+    // child is holding cannot make the shot miss.
+    const state = to(runOf([at("A", 0, 1000)]), 400);
+    expect(state.wave.letters[0].code).toBe("KeyA");
+    expect(fire(state, "KeyA").resolved[0]?.outcome).toBe("shot");
+  });
+
+  it("does nothing once the run is over", () => {
+    const dead = to(runOf([at("f", 0, 100), at("f", 200, 100)]), 400);
+    expect(dead.ending?.kind, "the premise: the run ended").toBe("breached");
+    expect(fire(dead, "KeyF")).toBe(dead);
+    expect(tick(dead, 1000)).toBe(dead);
+  });
+});
+
+describe("what lands takes the shield apart", () => {
+  it("takes a point off the zone above it and no others", () => {
+    const state = to(runOf([at("f", 0, 100)], { shield: 3 }), 100);
+    expect(state.resolved[0]).toEqual({ outcome: "landed", atMs: 100 });
+    expect(state.shield["l-index"], "the finger that types f").toBe(2);
+    expect(state.shield).toEqual({ ...evenShield(3), "l-index": 2 });
+  });
+
+  it("charges nothing for a letter that was shot", () => {
+    const state = to(
+      fire(to(runOf([at("f", 0, 1000)], { shield: 3 }), 400), "KeyF"),
+      5000,
+    );
+    expect(state.shield).toEqual(evenShield(3));
+    expect(state.resolved[0]?.outcome).toBe("shot");
+  });
+
+  it("lets the next letter through once a zone is exhausted", () => {
+    // The acceptance criterion, in three moments: a zone at zero is a hole and
+    // the run continues; the letter that lands in the hole is what ends it;
+    // and the finger it names is the finger that typed it.
+    const letters = [at("f", 0, 100), at("f", 200, 100)];
+    const state = runOf(letters, { shield: 1 });
+
+    const holed = to(state, 100);
+    expect(holed.shield["l-index"]).toBe(0);
+    expect(holed.ending, "a hole is not yet a death").toBeNull();
+
+    const dead = to(holed, 300);
+    expect(dead.ending).toEqual({
+      kind: "breached",
+      finger: "l-index",
+      index: 1,
+    });
+    expect(dead.resolved[1], "the letter that got through is recorded").toEqual(
+      { outcome: "landed", atMs: 300 },
+    );
+    expect(dead.shield["l-index"], "there was nothing left to take it").toBe(0);
+  });
+
+  it("ends on the first letter when the spec gives no shield at all", () => {
+    const state = to(runOf([at("f", 0, 100)], { shield: 0 }), 100);
+    expect(state.ending?.kind).toBe("breached");
+  });
+
+  it("breaks the streak when a letter gets through", () => {
+    // The streak means "are you keeping up", so a letter you let land ends it
+    // as surely as a wrong key does — and with it the repair it was earning.
+    const hit = fire(
+      to(runOf([at("f", 0, 400), at("j", 0, 1000)], { shield: 3 }), 100),
+      "KeyF",
+    );
+    expect(hit.combo, "one clean hit").toBe(1);
+    expect(to(hit, 1000).combo, "and then j got through").toBe(0);
+  });
+});
+
+describe("a tick resolves every landing inside it", () => {
+  it("resolves two letters that land in the same tick", () => {
+    // The realistic case is a browser that skipped a frame, and the shield has
+    // to end up reading the same as it would have over two ticks.
+    const state = tick(
+      runOf([at("f", 0, 100), at("j", 0, 200)], { shield: 3 }),
+      500,
+    );
+
+    expect(landed(state)).toEqual([0, 1]);
+    expect(state.resolved[0]).toEqual({ outcome: "landed", atMs: 100 });
+    expect(state.resolved[1], "each is timed by its own landing").toEqual({
+      outcome: "landed",
+      atMs: 200,
+    });
+    expect(state.shield["l-index"]).toBe(2);
+    expect(state.shield["r-index"]).toBe(2);
+    expect(state.timeMs).toBe(500);
+  });
+
+  it("charges a zone twice when both landings are its own", () => {
+    const state = tick(
+      runOf([at("f", 0, 100), at("f", 0, 200)], { shield: 3 }),
+      500,
+    );
+    expect(state.shield["l-index"], "two hits, not one").toBe(1);
+  });
+
+  it("resolves a whole backgrounded tab, letters it never saw included", () => {
+    // rAF stops when a tab is hidden, so `dtMs` can be a minute. Every letter
+    // in the interval lands, including ones that spawned *and* landed inside
+    // it and were airborne at no instant anybody sampled — dropping those
+    // would leave the shield disagreeing with the storm that damaged it.
+    const letters = ["f", "j", "d", "k", "s", "l"].map((ch, i) =>
+      at(ch, i * 1000, 500),
+    );
+    const state = tick(runOf(letters, { shield: 1 }), 60_000);
+
+    expect(landed(state), "all six").toEqual([0, 1, 2, 3, 4, 5]);
+    expect(state.shield, "six zones holed, the pinkies untouched").toEqual({
+      ...evenShield(1),
+      "l-index": 0,
+      "r-index": 0,
+      "l-middle": 0,
+      "r-middle": 0,
+      "l-ring": 0,
+      "r-ring": 0,
+    });
+    expect(state.ending, "survived to the end of the wave").toEqual({
+      kind: "cleared",
+    });
+  });
+
+  it("stops the clock at the landing that ends the run", () => {
+    // The rest of that interval never happened: letters still due in it stay
+    // unresolved rather than being charged to a shield the child no longer had.
+    const letters = [at("f", 0, 100), at("f", 200, 100), at("j", 400, 100)];
+    const state = tick(runOf(letters, { shield: 1 }), 60_000);
+
+    expect(state.ending).toEqual({
+      kind: "breached",
+      finger: "l-index",
+      index: 1,
+    });
+    expect(state.timeMs, "the run's own duration stays honest").toBe(300);
+    expect(state.resolved[2], "the third letter never got to land").toBeNull();
+    expect(state.shield["r-index"], "and never damaged anything").toBe(1);
+  });
+
+  it("never rewinds the storm", () => {
+    const state = to(runOf([at("f", 0, 1000)], { shield: 3 }), 400);
+    expect(tick(state, -1000).timeMs).toBe(400);
+  });
+});
+
+describe("the wave ends", () => {
+  it("clears with the shield untouched when every letter is shot", () => {
+    const letters = [
+      at("f", 0, 1000),
+      at("j", 400, 1000),
+      at("k", 800, 1000),
+      at(";", 1200, 1000),
+    ];
+    let state = runOf(letters, { shield: 3 });
+    for (const [ms, code] of [
+      [100, "KeyF"],
+      [500, "KeyJ"],
+      [900, "KeyK"],
+      [1300, "Semicolon"],
+    ] as const)
+      state = fire(to(state, ms), code);
+
+    expect(state.ending, "cleared as the last letter is shot").toEqual({
+      kind: "cleared",
+    });
+    expect(state.shield, "eight zones, all as the spec wrote them").toEqual(
+      evenShield(3),
+    );
+    expect(landed(state), "nothing got through").toEqual([]);
+    expect(state.combo).toBe(4);
+    expect(
+      state.timeMs,
+      "and it did not wait for the last letter to fall",
+    ).toBeLessThan(letters[3].landMs);
+  });
+
+  it("is born cleared when nothing can fall", () => {
+    // §8.3's empty storm, carried through to the reducer: a screen that ends,
+    // not a loop waiting for a letter that will never spawn.
+    const state = runOf([]);
+    expect(state.ending).toEqual({ kind: "cleared" });
+    expect(tick(state, 10_000)).toBe(state);
+  });
+});
+
+describe("repairs are the comeback path", () => {
+  /*
+   * The script all four of these run, so that the only thing that changes is
+   * `repairAt`: `f` lands and takes the left index finger's only point, two
+   * letters are shot cleanly, and then a second `f` lands on the zone that is
+   * either a hole or has just been mended.
+   */
+  const script = (over: Partial<WaveSpec>) => {
+    const letters = [
+      at("f", 0, 100),
+      at("j", 200, 200),
+      at("k", 500, 200),
+      at("f", 800, 100),
+    ];
+    let state = runOf(letters, { shield: 1, ...over });
+    state = fire(to(state, 300), "KeyJ");
+    state = fire(to(state, 600), "KeyK");
+    return state;
+  };
+
+  it("mends the weakest zone every repairAt hits, and it stops one", () => {
+    const mended = script({ repairAt: 2 });
+    expect(mended.combo, "two clean hits").toBe(2);
+    expect(mended.shield["l-index"], "the hole is a wall again").toBe(1);
+
+    const after = to(mended, 900);
+    expect(after.ending, "the second f is stopped, not fatal").toEqual({
+      kind: "cleared",
+    });
+    expect(after.shield["l-index"], "and costs the mended point").toBe(0);
+  });
+
+  it("does not repair at all when repairAt is 0", () => {
+    const unmended = script({ repairAt: 0 });
+    expect(unmended.combo).toBe(2);
+    expect(unmended.shield["l-index"], "still a hole").toBe(0);
+
+    const after = to(unmended, 900);
+    expect(after.ending, "and the same letter now ends the run").toEqual({
+      kind: "breached",
+      finger: "l-index",
+      index: 3,
+    });
+  });
+
+  it("needs the hits to be consecutive", () => {
+    // A miss between them breaks the streak, so the repair never arrives —
+    // which is what makes the comeback a reward for typing well rather than
+    // for surviving long enough.
+    const letters = [at("f", 0, 100), at("j", 200, 200), at("k", 500, 200)];
+    let state = runOf(letters, { shield: 1, repairAt: 2 });
+    state = fire(to(state, 300), "KeyJ");
+    state = fire(state, "KeyZ");
+    state = fire(to(state, 600), "KeyK");
+
+    expect(state.combo, "the streak restarted").toBe(1);
+    expect(state.shield["l-index"], "no repair").toBe(0);
+  });
+
+  it("repairs to exactly the cap and no further", () => {
+    // A wave whose repairs outran its damage would hand a strong player a
+    // shield deeper than the level ever wrote down — and "untouched" would
+    // stop meaning the eight-of-`shield` the run started with.
+    const letters = [
+      at("f", 0, 100),
+      ...["j", "k", "l", ";", "d", "s"].map((ch, i) =>
+        at(ch, 200 + i * 300, 200),
+      ),
+    ];
+    let state = runOf(letters, { shield: 2, repairAt: 1 });
+    state = to(state, 100);
+    expect(state.shield["l-index"], "one point of damage").toBe(1);
+
+    for (let i = 1; i < letters.length; i++)
+      state = fire(to(state, letters[i].spawnMs + 100), letters[i].code);
+
+    expect(state.combo, "six clean hits, six repairs offered").toBe(6);
+    expect(state.shield["l-index"], "mended to the cap on the first").toBe(2);
+    expect(state.shield, "and no zone anywhere above it").toEqual(
+      evenShield(2),
+    );
+  });
+});
+
+describe("the rules are pure, and they do not mutate what they are given", () => {
+  /** The script both tests below run: two hits, a miss, and a landing. */
+  const play = () => {
+    const letters = [at("f", 0, 1000), at("j", 300, 1000), at("k", 600, 400)];
+    let state = runOf(letters, { shield: 2, repairAt: 3 });
+    state = fire(to(state, 400), "KeyF");
+    state = fire(to(state, 700), "KeyJ");
+    state = fire(state, "KeyZ");
+    return to(state, 1200);
+  };
+
+  it("reads no clock, no DOM and no randomness", () => {
+    // The engine's lint boundary bans *imports* of React and the services
+    // layer, but nothing in it catches a bare `document` or a
+    // `requestAnimationFrame` — so the boundary cannot prove this and a test
+    // has to. Each global is made hostile for the length of one run: a reducer
+    // that so much as reads one throws here, in a millisecond, rather than
+    // three stories from now inside a game loop at 60fps.
+    const boom = () => {
+      throw new Error("the storm reducer must be pure");
+    };
+    const hostile = [
+      "document",
+      "window",
+      "requestAnimationFrame",
+      "performance",
+      "Date",
+    ];
+    const saved = hostile.map(
+      (name) =>
+        [name, Object.getOwnPropertyDescriptor(globalThis, name)] as const,
+    );
+    const realRandom = Math.random;
+
+    let state: StormState | null = null;
+    let thrown: unknown = null;
+    try {
+      for (const name of hostile)
+        Object.defineProperty(globalThis, name, {
+          configurable: true,
+          get: boom,
+        });
+      Math.random = boom;
+      state = play();
+    } catch (error) {
+      thrown = error;
+    } finally {
+      Math.random = realRandom;
+      for (const [name, descriptor] of saved)
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else delete (globalThis as Record<string, unknown>)[name];
+    }
+
+    expect(thrown).toBeNull();
+    expect(state?.resolved.map((r) => r?.outcome)).toEqual([
+      "shot",
+      "shot",
+      "landed",
+    ]);
+  });
+
+  it("returns new state rather than editing the state it was handed", () => {
+    // A reducer that mutated would pass every other test in this file — the
+    // returned state would be right, and only the caller holding the old one
+    // would ever find out. Freezing the input turns that into a throw.
+    const deepFreeze = <T>(value: T): T => {
+      if (value && typeof value === "object") {
+        Object.values(value).forEach(deepFreeze);
+        Object.freeze(value);
+      }
+      return value;
+    };
+
+    const start = deepFreeze(
+      runOf([at("f", 0, 1000), at("j", 300, 1000)], { shield: 2, repairAt: 2 }),
+    );
+    const fired = fire(to(start, 400), "KeyF");
+    const ticked = to(fired, 1400);
+
+    expect(fired.resolved[0]?.outcome).toBe("shot");
+    expect(ticked.shield["r-index"], "the second letter got through").toBe(1);
+
+    expect(start.timeMs, "the state we started from is untouched").toBe(0);
+    expect(start.resolved).toEqual([null, null]);
+    expect(start.combo).toBe(0);
+    expect(start.shield).toEqual(evenShield(2));
+    expect(start.ending).toBeNull();
+
+    // And the whole run again from the frozen start, which must come out the
+    // same: a reducer that mutated its input would have spent it.
+    expect(to(fire(to(start, 400), "KeyF"), 1400)).toEqual(ticked);
   });
 });

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -869,6 +869,44 @@ describe("repairs are the comeback path", () => {
     expect(state.shield["l-index"], "no repair").toBe(0);
   });
 
+  it("mends the weakest zone, not the first one it finds", () => {
+    // Every other case here damages exactly one zone, which makes "weakest",
+    // "last damaged" and "first not full" the same answer — so none of them
+    // pins the rule §8.5 actually states. Here two zones are damaged unequally
+    // and the weaker one is *later* in `SHIELD_FINGERS`: `a` takes one point
+    // off the left pinky, two `f`s take both points off the left index, and
+    // the clean shot on `j` offers a single repair. It has to go to the hole.
+    const letters = [
+      at("a", 0, 100),
+      at("f", 100, 100),
+      at("f", 200, 100),
+      at("j", 400, 200),
+    ];
+    let state = to(runOf(letters, { shield: 2, repairAt: 1 }), 300);
+    expect(state.shield["l-pinky"], "grazed").toBe(1);
+    expect(state.shield["l-index"], "a hole").toBe(0);
+
+    state = fire(to(state, 500), "KeyJ");
+    expect(state.shield["l-index"], "the hole is mended").toBe(1);
+    expect(state.shield["l-pinky"], "and the grazed zone is left alone").toBe(
+      1,
+    );
+  });
+
+  it("gives two equally weak zones to the earlier one on the board", () => {
+    // Nothing about the shield makes one of them the better answer, so the
+    // rule is the drawing order: the segment that lights up is one a child
+    // could in principle have predicted, and a replay mends the same one.
+    const letters = [at("f", 0, 100), at("j", 100, 100), at("k", 300, 200)];
+    let state = to(runOf(letters, { shield: 2, repairAt: 1 }), 400);
+    expect(state.shield["l-index"], "both zones down one").toBe(1);
+    expect(state.shield["r-index"]).toBe(1);
+
+    state = fire(state, "KeyK");
+    expect(state.shield["l-index"], "the earlier of the two is mended").toBe(2);
+    expect(state.shield["r-index"], "the later one waits its turn").toBe(1);
+  });
+
   it("repairs to exactly the cap and no further", () => {
     // A wave whose repairs outran its damage would hand a strong player a
     // shield deeper than the level ever wrote down — and "untouched" would
@@ -958,7 +996,14 @@ describe("the rules are pure, and they do not mutate what they are given", () =>
   it("returns new state rather than editing the state it was handed", () => {
     // A reducer that mutated would pass every other test in this file — the
     // returned state would be right, and only the caller holding the old one
-    // would ever find out. Freezing the input turns that into a throw.
+    // would ever find out. Freezing turns that into a throw.
+    //
+    // Every state the run passes through is frozen, not only the one it starts
+    // from, because `tick` copies the shield exactly when a letter landed. A
+    // repair that wrote through the shield it was handed would hide behind
+    // that copy for the whole of a run that only ever fires after a landing —
+    // so the fire that repairs, below, is given a shield an earlier state is
+    // still holding.
     const deepFreeze = <T>(value: T): T => {
       if (value && typeof value === "object") {
         Object.values(value).forEach(deepFreeze);
@@ -966,24 +1011,47 @@ describe("the rules are pure, and they do not mutate what they are given", () =>
       }
       return value;
     };
+    const tickTo = (state: StormState, ms: number) => deepFreeze(to(state, ms));
+    const shoot = (state: StormState, code: string) =>
+      deepFreeze(fire(state, code));
 
     const start = deepFreeze(
-      runOf([at("f", 0, 1000), at("j", 300, 1000)], { shield: 2, repairAt: 2 }),
+      runOf([at("f", 0, 100), at("j", 200, 400), at("k", 700, 300)], {
+        shield: 2,
+        repairAt: 1,
+      }),
     );
-    const fired = fire(to(start, 400), "KeyF");
-    const ticked = to(fired, 1400);
 
-    expect(fired.resolved[0]?.outcome).toBe("shot");
-    expect(ticked.shield["r-index"], "the second letter got through").toBe(1);
+    const damaged = tickTo(start, 100);
+    expect(damaged.shield["l-index"], "the f got through").toBe(1);
+
+    // Nothing lands between 100 and 300, so this tick hands `damaged`'s own
+    // shield straight on — and the hit on `j` repairs at `repairAt: 1`.
+    const mended = shoot(tickTo(damaged, 300), "KeyJ");
+    expect(mended.resolved[1]?.outcome, "a hit").toBe("shot");
+    expect(mended.shield["l-index"], "and the repair path ran").toBe(2);
+
+    const missed = shoot(mended, "KeyZ");
+    const ended = tickTo(missed, 1000);
+    expect(ended.resolved.map((r) => r?.outcome)).toEqual([
+      "landed",
+      "shot",
+      "landed",
+    ]);
 
     expect(start.timeMs, "the state we started from is untouched").toBe(0);
-    expect(start.resolved).toEqual([null, null]);
+    expect(start.resolved).toEqual([null, null, null]);
     expect(start.combo).toBe(0);
     expect(start.shield).toEqual(evenShield(2));
     expect(start.ending).toBeNull();
 
+    expect(damaged.shield["l-index"], "and so is the damaged one").toBe(1);
+    expect(damaged.resolved[1], "which never saw the shot").toBeNull();
+    expect(mended.combo, "and the miss did not reach back into it").toBe(1);
+
     // And the whole run again from the frozen start, which must come out the
     // same: a reducer that mutated its input would have spent it.
-    expect(to(fire(to(start, 400), "KeyF"), 1400)).toEqual(ticked);
+    const again = to(fire(fire(to(to(start, 100), 300), "KeyJ"), "KeyZ"), 1000);
+    expect(again).toEqual(ended);
   });
 });

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -1,6 +1,13 @@
 /**
- * Hailstorm's rules. This half of them is the wave: what falls, where, and when
- * (docs/typing.md §8.3).
+ * Hailstorm's rules, both halves: the wave — what falls, where, and when
+ * (docs/typing.md §8.3) — and the reducer that plays it (§8.4, §8.5).
+ *
+ * They are one module because they are one set of rules and the seam between
+ * them is a lie waiting to happen: the reducer's damage lands on the shield
+ * segment the wave already chose for a letter, and its "lowest letter" is the
+ * half-open interval the wave's schedule is written in. Two files would be two
+ * places to state each of those, and the second copy is always the one that
+ * drifts.
  *
  * A wave is generated **whole, up front, from a seed**, exactly as every deck
  * on this site is. That is not a stylistic echo — it is the story this module
@@ -26,8 +33,8 @@
  * on each of the twenty storm lessons — which will make this module reachable
  * from `decks/index.ts`, the front door every island on the site downloads
  * (§5.3, decision 7). So it must never grow a table. There is nothing here but
- * the spec, the RNG, and the keyboard: the characters a wave draws from arrive
- * as `spec.keys`, from a caller that already knows them.
+ * the spec, the RNG, the keyboard and the rules: the characters a wave draws
+ * from arrive as `spec.keys`, from a caller that already knows them.
  */
 import { keyX, strokeFor } from "@/engine/keyboard";
 import type { Finger } from "@/engine/keyboard";
@@ -143,7 +150,9 @@ export type StormLetter = {
    * belongs with it: the *lowest* letter on screen is the one with the greatest
    * `(t - spawnMs) / fallMs`, which is not the same order as `landMs` once two
    * letters fall at different speeds. Two orderings that look interchangeable
-   * and part company exactly where it matters are worth a sentence.
+   * and part company exactly where it matters are worth a sentence — and, now
+   * that something depends on the difference, a function: `targetIndex` aims by
+   * `progressAt` and never by this field.
    */
   landMs: number;
 };
@@ -256,4 +265,401 @@ export function buildWave(spec: WaveSpec, seed: number): Wave {
     letters,
     durationMs: letters.reduce((last, l) => Math.max(last, l.landMs), 0),
   };
+}
+
+/* ═══ The reducer: the wave, played (§8.4, §8.5, §8.9) ═══════════════════════
+ *
+ * Everything below is a pure function of the state it is handed. No clock, no
+ * `Math.random`, no DOM, no React — the loop reads a real clock, calls `tick`
+ * with the delta and writes transforms; the tests call the same two functions
+ * with numbers. "Did that letter get through" is therefore a question that can
+ * be asked without a browser, which is the only reason the shield's rules are
+ * testable at all.
+ */
+
+/**
+ * Is this letter on the field at `timeMs`?
+ *
+ * A letter occupies the **half-open** interval `[spawnMs, landMs)`: there the
+ * instant it spawns, gone the instant it lands, because landing is the tick
+ * that turns it into shield damage (decision 30).
+ *
+ * That convention is exported as a pair of predicates rather than written out
+ * where it is needed, because it is one `<` against one `<=` and more than one
+ * thing reads it: `targetIndex` decides what can be shot with `isAirborne`,
+ * `tick` decides what damages the shield with `hasLanded`, and the field will
+ * draw whatever `isAirborne` says is there (STM03). Spelled out at each of
+ * those, it would be three chances to pick the wrong side of a millisecond —
+ * and the wrong side of a millisecond is a letter that is both shootable and
+ * already spent.
+ *
+ * `hasLanded` is deliberately not `!isAirborne`: a letter that has not spawned
+ * yet is neither on the field nor landed, and the reducer must not charge the
+ * shield for a letter that has not fallen.
+ */
+export function isAirborne(letter: StormLetter, timeMs: number): boolean {
+  return letter.spawnMs <= timeMs && timeMs < letter.landMs;
+}
+
+/** Has this letter reached the shield by `timeMs`? See `isAirborne`. */
+export function hasLanded(letter: StormLetter, timeMs: number): boolean {
+  return letter.landMs <= timeMs;
+}
+
+/**
+ * How far down the field a letter is at `timeMs`: 0 at the top, 1 at the shield.
+ *
+ * One function rather than an expression repeated wherever it is wanted,
+ * because two of its readers must agree exactly: the renderer writes it into a
+ * `translateY` (STM03) and `targetIndex` takes the maximum of it to decide
+ * what the gun is aimed at. A child aims by looking, so the letter the game
+ * thinks is lowest has to be the letter that is drawn lowest.
+ *
+ * `fallMs` cannot be 0 while a letter is airborne — `spawn <= t < spawn +
+ * fall` has no solutions at `fall = 0` — so the division is safe everywhere
+ * the value is a position. Off the interval it still answers, and answers
+ * honestly: negative before the spawn, past 1 after the landing.
+ */
+export function progressAt(letter: StormLetter, timeMs: number): number {
+  return (timeMs - letter.spawnMs) / letter.fallMs;
+}
+
+/**
+ * The eight shield segments, in board order — left pinky to right pinky.
+ *
+ * An order rather than a set, because two things need it to be the *same*
+ * order: the shield is drawn as eight segments across the bottom of the field
+ * (STM03), and a repair has to break a tie between equally weak zones somehow.
+ * Using the order the child is looking at means the tie-break is at least a
+ * thing they could watch happen, rather than whatever order a `Record`'s keys
+ * came out in.
+ */
+export const SHIELD_FINGERS: readonly ShieldFinger[] = [
+  "l-pinky",
+  "l-ring",
+  "l-middle",
+  "l-index",
+  "r-index",
+  "r-middle",
+  "r-ring",
+  "r-pinky",
+];
+
+/** Hit points left in each of the eight zones. A zone at 0 is a hole (§8.5). */
+export type Shield = Readonly<Record<ShieldFinger, number>>;
+
+/**
+ * What became of one letter, and when.
+ *
+ * `atMs` is wave time — the instant of the press for a letter that was shot,
+ * and the letter's own `landMs` for one that got through. Its own landing and
+ * not the tick that noticed it, because a tick can arrive several landings
+ * late (see `tick`), and STM08 turns this into a `CardResult.ms` of
+ * `atMs - spawnMs` (§8.7). A card that timed a backgrounded tab instead of a
+ * fall would put a nonsense number in a child's record book for ever.
+ */
+export type LetterOutcome = {
+  outcome: "shot" | "landed";
+  atMs: number;
+};
+
+/**
+ * How a run finished, or `null` while it is still going.
+ *
+ * `breached` carries the finger rather than leaving it to be looked up later.
+ * Naming the finger that failed is the best thing this game tells a child
+ * (§8.5), and it must be the finger the letter actually fell on — so it is
+ * copied from the letter at the moment it got through, not re-derived from a
+ * shield that by then reads the same at several zones. `index` is the letter
+ * that ended it: what the death screen can show, and where its drill starts.
+ */
+export type StormEnding =
+  | { kind: "cleared" }
+  | { kind: "breached"; finger: ShieldFinger; index: number };
+
+/**
+ * A run, mid-storm.
+ *
+ * Everything here is a fact that cannot be recovered from the wave and the
+ * clock, and nothing here is a fact that can. There is no list of letters on
+ * screen, no cached lowest letter and no per-finger tally of what got through:
+ * the first two are `isAirborne` and `targetIndex` over a schedule that was
+ * decided before the run started, and the third is a `filter` over `resolved`
+ * that the death screen can do for itself. A second copy of any of them would
+ * be a second thing to keep in step sixty times a second, and the copy is
+ * always the one that ends up lying.
+ *
+ * `resolved` is parallel to `wave.letters` and indexed by the letter's
+ * identity (§8.3). Indexed rather than appended to, because resolution is
+ * **not** in spawn order: shoot the middle one of three and the array gets a
+ * hole in it. That indexing is also what makes the run a `Session` later with
+ * no bookkeeping — card _i_ is letter _i_, so `prompt`, `answer` and `factId`
+ * are its character and `ms` is `atMs - spawnMs` (§8.7, STM08).
+ *
+ * What the next two stories add, and why nothing here is in their way: STM06's
+ * score and best-combo watermark are two more numbers beside `combo`, written
+ * at the two moments this reducer already has — a hit in `fire`, and a broken
+ * streak. STM07 reads `ending` for the finger and counts `resolved` by finger
+ * for "let three through". Neither wants a different shape.
+ */
+export type StormState = {
+  /** The storm being played. Decided before the run; never changes during it. */
+  readonly wave: Wave;
+  /** ms since the wave started. Only ever moves forward. */
+  readonly timeMs: number;
+  /** Hit points left in each zone. Starts at `wave.spec.shield` all round. */
+  readonly shield: Shield;
+  /**
+   * What each letter came to, parallel to `wave.letters` — `null` while it is
+   * still to spawn or still falling.
+   */
+  readonly resolved: readonly (LetterOutcome | null)[];
+  /**
+   * Consecutive hits, unbroken by a miss or by a letter getting through.
+   *
+   * It is state and not a view's counter because a rule reads it: every
+   * `repairAt` of them puts a point back into the weakest zone (§8.5), which
+   * is the game's only comeback path and pays out for exactly the behaviour it
+   * exists to build. A letter that landed breaks the streak as surely as a
+   * wrong key does — the streak means "are you keeping up", and a letter you
+   * let through is the definition of not keeping up. STM06 hangs its
+   * multiplier on this same number, so a child sees one streak and not two.
+   */
+  readonly combo: number;
+  /** How the run finished, or `null` while it is live. */
+  readonly ending: StormEnding | null;
+};
+
+/**
+ * Stamp `cleared` on a state whose last letter has just been accounted for.
+ *
+ * Cleared is "every letter resolved" rather than "the clock passed
+ * `durationMs`", because shooting the last letter ends the wave there and
+ * then; the alternative leaves a child watching an empty field for the second
+ * and a half that letter would have taken to fall. The two agree wherever it
+ * matters — a letter is only ever resolved by being shot or by landing, and
+ * nothing can land after `durationMs`.
+ */
+const settled = (state: StormState): StormState =>
+  state.ending !== null || state.resolved.some((outcome) => outcome === null)
+    ? state
+    : { ...state, ending: { kind: "cleared" } };
+
+/**
+ * A run at time zero: full shield, nothing resolved, no streak.
+ *
+ * The wave is carried, not copied. The retry button, the results screen and
+ * the reducer are all meant to be looking at the same storm, and a state that
+ * owned its own copy of the schedule would be a second place for it to be
+ * wrong.
+ *
+ * An empty wave is born `cleared` — the same habit as `buildWave` not throwing
+ * (§8.3). A storm with nothing in it is a screen that ends, where a loop
+ * waiting on a letter that will never spawn is a run a child cannot leave.
+ */
+export function startStorm(wave: Wave): StormState {
+  const shield = Object.fromEntries(
+    SHIELD_FINGERS.map((finger) => [finger, wave.spec.shield]),
+  ) as Record<ShieldFinger, number>;
+
+  return settled({
+    wave,
+    timeMs: 0,
+    shield,
+    resolved: wave.letters.map(() => null),
+    combo: 0,
+    ending: null,
+  });
+}
+
+/**
+ * The lowest letter on the field, as an index into `wave.letters` — or `null`
+ * if nothing is falling.
+ *
+ * **Lowest is the greatest `progressAt`, and not the earliest `landMs`.** The
+ * two orderings look interchangeable and are not: every letter draws its own
+ * fall time, so a fast letter spawned second genuinely overtakes a slow one
+ * spawned first, and from the crossing until the landing the two orderings
+ * disagree about which is nearer the shield. Aiming by `landMs` would point
+ * the gun at a letter that is visibly higher up the screen — and the child is
+ * looking at the field, not at the schedule.
+ *
+ * On an exact tie — two letters at the same height, which is the single
+ * instant their lines cross — the lower index wins, which is the earlier
+ * spawn. Neither is fairer to a child who cannot see a difference between
+ * them, so the tie goes to the thing that is already a letter's identity
+ * (§8.3): the same wave replayed resolves the same dead heat the same way. A
+ * replay that diverged on a rounding difference would be a worse bug than
+ * either answer to the tie.
+ */
+export function targetIndex(state: StormState): number | null {
+  const { letters } = state.wave;
+  let lowest: number | null = null;
+  let best = -Infinity;
+
+  for (let index = 0; index < letters.length; index++) {
+    const letter = letters[index];
+    if (state.resolved[index] !== null) continue;
+    if (!isAirborne(letter, state.timeMs)) continue;
+    const progress = progressAt(letter, state.timeMs);
+    // Strictly greater, so a tie leaves the earlier index where it is.
+    if (progress > best) {
+      best = progress;
+      lowest = index;
+    }
+  }
+
+  return lowest;
+}
+
+/**
+ * The shield after a hit, with `repairAt` applied.
+ *
+ * The weakest zone rather than the last one damaged, because a hole is what
+ * ends a run: the segment at zero is simultaneously the one about to kill you
+ * and the one a single point is worth most in. "Weakest" picks it with no
+ * special case for holes at all.
+ *
+ * Two edges, both deliberate:
+ *
+ *   - **`repairAt: 0` disables repairs**, as `WaveSpec` declares — said out
+ *     loud rather than left to `combo % 0` being `NaN`. The arithmetic does
+ *     fall the right way on its own, which is the problem: the rule the spec
+ *     writes down would be an accident of IEEE, and the same expression hands
+ *     a *negative* `repairAt` a repair every other hit.
+ *   - **No zone ever exceeds `spec.shield`.** A wave whose repairs outran its
+ *     damage would hand a strong player a shield deeper than the level ever
+ *     wrote down, and the eight-of-`shield` a run starts with is exactly what
+ *     "the shield came through untouched" is reported against. At the cap the
+ *     repair is spent rather than banked — banking it would be a hit point
+ *     arriving at a moment nothing on screen explains.
+ */
+function repaired(shield: Shield, spec: WaveSpec, combo: number): Shield {
+  if (spec.repairAt <= 0 || combo % spec.repairAt !== 0) return shield;
+
+  // Ties go to the first in board order: deterministic, and the order the
+  // shield is drawn in, so the segment that lights up is one a child could in
+  // principle have predicted.
+  const weakest = SHIELD_FINGERS.reduce((low, finger) =>
+    shield[finger] < shield[low] ? finger : low,
+  );
+
+  return shield[weakest] >= spec.shield
+    ? shield
+    : { ...shield, [weakest]: shield[weakest] + 1 };
+}
+
+/**
+ * Advance the clock, and resolve everything that reached the shield on the way.
+ *
+ * ── A tick may be arbitrarily long ───────────────────────────────────────────
+ * `dtMs` is whatever the loop hands over, and a backgrounded tab hands over
+ * seconds: `requestAnimationFrame` stops, the child comes back, and a dozen
+ * letters are due at once. Every landing inside the interval is resolved, in
+ * the order it happened — including letters that spawned *and* landed inside
+ * the same tick and were never airborne at any instant anybody sampled.
+ * Dropping those would leave the shield quietly disagreeing with the storm
+ * that damaged it, and the disagreement would be invisible: the letters are
+ * gone from the screen either way.
+ *
+ * Whether a child should be *held responsible* for a tab they were not looking
+ * at is a different question, and it belongs to the clock (STM03): clamping
+ * the delta, or pausing on `visibilitychange`, is a decision the loop can only
+ * make deliberately because the rules underneath it are honest about the whole
+ * interval they were given.
+ */
+export function tick(state: StormState, dtMs: number): StormState {
+  if (state.ending !== null) return state;
+
+  // Time only moves forward. A clock handing back a negative delta is a bug in
+  // the loop, and rewinding the storm — un-landing letters the shield has
+  // already paid for — is not a recovery from it.
+  const timeMs = state.timeMs + Math.max(0, dtMs);
+
+  const landings = state.wave.letters
+    .map((letter, index) => ({ letter, index }))
+    .filter(
+      ({ letter, index }) =>
+        state.resolved[index] === null && hasLanded(letter, timeMs),
+    )
+    // In the order they happened, which is not spawn order: a fast letter
+    // spawned second can land first, and which zone breaks first decides which
+    // finger the death screen names. A dead heat falls back to the letter's
+    // index — its identity (§8.3) — so a replay resolves it the same way.
+    .sort((a, b) => a.letter.landMs - b.letter.landMs || a.index - b.index);
+
+  if (landings.length === 0) return { ...state, timeMs };
+
+  const resolved = state.resolved.slice();
+  const shield = { ...state.shield };
+  let combo = state.combo;
+  let ending: StormEnding | null = null;
+  let clock = timeMs;
+
+  for (const { letter, index } of landings) {
+    resolved[index] = { outcome: "landed", atMs: letter.landMs };
+    combo = 0;
+
+    if (shield[letter.finger] <= 0) {
+      // The zone above it is a hole, so there is nothing left to take the hit
+      // and the storm is through. The clock stops at that landing rather than
+      // at the end of the tick: the rest of this interval never happened, and
+      // the letters still due inside it stay unresolved rather than being
+      // charged to a shield the child no longer had.
+      ending = { kind: "breached", finger: letter.finger, index };
+      clock = letter.landMs;
+      break;
+    }
+
+    shield[letter.finger] -= 1;
+  }
+
+  return settled({ ...state, timeMs: clock, shield, resolved, combo, ending });
+}
+
+/**
+ * Fire at the lowest letter on screen. Anything else is a miss.
+ *
+ * ── Why only the lowest ──────────────────────────────────────────────────────
+ * The alternative is not "let the second letter count too"; it is a game with
+ * no wrong answer in it. If any letter on screen can be shot by its own key,
+ * the winning strategy is to hammer every key the wave draws from and let the
+ * matches happen — and the child doing that is practising nothing at all while
+ * the score congratulates them for it. Firing has to be able to be *wrong*
+ * before hitting can mean anything, and the only sense of "wrong" a
+ * falling-letter game can defend is out of order: the bottom letter is the one
+ * about to cost a shield point, so it is the one that is actually urgent.
+ *
+ * That is also what makes the difference between one letter in the air and
+ * three a difference in kind. With one, target and only letter are the same
+ * thing and the game is pure reaction. With three, taking the bottom one first
+ * is an act of prioritising under time pressure — reading ahead, which is the
+ * thing that separates a typist from a hunter — and it is a skill precisely
+ * because getting the order wrong costs something: the streak here, and the
+ * score STM06 hangs on the same number.
+ *
+ * A shot at an empty field is a miss for the same reason. It is exactly the
+ * spray this rule exists to make unprofitable, and a child who could keep
+ * their streak through it has found the strategy again by another route.
+ */
+export function fire(state: StormState, code: string): StormState {
+  if (state.ending !== null) return state;
+
+  // Compared by `code` and not by the character: a shifted legend and its base
+  // share a key, so `A` and `a` are both `KeyA` and the shift a child is
+  // holding cannot make the shot miss (decision 2).
+  const index = targetIndex(state);
+  if (index === null || state.wave.letters[index].code !== code)
+    return { ...state, combo: 0 }; // A miss: the streak, and nothing else.
+
+  const resolved = state.resolved.slice();
+  resolved[index] = { outcome: "shot", atMs: state.timeMs };
+  const combo = state.combo + 1;
+
+  return settled({
+    ...state,
+    resolved,
+    combo,
+    shield: repaired(state.shield, state.wave.spec, combo),
+  });
 }

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -491,6 +491,10 @@ export function startStorm(wave: Wave): StormState {
  * (§8.3): the same wave replayed resolves the same dead heat the same way. A
  * replay that diverged on a rounding difference would be a worse bug than
  * either answer to the tie.
+ *
+ * It does not read `state.ending`. A run that ended mid-wave still has letters
+ * in the air, so this still names one; `fire` asks only after its own guard,
+ * and a screen painting a reticle from it (STM03, STM06) has to guard too.
  */
 export function targetIndex(state: StormState): number | null {
   const { letters } = state.wave;
@@ -566,7 +570,11 @@ function repaired(shield: Shield, spec: WaveSpec, combo: number): Shield {
  * at is a different question, and it belongs to the clock (STM03): clamping
  * the delta, or pausing on `visibilitychange`, is a decision the loop can only
  * make deliberately because the rules underneath it are honest about the whole
- * interval they were given.
+ * interval they were given. Two things that loop cannot lean on: a `NaN` delta
+ * poisons `timeMs` for the rest of the run and ends nothing — no delta between
+ * two real clock readings is one, and clamping is STM03's — and neither a tick
+ * with no landing nor a missed `fire` returns the object it was handed, so
+ * identity is not a "nothing changed" signal.
  */
 export function tick(state: StormState, dtMs: number): StormState {
   if (state.ending !== null) return state;
@@ -605,7 +613,10 @@ export function tick(state: StormState, dtMs: number): StormState {
       // and the storm is through. The clock stops at that landing rather than
       // at the end of the tick: the rest of this interval never happened, and
       // the letters still due inside it stay unresolved rather than being
-      // charged to a shield the child no longer had.
+      // charged to a shield the child no longer had. That includes a letter
+      // tying this exact `landMs` from a higher index, which `hasLanded` now
+      // reads true of — so "got through" (STM07) counts `resolved`, never
+      // `hasLanded`.
       ending = { kind: "breached", finger: letter.finger, index };
       clock = letter.landMs;
       break;
@@ -628,7 +639,16 @@ export function tick(state: StormState, dtMs: number): StormState {
  * the score congratulates them for it. Firing has to be able to be *wrong*
  * before hitting can mean anything, and the only sense of "wrong" a
  * falling-letter game can defend is out of order: the bottom letter is the one
- * about to cost a shield point, so it is the one that is actually urgent.
+ * nearest the shield *on screen*, which is the one a child can see is most
+ * urgent and can aim at without knowing anything the field is not showing
+ * them.
+ *
+ * Nearest is not soonest. Letters fall at different speeds, so the letter due
+ * to land first may be a different one, visibly higher up the screen, from the
+ * moment two paths cross until one of them lands (decision 32, and
+ * `targetIndex`). The rule follows the field and not the schedule on purpose:
+ * a target picked by `landMs` would refuse the letter the child is watching
+ * drop and demand one they have no way to know was closer in time.
  *
  * That is also what makes the difference between one letter in the air and
  * three a difference in kind. With one, target and only letter are the same


### PR DESCRIPTION
## STM02 · The storm reducer

Hailstorm's rules as two pure functions in `src/engine/typing/storm.ts` —
`tick(state, dtMs)` and `fire(state, code)`. No DOM, no rAF, no React, so "did
that letter get through" is a question a test can ask without a browser.

Closes #148

## The state

`{ wave, timeMs, shield, resolved, combo, ending }`, and it stores nothing
derivable from those. There is no list of letters on screen and no cached
lowest letter — the first is `isAirborne` over a schedule fixed before the run
started, the second is `targetIndex`. A second copy of either would be a second
thing to keep in step sixty times a second, and the copy is always the one that
ends up lying.

`resolved` is indexed **parallel to `wave.letters`** rather than appended to,
because resolution is not in spawn order: shoot the middle one of three and the
array gets a hole in it. Indexing by the letter's identity is also what makes
the run a `Session` later with no bookkeeping — card *i* is letter *i*.

An outcome's `atMs` is the letter's own `landMs`, not the tick that noticed it.
A tick can arrive several landings late, and STM08 turns this into
`CardResult.ms = atMs - spawnMs`, so recording the frame instead of the fall
would quantise every card in a child's record book to whatever the clock
happened to sample.

## The field, as code rather than prose

`isAirborne` / `hasLanded` / `progressAt` are exported so the half-open
interval `[spawnMs, landMs)` is written once. `hasLanded` is deliberately
**not** `!isAirborne`: an unspawned letter is neither, and a caller that
reached for the negation would count letters that have not appeared yet as
having got through.

## The target is fall progress, not `landMs` (decision 32)

`targetIndex` maximises `(t - spawnMs) / fallMs`. The two orderings part company
as soon as two letters fall at different speeds, which is most of the ladder: a
slow letter spawned early is halfway down while a fast one spawned later has
barely started, and yet the fast one lands first. Aiming by the schedule would
point the gun at a letter visibly nearer the top of the screen, and the child is
looking at the field. Exact ties go to the earlier index (decision 33), so a
replay resolves the same dead heat the same way every time.

## Death stops the clock

A fatal landing ends the run at that letter's `landMs` and leaves later letters
inside the same tick interval **unresolved**, rather than charging them to a
shield the child no longer had. `tick` and `fire` on an ended state return the
same object.

## Repairs

Every `repairAt` consecutive hits mends the **weakest** zone — the one
simultaneously about to end the run and the one a point is worth most in, which
reaches a hole with no special case for it. Capped at `spec.shield`, so
"the shield came through untouched" keeps meaning the eight-of-`shield` a run
started with (decision 34). `repairAt: 0` disables repairs. A letter you let
land breaks the streak exactly as a wrong key does.

Decisions 32–35 are recorded in `docs/typing.md`, along with §8.4's target rule,
§8.5's repair edges and §8.9 on a tick resolving every landing inside it
(decision 35) — a backgrounded tab hands back seconds, and clamping that delta
is the loop's call to make deliberately, not a dishonesty to bury in the rules.

## Review pass

Three findings, all comments and tests. **No reducer behaviour changed.**

- A clause at the end of `fire`'s doc block claimed the bottom letter is the one
  about to cost a shield point — which is the very bug decision 32 exists to
  prevent, an argument in a comment for the implementation the code rejects. It
  now says nearest-on-screen, and says out loud that soonest may be someone else.
- "The weakest zone" was unpinned: substituting "first non-full in board order"
  for the `reduce` left all 52 tests green. Two tests now cover it — one damages
  two zones unequally with the weaker one later on the board, one ties them and
  asserts the earlier wins — and both fail under that substitution.
- The immutability test froze only the initial state, so it never reached the
  repair branch and a `repaired` that wrote through its argument would have been
  invisible. It now freezes every intermediate state and takes damage before
  mending it.

## Bundle

Nothing imports `storm.ts` at runtime yet, so it ships in no chunk — no reducer
symbol appears anywhere in `dist/`. The deck chunk is unchanged at 55,608 B with
an identical content hash against `develop`.

## Validation

`npm run type-check`, `npm run lint`, `npm run test:unit` (1915 passing),
`npm run build`, and the browser smoke test against the built output all pass.
