### PR TITLE
STM05 · The shield, in eight finger zones (#151)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1121,6 +1121,35 @@ the run ends, the screen says which finger let it through, and offers a drill
 of exactly the keys that zone covers — which is the trouble-facts machinery
 already in `records.ts`, pointed at a different question.
 
+**A zone is its finger's home-row span** (`FINGER_ZONES` in
+`engine/keyboard.ts`, decision 41). That is a choice between four rows rather
+than a derivation: every row divides into eight runs — no row hands a key back
+to a finger it has already passed — but the rows are staggered, so they
+disagree about where the divisions fall. The left pinky gives way to the left
+ring at 2 on the number row, at 2.5 on the top row, at 2.75 on the home row and
+at 3.25 on the bottom row, and a vertical seam can honour one of the four. The
+home row wins because it is the row the hands are ON: `a s d f` and `j k l ;`
+is where the fingers rest and what every reach returns to, so "your right ring
+finger" and "the column over `l`" are the same sentence to the child being told
+it. The eight spans tile the board exactly — 2.75 + 1 + 1 + 2 + 2 + 1 + 1 +
+4.25 = 15 — which is what makes a hole a gap in a wall rather than a dark patch
+beside one. Every other row is then off by the stagger and no further: a lane
+is never more than a quarter unit outside its own segment, which
+`keyboard.test.ts` pins at exactly that. `6` is the case to know — right index,
+but a quarter unit left of where the right index's segment starts, because that
+is where `6` really is.
+
+The segments take the same half-`--key-gap` step back the lanes do (§8.2), so a
+seam falls in the gutter between two keycaps instead of down the middle of one
+— and because both halves step back by the same amount, a letter is over its
+own segment exactly when its key is in its own zone.
+
+How much is left is the **height** of the block: a skyline of eight, which is a
+quantity that can be read across a field without counting, and which goes to
+nothing at zero and leaves an empty socket. A hole keeps that socket, in
+`--flare` — a child still has to be able to see WHICH finger the gap belongs
+to, and a wrong is what `--flare` means everywhere else on this site.
+
 That feedback is the best thing in this epic. A child watching their own right
 ring finger crumble learns something about their hands that no accuracy
 percentage will ever tell them.
@@ -1273,6 +1302,24 @@ falling. What it can and must do:
 - **No strobe, ever, in any mode.** Damage is one 150 ms tint, not a flash
   sequence. A hail of red flashes at 60fps is a photosensitivity risk and this
   site's youngest player is five.
+
+  The duration is the easy half. What would strobe is an animation _restarted_
+  every frame, which reads identically in the stylesheet — so the tint is a
+  child element mounted from a counter that only goes up: landings on that zone
+  for the damage tint, repairs into it for the mend (decision 42). A fresh
+  element runs its animation once; an unchanged counter is the same element and
+  does not restart it; and several letters landing on one zone inside a single
+  `tick` move the counter by several and are still one element, so they are
+  still one tint. Neither counter is stored — `resolved` says what landed and
+  where, and hit points say what is left, so repairs fall out of the two
+  (`zoneTally`).
+
+  Measured rather than asserted: `e2e/smoke.mjs` counts `animationstart` over a
+  whole run and holds it to one per letter that lands. Under a wave landing a
+  letter every 15 ms, 54 damage events drew 29 visible episodes — consecutive
+  hits on one zone re-peak a tint that is already lit rather than blinking it
+  off and on, which is the safe direction for that failure to go in.
+
 - **Fall speeds are capped** at the top of the ladder. "Whiteout" at lesson 89
   should be hard because there are many letters, not because one is a blur.
 
@@ -1339,48 +1386,50 @@ first when either optional field is added.
 
 ## 11 · Decisions, recorded
 
-|     | Decision                                                | Because                                                                                                    |
-| --- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| 1   | The keyboard layout is engine, not view                 | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture      |
-| 2   | `code`, not `key`                                       | Shift+`4` produces `$` and there is no `$` key to light up                                                 |
-| 3   | Keys release on a timer, not `keyup`                    | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                            |
-| 4   | The board is `aria-hidden`                              | Sixty announcing spans is not accessibility; the passage already carries the state                         |
-| 5   | The visual keyboard is never tappable                   | A tappable board is a hunt-and-peck trainer, which is the thing this is against                            |
-| 6   | Lesson text is generated, not written                   | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                        |
-| 7   | The lexicon must not be reachable from `decks/index.ts` | The same import took the shared chunk 46 KB → 222 KB once already                                          |
-| 8   | Ghost identity is the lesson, not the passage           | Every run generates different words; keying on them buckets every run alone                                |
-| 9   | Three pass bars, not one score                          | A single number says you failed; three say what to fix                                                     |
-| 10  | Accuracy is flat and high; speed scales                 | An accuracy bar you can hammer past teaches hammering                                                      |
-| 11  | The speed bar dips when a key arrives                   | You have just got slower and you should have                                                               |
-| 12  | The new-key gate                                        | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                         |
-| 13  | Per-key stats come from cards, not keystrokes           | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven        |
-| 14  | Progress is derived, never stored                       | No migration, self-heals when criteria change, cannot disagree with the record book                        |
-| 15  | Unlock is `max(cleared) + 1`                            | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                            |
-| 16  | Any checkpoint, any time                                | It is a placement test, a skip-ahead and an ordering rule in one sentence                                  |
-| 17  | A lesson has no ghost and no time penalty               | A penalty double-counts accuracy and makes the wpm number a lie                                            |
-| 18  | Hailstorm is a route in the typing island               | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard   |
-| 19  | Letters fall down their key's column                    | The lane is a spatial hint — the game teaches the layout the whole time it is played                       |
-| 20  | Only the lowest letter can be shot                      | Otherwise spraying the keyboard is a winning strategy                                                      |
-| 21  | The shield is eight finger zones                        | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise          |
-| 22  | Score can fall, XP cannot                               | XP is cumulative across years and four games; a bad five minutes must not lower a level                    |
-| 23  | A Hailstorm run is a `Session`                          | Record book, XP, badges and the drill builder all work with no new code                                    |
-| 24  | Hailstorm never gates the ladder                        | A tablet has no keys, and a reward that blocks you is not a reward                                         |
-| 25  | DOM, not canvas                                         | Eleven custom properties change the whole app's biome; a canvas is a hole in that                          |
-| 26  | US ANSI only, and say so                                | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                              |
-| 27  | A lesson's keyboard seeds; it does not overrule         | All hundred name a mode, so an override beats the player's own setting on every rung                       |
-| 28  | `eyes-up` reads the board the run was typed under       | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory         |
-| 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete    |
-| 30  | A falling letter is on the field on `[spawn, land)`     | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two        |
-| 31  | A letter carries its key, finger and lane               | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift         |
-| 32  | The target is the greatest fall progress, not `landMs`  | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen             |
-| 33  | An exact tie goes to the earlier spawn                  | The index is the letter's identity, so a replay resolves the same dead heat the same way                   |
-| 34  | A repair never lifts a zone above `spec.shield`         | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                   |
-| 35  | A tick resolves every landing inside it                 | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's              |
-| 36  | The field's lanes step back half a `--key-gap`          | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference |
-| 37  | `--key` is declared once, at the root                   | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key     |
-| 38  | A frame is clamped to 100ms of wave time                | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield     |
-| 39  | The loop writes `--drop`; the stylesheet owns the fall  | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either  |
-| 40  | The field re-renders on the picture, not on the frame   | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal       |
+|     | Decision                                                | Because                                                                                                     |
+| --- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| 1   | The keyboard layout is engine, not view                 | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture       |
+| 2   | `code`, not `key`                                       | Shift+`4` produces `$` and there is no `$` key to light up                                                  |
+| 3   | Keys release on a timer, not `keyup`                    | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                             |
+| 4   | The board is `aria-hidden`                              | Sixty announcing spans is not accessibility; the passage already carries the state                          |
+| 5   | The visual keyboard is never tappable                   | A tappable board is a hunt-and-peck trainer, which is the thing this is against                             |
+| 6   | Lesson text is generated, not written                   | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                         |
+| 7   | The lexicon must not be reachable from `decks/index.ts` | The same import took the shared chunk 46 KB → 222 KB once already                                           |
+| 8   | Ghost identity is the lesson, not the passage           | Every run generates different words; keying on them buckets every run alone                                 |
+| 9   | Three pass bars, not one score                          | A single number says you failed; three say what to fix                                                      |
+| 10  | Accuracy is flat and high; speed scales                 | An accuracy bar you can hammer past teaches hammering                                                       |
+| 11  | The speed bar dips when a key arrives                   | You have just got slower and you should have                                                                |
+| 12  | The new-key gate                                        | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                          |
+| 13  | Per-key stats come from cards, not keystrokes           | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven         |
+| 14  | Progress is derived, never stored                       | No migration, self-heals when criteria change, cannot disagree with the record book                         |
+| 15  | Unlock is `max(cleared) + 1`                            | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                             |
+| 16  | Any checkpoint, any time                                | It is a placement test, a skip-ahead and an ordering rule in one sentence                                   |
+| 17  | A lesson has no ghost and no time penalty               | A penalty double-counts accuracy and makes the wpm number a lie                                             |
+| 18  | Hailstorm is a route in the typing island               | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard    |
+| 19  | Letters fall down their key's column                    | The lane is a spatial hint — the game teaches the layout the whole time it is played                        |
+| 20  | Only the lowest letter can be shot                      | Otherwise spraying the keyboard is a winning strategy                                                       |
+| 21  | The shield is eight finger zones                        | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise           |
+| 22  | Score can fall, XP cannot                               | XP is cumulative across years and four games; a bad five minutes must not lower a level                     |
+| 23  | A Hailstorm run is a `Session`                          | Record book, XP, badges and the drill builder all work with no new code                                     |
+| 24  | Hailstorm never gates the ladder                        | A tablet has no keys, and a reward that blocks you is not a reward                                          |
+| 25  | DOM, not canvas                                         | Eleven custom properties change the whole app's biome; a canvas is a hole in that                           |
+| 26  | US ANSI only, and say so                                | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                               |
+| 27  | A lesson's keyboard seeds; it does not overrule         | All hundred name a mode, so an override beats the player's own setting on every rung                        |
+| 28  | `eyes-up` reads the board the run was typed under       | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory          |
+| 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete     |
+| 30  | A falling letter is on the field on `[spawn, land)`     | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two         |
+| 31  | A letter carries its key, finger and lane               | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift          |
+| 32  | The target is the greatest fall progress, not `landMs`  | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen              |
+| 33  | An exact tie goes to the earlier spawn                  | The index is the letter's identity, so a replay resolves the same dead heat the same way                    |
+| 34  | A repair never lifts a zone above `spec.shield`         | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                    |
+| 35  | A tick resolves every landing inside it                 | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's               |
+| 36  | The field's lanes step back half a `--key-gap`          | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference  |
+| 37  | `--key` is declared once, at the root                   | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key      |
+| 38  | A frame is clamped to 100ms of wave time                | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield      |
+| 39  | The loop writes `--drop`; the stylesheet owns the fall  | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either   |
+| 40  | The field re-renders on the picture, not on the frame   | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal        |
+| 41  | A shield segment is its finger's home-row span          | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on |
+| 42  | A tint is an element keyed by a counter, not a class    | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe   |
 
 ---
 

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -466,6 +466,56 @@ try {
     `${fall.pending} pending`,
   );
 
+  /*
+   * The shield, measured against the board it is defending.
+   *
+   * "Segments align with the finger zones of the keyboard beneath them" is an
+   * acceptance criterion with a number behind it, and this is the only place
+   * that number exists. `StormField.test.tsx` runs game.css's arithmetic in
+   * key units, which is the right altitude for the claim but resolves no
+   * `--key` and lays out no boxes; only a browser turns both into pixels at a
+   * viewport and can be asked whether one is actually over the other.
+   *
+   * Each segment is compared with the HOME-ROW keycaps of its own finger,
+   * because the home row is where the zones are cut (docs/typing.md §8.5,
+   * decision 41) — `a` and Caps under the left pinky's segment, `f` and `g`
+   * under the left index's. Half a pixel of tolerance, which is a rounding
+   * error and not room for a segment to have drifted a key.
+   */
+  const shield = await page.evaluate(() => {
+    const home = document.querySelector(".keyboard__row:nth-child(3)");
+    return [...document.querySelectorAll(".storm__zone")].map((zone) => {
+      const box = zone.getBoundingClientRect();
+      const caps = [
+        ...home.querySelectorAll(
+          `.keyboard__key[data-finger="${zone.dataset.finger}"]`,
+        ),
+      ].map((cap) => cap.getBoundingClientRect());
+      return {
+        finger: zone.dataset.finger,
+        left: box.left,
+        right: box.right,
+        capLeft: Math.min(...caps.map((cap) => cap.left)),
+        capRight: Math.max(...caps.map((cap) => cap.right)),
+        keys: caps.length,
+      };
+    });
+  });
+  check(
+    "each segment covers the home keys of its own finger, edge to edge",
+    shield.length === 8 &&
+      shield.every(
+        (zone, i) =>
+          zone.keys > 0 &&
+          zone.left <= zone.capLeft + 0.5 &&
+          zone.right >= zone.capRight - 0.5 &&
+          (i === 0 || Math.abs(zone.left - shield[i - 1].right) < 0.5),
+      ),
+    shield
+      .map((z) => `${z.finger} ${z.left.toFixed(1)}→${z.right.toFixed(1)}`)
+      .join(" "),
+  );
+
   // Leaving is what quitting is on this screen (there is no quit control until
   // the HUD lands), and it has to take the loop with it.
   await page.evaluate((id) => (location.hash = `#/p/${id}`), player);
@@ -474,6 +524,36 @@ try {
     "leaving mid-run cancels it",
     (await page.evaluate(() => window.__pendingFrames())) === 0,
   );
+
+  /*
+   * Damage is ONE tint, and the count is the proof.
+   *
+   * "No strobe, in any mode" (§8.10) is a safety constraint — a hail of red
+   * flashes at 60fps is a photosensitivity risk and the youngest player here
+   * is five — so it is measured rather than asserted about the stylesheet. The
+   * animation being 150ms says nothing on its own: what would strobe is an
+   * animation RESTARTED every frame, which reads identically in the CSS and
+   * would fire `animationstart` sixty times a second. So the events are
+   * counted over a whole run, and against the only number they may equal —
+   * one per letter that lands, twelve for this wave, since nothing can be shot
+   * yet and each is drawn by a counter that only moves when a letter reaches
+   * that zone.
+   */
+  await page.evaluate(() => {
+    window.__tints = [];
+    document.addEventListener(
+      "animationstart",
+      (event) => {
+        if (!event.animationName.startsWith("storm-")) return;
+        window.__tints.push({
+          name: event.animationName,
+          finger: event.target.closest(".storm__zone")?.dataset.finger,
+          at: Math.round(window.performance.now()),
+        });
+      },
+      true,
+    );
+  });
 
   // And a run that reaches its end stops itself. The stand-in wave is twelve
   // letters over 7.3s, none of which anything can shoot yet, so this waits out
@@ -493,6 +573,47 @@ try {
     "a finished wave stops its own loop, on screen and still mounted",
     ended.pending === 0 && ended.stones === 0 && ended.onScreen === 1,
     JSON.stringify(ended),
+  );
+
+  // The last letter lands on the frame the loop stops, so its tint is still a
+  // style change the browser has not run yet when `__pendingFrames` hits zero.
+  // A tint is 150ms; this waits out two of them before counting.
+  await page.waitForTimeout(300);
+  const damage = await page.evaluate(() => ({
+    tints: window.__tints,
+    zones: [...document.querySelectorAll(".storm__zone")].map((zone) => ({
+      finger: zone.dataset.finger,
+      hp: Number(window.getComputedStyle(zone).getPropertyValue("--hp")),
+      hole: zone.hasAttribute("data-hole"),
+    })),
+  }));
+  // The closest two tints on any one segment. A flash sequence is two of them
+  // inside the 150ms one is on screen for; this wave lands a letter every
+  // 300ms, so the honest answer here is about 300 and never below 150.
+  const closest = Math.min(
+    ...damage.tints.map((tint, i, all) => {
+      const previous = all
+        .slice(0, i)
+        .findLast((t) => t.finger === tint.finger);
+      return previous ? tint.at - previous.at : Infinity;
+    }),
+  );
+  check(
+    "damage tints once per landing, and never twice inside one tint",
+    damage.tints.length === 12 &&
+      damage.tints.every((tint) => tint.name === "storm-hit" && tint.finger) &&
+      closest >= 150,
+    `${damage.tints.length} tints, closest pair on one zone ${closest}ms apart`,
+  );
+  // Three zones took three letters each in this wave, and a zone at zero is a
+  // hole — drawn as one, off the same number the reducer holds.
+  const holes = damage.zones.filter((zone) => zone.hole);
+  check(
+    "a zone the storm emptied is drawn as a hole",
+    holes.length === 3 &&
+      holes.every((zone) => zone.hp === 0) &&
+      holes.map((zone) => zone.finger).join() === "l-index,r-index,r-middle",
+    damage.zones.map((z) => `${z.finger}:${z.hp.toFixed(2)}`).join(" "),
   );
 
   log(

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -541,6 +541,14 @@ try {
    */
   await page.evaluate(() => {
     window.__tints = [];
+    // What this counts, and what it does not. One listener on `document` sees
+    // a tint's `animationstart` only if the element is still in the document
+    // when the event dispatches, so a tint mounted and detached inside the
+    // same frame is never counted — 60 real mounts under a wave landing a
+    // letter every 15ms came back as 1. That direction is the safe one for the
+    // check below, which breaks as loudly on too few as on too many, but it
+    // makes this a floor on the tints that were drawn rather than a census of
+    // them. Do not reach for it as a general-purpose animation counter.
     document.addEventListener(
       "animationstart",
       (event) => {

--- a/src/engine/keyboard.test.ts
+++ b/src/engine/keyboard.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { KEYS, KEY_ROWS, keyX, reachable, strokeFor } from "./keyboard";
+import {
+  FINGER_ZONES,
+  KEYS,
+  KEY_ROWS,
+  keyX,
+  reachable,
+  strokeFor,
+} from "./keyboard";
 import type { Finger, KeyDef } from "./keyboard";
 import { TYPING_LEVELS } from "./decks/typing";
 
@@ -312,5 +319,97 @@ describe("the board", () => {
     for (const key of KEYS) {
       expect(key.finger, key.code).toBe(expected.get(key.code));
     }
+  });
+});
+
+describe("FINGER_ZONES", () => {
+  /** The eight, left to right — which is the order the shield is drawn in. */
+  const ordered = Object.entries(FINGER_ZONES).sort(
+    ([, a], [, b]) => a.x - b.x,
+  );
+
+  it("gives each of the eight the span its home keys occupy", () => {
+    // Written out rather than derived, for the reason `FINGERS` above is: this
+    // is the expected value, and a table edit that moved a seam would have to
+    // disagree with it here rather than quietly move the shield.
+    expect(FINGER_ZONES).toEqual({
+      "l-pinky": { x: 0, width: 2.75 }, // Caps and `a`
+      "l-ring": { x: 2.75, width: 1 }, // `s`
+      "l-middle": { x: 3.75, width: 1 }, // `d`
+      "l-index": { x: 4.75, width: 2 }, // `f` and `g`
+      "r-index": { x: 6.75, width: 2 }, // `h` and `j`
+      "r-middle": { x: 8.75, width: 1 }, // `k`
+      "r-ring": { x: 9.75, width: 1 }, // `l`
+      "r-pinky": { x: 10.75, width: 4.25 }, // `;`, `'` and Enter
+    });
+  });
+
+  it("tiles the whole board, with no gap and no overlap", () => {
+    // What makes eight segments a shield rather than eight bars: every column
+    // of the field is over exactly one finger, so a letter that gets through
+    // has exactly one zone to have got through, and a hole is a real gap in a
+    // wall rather than a dark patch beside one.
+    let edge = 0;
+    for (const [finger, zone] of ordered) {
+      expect(zone.x, finger).toBe(edge);
+      edge += zone.width;
+    }
+    expect(edge, "as wide as the board").toBe(15);
+    expect(ordered).toHaveLength(8);
+  });
+
+  it("has no zone for the thumbs", () => {
+    // Nothing falls on the space bar (§8.3), so the shield has no segment for
+    // it — and the home row this is grouped from carries no thumb key, which
+    // is what lets the record be exactly the eight without excluding one.
+    expect(Object.keys(FINGER_ZONES)).not.toContain("thumb");
+    expect(KEYS.filter((k) => k.row === 2 && k.finger === "thumb")).toEqual([]);
+  });
+
+  it("holds every one of a finger's home keys inside its own zone", () => {
+    for (const key of KEYS) {
+      if (key.row !== 2) continue;
+      const zone = FINGER_ZONES[key.finger as keyof typeof FINGER_ZONES];
+      expect(zone.x, key.code).toBeLessThanOrEqual(key.x);
+      expect(zone.x + zone.width, key.code).toBeGreaterThanOrEqual(
+        key.x + (key.width ?? 1),
+      );
+    }
+  });
+
+  it("keeps every other row within a quarter unit of it", () => {
+    // The cost of cutting the seams on one row. The rows are staggered, so a
+    // finger's keys are a slanted column and no vertical segment covers all of
+    // it: a bottom-row key lands exactly on its zone's right-hand seam, and the
+    // leftmost key of a finger's number-row column lands a quarter unit outside
+    // it. This pins both — which keys, and how far — because "a quarter of a
+    // key" is the claim the whole choice of row rests on, and a change that
+    // made it worse has to come here and say so.
+    const strays = KEYS.filter(
+      (key) => key.cap[0].length === 1 && key.finger !== "thumb",
+    ).map((key) => {
+      const zone = FINGER_ZONES[key.finger as keyof typeof FINGER_ZONES];
+      const lane = keyX(key.code)!;
+      return {
+        code: key.code,
+        out: Math.max(zone.x - lane, lane - (zone.x + zone.width), 0),
+      };
+    });
+
+    const outside = strays.filter((stray) => stray.out > 0);
+    // Seven keys, every one of them on the number row, every one of them a
+    // quarter unit LEFT of its own segment — so each is drawn over the segment
+    // of the finger next to it, on the inboard side. `6` is the one to know:
+    // right index, over the left index's block by a quarter of a key.
+    expect(outside.map((stray) => stray.code)).toEqual([
+      "Digit2",
+      "Digit3",
+      "Digit4",
+      "Digit6",
+      "Digit8",
+      "Digit9",
+      "Digit0",
+    ]);
+    expect(Math.max(...outside.map((stray) => stray.out))).toBe(0.25);
   });
 });

--- a/src/engine/keyboard.test.ts
+++ b/src/engine/keyboard.test.ts
@@ -399,8 +399,12 @@ describe("FINGER_ZONES", () => {
     const outside = strays.filter((stray) => stray.out > 0);
     // Seven keys, every one of them on the number row, every one of them a
     // quarter unit LEFT of its own segment — so each is drawn over the segment
-    // of the finger next to it, on the inboard side. `6` is the one to know:
-    // right index, over the left index's block by a quarter of a key.
+    // of the finger to its LEFT, which is a different neighbour on each hand:
+    // the outboard one on the left (2 over the pinky, 3 over the ring, 4 over
+    // the middle) and the inboard one on the right (8 over the index, 9 over
+    // the middle, 0 over the ring). `6` is the one to know: right index, over
+    // the LEFT index's block by a quarter of a key — the only one of the seven
+    // that crosses hands.
     expect(outside.map((stray) => stray.code)).toEqual([
       "Digit2",
       "Digit3",

--- a/src/engine/keyboard.ts
+++ b/src/engine/keyboard.ts
@@ -221,6 +221,78 @@ export function keyX(code: string): number | null {
   return key ? key.x + (key.width ?? 1) / 2 : null;
 }
 
+/**
+ * The board's home row: the eight keys the hands rest on, plus the keys
+ * outboard of them that the two pinkies also cover.
+ *
+ * A row index rather than `KeyDef.home`, which marks only the eight resting
+ * keys and the space bar — `Caps`, `'` and `Enter` are on this row and belong
+ * to a pinky, and a zone drawn without them would stop short of the edge of
+ * the board it is supposed to span.
+ */
+const HOME_ROW: KeyDef["row"] = 2;
+
+/** A stretch of the board, in the key units everything else here is in. */
+export type FingerZone = {
+  /** Left edge in key units, from the left edge of the board. */
+  x: number;
+  /** Width in key units. The board is 15 of them wide. */
+  width: number;
+};
+
+/**
+ * How much of the board each finger is responsible for, in key units.
+ *
+ * The second thing Hailstorm needs from this table, after the lane: its shield
+ * is eight segments across the bottom of the field, one per finger, and each
+ * one has to sit over the keys whose misses break it (docs/typing.md §8.5).
+ * Here rather than in the component that draws it for the same reason `keyX`
+ * is here — it is a fact about the plastic, and a second opinion about which
+ * keys the right ring finger covers would put the hole over the wrong hand.
+ *
+ * ── The home row is the zone ────────────────────────────────────────────────
+ * The eight spans are the home row's keys grouped by finger, and that is a
+ * choice between four rows rather than a derivation. Every row divides into
+ * eight runs — no row hands a key back to a finger it has already passed — but
+ * the four rows do not agree about WHERE the divisions fall, because the rows
+ * are staggered. The left pinky gives way to the left ring at 2 on the number
+ * row, at 2.5 on the top row, at 2.75 on the home row and at 3.25 on the
+ * bottom row. A vertical seam can honour one of those four, so the question
+ * is which row's seams the shield is drawn on.
+ *
+ * The home row, because it is the row the hands are literally on: `a s d f`
+ * and `j k l ;` is where a touch typist's fingers rest and what every reach
+ * returns to, so "your right ring finger" and "the column over `l`" are the
+ * same statement to the child being told it. The other rows are then off by
+ * the stagger and no more — a key never sits further than a quarter unit
+ * outside its own finger's zone, which is `keyboard.test.ts`'s to pin.
+ *
+ * The thumbs have no zone. Nothing falls on the space bar (§8.3), so the eight
+ * here are exactly the eight the shield is divided into, and the home row
+ * carries no thumb key for the cast below to have to exclude.
+ */
+export const FINGER_ZONES: Readonly<
+  Record<Exclude<Finger, "thumb">, FingerZone>
+> = (() => {
+  const zones: Partial<Record<Finger, FingerZone>> = {};
+
+  for (const key of KEYS) {
+    if (key.row !== HOME_ROW) continue;
+    const right = key.x + (key.width ?? 1);
+    const seen = zones[key.finger];
+    const left = seen ? Math.min(seen.x, key.x) : key.x;
+    zones[key.finger] = {
+      x: left,
+      width: (seen ? Math.max(seen.x + seen.width, right) : right) - left,
+    };
+  }
+
+  // Eight, because the home row carries no thumb key and every other finger
+  // has at least one on it. Both halves are the table's to keep and the
+  // board tests' to check, so this asserts rather than proves.
+  return zones as Record<Exclude<Finger, "thumb">, FingerZone>;
+})();
+
 export type Stroke = {
   /** The letter key. */
   code: string;

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -4,12 +4,18 @@ import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { KEYS, keyX, strokeFor } from "@/engine/keyboard";
-import { buildWave, fire, startStorm, tick } from "@/engine/typing/storm";
+import { FINGER_ZONES, KEYS, keyX, strokeFor } from "@/engine/keyboard";
+import {
+  SHIELD_FINGERS,
+  buildWave,
+  fire,
+  startStorm,
+  tick,
+} from "@/engine/typing/storm";
 
 import { StormField, aimedAt } from "./StormField";
 
-import type { KeyDef } from "@/engine/keyboard";
+import type { FingerZone, KeyDef } from "@/engine/keyboard";
 import type { StormState, WaveSpec } from "@/engine/typing/storm";
 
 /**
@@ -206,17 +212,40 @@ const stoneCentre = (lane: number) =>
  * compensates for. Reading the declarations means a change to either half
  * moves one side of the comparison and not the other.
  */
-const capCentre = (key: KeyDef) => {
+const capSpan = (key: KeyDef): [number, number] => {
   const vars = {
     "--key": 1,
     "--key-gap": GAP,
     "--x": key.x,
     "--w": key.width ?? 1,
   };
-  return (
-    unitsOf(declaration(".keyboard__key", "left"), vars) +
-    unitsOf(declaration(".keyboard__key", "width"), vars) / 2
-  );
+  const left = unitsOf(declaration(".keyboard__key", "left"), vars);
+  return [left, left + unitsOf(declaration(".keyboard__key", "width"), vars)];
+};
+
+const capCentre = (key: KeyDef) => {
+  const [left, right] = capSpan(key);
+  return (left + right) / 2;
+};
+
+/**
+ * Where a shield segment starts and ends, in the same units and out of the
+ * same sheet — `FINGER_ZONES` through the field's own `left` and `width`.
+ *
+ * A span rather than a centre, because a zone is a group of keys and the claim
+ * being checked is that it covers them: `l-index` is `f` and `g` together, and
+ * a segment centred on the pair while too narrow for it would put half of `g`
+ * over the right hand's shield.
+ */
+const zoneSpan = (zone: FingerZone): [number, number] => {
+  const vars = {
+    "--key": 1,
+    "--key-gap": GAP,
+    "--zone-x": zone.x,
+    "--zone-w": zone.width,
+  };
+  const left = unitsOf(declaration(".storm__zone", "left"), vars);
+  return [left, left + unitsOf(declaration(".storm__zone", "width"), vars)];
 };
 
 const cap = (code: string) => KEYS.find((k) => k.code === code)!;
@@ -318,8 +347,8 @@ describe("StormField", () => {
   });
 
   it("is drawn out of ice tokens, with no colour of its own", () => {
-    // Every colour is a world token, and none of the five is borrowed: a
-    // hailstone in `--lime` would be saying something was right about it.
+    // Every colour is a world token or a finger hue: a hailstone with a
+    // literal in it would be a stone that stayed the same in the next world.
     expect(storm).not.toMatch(/#[0-9a-f]{3}/i);
     expect(storm).not.toMatch(
       /\b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\(/,
@@ -330,7 +359,7 @@ describe("StormField", () => {
     // plumbing and there is nothing left to read. `color: rebeccapurple`
     // leaves a word, and so would any notation the list above forgets.
     const PLUMBING =
-      /var\(--[\w-]+\)|color-mix|calc|in oklab|solid|dashed|dotted|none|inset|transparent|currentcolor|[\d.]+(?:px|%|em|rem|ms|s)?|[-*,()/\s]/gi;
+      /var\(--[\w-]+\)|color-mix|calc|in oklab|solid|dashed|dotted|none|inherit|inset|transparent|currentcolor|[\d.]+(?:px|%|em|rem|ms|s)?|[-*,()/\s]/gi;
     const literals = [
       ...storm.matchAll(
         /(?:^|[;{])\s*([\w-]*(?:color|background|border|shadow|fill|stroke)[\w-]*)\s*:\s*([^;]+)/g,
@@ -339,8 +368,118 @@ describe("StormField", () => {
     expect(
       literals.map(([, prop, value]) => `${prop}: ${value.trim()}`),
     ).toEqual([]);
-    for (const name of ["--lime", "--flare", "--sky", "--gold", "--grape"])
+  });
+
+  it("borrows exactly the two telemetry colours it has something to say with", () => {
+    // The field itself borrows none of the five — a hailstone in `--lime`
+    // would be saying something was right about it. The shield borrows two,
+    // and only where they already mean what they mean everywhere else on this
+    // site: `--flare` is a wrong, and damage and a hole are the two wrongs
+    // this game has; `--lime` is a right, and a repair is bought with a run of
+    // them (§8.5). The other three would each be a lie about what happened —
+    // nothing on this screen is a ghost, a record or a badge.
+    const rules = [...storm.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(
+      ([, selector, body]) => ({ selector: selector.trim(), body }),
+    );
+    const drawnWith = (token: string) =>
+      rules
+        .filter((rule) => rule.body.includes(`var(${token})`))
+        .map((rule) => rule.selector)
+        .sort();
+
+    expect(drawnWith("--flare")).toEqual([
+      ".storm__hit",
+      ".storm__zone[data-hole]",
+    ]);
+    expect(drawnWith("--lime")).toEqual([".storm__mend"]);
+    for (const name of ["--sky", "--gold", "--grape"])
       expect(storm).not.toContain(`var(${name})`);
+  });
+
+  it("puts each shield segment over the keys of its own finger", () => {
+    // The other half of §8.2's claim, for the other end of the fall: a letter
+    // is over the cap that types it, and the segment it lands on is over the
+    // whole column of keys that finger is responsible for. Both are read out
+    // of the stylesheet in key units, so a change to the board's inset moves
+    // the caps and the segments together or fails here.
+    for (const finger of SHIELD_FINGERS) {
+      const [left, right] = zoneSpan(FINGER_ZONES[finger]);
+      const home = KEYS.filter((k) => k.row === 2 && k.finger === finger);
+
+      expect(home.length, finger).toBeGreaterThan(0);
+      for (const key of home) {
+        const [capLeft, capRight] = capSpan(key);
+        expect(left, `${finger} ⊃ ${key.code}`).toBeLessThanOrEqual(capLeft);
+        expect(right, `${finger} ⊃ ${key.code}`).toBeGreaterThanOrEqual(
+          capRight,
+        );
+      }
+    }
+  });
+
+  it("tiles the bottom of the sky in eight, centred on the plastic", () => {
+    const spans = SHIELD_FINGERS.map((finger) =>
+      zoneSpan(FINGER_ZONES[finger]),
+    );
+
+    // Edge to edge, in board order: a hole has to be a gap in a wall, and a
+    // wall with slack between its blocks would have holes in it already.
+    expect(spans).toHaveLength(8);
+    for (let i = 1; i < spans.length; i++)
+      expect(spans[i][0], SHIELD_FINGERS[i]).toBeCloseTo(spans[i - 1][1], 10);
+
+    // And the rail as a whole is centred on the DRAWN board rather than on the
+    // grid of slots behind it — which is what the half-gap step-back buys, and
+    // the reason a segment is allowed to overhang the sky by the same half gap
+    // at each end. Take the correction out and this fails by a whole gap on
+    // one side.
+    const board: [number, number] = [
+      capSpan(cap("CapsLock"))[0],
+      capSpan(cap("Enter"))[1],
+    ];
+    expect((spans[0][0] + spans[7][1]) / 2).toBeCloseTo(
+      (board[0] + board[1]) / 2,
+      10,
+    );
+  });
+
+  it("drops every letter within a quarter unit of its own segment", () => {
+    // What a vertical seam can and cannot do. The rows are staggered, so a
+    // finger's keys are a slanted column and no straight segment covers all of
+    // it: `6` is typed by the right index and its lane is a quarter unit left
+    // of where the right index's segment starts, because `6` really does sit
+    // that far left of `h` and `j` (§8.5, decision 41). The home row — the row
+    // the segments are drawn on, and the row the hands rest on — is always
+    // strictly inside. A quarter unit is the whole of the error, and this is
+    // where a change that made it worse would have to be argued for.
+    const strays = [];
+    for (const key of KEYS) {
+      const finger = key.finger;
+      // Only the keys a letter can fall from: no word legends, and no thumb —
+      // the space bar has no segment to fall on (§8.3).
+      if (key.cap[0].length !== 1 || finger === "thumb") continue;
+
+      const [left, right] = zoneSpan(FINGER_ZONES[finger]);
+      const centre = stoneCentre(keyX(key.code)!);
+      strays.push({ key, out: Math.max(left - centre, centre - right, 0) });
+    }
+
+    for (const { key, out } of strays) expect(out, key.code).toBeLessThan(0.26);
+    for (const { key, out } of strays)
+      if (key.row === 2) expect(out, key.code).toBe(0);
+    expect(Math.max(...strays.map((s) => s.out))).toBeCloseTo(0.25, 10);
+  });
+
+  it("keeps the shield inside a sky that has almost no height left", () => {
+    // The sky is the `minmax(0, 1fr)` track and it is what gives on a short
+    // viewport — about 78px at 1280×360 and about 21px at 1280×250. A shield
+    // in key units alone would be a fixed slab of a field with nothing left,
+    // so it is the smaller of a third of a key and a fifth of the sky. `cqh`
+    // is a length only because the sky is a size container, which the fall
+    // above already depends on.
+    expect(declaration(".storm__shield", "height")).toBe(
+      "min(calc(var(--key) * 0.34), 20cqh)",
+    );
   });
 
   it("draws what is in the air, and nothing that is spent", () => {

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -430,9 +430,13 @@ describe("StormField", () => {
 
     // And the rail as a whole is centred on the DRAWN board rather than on the
     // grid of slots behind it — which is what the half-gap step-back buys, and
-    // the reason a segment is allowed to overhang the sky by the same half gap
-    // at each end. Take the correction out and this fails by a whole gap on
-    // one side.
+    // the reason a segment is allowed to overhang the DRAWN BOARD by the same
+    // half gap at each end. The board, not the sky: the step-back moves the
+    // whole rail left, so measured against the sky it hangs half a gap past
+    // the left edge and stops half a gap short of the right. The caps are the
+    // frame that matters — they are what the assertion below compares against,
+    // and what a child aims at. Take the correction out and this fails by a
+    // whole gap on one side.
     const board: [number, number] = [
       capSpan(cap("CapsLock"))[0],
       capSpan(cap("Enter"))[1],

--- a/src/games/typing/storm/StormField.tsx
+++ b/src/games/typing/storm/StormField.tsx
@@ -2,6 +2,8 @@ import { isAirborne, progressAt, targetIndex } from "@/engine/typing/storm";
 
 import { LiveKeyboard } from "../keyboard/LiveKeyboard";
 
+import { StormShield } from "./StormShield";
+
 import type { StormState } from "@/engine/typing/storm";
 import type { CSSProperties } from "react";
 
@@ -50,9 +52,13 @@ import type { CSSProperties } from "react";
  * which letter each one is. A rendered index rather than the loop counting
  * children, for the same reason the React key is the index (§8.3): a filtered
  * list renumbers itself the instant something in the middle of it is shot.
+ * The shield is in the sky beside them and carries no such attribute, which is
+ * what makes the loop skip it: `Number(undefined)` is `NaN`, which indexes no
+ * letter. An EMPTY one would not — `Number("")` is `0` — and the shield would
+ * be written the first letter's fall, sixty times a second, as though it were
+ * the stone.
  *
- * The shield is STM05, and the eight segments belong on the line the letters
- * land on; firing and its reticle are STM06.
+ * Firing and its reticle are STM06.
  */
 
 /**
@@ -152,6 +158,12 @@ export function StormField({
             </span>
           );
         })}
+
+        {/* Last in the sky, so a letter reaching the bottom passes BEHIND the
+            wall it is breaking rather than in front of it — the only place the
+            two ever overlap, and the last frame of a fall is exactly where it
+            should read as a stone hitting something. */}
+        <StormShield state={state} />
       </div>
 
       <LiveKeyboard mode="keys" next={aimedAt(state)} />

--- a/src/games/typing/storm/StormShield.test.tsx
+++ b/src/games/typing/storm/StormShield.test.tsx
@@ -1,0 +1,197 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { FINGER_ZONES } from "@/engine/keyboard";
+import {
+  SHIELD_FINGERS,
+  buildWave,
+  fire,
+  startStorm,
+  tick,
+} from "@/engine/typing/storm";
+
+import { StormShield, zoneTally } from "./StormShield";
+
+import type { ShieldFinger, StormState, WaveSpec } from "@/engine/typing/storm";
+
+/**
+ * The shield, as a child reads it: eight segments, how much is left of each,
+ * and one event apiece when something happens to one (docs/typing.md §8.5).
+ *
+ * The geometry is NOT here. That a segment sits over its own finger's keys is
+ * a claim about this component's numbers *and* game.css's arithmetic, and
+ * `StormField.test.tsx` is where the stylesheet is read and run in key units —
+ * so the alignment lives beside the lane it shares its half-gap correction
+ * with, rather than in a second, weaker copy here.
+ */
+
+const only = (ch: string, over: Partial<WaveSpec> = {}): WaveSpec => ({
+  keys: [ch],
+  count: 4,
+  gap: [300, 300],
+  fall: [500, 500],
+  shield: 3,
+  repairAt: 0,
+  ...over,
+});
+
+const frameOf = (spec: WaveSpec, atMs: number): StormState =>
+  tick(startStorm(buildWave(spec, 7)), atMs);
+
+/** One rendered segment, as the attributes the stylesheet reads. */
+type Drawn = {
+  finger: string;
+  vars: Record<string, number>;
+  hole: boolean;
+  hit: number;
+  mend: number;
+};
+
+const segments = (state: StormState): Drawn[] =>
+  renderToStaticMarkup(<StormShield state={state} />)
+    .split('<div class="storm__zone"')
+    .slice(1)
+    .map((chunk) => ({
+      finger: /data-finger="([\w-]+)"/.exec(chunk)![1],
+      vars: Object.fromEntries(
+        [...chunk.matchAll(/(--[\w-]+):([\d.]+)/g)].map(([, name, value]) => [
+          name,
+          Number(value),
+        ]),
+      ),
+      hole: chunk.includes("data-hole"),
+      hit: (chunk.match(/class="storm__hit"/g) ?? []).length,
+      mend: (chunk.match(/class="storm__mend"/g) ?? []).length,
+    }));
+
+const at = (state: StormState, finger: ShieldFinger) =>
+  segments(state).find((zone) => zone.finger === finger)!;
+
+describe("StormShield", () => {
+  it("spans the field in eight, one per finger, in the reducer's order", () => {
+    // The same order the engine breaks a repair's ties in, which is what lets
+    // "the weakest zone" be a thing a child could have predicted by looking.
+    expect(segments(frameOf(only("f"), 0)).map((zone) => zone.finger)).toEqual([
+      ...SHIELD_FINGERS,
+    ]);
+  });
+
+  it("takes every span from the engine, and computes none of its own", () => {
+    for (const zone of segments(frameOf(only("f"), 0))) {
+      const span = FINGER_ZONES[zone.finger as ShieldFinger];
+      expect(zone.vars["--zone-x"], zone.finger).toBe(span.x);
+      expect(zone.vars["--zone-w"], zone.finger).toBe(span.width);
+    }
+  });
+
+  it("carries no `data-stone`, so the fall loop steps over it", () => {
+    // `useStormClock` walks the sky's children and reads `data-stone` off each
+    // one. Absent, that is `Number(undefined)` — `NaN`, which indexes no
+    // letter and is skipped. An EMPTY one would be `Number("")`, which is 0:
+    // the shield would be handed the first letter's `--drop` on every frame,
+    // as though it were the stone.
+    expect(
+      renderToStaticMarkup(<StormShield state={frameOf(only("f"), 0)} />),
+    ).not.toContain("data-stone");
+  });
+
+  it("draws hit points as a fraction of the level's own shield", () => {
+    // A fraction, so the stylesheet never learns how deep this wave's shield
+    // is — a level with six points a zone draws the same eight blocks.
+    const start = frameOf(only("f", { shield: 3 }), 0);
+    expect(at(start, "l-index").vars["--hp"]).toBe(1);
+
+    // One `f` has landed by 550ms: two of three left on the left index, and
+    // nothing taken off any other finger.
+    const hurt = frameOf(only("f", { shield: 3 }), 550);
+    expect(at(hurt, "l-index").vars["--hp"]).toBeCloseTo(2 / 3, 10);
+    expect(at(hurt, "r-index").vars["--hp"]).toBe(1);
+  });
+
+  it("reads a zone at zero as a hole, and nothing above it", () => {
+    const hurt = frameOf(only("f", { shield: 2 }), 550);
+    expect(at(hurt, "l-index").hole).toBe(false);
+
+    // Two landings into a two-point zone: empty, and the next `f` down this
+    // column ends the run.
+    const gone = frameOf(only("f", { shield: 2 }), 850);
+    expect(at(gone, "l-index").vars["--hp"]).toBe(0);
+    expect(at(gone, "l-index").hole).toBe(true);
+    expect(segments(gone).filter((zone) => zone.hole)).toHaveLength(1);
+  });
+
+  it("starts a run with nothing pulsing", () => {
+    // Both pulses are mounted by a counter, and a counter at zero renders no
+    // element — otherwise every segment would flash on the frame a wave began.
+    const start = segments(frameOf(only("f"), 0));
+    expect(start.map((zone) => zone.hit + zone.mend)).toEqual(Array(8).fill(0));
+  });
+
+  it("tints once for a landing, and once for two in the same tick", () => {
+    // The no-strobe rule, at the only altitude a unit test can hold it: one
+    // pulse element per zone however much damage arrived, and a counter that
+    // moves by two rather than a second element (§8.10). What that element
+    // then does — mount once, animate once, and not restart on a frame where
+    // nothing happened — is the browser's to answer, and `e2e/smoke.mjs` does.
+    const one = frameOf(only("f"), 550);
+    expect(at(one, "l-index").hit).toBe(1);
+    expect(zoneTally(one)["l-index"].hit).toBe(1);
+
+    // 30ms of gap and a 500ms fall puts two landings inside one 16ms frame.
+    const together = tick(
+      startStorm(buildWave(only("f", { gap: [30, 30] }), 7)),
+      540,
+    );
+    expect(together.resolved.filter(Boolean)).toHaveLength(2);
+    expect(zoneTally(together)["l-index"].hit).toBe(2);
+    expect(at(together, "l-index").hit).toBe(1);
+  });
+
+  it("pulses a repair when one is paid out", () => {
+    // A shield of two with a repair every second hit: one letter through, then
+    // two shot, and the weakest zone — the one that just took the hit — gets
+    // its point back (§8.5).
+    const spec = only("f", { shield: 2, repairAt: 2 });
+    const hurt = frameOf(spec, 550);
+    expect(at(hurt, "l-index").vars["--hp"]).toBe(0.5);
+    expect(at(hurt, "l-index").mend).toBe(0);
+
+    // A tick between the two shots, because the second letter has not spawned
+    // at 550ms and firing at an empty field is a miss that breaks the streak
+    // (§8.4) — which is the rule the repair hangs off.
+    const mended = fire(tick(fire(hurt, "KeyF"), 100), "KeyF");
+    expect(mended.shield["l-index"]).toBe(2);
+    expect(zoneTally(mended)["l-index"]).toEqual({ hit: 1, mend: 1 });
+    expect(at(mended, "l-index").mend).toBe(1);
+    expect(at(mended, "l-index").vars["--hp"]).toBe(1);
+  });
+
+  it("does not read the letter that ended the run as a repair", () => {
+    // The fatal landing is resolved as `landed` like any other, but `tick`
+    // breaks before the decrement — there was nothing left to take. Counting
+    // it against the hit points would leave the arithmetic one short and draw
+    // a lime pulse on the frame a child died.
+    const dead = frameOf(only("f", { shield: 1 }), 900);
+
+    expect(dead.ending).toEqual({
+      kind: "breached",
+      finger: "l-index",
+      index: 1,
+    });
+    expect(zoneTally(dead)["l-index"]).toEqual({ hit: 2, mend: 0 });
+    expect(at(dead, "l-index").mend).toBe(0);
+    // It still tints. A letter through a hole is the loudest thing that
+    // happens in this game, and the counter moved.
+    expect(at(dead, "l-index").hit).toBe(1);
+    expect(at(dead, "l-index").hole).toBe(true);
+  });
+
+  it("draws a shieldless wave as eight holes rather than eight NaNs", () => {
+    // `spec.shield: 0` is a legal wave — every zone starts as a hole and the
+    // first letter down ends it. `0 / 0` is the trap: CSS drops a NaN and
+    // would draw a full segment over a zone that is not there.
+    const naked = segments(frameOf(only("f", { shield: 0 }), 0));
+    expect(naked.map((zone) => zone.vars["--hp"])).toEqual(Array(8).fill(0));
+    expect(naked.every((zone) => zone.hole)).toBe(true);
+  });
+});

--- a/src/games/typing/storm/StormShield.tsx
+++ b/src/games/typing/storm/StormShield.tsx
@@ -1,0 +1,164 @@
+import { FINGER_ZONES } from "@/engine/keyboard";
+import { SHIELD_FINGERS } from "@/engine/typing/storm";
+
+import type { ShieldFinger, StormState } from "@/engine/typing/storm";
+import type { CSSProperties } from "react";
+
+/**
+ * The shield: eight segments across the bottom of the field, one per finger
+ * (docs/typing.md §8.5, decision 21).
+ *
+ * ── Why finger zones, and not one segment per key ────────────────────────────
+ * A per-key shield is the obvious build and it is the wrong one, because of
+ * what a child can do with what it tells them. A hole under `o` tells you
+ * nothing: `o` is one of forty-odd keys, it will not come round again for a
+ * while, and "get better at `o`" is not a thing anybody can practise. A hole
+ * under the **right ring finger** tells you what to practise — that finger is
+ * a lesson, a drill and a habit, and `o l . 9` are all behind it. It is also
+ * the one thing this game can teach that no accuracy percentage ever will: a
+ * child watching their own right ring finger crumble is learning something
+ * about their hands. Eight is small enough to read at a glance while a storm
+ * is falling, and forty-odd would be a strip of noise nobody could read at
+ * all.
+ *
+ * ── Over the fingers that broke it ───────────────────────────────────────────
+ * A segment is only that lesson if it is over the right keys, so the spans are
+ * `FINGER_ZONES` — the home row grouped by finger, in key units off the same
+ * `--key` the board and the lanes use (§8.2). Nothing here computes a
+ * position: the engine says which stretch of the board a finger owns, the
+ * stylesheet multiplies it, and there is no arithmetic in this file for the
+ * shield and the keyboard to disagree about. The one correction they share is
+ * half a `--key-gap`, which both the lane and the segment step back by, so a
+ * seam lands in the gutter between two keycaps rather than down the middle of
+ * one — written in `game.css` as `var(--key-gap) / 2` on both, and never as
+ * the number it currently works out to.
+ *
+ * ── One tint per landing, and never a flash sequence ─────────────────────────
+ * Damage is a single ~150ms tint (§8.10), and the mechanism is what keeps that
+ * true rather than the duration in the stylesheet. Each pulse is a child
+ * element keyed by a **counter that only ever goes up** — landings for the
+ * tint, repairs for the mend — so React mounts a fresh node exactly when one
+ * more of them has happened, and the animation on that node runs once. It
+ * cannot restart on a frame where nothing happened to that zone, because the
+ * key did not change; and two letters landing on one zone inside a single
+ * `tick` move the counter by two, which is still one mount and therefore still
+ * one tint. Nothing here holds a timer, and there is no state that could be
+ * left mid-flash by a screen that unmounted.
+ *
+ * The counters are read off the run rather than stored on it, which is what
+ * `StormState` asks of anything wanting a per-finger tally: `resolved` says
+ * what landed and where, and a zone's hit points say what is left, so the only
+ * unknown is how many repairs went in and that falls out of the other two.
+ */
+
+/** What one zone has been through: the two things worth drawing an event for. */
+export type ZoneTally = {
+  /** Letters that reached this zone. Each is one damage tint. */
+  readonly hit: number;
+  /** Points repaired back into it (§8.5). Each is one mend pulse. */
+  readonly mend: number;
+};
+
+/**
+ * The eight zones' histories, from the run itself.
+ *
+ * `hit` is a filter over `resolved` — the tally `StormState` deliberately does
+ * not keep, because a second copy of it is a second thing to hold in step
+ * sixty times a second.
+ *
+ * `mend` is arithmetic over the same: a zone's hit points are
+ * `spec.shield - absorbed + repairs` by construction, so solving for repairs
+ * needs nothing that is not already on screen. **Absorbed, not landed**: the
+ * letter that ends a run lands on a zone that is already at nothing and takes
+ * no point off it (`tick` breaks before the decrement), so counting it would
+ * read as a phantom repair on the frame a child dies. It still tints — it is
+ * the loudest thing that ever gets through — which is why the two counters are
+ * separate rather than one.
+ */
+export function zoneTally(state: StormState): Record<ShieldFinger, ZoneTally> {
+  const full = state.wave.spec.shield;
+  const fatal = state.ending?.kind === "breached" ? state.ending.index : -1;
+
+  const hit = {} as Record<ShieldFinger, number>;
+  const absorbed = {} as Record<ShieldFinger, number>;
+  for (const finger of SHIELD_FINGERS) {
+    hit[finger] = 0;
+    absorbed[finger] = 0;
+  }
+
+  state.resolved.forEach((outcome, index) => {
+    if (outcome?.outcome !== "landed") return;
+    const { finger } = state.wave.letters[index];
+    hit[finger] += 1;
+    if (index !== fatal) absorbed[finger] += 1;
+  });
+
+  return Object.fromEntries(
+    SHIELD_FINGERS.map((finger) => [
+      finger,
+      {
+        hit: hit[finger],
+        mend: state.shield[finger] + absorbed[finger] - full,
+      },
+    ]),
+  ) as Record<ShieldFinger, ZoneTally>;
+}
+
+/**
+ * The shield, as markup. A pure function of one `StormState`, like the rest of
+ * the field — see the file header for what each piece of it is for.
+ */
+export function StormShield({ state }: { state: StormState }) {
+  const full = state.wave.spec.shield;
+  const tally = zoneTally(state);
+
+  return (
+    <div className="storm__shield">
+      {SHIELD_FINGERS.map((finger) => {
+        const zone = FINGER_ZONES[finger];
+        const hp = state.shield[finger];
+        const { hit, mend } = tally[finger];
+
+        return (
+          <div
+            // The finger is the identity of a segment, and the order is
+            // `SHIELD_FINGERS` — the board order the reducer breaks ties in,
+            // so the zone a repair lights is the one a child could have
+            // predicted from watching (§8.5).
+            key={finger}
+            className="storm__zone"
+            // An attribute rather than a class, exactly as the keycaps carry
+            // theirs: it is one of a closed set the stylesheet enumerates, and
+            // it is what gives a segment the same hue as the keys under it.
+            data-finger={finger}
+            // A zone at zero is a hole, and the stylesheet has no way to ask
+            // what `--hp` is worth. `undefined` rather than `false` so the
+            // attribute is absent rather than present and false.
+            data-hole={hp <= 0 ? "" : undefined}
+            style={
+              {
+                "--zone-x": zone.x,
+                "--zone-w": zone.width,
+                // A fraction, so the stylesheet needs to know neither how deep
+                // this level's shield is nor how much of it is left. The
+                // division is guarded because `full` can be zero — a wave may
+                // declare no shield at all, and every zone of it starts as a
+                // hole — and `0 / 0` is a `NaN` that CSS cannot multiply, so
+                // the armour's height would be dropped for `auto`. That
+                // happens to look like the hole it is, which is exactly the
+                // kind of accident not to leave load-bearing.
+                "--hp": full > 0 ? hp / full : 0,
+              } as CSSProperties
+            }
+          >
+            {/* Mounted by the counter, and that is the whole no-strobe
+                mechanism (see the header). Rendered only above zero so the
+                eight segments do not all flash on the frame a run starts. */}
+            {hit > 0 && <span className="storm__hit" key={`hit${hit}`} />}
+            {mend > 0 && <span className="storm__mend" key={`mend${mend}`} />}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -2169,15 +2169,14 @@ label.segmented__btn {
    shared width is the alignment, and it is why the sky is not simply the full
    width of the field.
 
-   The bottom border is the line the letters land on. STM05 replaces it with
-   the eight shield segments, one per finger; until then it is what makes the
-   fall legible — a stone at the bottom of the sky is a stone that got
-   through. */
+   The line the letters land on is the shield, at the bottom of this box and
+   inside it (below). It replaced a `border-bottom` here, and had to: a border
+   is one line where the thing a child has to read is eight, and the eight
+   have to be able to break one at a time. */
 .storm__sky {
   position: relative;
   width: calc(15 * var(--key));
   margin-inline: auto;
-  border-bottom: 1px solid var(--hairline);
 
   /* A size container, so the fall below can be written in the height of the
      sky. It has to be: the fall is a transform, and a percentage inside a
@@ -2259,4 +2258,190 @@ label.segmented__btn {
   font-size: calc(var(--key) * 0.6);
   line-height: 1;
   color: var(--chalk);
+}
+
+/* ── Hailstorm: the shield ───────────────────────────────────────────────
+   The eight segments the letters land on, one per finger (docs/typing.md
+   §8.5, decisions 21 and 41).
+
+   **A segment sits over its own finger's keys.** `--zone-x` and `--zone-w`
+   are `FINGER_ZONES` — the home row grouped by finger, in the same key units
+   as a lane and a keycap, off the same one `--key`. So the shield, the board
+   and the falling letters are three readings of one table, and there is no
+   arithmetic here for them to disagree about. The whole rail is 15 units,
+   which is the width of the sky and of the board.
+
+   The half `--key-gap` is the lane's correction (§8.2, decision 36) applied
+   to a span instead of a point, and for the same reason: a keycap is drawn
+   inset inside its slot, so the gutter a child sees between `s` and `d` is
+   half a gap to the left of the slot boundary between them. Stepping the
+   whole rail back by that puts every seam in a gutter rather than down the
+   middle of a cap, and — because both the lane and the segment step back by
+   the same amount — a letter is over its own segment exactly when its key is
+   in its own zone, with the correction cancelling out of the comparison.
+
+   Colour is the other half of "over its own finger": a segment is the hue of
+   the keys beneath it, out of the same eight `--finger-*` tokens the board
+   uses, so the sage block over `h` and `j` is the sage keys' block and
+   nothing has to be counted to see it. Two of the telemetry five are here and no
+   others, both meaning what they mean everywhere else on this site: `--flare`
+   for damage and for a hole, which are the two wrongs this game has, and
+   `--lime` for a repair, which is paid for by a run of right answers.    */
+
+/* The rail: the bottom of the sky, and never more than a fifth of it.
+
+   The `cqh` term is not defensive. The sky is a `minmax(0, 1fr)` track (see
+   `.storm` above) and it is what gives when the viewport is short: about 78px
+   of sky at 1280×360 and about 21px at 1280×250. A shield in key units alone
+   would be a fixed slab of a field that had almost nothing left, so it is the
+   smaller of the two — a third of a key where there is room, and a fifth of
+   the sky where there is not. */
+.storm__shield {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: min(calc(var(--key) * 0.34), 20cqh);
+}
+
+/* One finger's segment: the socket, which is what a zone at zero is reduced
+   to, and the armour drawn inside it below. */
+.storm__zone {
+  /* Overwritten per finger below. The neutral is never drawn — every zone
+     carries a `data-finger` and the thumbs have no zone — but a segment with
+     no hue at all would be invisible rather than obviously wrong. */
+  --finger: var(--chalk-dim);
+  /* Hit points left, as a fraction of the level's own `shield`. The component
+     divides, so nothing here knows how deep this wave's shield is. */
+  --hp: 1;
+
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--zone-x) * var(--key) - var(--key-gap) / 2);
+  width: calc(var(--zone-w) * var(--key));
+
+  border: 1px solid color-mix(in oklab, var(--hairline) 85%, transparent);
+  border-radius: calc(var(--key) * 0.09);
+  background: color-mix(in oklab, var(--ink-900) 60%, transparent);
+}
+
+/* The armour. Its height IS the hit points — a skyline of eight blocks, which
+   is a quantity a five-year-old can read across a field without counting
+   anything, and which goes to nothing at zero and leaves the socket empty.
+
+   `height` rather than a transform, unlike the stones above: this changes when
+   a letter lands or a repair pays out, not sixty times a second, so the layout
+   property is the honest one and costs nothing. The transition is what makes a
+   repair visible as a repair — the block grows back where damage drops it —
+   and it ends where `--hp` says either way, so `prefers-reduced-motion`
+   clamping every transition to 0.001ms (base.css) loses the movement and none
+   of the reading. */
+.storm__zone::before {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: calc(var(--hp) * 100%);
+
+  border-radius: inherit;
+  background: color-mix(in oklab, var(--finger) 62%, var(--ink-800));
+  box-shadow: 0 0 calc(var(--key) * 0.2)
+    color-mix(in oklab, var(--finger) 30%, transparent);
+
+  transition: height 200ms var(--ease-out);
+}
+
+/* A hole: no armour left, and the next letter down this column ends the run.
+   The socket stays — it is what keeps the eight readable, so a child can still
+   see WHICH finger the gap belongs to — but it goes to `--flare`, which is
+   what a wrong reads as everywhere else on this site. Faint on purpose: this
+   sits on screen for the rest of the run, and it must not compete with the
+   150ms tint of something actually happening. */
+.storm__zone[data-hole] {
+  border-color: color-mix(in oklab, var(--flare) 38%, transparent);
+  background: color-mix(in oklab, var(--flare) 10%, transparent);
+}
+
+/* ── One tint, once ──────────────────────────────────────────────────────
+   Damage is a single ~150ms wash of `--flare` over the segment that took it,
+   and a repair a slightly longer one of `--lime`. Neither is a flash sequence
+   and neither can become one: the animation is a single pass — no
+   `alternate`, nothing infinite — and the element it runs on is mounted by
+   `StormShield` from a counter that only goes up, so it exists exactly once
+   per landing and once per repair. Two letters landing on one zone inside a
+   single `tick` move that counter by two, which is still one element and
+   therefore still one tint (§8.10).
+
+   Both rest at `opacity: 0` and animate down to it, so the animation adds
+   nothing to the picture once it is over and `prefers-reduced-motion` — which
+   clamps every animation to one 0.001ms pass — leaves the segment exactly as
+   it would have found it. What a child who asked for less motion still gets
+   is the block's own height, which is the damage itself rather than a report
+   of it.                                                                  */
+.storm__hit,
+.storm__mend {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  opacity: 0;
+}
+
+.storm__hit {
+  background: var(--flare);
+  animation: storm-hit 150ms var(--ease-out);
+}
+
+.storm__mend {
+  background: var(--lime);
+  animation: storm-mend 240ms var(--ease-out);
+}
+
+@keyframes storm-hit {
+  from {
+    opacity: 0.85;
+  }
+}
+
+@keyframes storm-mend {
+  from {
+    opacity: 0.7;
+  }
+}
+
+/* The same eight hues the keycaps carry, on the same closed set of fingers —
+   see the board's block above, and tokens.css for why none of them is one of
+   the telemetry five. There is no thumb segment: nothing falls on the space
+   bar (§8.3). */
+.storm__zone[data-finger="l-index"] {
+  --finger: var(--finger-l-index);
+}
+
+.storm__zone[data-finger="l-middle"] {
+  --finger: var(--finger-l-middle);
+}
+
+.storm__zone[data-finger="l-ring"] {
+  --finger: var(--finger-l-ring);
+}
+
+.storm__zone[data-finger="l-pinky"] {
+  --finger: var(--finger-l-pinky);
+}
+
+.storm__zone[data-finger="r-index"] {
+  --finger: var(--finger-r-index);
+}
+
+.storm__zone[data-finger="r-middle"] {
+  --finger: var(--finger-r-middle);
+}
+
+.storm__zone[data-finger="r-ring"] {
+  --finger: var(--finger-r-ring);
+}
+
+.storm__zone[data-finger="r-pinky"] {
+  --finger: var(--finger-r-pinky);
 }


### PR DESCRIPTION
## STM05 · The shield, in eight finger zones

The shield spans the bottom of the storm field in **eight segments, one per finger**. Thumbs are excluded because nothing falls on the space bar — a thumb has no letters, so it would be a segment that could never take damage.

### A segment is its finger's home-row span (decision 41)

This is a choice between four rows, not a derivation. Every row divides into eight runs — no row hands a key back to a finger it has already passed — but the rows are staggered, so they disagree about where the seams fall. The left pinky yields to the left ring at **2** on the number row, **2.5** on the top row, **2.75** on the home row and **3.25** on the bottom row, and one vertical seam can honour only one of the four.

The home row wins twice over. It is the row the hands rest ON — `a s d f` / `j k l ;` is where every reach returns to, so "your right ring finger" and "the column over `l`" are the same sentence to the child being told it. And its eight runs tile the board exactly:

```
2.75 + 1 + 1 + 2 + 2 + 1 + 1 + 4.25 = 15
```

That exact tiling is what makes a hole read as a gap in a wall rather than a dark patch beside one.

Segments take the same `var(--key-gap) / 2` step-back the lanes do (§8.2, decision 36), so a seam lands in the gutter between two keycaps instead of down the middle of one. Because both halves step back by the same amount, a letter is over its own segment exactly when its key is in its own zone.

### The damage tint is an element keyed by a counter, not a class (decision 42)

The tint is a new node keyed by a damage counter rather than a class toggled on a persistent one. A single-pass animation on a freshly mounted node cannot restart on a frame where nothing happened — which is precisely what a strobe is. This is why **no `StormState` field was added**, and why `redrawn` already sees every change: the counter is the state, and the key is the trigger.

### Measurements

- Eight segments tile the board within **1/64px** at five viewport sizes.
- The rail is centred on the drawn board to **<0.01px**.
- Each segment starts **1.70px** left of its finger's leftmost home cap and ends **1.80px** right of its rightmost.
- Sky **78px** / rail **11px** at 1280×360; **21.1** / **4.2** at 1280×250.

### No strobe, stated as measured

The photosensitivity requirement is verified, not asserted:

- **60 letters landing on one zone at 15ms intervals** produce a flat **0.850** opacity for **900ms**, followed by a single ease-out decay — **no modulation at all**, because each new tint starts its animation at t≈0.
- Across all eight zones: **24 visible episodes** with a **≥90ms floor**, on a **77×13px** block — **<0.1% of the viewport**.
- Under `prefers-reduced-motion: reduce`: **zero non-zero opacity samples**, with damage and repair still readable as an instant height change.

### Known mismatch, disclosed

**Seven keys sit outside their own segment**: `Digit2`, `Digit3`, `Digit4`, `Digit6`, `Digit8`, `Digit9`, `Digit0` — each **0.25 units to the left**. That is the **outboard** neighbour on the left hand and the **inboard** one on the right; `6` is the only key that crosses hands.

The bound is tight and the consequence is small:

- The **home row is always strictly inside** its own segment.
- The **hole is always drawn on the true finger**, because the reducer decrements `letter.finger` — not the lane position.

So only the **last frame of a stray letter's fall** is a quarter unit off. This is documented in §8.5 and pinned twice in tests (`src/engine/keyboard.test.ts`, `src/games/typing/storm/StormField.test.tsx`) — both which keys, and how far.

### Review pass

Two findings, **both comment accuracy in test files; no production defect**:

1. A claim that the strays land "inboard" — true for the right hand, **false for `Digit2`/`3`/`4`**. Corrected.
2. A claim that a segment overhangs the **sky** symmetrically, when the symmetric frame is the **drawn board**. Corrected.

Also added a caveat where the smoke suite's `animationstart` counter is defined: it **undercounts when a node detaches before dispatch** (60 mounts read as 1), so it is a **floor rather than a census**.

### Validation

`type-check`, `build` (static), `lint`, unit (95 files / 1972 tests) and the browser smoke suite all pass.

Closes #151
