### PR TITLE
STM03 · The field — lanes off the keyboard's geometry (#149)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -961,20 +961,45 @@ The keyboard component sits at the bottom of the field, lit by the same
 `useKeyEcho` the lessons use. It is literally the gun.
 
 Lanes are key units, not pixels, so the field and the board scale together off
-one `--key` custom property.
+one `--key` custom property — **declared once, at the root**. It lived on
+`.keyboard` until the field was built, and could not stay there: a custom
+property inherits downwards only, so a value declared on the board is a value
+the sky above it cannot read. The alternative was a second clamp with the same
+numbers in the storm's own block, which is precisely the drift this is supposed
+to rule out — a lane and the cap it names, free to disagree about how wide a
+key is (decision 37).
 
-They scale off it differently, though, and the difference is worth writing down
-before the field is built. `keyX` returns the centre of a key's **slot**, while
-the drawn keycap is inset inside that slot: `game.css` gives it
+They scale off it differently, though, and the difference had to be resolved
+rather than inherited. `keyX` returns the centre of a key's **slot**, while the
+drawn keycap is inset inside that slot: `game.css` gives it
 `width: calc(var(--w) * var(--key) - var(--key-gap))`, with `--key-gap` set to
 `calc(var(--key) * 0.09)`. So a cap's visual centre is `--key * (x + w/2 -
 0.045)` while its lane is `--key * (x + w/2)` — a letter placed at
-`left: calc(var(--lane) * var(--key))` and centred with `translateX(-50%)` sits
+`left: calc(var(--lane) * var(--key))` and centred on that point would sit
 **0.045 key units right of the centre of the cap it names**, about 1.7px at the
-2.4rem ceiling of `--key` and about 0.8px at the 1.05rem floor. Whether the
-field subtracts that half-gap is the field's own call to make deliberately
-(§13, item 18); it is recorded here so that it is neither inherited unknowingly
-nor "corrected" into a real misalignment.
+2.4rem ceiling of `--key` and about 0.8px at the 1.05rem floor.
+
+**The field subtracts it** (decision 36):
+
+```css
+left: calc(var(--lane) * var(--key) - var(--key-gap) / 2);
+```
+
+Two reasons, and the second is the one that matters in a year. A child aims at
+the plastic, not at the slot — "`f` falls onto `f`" is a claim about the thing
+on screen called `f`, and the cap is the only `f` there is. And the offset is
+not a constant of nature: it is half of whatever the board insets its caps by,
+so `var(--key-gap) / 2` is the correction at any gap, while the 0.045 it
+currently works out to would be a second number to keep in step with the first.
+Written this way a chunkier keyboard moves the lanes with it and nothing has to
+be remembered.
+
+Sub-pixel, and therefore worth being explicit about what it is not: this is not
+a fudge factor found by nudging until it looked right. It is the difference
+between two positions the stylesheet computes, and the same subtraction makes
+`stoneCentre` and `capCentre` equal to ten decimal places in
+`StormField.test.tsx` — in key units, so the test cannot be satisfied by a
+pixel that happened to round the right way at one size.
 
 ### 8.3 · A wave, from a seed
 
@@ -1238,9 +1263,12 @@ syllabus, and it is the one piece of UI in this epic worth spending real design
 time on.
 
 Component budget: `LessonLadder`, `LessonTile`, `LessonBrief`, `PassBars`,
-`Keyboard`, `StormField`, `StormShield`. All under the 300-line cap; the ladder
-is the only one that will come close, and the brief splitting out is why it
-won't.
+`Keyboard`, `StormRun`, `StormField`, `StormShield`. All under the 300-line cap;
+the ladder is the only one that will come close, and the brief splitting out is
+why it won't. `StormRun` is the route and `StormField` is the screen it draws:
+the field is a pure function of one `StormState`, so the wave, the clock and
+(later) the saving live above it and every frame it can be in is renderable
+from a value.
 
 ---
 
@@ -1267,43 +1295,45 @@ first when either optional field is added.
 
 ## 11 · Decisions, recorded
 
-|     | Decision                                                | Because                                                                                                  |
-| --- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| 1   | The keyboard layout is engine, not view                 | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture    |
-| 2   | `code`, not `key`                                       | Shift+`4` produces `$` and there is no `$` key to light up                                               |
-| 3   | Keys release on a timer, not `keyup`                    | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                          |
-| 4   | The board is `aria-hidden`                              | Sixty announcing spans is not accessibility; the passage already carries the state                       |
-| 5   | The visual keyboard is never tappable                   | A tappable board is a hunt-and-peck trainer, which is the thing this is against                          |
-| 6   | Lesson text is generated, not written                   | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                      |
-| 7   | The lexicon must not be reachable from `decks/index.ts` | The same import took the shared chunk 46 KB → 222 KB once already                                        |
-| 8   | Ghost identity is the lesson, not the passage           | Every run generates different words; keying on them buckets every run alone                              |
-| 9   | Three pass bars, not one score                          | A single number says you failed; three say what to fix                                                   |
-| 10  | Accuracy is flat and high; speed scales                 | An accuracy bar you can hammer past teaches hammering                                                    |
-| 11  | The speed bar dips when a key arrives                   | You have just got slower and you should have                                                             |
-| 12  | The new-key gate                                        | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                       |
-| 13  | Per-key stats come from cards, not keystrokes           | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven      |
-| 14  | Progress is derived, never stored                       | No migration, self-heals when criteria change, cannot disagree with the record book                      |
-| 15  | Unlock is `max(cleared) + 1`                            | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                          |
-| 16  | Any checkpoint, any time                                | It is a placement test, a skip-ahead and an ordering rule in one sentence                                |
-| 17  | A lesson has no ghost and no time penalty               | A penalty double-counts accuracy and makes the wpm number a lie                                          |
-| 18  | Hailstorm is a route in the typing island               | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard |
-| 19  | Letters fall down their key's column                    | The lane is a spatial hint — the game teaches the layout the whole time it is played                     |
-| 20  | Only the lowest letter can be shot                      | Otherwise spraying the keyboard is a winning strategy                                                    |
-| 21  | The shield is eight finger zones                        | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise        |
-| 22  | Score can fall, XP cannot                               | XP is cumulative across years and four games; a bad five minutes must not lower a level                  |
-| 23  | A Hailstorm run is a `Session`                          | Record book, XP, badges and the drill builder all work with no new code                                  |
-| 24  | Hailstorm never gates the ladder                        | A tablet has no keys, and a reward that blocks you is not a reward                                       |
-| 25  | DOM, not canvas                                         | Eleven custom properties change the whole app's biome; a canvas is a hole in that                        |
-| 26  | US ANSI only, and say so                                | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                            |
-| 27  | A lesson's keyboard seeds; it does not overrule         | All hundred name a mode, so an override beats the player's own setting on every rung                     |
-| 28  | `eyes-up` reads the board the run was typed under       | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory       |
-| 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete  |
-| 30  | A falling letter is on the field on `[spawn, land)`     | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two      |
-| 31  | A letter carries its key, finger and lane               | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift       |
-| 32  | The target is the greatest fall progress, not `landMs`  | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen           |
-| 33  | An exact tie goes to the earlier spawn                  | The index is the letter's identity, so a replay resolves the same dead heat the same way                 |
-| 34  | A repair never lifts a zone above `spec.shield`         | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                 |
-| 35  | A tick resolves every landing inside it                 | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's            |
+|     | Decision                                                | Because                                                                                                    |
+| --- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 1   | The keyboard layout is engine, not view                 | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture      |
+| 2   | `code`, not `key`                                       | Shift+`4` produces `$` and there is no `$` key to light up                                                 |
+| 3   | Keys release on a timer, not `keyup`                    | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                            |
+| 4   | The board is `aria-hidden`                              | Sixty announcing spans is not accessibility; the passage already carries the state                         |
+| 5   | The visual keyboard is never tappable                   | A tappable board is a hunt-and-peck trainer, which is the thing this is against                            |
+| 6   | Lesson text is generated, not written                   | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                        |
+| 7   | The lexicon must not be reachable from `decks/index.ts` | The same import took the shared chunk 46 KB → 222 KB once already                                          |
+| 8   | Ghost identity is the lesson, not the passage           | Every run generates different words; keying on them buckets every run alone                                |
+| 9   | Three pass bars, not one score                          | A single number says you failed; three say what to fix                                                     |
+| 10  | Accuracy is flat and high; speed scales                 | An accuracy bar you can hammer past teaches hammering                                                      |
+| 11  | The speed bar dips when a key arrives                   | You have just got slower and you should have                                                               |
+| 12  | The new-key gate                                        | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                         |
+| 13  | Per-key stats come from cards, not keystrokes           | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven        |
+| 14  | Progress is derived, never stored                       | No migration, self-heals when criteria change, cannot disagree with the record book                        |
+| 15  | Unlock is `max(cleared) + 1`                            | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                            |
+| 16  | Any checkpoint, any time                                | It is a placement test, a skip-ahead and an ordering rule in one sentence                                  |
+| 17  | A lesson has no ghost and no time penalty               | A penalty double-counts accuracy and makes the wpm number a lie                                            |
+| 18  | Hailstorm is a route in the typing island               | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard   |
+| 19  | Letters fall down their key's column                    | The lane is a spatial hint — the game teaches the layout the whole time it is played                       |
+| 20  | Only the lowest letter can be shot                      | Otherwise spraying the keyboard is a winning strategy                                                      |
+| 21  | The shield is eight finger zones                        | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise          |
+| 22  | Score can fall, XP cannot                               | XP is cumulative across years and four games; a bad five minutes must not lower a level                    |
+| 23  | A Hailstorm run is a `Session`                          | Record book, XP, badges and the drill builder all work with no new code                                    |
+| 24  | Hailstorm never gates the ladder                        | A tablet has no keys, and a reward that blocks you is not a reward                                         |
+| 25  | DOM, not canvas                                         | Eleven custom properties change the whole app's biome; a canvas is a hole in that                          |
+| 26  | US ANSI only, and say so                                | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                              |
+| 27  | A lesson's keyboard seeds; it does not overrule         | All hundred name a mode, so an override beats the player's own setting on every rung                       |
+| 28  | `eyes-up` reads the board the run was typed under       | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory         |
+| 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete    |
+| 30  | A falling letter is on the field on `[spawn, land)`     | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two        |
+| 31  | A letter carries its key, finger and lane               | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift         |
+| 32  | The target is the greatest fall progress, not `landMs`  | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen             |
+| 33  | An exact tie goes to the earlier spawn                  | The index is the letter's identity, so a replay resolves the same dead heat the same way                   |
+| 34  | A repair never lifts a zone above `spec.shield`         | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                   |
+| 35  | A tick resolves every landing inside it                 | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's              |
+| 36  | The field's lanes step back half a `--key-gap`          | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference |
+| 37  | `--key` is declared once, at the root                   | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key     |
 
 ---
 

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -996,9 +996,14 @@ be remembered.
 
 Sub-pixel, and therefore worth being explicit about what it is not: this is not
 a fudge factor found by nudging until it looked right. It is the difference
-between two positions the stylesheet computes, and the same subtraction makes
-`stoneCentre` and `capCentre` equal to ten decimal places in
-`StormField.test.tsx` — in key units, so the test cannot be satisfied by a
+between two positions the stylesheet computes, and `StormField.test.tsx`
+computes both of them the way a browser would — reading the field's `left` and
+the board's `left` and `width` out of `game.css` and evaluating them with
+`--key` as the unit. `stoneCentre` and `capCentre` come out equal to ten
+decimal places, and stop being equal the moment either declaration moves
+without the other: inset the caps by `var(--key-gap) * 2` and the test fails by
+the half gap the lane no longer matches, rather than the board quietly drifting
+1.7px off every letter. In key units, so nothing here can be satisfied by a
 pixel that happened to round the right way at one size.
 
 ### 8.3 · A wave, from a seed

--- a/src/games/typing/App.tsx
+++ b/src/games/typing/App.tsx
@@ -10,6 +10,7 @@ import PlayerSelect from "@/components/screens/PlayerSelect";
 import TypingSetup from "./TypingSetup";
 import TypingTrack from "./TypingTrack";
 import TypingResults from "./TypingResults";
+import StormRun from "./storm/StormRun";
 
 /**
  * The typing game, as its own island.
@@ -73,6 +74,11 @@ function Shell() {
         <Route path="/" element={<PlayerSelect />} />
         <Route path="/p/:profileId" element={<TypingSetup />} />
         <Route path="/p/:profileId/go" element={<TypingTrack />} />
+        {/* Hailstorm (docs/typing.md §9). Its own route rather than a mode of
+            `/go`, because it shares none of that screen's machinery — no
+            passage, no input, no ghost — and all of its own. Nothing links
+            here until the storm tiles land on the ladder (STM10). */}
+        <Route path="/p/:profileId/storm" element={<StormRun />} />
         <Route path="/p/:profileId/results" element={<TypingResults />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -1,0 +1,241 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { KEYS, keyX, strokeFor } from "@/engine/keyboard";
+import { buildWave, fire, startStorm, tick } from "@/engine/typing/storm";
+
+import { StormField, aimedAt } from "./StormField";
+
+import type { KeyDef } from "@/engine/keyboard";
+import type { StormState, WaveSpec } from "@/engine/typing/storm";
+
+/**
+ * The one claim this screen exists to keep: a letter falls down the column of
+ * its own key (docs/typing.md §8.2, decision 19).
+ *
+ * It is worth testing at this altitude because it can be broken by a change to
+ * either half and looks fine from both. The engine can hand over a lane it
+ * measured from the wrong edge of a key; the stylesheet can multiply it by the
+ * wrong unit, or forget that the keycap is drawn inset inside its slot. Every
+ * one of those type-checks, renders, and teaches a child that `y` lives
+ * somewhere it does not — which is worse than not drawing the hint at all,
+ * because they will believe it.
+ *
+ * So the geometry is checked in KEY UNITS, end to end: the lane the component
+ * writes, against the cap the board draws, through the arithmetic game.css
+ * actually performs. No pixels are involved on either side, which is the
+ * property being defended.
+ */
+
+const css = readFileSync(
+  fileURLToPath(new URL("../../../styles/game.css", import.meta.url)),
+  "utf8",
+);
+
+/** Where the field's own rules start in the game stylesheet. */
+const STORM_BLOCK = "/* ── Hailstorm: the field";
+
+/**
+ * The field's rules with the prose taken out.
+ *
+ * The comments in this block quote the very things being asserted against —
+ * "`height`, not `min-height`", "390px of height" — so a test reading them
+ * would be marking the explanation rather than the stylesheet.
+ */
+const storm = css
+  .slice(css.indexOf(STORM_BLOCK))
+  .replace(/\/\*[\s\S]*?\*\//g, "");
+
+/**
+ * The keycap inset, as the fraction of a key unit game.css sets it to.
+ *
+ * Read out of the stylesheet rather than written down here, because the whole
+ * point of the arithmetic below is that one number governs both the cap and
+ * the lane. A test carrying its own copy could agree with neither.
+ */
+const GAP = Number(
+  /--key-gap:\s*calc\(var\(--key\)\s*\*\s*([\d.]+)\)/.exec(css)![1],
+);
+
+/** A wave of nothing but `ch`, so which letter falls is not left to a seed. */
+const only = (ch: string, count = 1, fallMs = 1000): WaveSpec => ({
+  keys: [ch],
+  count,
+  gap: [300, 300],
+  fall: [fallMs, fallMs],
+  shield: 3,
+  repairAt: 0,
+});
+
+const frameOf = (spec: WaveSpec, atMs: number): StormState =>
+  tick(startStorm(buildWave(spec, 7)), atMs);
+
+const draw = (state: StormState) =>
+  renderToStaticMarkup(<StormField state={state} />);
+
+/** Every falling letter in a rendered field, as `{ ch, lane }`. */
+const stones = (state: StormState) =>
+  [
+    ...draw(state).matchAll(
+      /class="storm__letter" style="--lane:([\d.]+);--drop:([\d.e-]+)"[^>]*>(.)</g,
+    ),
+  ].map(([, lane, drop, ch]) => ({
+    ch,
+    lane: Number(lane),
+    drop: Number(drop),
+  }));
+
+/**
+ * Where a falling letter's middle lands, in key units.
+ *
+ * `left: calc(var(--lane) * var(--key) - var(--key-gap) / 2)` with
+ * `translate: -50% 0` — the stylesheet's arithmetic, done in units.
+ */
+const stoneCentre = (lane: number) => lane - GAP / 2;
+
+/**
+ * Where a drawn keycap's middle sits, in the same units.
+ *
+ * `left: calc(var(--x) * var(--key))` and
+ * `width: calc(var(--w) * var(--key) - var(--key-gap))` — so the cap starts at
+ * its slot's left edge and is a whole gap narrower than the slot is.
+ */
+const capCentre = (key: KeyDef) => key.x + ((key.width ?? 1) - GAP) / 2;
+
+const cap = (code: string) => KEYS.find((k) => k.code === code)!;
+
+describe("StormField", () => {
+  it("puts a letter over the cap that types it, to the pixel", () => {
+    // The claim, at last: `f` falls onto `f`. Not "near" it and not "over its
+    // slot" — the middle of the falling letter and the middle of the drawn
+    // keycap are the same point on the screen, because the lane steps back by
+    // exactly the half-gap the cap is inset by.
+    const [f] = stones(frameOf(only("f"), 500));
+
+    expect(f.ch).toBe("f");
+    expect(stoneCentre(f.lane)).toBeCloseTo(capCentre(cap("KeyF")), 10);
+  });
+
+  it("puts `y` between `g` and `h`, because that is where `y` is", () => {
+    const [y] = stones(frameOf(only("y"), 500));
+    const centre = stoneCentre(y.lane);
+
+    expect(centre).toBeGreaterThan(capCentre(cap("KeyG")));
+    expect(centre).toBeLessThan(capCentre(cap("KeyH")));
+
+    // And where between them: a quarter of a unit left of `h` and three
+    // quarters right of `g`, because the top row is staggered a quarter unit
+    // out from the home row rather than half. That is the plastic — `y` really
+    // does sit up and slightly left of `h` — and it is the whole spatial hint:
+    // a child who reaches towards `h` for a falling `y` has learnt something
+    // true about where their finger has to go.
+    expect(capCentre(cap("KeyH")) - centre).toBeCloseTo(0.25, 10);
+    expect(centre - capCentre(cap("KeyG"))).toBeCloseTo(0.75, 10);
+  });
+
+  it("takes every lane from the engine, and computes none of its own", () => {
+    // Both hands, both staggers, and a shifted character whose lane is its
+    // letter's key rather than the shift's.
+    for (const ch of ["a", "f", "y", "p", ";", "?", "M"]) {
+      const [stone] = stones(frameOf(only(ch), 500));
+      expect(stone.lane).toBe(keyX(strokeFor(ch)!.code));
+    }
+  });
+
+  it("scales the lane by the key unit, and never by a pixel", () => {
+    const rule = /\.storm__letter\s*{[^}]*}/.exec(storm)![0];
+
+    expect(rule).toContain(
+      "left: calc(var(--lane) * var(--key) - var(--key-gap) / 2)",
+    );
+    // No length in this block is absolute except a hairline border: a field
+    // measured in pixels would come apart from the board the moment `--key`
+    // moved, which is at every viewport width.
+    expect(storm.replace(/1px solid/g, "")).not.toMatch(/\d+px/);
+  });
+
+  it("draws one key unit, shared with the board it is aiming at", () => {
+    // The AC's "one source of truth" is the `KEY_ROWS` table for the lanes and
+    // this custom property for the scale. Two declarations of it — one on the
+    // board, one on the field — is exactly how a lane and a cap start
+    // disagreeing about how wide a key is.
+    expect(css.match(/--key:\s/g)).toHaveLength(1);
+    expect(/:root\s*{\s*--key:/.test(css)).toBe(true);
+  });
+
+  it("fills the viewport minus the ad band, and does not scroll", () => {
+    const field = /\.storm\s*{[^}]*}/.exec(storm)![0];
+
+    // `height`, not `min-height`: a field that may grow is a field that
+    // scrolls, and the letters would go on falling off screen.
+    expect(field).toContain("height: calc(100dvh - var(--ad-h))");
+    expect(field).not.toContain("min-height");
+    expect(field).toContain("overflow: hidden");
+  });
+
+  it("is drawn out of ice tokens, with no colour of its own", () => {
+    // Every colour is a world token, and none of the five is borrowed: a
+    // hailstone in `--lime` would be saying something was right about it.
+    expect(storm).not.toMatch(/#[0-9a-f]{3}/i);
+    expect(storm).not.toMatch(/\brgba?\(/);
+    for (const name of ["--lime", "--flare", "--sky", "--gold", "--grape"])
+      expect(storm).not.toContain(`var(${name})`);
+  });
+
+  it("draws what is in the air, and nothing that is spent", () => {
+    // Four letters, 300ms apart, each crossing the field in half a second: by
+    // 950ms the first two have landed and the last two are still falling.
+    const state = frameOf(only("j", 4, 500), 950);
+
+    expect(stones(state)).toHaveLength(2);
+    expect(state.resolved[0]).not.toBeNull();
+    expect(state.resolved[1]).not.toBeNull();
+
+    // And one that was shot leaves at the press rather than at its landing —
+    // `resolved` is what is drawn from, not the clock alone.
+    expect(stones(fire(state, "KeyJ"))).toHaveLength(1);
+  });
+
+  it("puts a stone at the top when it spawns and at the line when it lands", () => {
+    expect(stones(frameOf(only("j"), 0))[0].drop).toBe(0);
+    expect(stones(frameOf(only("j"), 750))[0].drop).toBeCloseTo(0.75, 10);
+  });
+
+  it("mounts the board as the gun, and lets it point at nothing", () => {
+    const html = draw(frameOf(only("f"), 500));
+
+    // The same picture the lessons put under the passage — one board, one
+    // layout, one echo listener.
+    expect(html.match(/class="keyboard__key/g)).toHaveLength(KEYS.length);
+
+    // But no hint, ever. A board that pointed at the next key would be
+    // playing the game for the child (§8.1).
+    expect(html).not.toContain("is-next");
+  });
+
+  it("marks presses against the lowest letter, and against none once dead", () => {
+    const state = frameOf(only("f", 3), 500);
+    expect(aimedAt(state)).toBe("f");
+
+    // `targetIndex` answers "which is lowest", not "is this run alive", so it
+    // still names a letter on a dead run. The screen is where that has to be
+    // caught, or the board goes on flaring at a child who has already lost.
+    const dead: StormState = {
+      ...state,
+      ending: { kind: "breached", finger: "l-index", index: 0 },
+    };
+    expect(aimedAt(dead)).toBeNull();
+  });
+
+  it("says what the screen is, without reading out the hailstorm", () => {
+    const html = draw(frameOf(only("f"), 500));
+
+    expect(html).toContain("Hailstorm");
+    // The sky churns sixty times a second once STM04 lands; the board is
+    // sixty spans. Neither is an announcement anybody could act on.
+    expect(html.match(/aria-hidden="true"/g)).toHaveLength(2);
+  });
+});

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -26,8 +26,9 @@ import type { StormState, WaveSpec } from "@/engine/typing/storm";
  *
  * So the geometry is checked in KEY UNITS, end to end: the lane the component
  * writes, against the cap the board draws, through the arithmetic game.css
- * actually performs. No pixels are involved on either side, which is the
- * property being defended.
+ * actually performs — both sides read out of the stylesheet rather than
+ * restated here, for the reason `capCentre` gives. No pixels are involved on
+ * either side, which is the property being defended.
  */
 
 const css = readFileSync(
@@ -50,15 +51,100 @@ const storm = css
   .replace(/\/\*[\s\S]*?\*\//g, "");
 
 /**
+ * The whole stylesheet with its prose taken out, so a declaration is read from
+ * the rule that ships and never from a comment describing it.
+ */
+const sheet = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+/**
+ * The one value game.css declares for `prop` on exactly `selector`.
+ *
+ * Exactly one, deliberately. A second declaration of the cap's width in a
+ * later block is the drift this whole file is about, and read leniently it
+ * would shadow the rule below without failing anything.
+ */
+const declaration = (selector: string, prop: string): string => {
+  const found = [...sheet.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+    .filter(([, list]) => list.trim() === selector)
+    .map(([, , body]) =>
+      new RegExp(`(?:^|;)\\s*${prop}:\\s*([^;]+)`).exec(body),
+    )
+    .filter((match) => match !== null)
+    .map((match) => match[1].trim());
+
+  if (found.length !== 1)
+    throw new Error(
+      `expected one \`${prop}\` on \`${selector}\`, found ${found.length}`,
+    );
+  return found[0];
+};
+
+/**
+ * `a * b - c / 2`, the way a browser reads it: multiply and divide first, then
+ * add and subtract, left to right. Parentheses are already flattened out by
+ * `unitsOf`, which is the only caller.
+ */
+const arithmetic = (expr: string): number => {
+  const tokens = expr
+    .trim()
+    .split(/\s*([+\-*/])\s*/)
+    .filter((token) => token !== "");
+  if (tokens[0] === "+" || tokens[0] === "-") tokens.unshift("0");
+
+  const terms = [Number(tokens[0])];
+  const signs: string[] = [];
+  for (let i = 1; i < tokens.length; i += 2) {
+    const value = Number(tokens[i + 1]);
+    if (tokens[i] === "*") terms[terms.length - 1] *= value;
+    else if (tokens[i] === "/") terms[terms.length - 1] /= value;
+    else {
+      signs.push(tokens[i]);
+      terms.push(value);
+    }
+  }
+
+  const total = signs.reduce(
+    (sum, sign, i) => (sign === "+" ? sum + terms[i + 1] : sum - terms[i + 1]),
+    terms[0],
+  );
+  if (Number.isNaN(total))
+    throw new Error(`not an expression in key units: ${expr}`);
+  return total;
+};
+
+/**
+ * A CSS length expression, evaluated in key units — `--key` is 1, and every
+ * other custom property is supplied by the caller.
+ *
+ * Enough of `calc()` to run the four declarations this file reads, and no
+ * more: an expression naming a property the caller did not supply throws,
+ * rather than quietly evaluating as though it were nothing.
+ */
+const unitsOf = (expr: string, vars: Record<string, number>): number => {
+  const filled = expr.replace(/var\((--[\w-]+)\)/g, (_, name: string) => {
+    if (!(name in vars))
+      throw new Error(
+        `\`${expr}\` reads ${name}, which this test does not model`,
+      );
+    return `(${vars[name]})`;
+  });
+
+  let flat = filled.replace(/\bcalc\b/g, "");
+  while (flat.includes("("))
+    flat = flat.replace(/\(([^()]*)\)/, (_, inner: string) =>
+      String(arithmetic(inner)),
+    );
+  return arithmetic(flat);
+};
+
+/**
  * The keycap inset, as the fraction of a key unit game.css sets it to.
  *
  * Read out of the stylesheet rather than written down here, because the whole
  * point of the arithmetic below is that one number governs both the cap and
  * the lane. A test carrying its own copy could agree with neither.
  */
-const GAP = Number(
-  /--key-gap:\s*calc\(var\(--key\)\s*\*\s*([\d.]+)\)/.exec(css)![1],
-);
+const GAP = unitsOf(declaration(":root", "--key-gap"), { "--key": 1 });
 
 /** A wave of nothing but `ch`, so which letter falls is not left to a seed. */
 const only = (ch: string, count = 1, fallMs = 1000): WaveSpec => ({
@@ -91,19 +177,42 @@ const stones = (state: StormState) =>
 /**
  * Where a falling letter's middle lands, in key units.
  *
- * `left: calc(var(--lane) * var(--key) - var(--key-gap) / 2)` with
- * `translate: -50% 0` — the stylesheet's arithmetic, done in units.
+ * The field's own `left` declaration, run rather than restated. `translate:
+ * -50% 0` — pinned below, because this depends on it — centres the stone on
+ * that point, so what comes back is the middle and not the left edge.
  */
-const stoneCentre = (lane: number) => lane - GAP / 2;
+const stoneCentre = (lane: number) =>
+  unitsOf(declaration(".storm__letter", "left"), {
+    "--key": 1,
+    "--key-gap": GAP,
+    "--lane": lane,
+  });
 
 /**
- * Where a drawn keycap's middle sits, in the same units.
+ * Where a drawn keycap's middle sits, in the same units — from the board's own
+ * `left` and `width`, which is where the inset the lane compensates for is
+ * actually written down.
  *
- * `left: calc(var(--x) * var(--key))` and
- * `width: calc(var(--w) * var(--key) - var(--key-gap))` — so the cap starts at
- * its slot's left edge and is a whole gap narrower than the slot is.
+ * Both sides coming out of the sheet is the whole point. Two hand-written
+ * models would each carry the half-gap term they were meant to be checking,
+ * and it would cancel across the assertion: subtract half a gap from the lane,
+ * fold half a gap into the cap, and the two agree for ANY gap — including
+ * none, and including a board that insets its caps by twice what the field
+ * compensates for. Reading the declarations means a change to either half
+ * moves one side of the comparison and not the other.
  */
-const capCentre = (key: KeyDef) => key.x + ((key.width ?? 1) - GAP) / 2;
+const capCentre = (key: KeyDef) => {
+  const vars = {
+    "--key": 1,
+    "--key-gap": GAP,
+    "--x": key.x,
+    "--w": key.width ?? 1,
+  };
+  return (
+    unitsOf(declaration(".keyboard__key", "left"), vars) +
+    unitsOf(declaration(".keyboard__key", "width"), vars) / 2
+  );
+};
 
 const cap = (code: string) => KEYS.find((k) => k.code === code)!;
 
@@ -151,6 +260,10 @@ describe("StormField", () => {
     expect(rule).toContain(
       "left: calc(var(--lane) * var(--key) - var(--key-gap) / 2)",
     );
+    // And that `left` is the letter's CENTRE rather than its left edge, which
+    // is what `stoneCentre` above reads it as. Lose the translate and every
+    // letter moves half a stone right of the key it names.
+    expect(rule).toContain("translate: -50% 0");
     // No length in this block is absolute except a hairline border: a field
     // measured in pixels would come apart from the board the moment `--key`
     // moved, which is at every viewport width.
@@ -180,7 +293,24 @@ describe("StormField", () => {
     // Every colour is a world token, and none of the five is borrowed: a
     // hailstone in `--lime` would be saying something was right about it.
     expect(storm).not.toMatch(/#[0-9a-f]{3}/i);
-    expect(storm).not.toMatch(/\brgba?\(/);
+    expect(storm).not.toMatch(
+      /\b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\(/,
+    );
+
+    // Notations can be listed; the named colours cannot, so they are caught
+    // from the other end: strip a colour-bearing value of its tokens and its
+    // plumbing and there is nothing left to read. `color: rebeccapurple`
+    // leaves a word, and so would any notation the list above forgets.
+    const PLUMBING =
+      /var\(--[\w-]+\)|color-mix|calc|in oklab|solid|dashed|dotted|none|inset|transparent|currentcolor|[\d.]+(?:px|%|em|rem|ms|s)?|[-*,()/\s]/gi;
+    const literals = [
+      ...storm.matchAll(
+        /(?:^|[;{])\s*([\w-]*(?:color|background|border|shadow|fill|stroke)[\w-]*)\s*:\s*([^;]+)/g,
+      ),
+    ].filter(([, , value]) => /[a-z]/i.test(value.replace(PLUMBING, "")));
+    expect(
+      literals.map(([, prop, value]) => `${prop}: ${value.trim()}`),
+    ).toEqual([]);
     for (const name of ["--lime", "--flare", "--sky", "--gold", "--grape"])
       expect(storm).not.toContain(`var(${name})`);
   });

--- a/src/games/typing/storm/StormField.tsx
+++ b/src/games/typing/storm/StormField.tsx
@@ -1,0 +1,126 @@
+import { isAirborne, progressAt, targetIndex } from "@/engine/typing/storm";
+
+import { LiveKeyboard } from "../keyboard/LiveKeyboard";
+
+import type { StormState } from "@/engine/typing/storm";
+import type { CSSProperties } from "react";
+
+/**
+ * Hailstorm's field: the sky the letters fall through, and the gun under it
+ * (docs/typing.md §8.2, decision 19).
+ *
+ * ── A letter falls down the column of its own key ────────────────────────────
+ * `f` falls onto `f`. `y` falls between `g` and `h`, because that is where `y`
+ * is. That is the whole design and it is the reason `KeyDef.x` is in the
+ * engine rather than in the picture of a keyboard: the horizontal position of
+ * a falling letter is a spatial hint about where its key is, handed to a child
+ * a second or two before they have to find it. The game is not themed around a
+ * keyboard — it is teaching the layout geometrically the entire time it is
+ * being played.
+ *
+ * Nothing here computes a lane. `StormLetter.lane` is `keyX(code)` resolved
+ * once when the wave was built (§8.3), and this writes it into a custom
+ * property that `game.css` multiplies by `--key`. So the field and the drawn
+ * board cannot disagree about where a key is: they read one `KEY_ROWS` table
+ * and one `--key` unit, and neither of them holds a pixel.
+ *
+ * ── The board is the gun ─────────────────────────────────────────────────────
+ * `LiveKeyboard` — the same component and the same `useKeyEcho` the lessons
+ * put under the passage — rather than a second keyboard drawn for the game.
+ * One board means one layout, one echo listener and one set of finger colours;
+ * a child who has spent forty lessons learning to glance at that picture
+ * should meet the same picture here.
+ *
+ * `mode="keys"` is doing real work. It keeps the echo's expectation — so the
+ * key you fire with lights `--lime` and a wrong one flares `--flare` — while
+ * withholding the next-key HINT, which the storm must never show: a board that
+ * pointed at the answer would be playing the game for the child, and §8.1's
+ * whole claim is that this drills the one thing a passage cannot, which is
+ * finding a key you were not told about.
+ *
+ * ── What this story does not do ──────────────────────────────────────────────
+ * The field is a pure function of a `StormState`: hand it a frame and it draws
+ * that frame. It holds no clock, so nothing here moves — STM04 drives `--drop`
+ * from a `requestAnimationFrame` loop, and `transform` is deliberately left
+ * unused so that loop can write it without disturbing the lane centring (the
+ * CSS uses the `translate` property instead). The shield is STM05, and the
+ * eight segments belong on the line the letters land on; firing and its
+ * reticle are STM06.
+ */
+
+/**
+ * The character the gun is marked against, or `null` for none.
+ *
+ * Only the lowest letter on screen can be shot (§8.4), so it is the only one a
+ * key can be right for — and the echo needs exactly that character to tell a
+ * hit from a miss on the press, before anything has re-rendered (§4.3).
+ *
+ * The `ending` guard is the whole reason this is a function. `targetIndex`
+ * deliberately does not read it: the reducer's question is "which letter is
+ * lowest", not "is this run still alive", and a run that ended mid-wave still
+ * has letters in the air for it to answer with. So a screen that draws
+ * anything off that index has to guard for itself, and this is the screen —
+ * without it, the board would go on flaring `--flare` at a child whose run was
+ * already over, marking their keys against a letter nothing can shoot.
+ */
+export function aimedAt(state: StormState): string | null {
+  if (state.ending !== null) return null;
+  const index = targetIndex(state);
+  return index === null ? null : state.wave.letters[index].ch;
+}
+
+/**
+ * The field, as markup: the sky, whatever is falling through it, and the board
+ * at the bottom. A pure function of one `StormState` — see the file header for
+ * why, and for what the next four stories hang off it.
+ */
+export function StormField({ state }: { state: StormState }) {
+  return (
+    <main className="storm">
+      {/* The screen's name, for the one visitor who cannot see any of it. The
+          field itself is hidden below — see the sky. */}
+      <h1 className="u-sr">Hailstorm</h1>
+
+      {/*
+        `aria-hidden`, for the reason the board is (§4.4): what is in here
+        changes sixty times a second under STM04's loop, and a live region
+        reading out a hailstorm is a denial of service rather than an
+        accommodation. Nothing is announced that a child could act on anyway —
+        the game is a physical keyboard and a reaction time. The device with no
+        keys is told so honestly, and that is STM09's story.
+      */}
+      <div className="storm__sky" aria-hidden="true">
+        {state.wave.letters.map((letter, index) => {
+          // Resolved is gone: a letter that was shot leaves the screen at the
+          // press, and one that landed left it at the shield. `isAirborne` is
+          // the half-open `[spawnMs, landMs)` the reducer damages the shield
+          // on (decision 30) — asking it here rather than re-deciding which
+          // side of the millisecond a landing falls on.
+          if (state.resolved[index] !== null) return null;
+          if (!isAirborne(letter, state.timeMs)) return null;
+
+          return (
+            <span
+              // The index is the letter's identity (§8.3): the wave is built
+              // once and never grows, so this key cannot shift under a letter
+              // mid-fall — which it would if the drawn letters were numbered
+              // by their position in a filtered list.
+              key={index}
+              className="storm__letter"
+              style={
+                {
+                  "--lane": letter.lane,
+                  "--drop": progressAt(letter, state.timeMs),
+                } as CSSProperties
+              }
+            >
+              {letter.ch}
+            </span>
+          );
+        })}
+      </div>
+
+      <LiveKeyboard mode="keys" next={aimedAt(state)} />
+    </main>
+  );
+}

--- a/src/games/typing/storm/StormRun.tsx
+++ b/src/games/typing/storm/StormRun.tsx
@@ -1,0 +1,89 @@
+import { Navigate, useParams } from "react-router-dom";
+
+import { usePlayer } from "@/components/state/HubContext";
+import { unlockedAt } from "@/engine/typing/keys";
+import { buildWave, startStorm, tick } from "@/engine/typing/storm";
+
+import { StormField } from "./StormField";
+
+import type { WaveSpec } from "@/engine/typing/storm";
+
+/**
+ * The Hailstorm route (docs/typing.md §9), holding one frame of a storm.
+ *
+ * The field is a pure function of a `StormState` and STM03 has no clock, so
+ * what this screen hands it is a **still frame**: a wave built from a seed,
+ * wound forward to the moment every letter has spawned and none has landed.
+ * That is enough to be the thing this story is about — twelve letters, each
+ * one over the cap that types it, above the board that will shoot them — and
+ * it is deliberately not a game yet. STM04 puts a `requestAnimationFrame` loop
+ * where `PREVIEW_MS` is, STM05 draws the shield on the line they land on,
+ * STM06 gives the screen its HUD and its way out, and STM10 replaces this
+ * stand-in wave with the twenty the ladder actually names.
+ *
+ * Unlinked on purpose. Nothing on the ladder points here until STM10 puts the
+ * storm tiles on it, so the only way in is the URL — which is exactly what a
+ * screen with no quit button should be.
+ */
+
+/**
+ * A stand-in storm: everything a child has met by the end of block 4, falling
+ * one after another.
+ *
+ * `unlockedAt` rather than a hand-written pool, because "a wave draws only on
+ * keys the ladder has already taught" is the rule STM10 has to keep and a
+ * stand-in that broke it would be a stand-in nobody could reason from.
+ *
+ * The gap and the fall are single values rather than ranges so the frame below
+ * comes out as a clean staircase — twelve letters evenly spaced down the sky,
+ * one lane each — which is what makes a lane visibly checkable against the cap
+ * under it. A real level samples both from a range (§8.3); this one is a
+ * ruler.
+ */
+const PREVIEW_SPEC: WaveSpec = {
+  keys: [...unlockedAt(40)],
+  count: 12,
+  gap: [300, 300],
+  fall: [4000, 4000],
+  shield: 3,
+  repairAt: 0,
+};
+
+/**
+ * The seed, picked so the twelve letters land on twelve different keys across
+ * both hands rather than stuttering on three — and so that the two this story
+ * is named after, `f` and `y`, are the two lowest on the screen, right above
+ * the caps they are claimed to line up with.
+ *
+ * A wave is replayable from `(spec, seed)` (§8.3), so a still frame of one is
+ * reproducible too: this screen looks the same on every machine and in every
+ * session, which is what makes "does `y` fall between `g` and `h`" a question
+ * anybody can go and look at rather than one that depends on a lucky roll.
+ */
+const PREVIEW_SEED = 353;
+
+/**
+ * The instant the frame is taken: the last letter's spawn.
+ *
+ * Every letter is in the air at exactly this moment — the twelfth has just
+ * appeared and the first, 3300ms into a 4000ms fall, is still a fifth of the
+ * sky above the shield. Nothing has landed, so nothing has been resolved and
+ * the shield is untouched.
+ */
+const PREVIEW_MS = PREVIEW_SPEC.gap[0] * (PREVIEW_SPEC.count - 1);
+
+const PREVIEW = tick(
+  startStorm(buildWave(PREVIEW_SPEC, PREVIEW_SEED)),
+  PREVIEW_MS,
+);
+
+export default function StormRun() {
+  const { profileId } = useParams();
+  const profile = usePlayer(profileId);
+
+  // Same guard as the other run screens: a URL naming a player who isn't on
+  // this device goes back to the picker rather than rendering half a game.
+  if (!profile) return <Navigate to="/" replace />;
+
+  return <StormField state={PREVIEW} />;
+}

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1864,16 +1864,35 @@ label.segmented__btn {
    legends are its chalk, and the eight hues on top are the same in all of
    them because a finger doesn't change biome.                             */
 
-.keyboard {
-  /* The one dial. The board is fifteen key units wide and every key knows its
-     own left edge in those units, so a key is a fifteenth of the room there
-     is — floored so it stays legible on a narrow phone, capped so it doesn't
-     become furniture on a desktop. The dvh term is what makes a phone in
-     landscape work: five rows and the passage above them are sharing about
-     390px of height, and width alone would happily spend all of it. */
+/* The one dial, and it is at the ROOT because two screens now scale off it.
+
+   The board is fifteen key units wide and every key knows its own left edge
+   in those units, so a key is a fifteenth of the room there is — floored so
+   it stays legible on a narrow phone, capped so it doesn't become furniture
+   on a desktop. The dvh term is what makes a phone in landscape work: five
+   rows and whatever they are under — the passage, or a sky full of falling
+   letters — are sharing about 390px of height, and width alone would happily
+   spend all of it.
+
+   It lived on `.keyboard` until Hailstorm, which positions falling letters in
+   key units in the sky ABOVE the board (docs/typing.md §8.2): a custom
+   property inherits downwards only, so a value declared on the board is a
+   value the field cannot read. The alternative was a second clamp with the
+   same five numbers in the storm's own block, and that is the one thing this
+   must not be — a lane and the cap it names would then be free to drift
+   apart, which is a spatial hint teaching the wrong geometry.
+
+   `--key-gap` is here for the same reason and one more: it is the inset that
+   turns a key's slot into the keycap drawn inside it, so it is also what the
+   field subtracts half of to centre a letter over the CAP rather than over
+   the slot (decision 36). One declaration, and both halves of that stay
+   true at every size. */
+:root {
   --key: clamp(1.05rem, min(5.6vw, 9dvh), 2.4rem);
   --key-gap: calc(var(--key) * 0.09);
+}
 
+.keyboard {
   display: grid;
   gap: var(--key-gap);
   width: calc(15 * var(--key));
@@ -2090,4 +2109,126 @@ label.segmented__btn {
 .keyboard__key.is-wrong {
   border-color: var(--flare);
   background: color-mix(in oklab, var(--flare) 78%, var(--ink-800));
+}
+
+/* ── Hailstorm: the field ────────────────────────────────────────────────
+   The sky the letters fall through, and the board underneath that shoots
+   them (docs/typing.md §8.2, decision 19).
+
+   **A letter falls down the column of its own key.** `f` falls onto `f`; `y`
+   falls between `g` and `h`, because that is where `y` is. Everything in this
+   block is in service of that one claim, and everything it needs to keep it
+   is already here: `StormLetter.lane` is `keyX(code)` in key units, and the
+   caps below are `KeyDef.x` in the same units against the same `--key`. Two
+   readings of one table, so there is no arithmetic in this file for a lane
+   and a cap to disagree about.
+
+   No pixel constant appears anywhere in the geometry — a lane, a hailstone
+   and the fall are all multiples of `--key`, so the field and the board
+   change size together or not at all. And no colour here is a literal: the
+   ice world's tokens draw the sky and the stones, and the telemetry five stay
+   out of it until there is something to signal. A hailstone in `--lime` would
+   be telling a child something was right about it.                        */
+
+.storm {
+  /* A hailstone, in key units: a little wider than the cap it is aimed at, so
+     the glyph reads at the top of the screen. Named because the fall
+     arithmetic needs it too — a letter travels the sky MINUS its own height,
+     which is what leaves it whole at the top and resting on the line at the
+     bottom rather than half off each end. */
+  --stone: calc(var(--key) * 1.15);
+
+  /* One viewport minus the ad band above it, exactly as `.race` is sized and
+     for a sharper version of the same reason. `height`, not `min-height`: a
+     field that may grow is a field that scrolls, and a page that scrolls
+     under a thumb mid-run is worse here than in a race — the letters would
+     still be falling somewhere off screen. */
+  height: calc(100dvh - var(--ad-h));
+  overflow: hidden;
+
+  display: grid;
+  /* The sky gives, the board never does. `minmax(0, 1fr)` is what lets the
+     sky be shorter than its content wants (the stones are absolutely
+     positioned inside it, so it has no content of its own to insist on) and
+     `auto` hands the board its five rows at whatever `--key` currently is.
+
+     That order is the opposite of the passage screen's, where a viewport too
+     short for both hides the board and lets the words carry on (the
+     `max-height` rule above, scoped to `.typing` and therefore not this).
+     Here the board is the gun: a child who cannot see it is not being asked
+     to read faster, they are being asked to shoot with nothing. So the sky is
+     what shrinks, down to nothing if it has to. */
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: clamp(0.35rem, 1.5vh, 1rem);
+  padding: clamp(0.4rem, 1.5vh, 1rem) clamp(0.5rem, 2vw, 1rem);
+}
+
+/* Fifteen key units of sky, centred over fifteen key units of board, so a
+   lane and its cap are the same column of the screen and not merely the same
+   number. `.keyboard` centres itself the same way at the same width — that
+   shared width is the alignment, and it is why the sky is not simply the full
+   width of the field.
+
+   The bottom border is the line the letters land on. STM05 replaces it with
+   the eight shield segments, one per finger; until then it is what makes the
+   fall legible — a stone at the bottom of the sky is a stone that got
+   through. */
+.storm__sky {
+  position: relative;
+  width: calc(15 * var(--key));
+  margin-inline: auto;
+  border-bottom: 1px solid var(--hairline);
+
+  /* Nothing in here is an interface. A drag should not select a hailstorm,
+     and a tap should not land on a letter — the only thing that fires in this
+     game is a key (§8.8). */
+  pointer-events: none;
+  user-select: none;
+}
+
+.storm__letter {
+  position: absolute;
+
+  /* ── The lane ──────────────────────────────────────────────────────────
+     `--lane` is `keyX(code)`: the centre of the key's SLOT, in key units from
+     the left edge of the board. The cap is drawn INSIDE that slot, inset by
+     `--key-gap` on its width, so the middle of the plastic a child is looking
+     at sits half a gap to the left of the middle of the slot. Half a
+     `--key-gap` back is therefore the difference between a letter over its
+     key and a letter over the seam beside it (§8.2, decision 36).
+
+     Written as `var(--key-gap) / 2` and never as the 0.045 it currently works
+     out to: the offset is half of whatever the board insets its caps by, so
+     expressed this way a chunkier keyboard moves the lanes with it, and there
+     is no second number to keep in step. */
+  left: calc(var(--lane) * var(--key) - var(--key-gap) / 2);
+
+  /* ── The fall ──────────────────────────────────────────────────────────
+     `--drop` is `progressAt`: 0 the instant a letter spawns, 1 the instant it
+     reaches the shield. The percentage resolves against the sky, so the whole
+     fall is one multiplication and the field never learns how tall it is.
+
+     This is the seam STM04 takes over — a `requestAnimationFrame` loop
+     writing `--drop`, or `transform`, per frame. `transform` is left
+     deliberately unused: the centring below is the `translate` property, so a
+     loop can write a transform without wiping the lane out from under the
+     letter it is moving. */
+  top: calc(var(--drop) * (100% - var(--stone)));
+  translate: -50% 0;
+
+  display: grid;
+  place-items: center;
+  width: var(--stone);
+  height: var(--stone);
+
+  border: 1px solid color-mix(in oklab, var(--accent) 42%, transparent);
+  border-radius: calc(var(--key) * 0.3);
+  background: color-mix(in oklab, var(--ink-800) 88%, transparent);
+  box-shadow: 0 0 calc(var(--key) * 0.45)
+    color-mix(in oklab, var(--accent) 18%, transparent);
+
+  font-family: var(--font-mono);
+  font-size: calc(var(--key) * 0.6);
+  line-height: 1;
+  color: var(--chalk);
 }


### PR DESCRIPTION
## STM03 · The field

A letter now falls down the column of the key that types it. `f` falls onto `f`; `y` falls between `g` and `h`, because that is where `y` is.

**Lanes come off the keyboard's geometry.** Nothing in the field computes a lane. `StormLetter.lane` is `keyX(code)`, resolved once when the wave is built, written into `--lane` and multiplied by `--key` in CSS. The field and the drawn board read one `KEY_ROWS` table, so a key that moves on the board moves the lane above it — there is no second copy of the layout to drift.

**Letters fall in key units, off one `--key`.** That unit — with `--key-gap` — moved from `.keyboard` to `:root`, because a custom property inherits downward only and the sky *above* the board could not otherwise read the unit the board scales by (decision 37). The alternative, a second clamp restating the same numbers in the storm's block, is exactly the drift this rules out. The move is inert: verified with the lesson and free-play keyboards pixel-identical against a `develop` worktree build — 576px wide, 34.94px caps at the 2.4rem ceiling, before and after.

**The 0.045 key-unit offset is compensated for, not inherited** (decision 36). `keyX` centres a key's *slot*; the cap is drawn inset inside it, so the plastic a child aims at sits half a gap to the left. Two reasons to compensate: "`f` falls onto `f`" is a claim about the thing on screen called `f`, and the cap is the only `f` there is; and the offset is not a constant — it is half of whatever the board insets its caps by. So it is written `var(--key-gap) / 2` rather than as a literal 0.045, which would be a second number to keep in step.

**The board underneath is the gun.** `Keyboard` is mounted as-is and lit by the same `useKeyEcho` the lessons put under the passage — `mode="keys"` keeps the echo's expectation while withholding the next-key hint, because a board that pointed at the answer would play the game for the child.

### Measurements

- Stone and cap centres agree to within **1/64 px** across `f`, `j`, `y`, `q`, `p`, space, Bksp and right Shift, at **four distinct `--key` values including both clamp ends**.
- `y` lands at **619.06**, between `g` at **590.27** and `h` at **628.66**.
- Field is **90/710** at 1280x800 and **90/300** at 844x390.
- **No horizontal or vertical overflow** at any viewport down to 240x600.

### Review pass

The alignment test was **vacuous with respect to the compensation it was named for**: `stoneCentre` and `capCentre` were both hand-written models of `game.css`, so the `GAP/2` term appeared on both sides of the assertion and cancelled. A real **1.727px** misalignment — insetting the caps by twice what the field compensates for — left all 12 tests green.

Both sides now derive their inputs from `game.css` itself, via a `declaration(selector, prop)` helper that reads the one value the stylesheet declares for a property on a selector and **throws if it is declared twice**, since a second declaration of the cap's width is the drift the file exists to catch. The test now fails under the sabotage, by exactly the 0.045 key units it is off by.

`docs/typing.md` §8.2 corrected — it claimed "the same subtraction makes `stoneCentre` and `capCentre` equal", which was the one thing the old test could not show. The colour guard was widened to `hsl/hwb/lab/lch/oklab/oklch/color()` plus named colours.

### Out of scope

Motion (STM04), the shield (STM05), firing and the HUD (STM06), and the twenty real waves (STM10). Until then `StormRun` holds one still frame of a seeded stand-in wave, and nothing links to the route.

Closes #149
