### PR TITLE
STM06 · Firing — the lowest letter, the combo, the score (#152)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1189,6 +1189,51 @@ under four seconds and streaks up to ×2, which is exactly the shape a shooter
 wants — and reusing it means a Hailstorm level and a flash-card race pay out on
 the same scale, which they must, because it is one profile and one level ring.
 
+**One streak, one multiplier, two currencies.** A hit is worth `HIT_POINTS`
+(ten) scaled by `comboMultiplier(combo)` — the same ×1 to ×2 curve `cardXp`
+folds into a card, moved into `engine/combo.ts` so both games read one copy of
+it. So the `×1.6` a child watches climb in the HUD is the figure their XP is
+being paid at, and the score and the payout cannot tell them two different
+stories about one run. The storm may not import `progress.ts` to get it: that
+module reaches `decks/index.ts`, the front door every island downloads, and
+STM10 puts a `WaveSpec` on each storm lesson (§5.3, decision 7).
+
+**A wrong key costs `MISS_POINTS` (ten) and the streak.** Equal to a plain hit
+on purpose — one wrong key undoes one clean one, which is a sentence a
+five-year-old can hold — while a hit on a long streak is worth two of them. The
+real cost is the second half anyway: every later hit is paid at a multiplier
+that has to be earned again. A letter that gets through costs the score
+nothing; it has already cost a shield point, and one failure should not be
+charged twice (decision 46).
+
+The score is allowed to go negative, and is drawn negative. It is the run's own
+number, it ends with the run, and a floor on it would be the game declining to
+say what just happened.
+
+**A stroke at an empty sky is a miss (§8.4), and the board says so**
+(decision 43). That needed deciding rather than inheriting: with nothing in the
+air there is no expected character, and `useKeyEcho` marks nothing wrong when
+nothing is expected — so every key would have lit `--lime` for "that was
+right" while the score fell by ten. The field passes `emptyIsWrong` while the
+gun is live, which turns the echo's "nothing to judge" into "nothing that could
+be right", and every key flares. Once the run is over the flag goes off with
+the gun: `aimedAt` is null for both reasons, and this is what tells them apart.
+
+**Key auto-repeat is not a shot** (decision 44). A held key repeats about
+thirty times a second, and a gun that fired on it would let a child spray by
+leaning on one key, drain a score they never pressed for, and strobe the miss
+flash at 30Hz — which §8.10 forbids outright. `HELD` — shift, ctrl, alt, cmd —
+is not a shot either, and it is imported from `useKeyEcho` rather than
+restated, so the keys that never flare and the keys that never cost are one
+list.
+
+The HUD lives **inside the sky**, absolutely positioned over it and painted
+behind the stones (decision 45). `.storm` is a two-track grid whose only
+flexible track is the sky, and the sky is down to a few dozen pixels on a short
+viewport (§8.2) — so a HUD row would come out of the one thing with nothing
+left to give. What a run paid is shown there too, once it is over, until STM07
+gives the ending a screen of its own.
+
 ### 8.7 · A run is a `Session`
 
 A falling letter maps onto a `CardResult` with nothing forced: `prompt` and
@@ -1281,11 +1326,11 @@ sky is a size container and the travel is written in `cqh`.
 Neither an empty `tick` nor a missed `fire` returns the object it was handed,
 so `===` on the state says "changed" sixty times a second and means nothing.
 What React is re-rendered for is every field of a `StormState` except the
-clock and the wave — `resolved`, `shield`, `combo` and `ending` — plus the two
-things the clock alone moves: a letter appearing, which no field records
-because it is a time crossing, and the target changing, which two letters at
-different speeds can do mid-air with nothing else happening at all
-(decision 32). Miss that second one and the board goes on marking a child's
+clock and the wave — `resolved`, `shield`, `combo`, `score`, `misses` and
+`ending` — plus the two things the clock alone moves: a letter appearing,
+which no field records because it is a time crossing, and the target changing,
+which two letters at different speeds can do mid-air with nothing happening at
+all (decision 32). Miss that second one and the board goes on marking a child's
 keys against a letter that is no longer the lowest. The wave is the field left
 out on purpose: it is fixed for the life of a run, so it cannot change under a
 running loop, and a screen handed a different wave is a different run — which
@@ -1306,7 +1351,8 @@ falling. What it can and must do:
   The duration is the easy half. What would strobe is an animation _restarted_
   every frame, which reads identically in the stylesheet — so the tint is a
   child element mounted from a counter that only goes up: landings on that zone
-  for the damage tint, repairs into it for the mend (decision 42). A fresh
+  for the damage tint, repairs into it for the mend, and the run's own miss
+  count for the `--flare` wash over the score (decision 42). A fresh
   element runs its animation once; an unchanged counter is the same element and
   does not restart it; and several letters landing on one zone inside a single
   `tick` move the counter by several and are still one element, so they are
@@ -1386,50 +1432,54 @@ first when either optional field is added.
 
 ## 11 · Decisions, recorded
 
-|     | Decision                                                | Because                                                                                                     |
-| --- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| 1   | The keyboard layout is engine, not view                 | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture       |
-| 2   | `code`, not `key`                                       | Shift+`4` produces `$` and there is no `$` key to light up                                                  |
-| 3   | Keys release on a timer, not `keyup`                    | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                             |
-| 4   | The board is `aria-hidden`                              | Sixty announcing spans is not accessibility; the passage already carries the state                          |
-| 5   | The visual keyboard is never tappable                   | A tappable board is a hunt-and-peck trainer, which is the thing this is against                             |
-| 6   | Lesson text is generated, not written                   | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                         |
-| 7   | The lexicon must not be reachable from `decks/index.ts` | The same import took the shared chunk 46 KB → 222 KB once already                                           |
-| 8   | Ghost identity is the lesson, not the passage           | Every run generates different words; keying on them buckets every run alone                                 |
-| 9   | Three pass bars, not one score                          | A single number says you failed; three say what to fix                                                      |
-| 10  | Accuracy is flat and high; speed scales                 | An accuracy bar you can hammer past teaches hammering                                                       |
-| 11  | The speed bar dips when a key arrives                   | You have just got slower and you should have                                                                |
-| 12  | The new-key gate                                        | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                          |
-| 13  | Per-key stats come from cards, not keystrokes           | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven         |
-| 14  | Progress is derived, never stored                       | No migration, self-heals when criteria change, cannot disagree with the record book                         |
-| 15  | Unlock is `max(cleared) + 1`                            | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                             |
-| 16  | Any checkpoint, any time                                | It is a placement test, a skip-ahead and an ordering rule in one sentence                                   |
-| 17  | A lesson has no ghost and no time penalty               | A penalty double-counts accuracy and makes the wpm number a lie                                             |
-| 18  | Hailstorm is a route in the typing island               | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard    |
-| 19  | Letters fall down their key's column                    | The lane is a spatial hint — the game teaches the layout the whole time it is played                        |
-| 20  | Only the lowest letter can be shot                      | Otherwise spraying the keyboard is a winning strategy                                                       |
-| 21  | The shield is eight finger zones                        | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise           |
-| 22  | Score can fall, XP cannot                               | XP is cumulative across years and four games; a bad five minutes must not lower a level                     |
-| 23  | A Hailstorm run is a `Session`                          | Record book, XP, badges and the drill builder all work with no new code                                     |
-| 24  | Hailstorm never gates the ladder                        | A tablet has no keys, and a reward that blocks you is not a reward                                          |
-| 25  | DOM, not canvas                                         | Eleven custom properties change the whole app's biome; a canvas is a hole in that                           |
-| 26  | US ANSI only, and say so                                | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                               |
-| 27  | A lesson's keyboard seeds; it does not overrule         | All hundred name a mode, so an override beats the player's own setting on every rung                        |
-| 28  | `eyes-up` reads the board the run was typed under       | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory          |
-| 29  | `unbroken` is gated on the wave having a length         | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete     |
-| 30  | A falling letter is on the field on `[spawn, land)`     | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two         |
-| 31  | A letter carries its key, finger and lane               | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift          |
-| 32  | The target is the greatest fall progress, not `landMs`  | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen              |
-| 33  | An exact tie goes to the earlier spawn                  | The index is the letter's identity, so a replay resolves the same dead heat the same way                    |
-| 34  | A repair never lifts a zone above `spec.shield`         | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                    |
-| 35  | A tick resolves every landing inside it                 | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's               |
-| 36  | The field's lanes step back half a `--key-gap`          | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference  |
-| 37  | `--key` is declared once, at the root                   | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key      |
-| 38  | A frame is clamped to 100ms of wave time                | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield      |
-| 39  | The loop writes `--drop`; the stylesheet owns the fall  | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either   |
-| 40  | The field re-renders on the picture, not on the frame   | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal        |
-| 41  | A shield segment is its finger's home-row span          | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on |
-| 42  | A tint is an element keyed by a counter, not a class    | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe   |
+|     | Decision                                                 | Because                                                                                                     |
+| --- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| 1   | The keyboard layout is engine, not view                  | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture       |
+| 2   | `code`, not `key`                                        | Shift+`4` produces `$` and there is no `$` key to light up                                                  |
+| 3   | Keys release on a timer, not `keyup`                     | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                             |
+| 4   | The board is `aria-hidden`                               | Sixty announcing spans is not accessibility; the passage already carries the state                          |
+| 5   | The visual keyboard is never tappable                    | A tappable board is a hunt-and-peck trainer, which is the thing this is against                             |
+| 6   | Lesson text is generated, not written                    | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                         |
+| 7   | The lexicon must not be reachable from `decks/index.ts`  | The same import took the shared chunk 46 KB → 222 KB once already                                           |
+| 8   | Ghost identity is the lesson, not the passage            | Every run generates different words; keying on them buckets every run alone                                 |
+| 9   | Three pass bars, not one score                           | A single number says you failed; three say what to fix                                                      |
+| 10  | Accuracy is flat and high; speed scales                  | An accuracy bar you can hammer past teaches hammering                                                       |
+| 11  | The speed bar dips when a key arrives                    | You have just got slower and you should have                                                                |
+| 12  | The new-key gate                                         | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                          |
+| 13  | Per-key stats come from cards, not keystrokes            | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven         |
+| 14  | Progress is derived, never stored                        | No migration, self-heals when criteria change, cannot disagree with the record book                         |
+| 15  | Unlock is `max(cleared) + 1`                             | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                             |
+| 16  | Any checkpoint, any time                                 | It is a placement test, a skip-ahead and an ordering rule in one sentence                                   |
+| 17  | A lesson has no ghost and no time penalty                | A penalty double-counts accuracy and makes the wpm number a lie                                             |
+| 18  | Hailstorm is a route in the typing island                | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard    |
+| 19  | Letters fall down their key's column                     | The lane is a spatial hint — the game teaches the layout the whole time it is played                        |
+| 20  | Only the lowest letter can be shot                       | Otherwise spraying the keyboard is a winning strategy                                                       |
+| 21  | The shield is eight finger zones                         | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise           |
+| 22  | Score can fall, XP cannot                                | XP is cumulative across years and four games; a bad five minutes must not lower a level                     |
+| 23  | A Hailstorm run is a `Session`                           | Record book, XP, badges and the drill builder all work with no new code                                     |
+| 24  | Hailstorm never gates the ladder                         | A tablet has no keys, and a reward that blocks you is not a reward                                          |
+| 25  | DOM, not canvas                                          | Eleven custom properties change the whole app's biome; a canvas is a hole in that                           |
+| 26  | US ANSI only, and say so                                 | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                               |
+| 27  | A lesson's keyboard seeds; it does not overrule          | All hundred name a mode, so an override beats the player's own setting on every rung                        |
+| 28  | `eyes-up` reads the board the run was typed under        | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory          |
+| 29  | `unbroken` is gated on the wave having a length          | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete     |
+| 30  | A falling letter is on the field on `[spawn, land)`      | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two         |
+| 31  | A letter carries its key, finger and lane                | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift          |
+| 32  | The target is the greatest fall progress, not `landMs`   | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen              |
+| 33  | An exact tie goes to the earlier spawn                   | The index is the letter's identity, so a replay resolves the same dead heat the same way                    |
+| 34  | A repair never lifts a zone above `spec.shield`          | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                    |
+| 35  | A tick resolves every landing inside it                  | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's               |
+| 36  | The field's lanes step back half a `--key-gap`           | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference  |
+| 37  | `--key` is declared once, at the root                    | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key      |
+| 38  | A frame is clamped to 100ms of wave time                 | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield      |
+| 39  | The loop writes `--drop`; the stylesheet owns the fall   | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either   |
+| 40  | The field re-renders on the picture, not on the frame    | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal        |
+| 41  | A shield segment is its finger's home-row span           | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on |
+| 42  | A tint is an element keyed by a counter, not a class     | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe   |
+| 43  | A stroke at an empty sky flares the whole board          | It costs ten points and the streak, and a key that costs a child points must not light `--lime`             |
+| 44  | Key auto-repeat is not a shot                            | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                   |
+| 45  | The HUD is drawn inside the sky, not as a row of its own | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give              |
+| 46  | A wrong key costs score; a letter through costs shield   | One failure, one cost — the landing has already taken the thing that ends runs                              |
 
 ---
 
@@ -1445,7 +1495,7 @@ The four that carry this epic, in the order they are worth writing:
 3. **`configKey` is frozen.** Every config shape saved before this epic
    produces byte-identical keys. Runs from before must still find their ghosts.
 4. **The storm reducer.** Spawn schedule, lowest-target resolution, shield
-   depletion, repair, death — all pure, all without a DOM.
+   depletion, repair, scoring, death — all pure, all without a DOM.
 
 Plus the ones that are cheap and catch the embarrassing failures: `strokeFor`
 round-trips every character in every lesson; the hundred lessons have unique

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -15,6 +15,50 @@ const log = (...a) => console.log(...a);
 
 const browser = await chromium.launch();
 const page = await browser.newPage({ viewport: { width: 1280, height: 1000 } });
+
+/*
+ * `SMOKE_CPU=4` runs the whole walk on a quarter of this machine's processor.
+ *
+ * Every timing-sensitive thing below is timing-sensitive *because a CI runner
+ * is slower than a laptop*, and a check that only ever runs at full speed is a
+ * check whose margins nobody has measured. This is the knob that measures
+ * them: a hailstorm flake that took a run of CI to see reproduces here in
+ * thirty seconds at `SMOKE_CPU=10`, and a fix for one is not demonstrated
+ * until it has been run under it.
+ *
+ * Off by default, because the point of the ordinary run is to be fast.
+ */
+const CPU = Number(process.env.SMOKE_CPU ?? 1);
+if (CPU > 1) {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Emulation.setCPUThrottlingRate", { rate: CPU });
+  log(`(processor throttled ${CPU}×)`);
+}
+
+/*
+ * `SMOKE_LAG=300` puts 300ms between deciding on a key and pressing it.
+ *
+ * The other half of a slow runner, and the half `SMOKE_CPU` cannot show. CPU
+ * throttling slows the *page*, and the hailstorm's clock slows with it
+ * (`MAX_STEP_MS` caps how much wave time one frame may be worth), so the game
+ * politely waits for a throttled driver. What a loaded CI box actually does is
+ * the opposite: the browser keeps its frames while the node process driving it
+ * is starved, so the wave falls at full speed into a hand that has gone slow.
+ *
+ * That gap is where a shot at "the lowest letter" turns into a shot at the
+ * letter that used to be lowest, and it is the whole of the flake this knob
+ * exists to reproduce. Anything below that reads the field and then acts on it
+ * must survive `SMOKE_LAG=500`.
+ */
+const LAG = Number(process.env.SMOKE_LAG ?? 0);
+if (LAG) log(`(${LAG}ms of driver lag before every keypress)`);
+
+/** A keystroke, taken as slowly as `SMOKE_LAG` says a starved driver takes it. */
+const press = async (key) => {
+  if (LAG) await page.waitForTimeout(LAG);
+  await page.keyboard.press(key);
+};
+
 const errors = [];
 page.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
 page.on(
@@ -285,9 +329,27 @@ try {
     JSON.stringify(benchBox),
   );
 
+  /*
+   * Print media, said again — and it has to be said again after every one of
+   * these navigations.
+   *
+   * The emulation does not reliably survive a cross-document load: the page
+   * comes back with `matchMedia("print")` false, the masthead laid out and the
+   * sheet where the *screen* puts it, which measures as a sheet indented 232px
+   * into a page it should start at the corner of. That is not a settling race
+   * — it does not resolve at 1.4s, throttled or not — so waiting cannot fix
+   * it; it can only decide the checks below are measuring the screen and
+   * saying "print".
+   *
+   * It stayed hidden because a laptop happened to keep the emulation across
+   * this hop and a throttled run did not. Restating it costs one call and
+   * makes the media the measurement's own, rather than something inherited
+   * from whatever ran before it.
+   */
   await page.goto(`${BASE}/printables/lined-paper`, {
     waitUntil: "networkidle",
   });
+  await page.emulateMedia({ media: "print" });
   const catalogBox = await page.locator(".sheet").first().boundingBox();
   check(
     "a catalog page puts the same sheet in the same place",
@@ -316,6 +378,9 @@ try {
   await page.goto(`${BASE}/printables/templates/blank-flashcards`, {
     waitUntil: "networkidle",
   });
+  // Again, for the reason above. Every measurement in this section says "on the
+  // paper", and only this line makes that true of the page it just loaded.
+  await page.emulateMedia({ media: "print" });
   const face = await page.locator(".sheet__cut-card").first().boundingBox();
   check(
     "a blank flashcard is 3.75in by 2.25in on the paper",
@@ -677,9 +742,35 @@ try {
    * Every press is deterministic without knowing the wave, because the target
    * is the lowest letter and this stand-in falls every letter at one speed —
    * so the lowest is the earliest still on the field, and its own character
-   * shoots it. A key that is not that character is a miss whatever else is in
-   * the air, which is the other half of §8.4 and the reason the misses below
-   * need no timing at all.
+   * shoots it.
+   *
+   * ── Nothing here may read the field and then act on the reading ───────────
+   * The reducer marks a key against the target it holds **when the key
+   * arrives**, and the target moves on its own: the letter that was lowest
+   * lands, and the one behind it inherits the gun. So a shot chosen from a
+   * reading is a shot at where the wave *was*, and every millisecond between
+   * the two is a millisecond that reading has to stay true for. On this
+   * machine that gap is a few ms and nothing ever moved inside it; on a runner
+   * with a starved driver it is long enough for a letter to land, and the run
+   * that found this connected four times out of five and then failed three
+   * assertions that all presupposed the fifth (`SMOKE_LAG` reproduces it).
+   *
+   * Two rules keep the presses below true whatever the gap is, and they are
+   * the reason there is no timing anywhere in this section:
+   *
+   *   - **Aim only where a keypress can still land.** `armed()` refuses a
+   *     letter in the last of its fall, so the shot has a second of wave time
+   *     in hand — and wave time never runs faster than the clock, so that
+   *     second is a second on any hardware.
+   *   - **Miss with a key nothing in the sky is wearing.** Whichever letter
+   *     inherits the gun, it is one that was already airborne when the sky was
+   *     read (a spawn arrives at the top and cannot be the lowest), so a key
+   *     that matched none of them cannot turn into a hit in flight.
+   *
+   * And what cannot be guaranteed is checked rather than assumed: every press
+   * below is confirmed against the HUD before the next one is taken, so a shot
+   * that did not connect is named where it happened instead of surfacing as
+   * arithmetic three checks later.
    */
   await page.evaluate(() => {
     window.__tints = [];
@@ -697,20 +788,101 @@ try {
       attributeFilter: ["class"],
     });
   });
-  await storm();
 
-  /** The lowest letter on the field — what the gun is aimed at — or null. */
-  const aimed = () =>
+  /**
+   * What is in the sky, and which of it the gun is on: every character up
+   * there, plus the lowest stone and how far down it is. Read as one snapshot
+   * because the two are only usable together — a key is chosen against the
+   * whole sky and aimed at the lowest of it.
+   */
+  const read = () =>
     page.evaluate(() => {
       const stones = [...document.querySelectorAll(".storm__letter")];
-      if (stones.length === 0) return null;
       // Lowest is the earliest spawn here, and `data-stone` is the letter's
       // index in the wave, which is spawn order (§8.3).
-      const low = stones.reduce((a, b) =>
-        Number(a.dataset.stone) <= Number(b.dataset.stone) ? a : b,
-      );
-      return { index: Number(low.dataset.stone), ch: low.textContent };
+      let low = null;
+      for (const stone of stones)
+        if (
+          low === null ||
+          Number(stone.dataset.stone) < Number(low.dataset.stone)
+        )
+          low = stone;
+      return {
+        chars: stones.map((stone) => stone.textContent.toLowerCase()),
+        index: low && Number(low.dataset.stone),
+        ch: low && low.textContent,
+        drop:
+          low &&
+          Number(window.getComputedStyle(low).getPropertyValue("--drop")),
+      };
     });
+
+  /**
+   * The same reading, but only once the lowest letter is one a keypress can
+   * still reach. `null` if the field offered no such letter inside `budgetMs`.
+   *
+   * The wait runs **in the page**, on the same frames the game is drawn on,
+   * which is what makes this a fix rather than a wider margin: a driver-side
+   * poll pays a round trip for every look and then another to press, so its
+   * reading is at best one round trip stale. This pays one, and the answer is
+   * a frame old.
+   *
+   * `0.7` is the last drop it will aim at. `--drop` is the 0→1 the renderer
+   * writes on each stone (STM03), the stand-in's fall is four seconds of wave
+   * time, and wave time only ever runs slower than the clock — so leaving the
+   * last three tenths of a fall unshot leaves at least 1.2s of real time for
+   * the press to arrive in. Waiting is the ordinary case and not a slow
+   * machine: a letter spawns every 300ms, this shoots faster than that, and
+   * the sky between a shot and the next spawn is genuinely empty.
+   *
+   * **The budget is short on purpose.** There are only two reasons to wait —
+   * the next spawn (300ms) and, at the very start, a first letter that was
+   * already too low when the driver arrived. Neither takes 2.5s, and past that
+   * the wave has simply outrun the hand: from the first landing onwards the
+   * lowest letter is always in the last tenth of its fall, so there is no
+   * letter left that a press can be promised to reach and no amount of further
+   * waiting will produce one. A fresh wave is the only way back, which is what
+   * `cleanRun` does with this `null`.
+   */
+  const armed = async (budgetMs = 2500) => {
+    const handle = await page
+      .waitForFunction(
+        (room) => {
+          const stones = [...document.querySelectorAll(".storm__letter")];
+          if (stones.length === 0) return null;
+          let low = stones[0];
+          for (const stone of stones)
+            if (Number(stone.dataset.stone) < Number(low.dataset.stone))
+              low = stone;
+          const drop = Number(
+            window.getComputedStyle(low).getPropertyValue("--drop"),
+          );
+          if (!(drop <= room)) return null;
+          return {
+            chars: stones.map((stone) => stone.textContent.toLowerCase()),
+            index: Number(low.dataset.stone),
+            ch: low.textContent,
+            drop,
+          };
+        },
+        0.7,
+        { timeout: budgetMs },
+      )
+      .catch(() => null);
+    return handle && (await handle.jsonValue());
+  };
+
+  /**
+   * A key that would miss whatever happens next: one no letter in `chars` is
+   * wearing. See the header — the gun can only ever pass to a letter that was
+   * already in that reading, so a key none of them answers to stays a miss
+   * however long the press takes to arrive.
+   *
+   * The order is the rarest keys first, which is only so the flare in the
+   * check below reads as a wrong key rather than as a near miss.
+   */
+  const missKey = (chars) =>
+    [..."qzxjvkbpygwmcfhdlrsnoaietu"].find((ch) => !chars.includes(ch));
 
   /** The HUD as a child reads it, plus what the field has left. */
   const hud = () =>
@@ -726,27 +898,115 @@ try {
       };
     });
 
-  // Five clean hits, each fired at the letter nearest the shield as it comes.
-  // The loop waits rather than pressing into an empty sky, because a shot at
-  // nothing is a miss and this half is about what a run of hits is worth.
+  /**
+   * The score the HUD settles on after a press, or `null` if it never moved.
+   *
+   * Waiting on the *change* rather than on a value is what makes this usable
+   * as a verdict: every stroke the reducer accepts moves the score — up by the
+   * hit's worth, down by `MISS_POINTS` — and nothing else moves it at all,
+   * because a letter reaching the shield costs a shield point and no points
+   * (§8.4). So the sign of the move says which of the two happened, and no
+   * move inside the budget says the stroke reached nothing — a run that had
+   * already ended, or a screen that has stopped listening.
+   */
+  const scored = async (before, budgetMs = 8000) => {
+    const handle = await page
+      .waitForFunction(
+        (was) => {
+          const now = Number(
+            document.querySelector(".storm__score")?.textContent,
+          );
+          return Number.isFinite(now) && now !== was ? { now } : null;
+        },
+        before,
+        { timeout: budgetMs },
+      )
+      .catch(() => null);
+    return handle ? (await handle.jsonValue()).now : null;
+  };
+
+  /**
+   * One go at a clean run: a fresh wave, then `HITS` shots that each connect —
+   * or the first one that did not, said out loud.
+   *
+   * A fresh wave per go rather than a recovery, because there is no recovering
+   * a streak: the thing being measured is five hits *in a row*, and a shot
+   * that missed has already reset the multiplier every later hit would be paid
+   * at. Restarting is also free and honest here — `storm()` is the same exit
+   * and re-entry a child takes between two goes, the wave is replayed from its
+   * seed, and the counters below are of whatever the last go left behind.
+   */
   const HITS = 5;
-  const shot = [];
-  for (let tries = 0; tries < 60 && shot.length < HITS; tries++) {
-    const target = await aimed();
-    if (target === null) {
-      await page.waitForTimeout(20);
-      continue;
+  const cleanRun = async () => {
+    await page.evaluate(() => {
+      window.__tints = [];
+      window.__flares = [];
+    });
+    await storm();
+
+    const shot = [];
+    let score = 0;
+    while (shot.length < HITS) {
+      const target = await armed();
+      if (!target) return { shot, missed: "the sky never offered a target" };
+      await press(target.ch);
+      const after = await scored(score);
+      if (after === null)
+        return {
+          shot,
+          missed: `"${target.ch}" (letter ${target.index}) drew no answer at all`,
+        };
+      if (after < score)
+        return {
+          shot,
+          missed:
+            `"${target.ch}" was aimed at letter ${target.index} ` +
+            `${target.drop.toFixed(2)} of the way down and missed ` +
+            `(${score} → ${after})`,
+        };
+      shot.push(target.index);
+      score = after;
     }
-    await page.keyboard.press(target.ch);
-    shot.push(target.index);
+    return { shot, missed: null };
+  };
+
+  // Five clean hits, each fired at the letter nearest the shield as it comes.
+  let run = await cleanRun();
+  const restarts = [];
+  for (let go = 1; go < 3 && run.missed !== null; go++) {
+    restarts.push(run.missed);
+    run = await cleanRun();
   }
+  const shot = run.shot;
+  check(
+    // Named apart from the arithmetic below it on purpose. "The gun connected
+    // five times" and "five hits are worth 65" are two different claims, and a
+    // wave that outran the driver is a fact about this harness where a 65 that
+    // came back 50 is a fact about the reducer. Reported as one, a short count
+    // reads as a scoring bug — which is exactly how this cost an afternoon.
+    "the gun connected five times running",
+    run.missed === null && shot.length === HITS,
+    run.missed
+      ? `${shot.length} of ${HITS} — ${run.missed}`
+      : `shot ${shot.join()}` +
+          (restarts.length
+            ? ` (after ${restarts.length}: ${restarts[0]})`
+            : ""),
+  );
   const combo = await hud();
   check(
     "a run of clean hits climbs, and the multiplier climbs with it",
     // 11 + 12 + 13 + 14 + 15: ten points a hit, at the multiplier the hit
     // itself lands on. The fifth is ×1.5 and the HUD says so.
+    //
+    // The indices are asked to ascend rather than to be `0,1,2,3,4`: the gun
+    // takes the lowest letter, so a run that started a letter or two into the
+    // wave — the driver was slow to arrive, and `armed()` let the first letter
+    // land rather than shoot at one it could not reach — walked down the wave
+    // exactly as correctly. What ascending forbids is the thing that would be
+    // a bug: a letter shot twice, or the gun going back up the field.
     shot.length === HITS &&
-      shot.join() === "0,1,2,3,4" &&
+      shot.every((index, i) => i === 0 || index > shot[i - 1]) &&
       combo.score === 65 &&
       combo.combo === "×1.5" &&
       combo.hot,
@@ -755,19 +1015,32 @@ try {
 
   // And a wrong key, against a letter that is really there: the one case that
   // is not a shot at an empty sky, so it takes the target's own neighbours out
-  // of the argument. `q` unless the target is a `q`.
-  const target = await aimed();
-  const wrongKey = target?.ch.toLowerCase() === "q" ? "z" : "q";
-  await page.keyboard.press(wrongKey);
+  // of the argument.
+  //
+  // Which has to be *waited* for and then *checked*, neither of which it used
+  // to be — five hits land inside one spawn gap, so at full speed the sky
+  // directly after them is empty and this was quietly the empty-sky case it
+  // says it is not. A letter, not a shootable letter: what the stroke needs is
+  // something up there to be refused by, and waiting for one the gun could
+  // have hit would spend wave time the misses below still need.
+  await page
+    .waitForSelector(".storm__letter", { timeout: 2000 })
+    .catch(() => {});
+  const aimedAt = await read();
+  const wrongKey = missKey(aimedAt.chars);
+  await press(wrongKey);
+  await scored(combo.score);
   const missed = await hud();
   check(
     "a wrong key costs a hit's worth, breaks the combo, and flares the board",
-    missed.score === combo.score - 10 &&
+    aimedAt.chars.length > 0 &&
+      missed.score === combo.score - 10 &&
       missed.combo === "×1.0" &&
       !missed.hot &&
       missed.flares.length === 1 &&
       missed.flares[0].toLowerCase() === wrongKey,
-    `${combo.score} → ${missed.score} at ${missed.combo}, ` +
+    `"${wrongKey}" into a sky of ${aimedAt.chars.join("")}: ` +
+      `${combo.score} → ${missed.score} at ${missed.combo}, ` +
       `flared ${JSON.stringify(missed.flares)}`,
   );
 
@@ -786,16 +1059,32 @@ try {
   // inside 21ms also draw one. The 200ms is what buys each flash a frame of
   // its own, and at that cadence all eight are counted.
   const MISSES = 8;
+  // Presses the HUD never answered. Each one would be a miss the flash count
+  // at the bottom is short by, and the reason is worth carrying to the check
+  // rather than leaving as a number that is ten out.
+  const unanswered = [];
+  let running = missed.score;
   for (let i = 1; i < MISSES; i++) {
     await page.waitForTimeout(200);
-    const next = await aimed();
-    await page.keyboard.press(next?.ch.toLowerCase() === "q" ? "z" : "q");
+    // The plain reading, not `armed()`: a miss needs a key nothing in the sky
+    // is wearing, which every reading gives, and waiting for a *shootable*
+    // letter here would spend wave time this run does not have to spare.
+    await press(missKey((await read()).chars));
+    const after = await scored(running);
+    if (after === null) unanswered.push(i);
+    else running = after;
   }
   const sunk = await hud();
   check(
     "the score goes negative, and is drawn negative",
-    sunk.score === 65 - MISSES * 10,
-    `${sunk.score} after ${MISSES} wrong keys`,
+    // Off `combo.score` and not off 65. The claim is that eight wrong keys
+    // cost eight hits' worth and take the run under, which is a statement
+    // about the run that was actually played — and a run that scored something
+    // else has a scoring bug to report on its own line above, not an
+    // arithmetic mismatch on this one.
+    sunk.score === combo.score - MISSES * 10 && sunk.score < 0,
+    `${combo.score} → ${sunk.score} after ${MISSES} wrong keys` +
+      (unanswered.length ? `, ${unanswered.length} unanswered` : ""),
   );
 
   // Then the rest of the wave lands and the run ends itself, exactly as the
@@ -818,9 +1107,17 @@ try {
   const hits = played.filter((tint) => tint.name === "storm-hit");
   const flashes = played.filter((tint) => tint.name === "storm-miss");
   check(
-    "five letters shot are five that never reached the shield",
-    hits.length === 12 - HITS && hits.every((tint) => tint.finger),
-    `${hits.length} damage tints for ${12 - HITS} landings`,
+    // Twelve is the wave and `shot.length` is what the gun took out of it, so
+    // this is "every letter is accounted for exactly once" — a shot letter or
+    // a damaged zone, never both and never neither. Counted off the shots that
+    // actually connected rather than off `HITS`, because a short run is a
+    // failure the check above has already named: repeating it here as a tint
+    // census would say "the shield is drawing the wrong number of hits", which
+    // is a different and much more alarming bug than the one that happened.
+    "letters shot are letters that never reached the shield",
+    hits.length === 12 - shot.length && hits.every((tint) => tint.finger),
+    `${hits.length} damage tints for ${12 - shot.length} landings ` +
+      `after ${shot.length} shot`,
   );
   check(
     "one flash of red per wrong key, and never two inside one flash",

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -402,6 +402,12 @@ try {
   // Nothing links to the storm until the ladder grows its tiles, so the URL is
   // the only way in — which is what the route is for at this stage.
   const storm = async () => {
+    // Out to the ladder first, so this is a fresh mount every time it is
+    // called: a hash set to the one it already holds fires no navigation, and
+    // the run below it would be whatever the last one finished as. Leaving is
+    // also the only way out of the storm there is, so this is the same exit a
+    // child takes between two goes at it.
+    await page.evaluate((id) => (location.hash = `#/p/${id}`), player);
     await page.evaluate((id) => (location.hash = `#/p/${id}/storm`), player);
     await page.waitForSelector(".storm__letter", { timeout: 8000 });
   };
@@ -516,8 +522,9 @@ try {
       .join(" "),
   );
 
-  // Leaving is what quitting is on this screen (there is no quit control until
-  // the HUD lands), and it has to take the loop with it.
+  // Leaving is what quitting is on this screen (there is no quit control), and
+  // it has to take the loop with it — and, since the gun landed, the keydown
+  // listener beside it.
   await page.evaluate((id) => (location.hash = `#/p/${id}`), player);
   await page.waitForTimeout(500);
   check(
@@ -535,9 +542,16 @@ try {
    * animation RESTARTED every frame, which reads identically in the CSS and
    * would fire `animationstart` sixty times a second. So the events are
    * counted over a whole run, and against the only number they may equal —
-   * one per letter that lands, twelve for this wave, since nothing can be shot
-   * yet and each is drawn by a counter that only moves when a letter reaches
-   * that zone.
+   * one per letter that lands, twelve for this wave, because **this run is
+   * played with nothing pressed** and each tint is drawn by a counter that
+   * only moves when a letter reaches that zone.
+   *
+   * Nothing pressed is now a choice rather than a fact about the game: keys
+   * fire (§8.6), and the run below this one plays the same wave with a child's
+   * hands on it. Twelve landings is the densest this wave gets, so it is the
+   * right run to measure a strobe in — and it is measured here at every storm
+   * animation there is, not only the shield's, which is what makes "no miss
+   * flashed" a claim of this run rather than an absence nobody looked for.
    */
   await page.evaluate(() => {
     window.__tints = [];
@@ -564,8 +578,8 @@ try {
   });
 
   // And a run that reaches its end stops itself. The stand-in wave is twelve
-  // letters over 7.3s, none of which anything can shoot yet, so this waits out
-  // a whole storm.
+  // letters over 7.3s, and nothing is pressed at it, so this waits out a whole
+  // storm and every letter of it lands.
   await storm();
   await page
     .waitForFunction(() => window.__pendingFrames() === 0, null, {
@@ -595,26 +609,50 @@ try {
       hole: zone.hasAttribute("data-hole"),
     })),
   }));
-  // The closest two tints on any one segment. A flash sequence is two of them
-  // inside the 150ms one is on screen for; this wave lands a letter every
-  // 300ms, so the honest answer here is about 300 and never below 150.
-  const closest = Math.min(
-    ...damage.tints.map((tint, i, all) => {
-      const previous = all
-        .slice(0, i)
-        .findLast((t) => t.finger === tint.finger);
-      return previous ? tint.at - previous.at : Infinity;
-    }),
-  );
+  /**
+   * The closest two of these animations that belong to the same thing, in ms —
+   * `Infinity` where nothing lit twice. `keyOf` says what "the same thing" is:
+   * a shield segment for damage, the HUD for a miss.
+   *
+   * This is the whole no-strobe measurement. A flash sequence is two events
+   * inside the ~150ms one pass is on screen for, so the number below the
+   * duration is the failure and the number above it is the hand or the wave
+   * moving. Written once because both halves of §8.10 are measured with it.
+   */
+  const rhythm = (tints, keyOf) =>
+    Math.min(
+      ...tints.map((tint, i, all) => {
+        const previous = all
+          .slice(0, i)
+          .findLast((t) => keyOf(t) === keyOf(tint));
+        return previous ? tint.at - previous.at : Infinity;
+      }),
+    );
+  const shieldTints = damage.tints.filter((tint) => tint.name === "storm-hit");
+  const closest = rhythm(shieldTints, (tint) => tint.finger);
   check(
     "damage tints once per landing, and never twice inside one tint",
     damage.tints.length === 12 &&
-      damage.tints.every((tint) => tint.name === "storm-hit" && tint.finger) &&
+      shieldTints.length === 12 &&
+      shieldTints.every((tint) => tint.finger) &&
       closest >= 150,
-    `${damage.tints.length} tints, closest pair on one zone ${closest}ms apart`,
+    `${damage.tints.length} storm animations, all shield damage, ` +
+      `closest pair on one zone ${closest}ms apart`,
+  );
+  // Twelve is the whole census and not only the shield's share of it: no key
+  // was pressed at this wave, so the HUD's `--flare` (one per wrong key) and
+  // the shield's `--lime` mend (this spec repairs at nothing) each drew none.
+  // Counting them here is what stops a run of the game flashing something a
+  // check aimed only at zones would never have looked at.
+  check(
+    "and nothing else on the screen animated at all",
+    damage.tints.filter((tint) => tint.name !== "storm-hit").length === 0,
+    [...new Set(damage.tints.map((tint) => tint.name))].join() || "none",
   );
   // Three zones took three letters each in this wave, and a zone at zero is a
-  // hole — drawn as one, off the same number the reducer holds.
+  // hole — drawn as one, off the same number the reducer holds. Twelve
+  // landings is what the numbers below are of: shoot one of those letters and
+  // its zone keeps the point, which the run after this one does.
   const holes = damage.zones.filter((zone) => zone.hole);
   check(
     "a zone the storm emptied is drawn as a hole",
@@ -622,6 +660,177 @@ try {
       holes.every((zone) => zone.hp === 0) &&
       holes.map((zone) => zone.finger).join() === "l-index,r-index,r-middle",
     damage.zones.map((z) => `${z.finger}:${z.hp.toFixed(2)}`).join(" "),
+  );
+
+  /*
+   * The same wave again, with a child's hands on it: the gun, the combo and
+   * what a wrong key costs (docs/typing.md §8.6).
+   *
+   * A real browser is the only place this can be asked. The rules are pure and
+   * `storm.test.ts` proves every one of them in a millisecond — a hit is ten
+   * points times the streak it lands on, a wrong key is ten off and the streak
+   * gone — but "the key a child presses reaches those rules, and the number
+   * they are looking at is the one that came back" is a claim about a window
+   * listener, a rAF loop and a React tree, and none of the three exist in the
+   * unit suite. What is measured here is the join: press a key, read the HUD.
+   *
+   * Every press is deterministic without knowing the wave, because the target
+   * is the lowest letter and this stand-in falls every letter at one speed —
+   * so the lowest is the earliest still on the field, and its own character
+   * shoots it. A key that is not that character is a miss whatever else is in
+   * the air, which is the other half of §8.4 and the reason the misses below
+   * need no timing at all.
+   */
+  await page.evaluate(() => {
+    window.__tints = [];
+    // Every cap that goes red, kept rather than caught: `useKeyEcho` releases
+    // a key 120ms after the press (§4.3), and a check that read the DOM after
+    // a round trip would be racing that timer for its evidence.
+    window.__flares = [];
+    new window.MutationObserver((records) => {
+      for (const record of records)
+        if (record.target.classList.contains("is-wrong"))
+          window.__flares.push(record.target.textContent);
+    }).observe(document.body, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+  });
+  await storm();
+
+  /** The lowest letter on the field — what the gun is aimed at — or null. */
+  const aimed = () =>
+    page.evaluate(() => {
+      const stones = [...document.querySelectorAll(".storm__letter")];
+      if (stones.length === 0) return null;
+      // Lowest is the earliest spawn here, and `data-stone` is the letter's
+      // index in the wave, which is spawn order (§8.3).
+      const low = stones.reduce((a, b) =>
+        Number(a.dataset.stone) <= Number(b.dataset.stone) ? a : b,
+      );
+      return { index: Number(low.dataset.stone), ch: low.textContent };
+    });
+
+  /** The HUD as a child reads it, plus what the field has left. */
+  const hud = () =>
+    page.evaluate(() => {
+      const combo = document.querySelector(".storm__combo");
+      return {
+        score: Number(document.querySelector(".storm__score").textContent),
+        combo: combo.textContent,
+        hot: combo.hasAttribute("data-hot"),
+        stones: document.querySelectorAll(".storm__letter").length,
+        xp: document.querySelector(".storm__xp")?.textContent ?? null,
+        flares: window.__flares,
+      };
+    });
+
+  // Five clean hits, each fired at the letter nearest the shield as it comes.
+  // The loop waits rather than pressing into an empty sky, because a shot at
+  // nothing is a miss and this half is about what a run of hits is worth.
+  const HITS = 5;
+  const shot = [];
+  for (let tries = 0; tries < 60 && shot.length < HITS; tries++) {
+    const target = await aimed();
+    if (target === null) {
+      await page.waitForTimeout(20);
+      continue;
+    }
+    await page.keyboard.press(target.ch);
+    shot.push(target.index);
+  }
+  const combo = await hud();
+  check(
+    "a run of clean hits climbs, and the multiplier climbs with it",
+    // 11 + 12 + 13 + 14 + 15: ten points a hit, at the multiplier the hit
+    // itself lands on. The fifth is ×1.5 and the HUD says so.
+    shot.length === HITS &&
+      shot.join() === "0,1,2,3,4" &&
+      combo.score === 65 &&
+      combo.combo === "×1.5" &&
+      combo.hot,
+    `shot ${shot.join()} → ${combo.score} at ${combo.combo}`,
+  );
+
+  // And a wrong key, against a letter that is really there: the one case that
+  // is not a shot at an empty sky, so it takes the target's own neighbours out
+  // of the argument. `q` unless the target is a `q`.
+  const target = await aimed();
+  const wrongKey = target?.ch.toLowerCase() === "q" ? "z" : "q";
+  await page.keyboard.press(wrongKey);
+  const missed = await hud();
+  check(
+    "a wrong key costs a hit's worth, breaks the combo, and flares the board",
+    missed.score === combo.score - 10 &&
+      missed.combo === "×1.0" &&
+      !missed.hot &&
+      missed.flares.length === 1 &&
+      missed.flares[0].toLowerCase() === wrongKey,
+    `${combo.score} → ${missed.score} at ${missed.combo}, ` +
+      `flared ${JSON.stringify(missed.flares)}`,
+  );
+
+  // Seven more, at a rate a child could actually hammer at. The point of them
+  // is the score going under: it is the run's own number and it is allowed to.
+  //
+  // The 200ms is spacing, not patience, and it is what the flash count at the
+  // bottom of this section depends on: the HUD's `--flare` is an element keyed
+  // by the miss counter, so two misses inside one frame replace it before its
+  // animation has started and draw ONE flash between them — the same
+  // under-count the shield's tint has for two landings in one tick (§8.10),
+  // and the same safe direction. Pressed back to back, eight wrong keys drew
+  // seven flashes.
+  const MISSES = 8;
+  for (let i = 1; i < MISSES; i++) {
+    await page.waitForTimeout(200);
+    const next = await aimed();
+    await page.keyboard.press(next?.ch.toLowerCase() === "q" ? "z" : "q");
+  }
+  const sunk = await hud();
+  check(
+    "the score goes negative, and is drawn negative",
+    sunk.score === 65 - MISSES * 10,
+    `${sunk.score} after ${MISSES} wrong keys`,
+  );
+
+  // Then the rest of the wave lands and the run ends itself, exactly as the
+  // untouched one did.
+  await page
+    .waitForFunction(() => window.__pendingFrames() === 0, null, {
+      timeout: 15000,
+    })
+    .catch(() => {});
+  await page.waitForTimeout(300);
+  const paid = await hud();
+  const earned = Number(/\+(\d+) XP/.exec(paid.xp ?? "")?.[1]);
+  check(
+    "score can fall; XP cannot — a negative run still pays what it hit",
+    paid.score < 0 && paid.xp !== null && earned > 0,
+    `score ${paid.score}, ${paid.xp}`,
+  );
+
+  const played = await page.evaluate(() => window.__tints);
+  const hits = played.filter((tint) => tint.name === "storm-hit");
+  const flashes = played.filter((tint) => tint.name === "storm-miss");
+  check(
+    "five letters shot are five that never reached the shield",
+    hits.length === 12 - HITS && hits.every((tint) => tint.finger),
+    `${hits.length} damage tints for ${12 - HITS} landings`,
+  );
+  check(
+    "one flash of red per wrong key, and never two inside one flash",
+    // The HUD's flare is mounted from the miss counter exactly as the shield's
+    // tint is from the landing counter (§8.10, decision 42), so the same
+    // measurement holds it: one element per event, and no element restarted.
+    // 220ms is the flash; the presses above are 200ms apart on purpose, so a
+    // pair closer than that would be the animation restarting rather than the
+    // hand moving.
+    flashes.length === MISSES &&
+      flashes.every((tint) => tint.finger === undefined) &&
+      rhythm(flashes, () => "hud") >= 150,
+    `${flashes.length} flashes for ${MISSES} wrong keys, ` +
+      `closest pair ${rhythm(flashes, () => "hud")}ms apart`,
   );
 
   log(

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -776,11 +776,15 @@ try {
   //
   // The 200ms is spacing, not patience, and it is what the flash count at the
   // bottom of this section depends on: the HUD's `--flare` is an element keyed
-  // by the miss counter, so two misses inside one frame replace it before its
-  // animation has started and draw ONE flash between them — the same
-  // under-count the shield's tint has for two landings in one tick (§8.10),
-  // and the same safe direction. Pressed back to back, eight wrong keys drew
-  // seven flashes.
+  // by the miss counter, so misses landing inside one frame replace the element
+  // before its animation has started, and the listener on `document` sees ONE
+  // `animationstart` for all of them — the same under-count the shield's tint
+  // has for two landings in one tick (§8.10, and the note above the damage run
+  // in this file), and the same safe direction. It is not a one-in-eight
+  // rounding error. Measured on this build: eight wrong keys pressed back to
+  // back land inside 10ms, mount eight elements and draw ONE flash; thirty
+  // inside 21ms also draw one. The 200ms is what buys each flash a frame of
+  // its own, and at that cadence all eight are counted.
   const MISSES = 8;
   for (let i = 1; i < MISSES; i++) {
     await page.waitForTimeout(200);

--- a/src/engine/combo.ts
+++ b/src/engine/combo.ts
@@ -1,0 +1,33 @@
+/**
+ * What a streak is worth: one multiplier, for every game that keeps one.
+ *
+ * It is its own module rather than a pair of exports in `progress.ts` because
+ * of who needs it now. `cardXp` folds this curve into the XP for a card, the
+ * race draws it on the combo badge, and Hailstorm scales a hit by it and
+ * prints it in the HUD (docs/typing.md §8.6) — and `engine/typing/storm.ts`
+ * may not import `progress.ts`. That file is reachable from
+ * `engine/decks/index.ts`, the front door every island on the site downloads,
+ * and `progress.ts` pulls the deck registry, the hundred lessons and the
+ * ladder in behind it (§5.3, decision 7); STM10 also puts a `WaveSpec` on each
+ * storm lesson, which would close the import into a cycle.
+ *
+ * The alternative was a second `1 + min(streak, 10) / 10` written in the storm,
+ * and a second copy of a curve is how a race and a shooter end up paying out
+ * on scales that only look the same. A leaf module both can import is three
+ * lines and cannot drift.
+ */
+
+/**
+ * How many hits a combo counts before it stops growing.
+ *
+ * Ten, so the ceiling is ×2 — worth chasing, and reachable inside a run that
+ * a five-year-old will finish. Uncapped it would make the last card of a long
+ * race worth more than the first twenty put together, which stops rewarding
+ * accuracy and starts rewarding length.
+ */
+const MAX_COMBO_STEPS = 10;
+
+/** What the next answer is worth, given the streak it lands on: ×1 to ×2. */
+export function comboMultiplier(streak: number) {
+  return 1 + Math.min(streak, MAX_COMBO_STEPS) / 10;
+}

--- a/src/engine/progress.ts
+++ b/src/engine/progress.ts
@@ -66,11 +66,15 @@ export function cardXp(ms: number, streakAfter: number) {
  * So the run's misses cost score and nothing else, and the two numbers are
  * kept apart at exactly this line.
  *
- * The floor is unreachable today and is kept anyway: every term below is a
- * `cardXp`, which is never negative, so the `max` cannot bite as the sum
- * stands. What it defends is the next term somebody adds — a penalty per miss,
- * a charge for a letter that got through — which would look local and correct
- * here and would be a level ring running backwards on a profile.
+ * **The `max(0, …)` is deliberate and must not be removed.** It cannot bite as
+ * the sum stands — every term below is a `cardXp`, which is never negative —
+ * so no input can drive it, no test can pin it, and deleting it leaves the
+ * suite entirely green. That is the reason it is written down here rather than
+ * left to be rediscovered: it guards the NEXT term somebody adds, not today's.
+ * A penalty per miss, or a charge for a letter that got through, would look
+ * local and correct at the fold below and would be a child's level ring
+ * running backwards on their profile. Nothing in the tooling can say that to
+ * whoever adds one, so this paragraph does; unreachable is not unnecessary.
  *
  * ── Computed once, at the end, from the run's hits ───────────────────────
  * Not accumulated frame by frame: `resolved` already says which letters were

--- a/src/engine/progress.ts
+++ b/src/engine/progress.ts
@@ -1,8 +1,10 @@
+import { comboMultiplier } from "@/engine/combo";
 import { OPERATION_ORDER } from "@/engine/decks/flashcards";
 import { isFlash, isTyping, isWords } from "@/engine/decks";
 import { ladderProgress } from "@/engine/typing/ladder";
 import { forcedKeyboard, lessonById } from "@/engine/typing/lessons";
 import { verdictFor } from "@/engine/typing/verdict";
+import type { StormState } from "@/engine/typing/storm";
 import type { Session } from "@/engine/types";
 
 /* ── Levels ──────────────────────────────────────────────────────────────
@@ -40,7 +42,6 @@ export function levelFromXp(xp: number): LevelInfo {
 /* ── Race scoring ───────────────────────────────────────────────────────── */
 
 const SPEED_TARGET_MS = 4000;
-const MAX_COMBO_STEPS = 10;
 
 /** XP for one correct card. Wrong cards score nothing but cost no XP either. */
 export function cardXp(ms: number, streakAfter: number) {
@@ -48,12 +49,57 @@ export function cardXp(ms: number, streakAfter: number) {
     0,
     Math.min(15, Math.round((SPEED_TARGET_MS - ms) / 200)),
   );
-  const multiplier = 1 + Math.min(streakAfter, MAX_COMBO_STEPS) / 10;
-  return Math.round((10 + speed) * multiplier);
+  return Math.round((10 + speed) * comboMultiplier(streakAfter));
 }
 
-export function comboMultiplier(streak: number) {
-  return 1 + Math.min(streak, MAX_COMBO_STEPS) / 10;
+/**
+ * What a Hailstorm run pays into the profile (docs/typing.md §8.6).
+ *
+ * ── Score can fall; XP cannot ────────────────────────────────────────────
+ * The storm's own score goes DOWN on a wrong key, because losing points has
+ * to be visible and immediate or it is not a consequence. This number is the
+ * other one, and it is floored at zero on purpose: XP is cumulative across
+ * years and across four games, and it is what a child's level ring is drawn
+ * from. A mechanic that could take XP away would mean a level going BACKWARDS
+ * because they had a bad five minutes in a shooter — a punishment that
+ * outlives the run it was earned in, aimed at the youngest player on the site.
+ * So the run's misses cost score and nothing else, and the two numbers are
+ * kept apart at exactly this line.
+ *
+ * The floor is unreachable today and is kept anyway: every term below is a
+ * `cardXp`, which is never negative, so the `max` cannot bite as the sum
+ * stands. What it defends is the next term somebody adds — a penalty per miss,
+ * a charge for a letter that got through — which would look local and correct
+ * here and would be a level ring running backwards on a profile.
+ *
+ * ── Computed once, at the end, from the run's hits ───────────────────────
+ * Not accumulated frame by frame: `resolved` already says which letters were
+ * shot, when, and on what streak, so this is a fold over a finished run rather
+ * than a second tally kept in step with the reducer sixty times a second.
+ *
+ * `cardXp` is reused UNCHANGED, and that is the point of it. It already
+ * rewards a hit under four seconds and a streak up to ×2, which is the shape a
+ * shooter wants — and using it means a Hailstorm level and a flash-card race
+ * pay out on the same scale, which they must, because it is one profile and
+ * one level ring. `ms` is how long the letter was in the air (§8.7) and the
+ * streak is the combo the shot landed on, so both arguments mean here what
+ * they mean on a card.
+ */
+export function stormXp(state: StormState): number {
+  return Math.max(
+    0,
+    state.resolved.reduce<number>(
+      (sum, outcome, index) =>
+        outcome?.outcome === "shot"
+          ? sum +
+            cardXp(
+              outcome.atMs - state.wave.letters[index].spawnMs,
+              outcome.combo,
+            )
+          : sum,
+      0,
+    ),
+  );
 }
 
 export type FinishBonuses = {

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { keyX, strokeFor } from "@/engine/keyboard";
+import { cardXp, stormXp } from "@/engine/progress";
 import { unlockedAt } from "./keys";
 import {
   SHIELD_FINGERS,
@@ -585,7 +586,11 @@ describe("firing resolves the lowest letter, and nothing else", () => {
 
   it("shoots the lowest letter with its own key", () => {
     const state = fire(two(), "KeyF");
-    expect(state.resolved[0]).toEqual({ outcome: "shot", atMs: 500 });
+    expect(state.resolved[0]).toEqual({
+      outcome: "shot",
+      atMs: 500,
+      combo: 1,
+    });
     expect(state.resolved[1], "the letter above it is untouched").toBeNull();
     expect(state.combo).toBe(1);
     expect(state.shield, "a hit costs the shield nothing").toEqual(
@@ -638,10 +643,187 @@ describe("firing resolves the lowest letter, and nothing else", () => {
   });
 });
 
+/* ═══ Score, combo and XP (§8.6) ═════════════════════════════════════════════
+ *
+ * Two numbers with opposite rules, which is the whole of this section: the
+ * score is the run's and may fall, the XP is the profile's and may not. They
+ * are tested together because the only way to get them wrong is to let one
+ * become the other.
+ */
+
+/**
+ * Twelve `f`s in the air at once, and nothing else.
+ *
+ * Every letter falls for twenty seconds from within the first tenth of a
+ * second, so at 200ms all twelve are airborne and none can land during a test.
+ * They are all the same character, and the target is the greatest fall
+ * progress — which for equal fall times is the earliest spawn — so `KeyF`
+ * shoots them in index order and a chain of hits needs no clock at all.
+ * `KeyZ` is a wrong key for every one of them.
+ */
+const volley = (): StormState =>
+  to(
+    runOf(
+      Array.from({ length: 12 }, (_, i) => at("f", i * 10, 20_000)),
+      { shield: 9 },
+    ),
+    200,
+  );
+
+/** Fire `codes` in order, and report the score after each one. */
+const scores = (state: StormState, codes: string[]): number[] =>
+  codes.map((code) => (state = fire(state, code)).score);
+
+describe("a run of clean hits is worth more", () => {
+  it("pays a hit at the multiplier the hit itself lands on", () => {
+    // Ten points, scaled by the streak AFTER the hit — the same convention
+    // `cardXp(ms, streakAfter)` pays a flash card at, and the same number the
+    // HUD is showing by the time a child looks at it. So the first hit is
+    // ×1.1 and not ×1.
+    expect(scores(volley(), Array(4).fill("KeyF"))).toEqual([11, 23, 36, 50]);
+  });
+
+  it("stops growing at ×2, ten in a row", () => {
+    // `comboMultiplier` caps at ten steps, so the eleventh and twelfth hits
+    // are worth exactly what the tenth was. Uncapped, the end of a long wave
+    // would be worth more than the whole of the start of it.
+    const gains = scores(volley(), Array(12).fill("KeyF")).map(
+      (score, i, all) => score - (all[i - 1] ?? 0),
+    );
+    expect(gains).toEqual([11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 20, 20]);
+  });
+
+  it("records the streak each letter was shot on", () => {
+    // Not recoverable from anything else in the run — a wrong key breaks the
+    // combo and resolves no letter — and `stormXp` needs it to pay the hit at
+    // the multiplier the child actually had.
+    const state = fire(fire(fire(volley(), "KeyF"), "KeyZ"), "KeyF");
+    expect(state.resolved.map((outcome) => outcome?.combo)).toEqual([
+      1,
+      1,
+      ...Array(10).fill(undefined),
+    ]);
+    expect(state.resolved[1]).toEqual({ outcome: "shot", atMs: 200, combo: 1 });
+  });
+});
+
+describe("a wrong key costs", () => {
+  it("takes points off and breaks the streak in the same stroke", () => {
+    const built = fire(fire(fire(volley(), "KeyF"), "KeyF"), "KeyF");
+    expect([built.score, built.combo, built.misses]).toEqual([36, 3, 0]);
+
+    const missed = fire(built, "KeyZ");
+    expect(missed.score, "one wrong key undoes one plain hit").toBe(26);
+    expect(missed.combo, "and the multiplier with it").toBe(0);
+    expect(missed.misses).toBe(1);
+    expect(missed.resolved, "and nothing on the field moved").toEqual(
+      built.resolved,
+    );
+
+    // The next hit is back at ×1.1, which is the real cost of the miss: the
+    // ten points, and every later hit paid at a multiplier that has to be
+    // earned again.
+    expect(fire(missed, "KeyF").score - missed.score).toBe(11);
+  });
+
+  it("charges the same for a shot at an empty sky", () => {
+    // Spraying between letters is the same strategy by another route (§8.4),
+    // so it costs the same. The screen has to say so too, which is what
+    // `emptyIsWrong` is for — a key that costs points must not light `--lime`.
+    const empty = runOf([at("f", 1000, 500)]);
+    expect(targetIndex(empty), "the premise: nothing is falling").toBeNull();
+
+    const state = fire(empty, "KeyF");
+    expect([state.score, state.misses]).toEqual([-10, 1]);
+  });
+
+  it("lets the score go negative, because it is the run's own", () => {
+    // A five-year-old who hammers the board bottoms out below zero and can
+    // see it. Nothing about that reaches the profile: `stormXp` is floored,
+    // and it is floored at the other end of the run rather than here.
+    const sprayed = fire(fire(fire(volley(), "KeyZ"), "KeyQ"), "KeyP");
+    expect(sprayed.score).toBe(-30);
+    expect(sprayed.misses).toBe(3);
+    expect(stormXp(sprayed)).toBe(0);
+  });
+
+  it("charges a letter that got through to the shield and not to the score", () => {
+    // One wrong, one cost. A landing has already taken a shield point, which
+    // is the thing that ends runs, and charging for it twice would make the
+    // number that goes down mean two different failures at once.
+    const hit = fire(
+      to(runOf([at("f", 0, 400), at("j", 0, 1000)]), 100),
+      "KeyF",
+    );
+    const through = to(hit, 1200);
+
+    expect(through.resolved[1]?.outcome, "the j landed").toBe("landed");
+    expect(through.score, "and cost the score nothing").toBe(hit.score);
+    expect(through.misses, "it is not a wrong key").toBe(0);
+    expect(through.combo, "it does break the streak").toBe(0);
+  });
+});
+
+describe("score can fall; XP cannot", () => {
+  /**
+   * `stormXp` lives in `engine/progress.ts` beside `cardXp` — the storm's own
+   * module may not import it, because it is reachable from `decks/index.ts`
+   * and would drag the deck registry and the hundred lessons in behind it
+   * (§5.3, decision 7). It is tested here anyway: what it means is a rule
+   * about a run, and the run is what this file builds.
+   */
+  it("pays each hit exactly what `cardXp` pays a card", () => {
+    // Reused unchanged, which is what makes a Hailstorm level and a
+    // flash-card race pay out on the same scale. Restating the curve here
+    // would only pin a copy of it, so the assertion is against `cardXp`
+    // itself, on the arguments §8.7 says a hit hands it: how long the letter
+    // was in the air, and the streak it was shot on.
+    const state = fire(fire(volley(), "KeyF"), "KeyF");
+    const shots = [
+      { ms: 200 - 0, combo: 1 },
+      { ms: 200 - 10, combo: 2 },
+    ];
+
+    expect(stormXp(state)).toBe(
+      shots.reduce((sum, shot) => sum + cardXp(shot.ms, shot.combo), 0),
+    );
+    // And it is a real number rather than an accident of two zeroes.
+    expect(stormXp(state)).toBeGreaterThan(0);
+  });
+
+  it("pays nothing for a letter that landed, and never less than nothing", () => {
+    // The floor is what §8.6 turns on: XP is cumulative across years and four
+    // games, so a run a child played badly may pay nothing and must never take
+    // anything away. Here the score is deep in the red and the XP is zero,
+    // which is the pair the whole rule exists to keep apart.
+    const beaten = to(
+      fire(fire(runOf([at("f", 0, 200)], { shield: 3 }), "KeyZ"), "KeyQ"),
+      500,
+    );
+
+    expect(beaten.resolved[0]?.outcome).toBe("landed");
+    expect(beaten.score).toBeLessThan(0);
+    expect(stormXp(beaten)).toBe(0);
+  });
+
+  it("is a fold over the run rather than a tally kept during it", () => {
+    // The same state twice is the same XP, and a state built two ways is the
+    // same XP: nothing about the number depends on how many times it was
+    // asked for, which is what "computed once at the end" has to survive.
+    const state = fire(fire(fire(volley(), "KeyF"), "KeyZ"), "KeyF");
+    expect(stormXp(state)).toBe(stormXp(state));
+    expect(stormXp(startStorm(state.wave)), "an untouched run pays 0").toBe(0);
+  });
+});
+
 describe("what lands takes the shield apart", () => {
   it("takes a point off the zone above it and no others", () => {
     const state = to(runOf([at("f", 0, 100)], { shield: 3 }), 100);
-    expect(state.resolved[0]).toEqual({ outcome: "landed", atMs: 100 });
+    expect(state.resolved[0]).toEqual({
+      outcome: "landed",
+      atMs: 100,
+      combo: 0,
+    });
     expect(state.shield["l-index"], "the finger that types f").toBe(2);
     expect(state.shield).toEqual({ ...evenShield(3), "l-index": 2 });
   });
@@ -673,7 +855,7 @@ describe("what lands takes the shield apart", () => {
       index: 1,
     });
     expect(dead.resolved[1], "the letter that got through is recorded").toEqual(
-      { outcome: "landed", atMs: 300 },
+      { outcome: "landed", atMs: 300, combo: 0 },
     );
     expect(dead.shield["l-index"], "there was nothing left to take it").toBe(0);
   });
@@ -705,10 +887,15 @@ describe("a tick resolves every landing inside it", () => {
     );
 
     expect(landed(state)).toEqual([0, 1]);
-    expect(state.resolved[0]).toEqual({ outcome: "landed", atMs: 100 });
+    expect(state.resolved[0]).toEqual({
+      outcome: "landed",
+      atMs: 100,
+      combo: 0,
+    });
     expect(state.resolved[1], "each is timed by its own landing").toEqual({
       outcome: "landed",
       atMs: 200,
+      combo: 0,
     });
     expect(state.shield["l-index"]).toBe(2);
     expect(state.shield["r-index"]).toBe(2);

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -36,6 +36,7 @@
  * the spec, the RNG, the keyboard and the rules: the characters a wave draws
  * from arrive as `spec.keys`, from a caller that already knows them.
  */
+import { comboMultiplier } from "@/engine/combo";
 import { keyX, strokeFor } from "@/engine/keyboard";
 import type { Finger } from "@/engine/keyboard";
 import { between, mulberry32 } from "@/engine/random";
@@ -357,10 +358,20 @@ export type Shield = Readonly<Record<ShieldFinger, number>>;
  * late (see `tick`), and STM08 turns this into a `CardResult.ms` of
  * `atMs - spawnMs` (§8.7). A card that timed a backgrounded tab instead of a
  * fall would put a nonsense number in a child's record book for ever.
+ *
+ * `combo` is the streak the shot left the run on — the number the HUD draws
+ * its multiplier from the instant after it — and 0 for a letter that got
+ * through, since a landing is what breaks a streak. It is recorded rather than recovered
+ * because it cannot be recovered: a wrong key breaks the combo and resolves no
+ * letter, so nothing in `resolved` remembers that it happened, and a run's XP
+ * counted back off this array without it would pay a child for a streak they
+ * did not keep. `stormXp` folds exactly this pair — `atMs - spawnMs` and
+ * `combo` — through `cardXp` when the run is over (§8.6).
  */
 export type LetterOutcome = {
   outcome: "shot" | "landed";
   atMs: number;
+  combo: number;
 };
 
 /**
@@ -396,11 +407,9 @@ export type StormEnding =
  * no bookkeeping — card _i_ is letter _i_, so `prompt`, `answer` and `factId`
  * are its character and `ms` is `atMs - spawnMs` (§8.7, STM08).
  *
- * What the next two stories add, and why nothing here is in their way: STM06's
- * score and best-combo watermark are two more numbers beside `combo`, written
- * at the two moments this reducer already has — a hit in `fire`, and a broken
- * streak. STM07 reads `ending` for the finger and counts `resolved` by finger
- * for "let three through". Neither wants a different shape.
+ * What the next story adds, and why nothing here is in its way: STM07 reads
+ * `ending` for the finger and counts `resolved` by finger for "let three
+ * through". It wants no different shape.
  */
 export type StormState = {
   /** The storm being played. Decided before the run; never changes during it. */
@@ -422,13 +431,56 @@ export type StormState = {
    * is the game's only comeback path and pays out for exactly the behaviour it
    * exists to build. A letter that landed breaks the streak as surely as a
    * wrong key does — the streak means "are you keeping up", and a letter you
-   * let through is the definition of not keeping up. STM06 hangs its
-   * multiplier on this same number, so a child sees one streak and not two.
+   * let through is the definition of not keeping up.
+   *
+   * The score multiplier hangs on this same number, through the same
+   * `comboMultiplier` a race pays its cards at — so a child sees ONE streak,
+   * and the ×1.6 in the HUD is the ×1.6 their XP is worth (§8.6).
    */
   readonly combo: number;
+  /**
+   * The run's own score. Starts at 0, and **may go negative** (§8.6).
+   *
+   * Kept rather than derived because it cannot be derived: a wrong key costs
+   * points and resolves no letter, so `resolved` has no record of it, and the
+   * multiplier a hit was paid at is history the moment the streak moves on.
+   *
+   * It is not XP and it never becomes XP. `stormXp` is computed once at the
+   * end, from the hits alone and floored at zero, precisely so that this
+   * number is free to fall (see `progress.ts`).
+   */
+  readonly score: number;
+  /**
+   * Wrong keys — shots that hit nothing, including shots at an empty sky.
+   *
+   * A count and not a list, because the two things that read it want a number:
+   * the HUD mounts one `--flare` flash per miss off it (a counter that only
+   * goes up cannot restart an animation, §8.10, decision 42), and STM08 owes a
+   * saved session an `incorrect` that counts what a child got wrong rather
+   * than only what the shield paid for.
+   */
+  readonly misses: number;
   /** How the run finished, or `null` while it is live. */
   readonly ending: StormEnding | null;
 };
+
+/**
+ * What a clean hit is worth before the combo multiplier, and what a wrong key
+ * costs (§8.6).
+ *
+ * Equal, and that is the whole of the balance: **one wrong key undoes one
+ * plain hit**, which is a sentence a five-year-old can hold on to. A hit on a
+ * long streak is worth two of them (×2 at ten in a row), so keeping a run
+ * clean pays for itself twice over — once in the multiplier, and once in the
+ * misses it did not make.
+ *
+ * A letter that gets through costs neither. It has already cost a shield
+ * point, which is the thing that ends runs, and charging for it twice would
+ * make the number that goes down mean two different failures at once
+ * (decision 46).
+ */
+export const HIT_POINTS = 10;
+export const MISS_POINTS = 10;
 
 /**
  * Stamp `cleared` on a state whose last letter has just been accounted for.
@@ -468,6 +520,8 @@ export function startStorm(wave: Wave): StormState {
     shield,
     resolved: wave.letters.map(() => null),
     combo: 0,
+    score: 0,
+    misses: 0,
     ending: null,
   });
 }
@@ -494,7 +548,8 @@ export function startStorm(wave: Wave): StormState {
  *
  * It does not read `state.ending`. A run that ended mid-wave still has letters
  * in the air, so this still names one; `fire` asks only after its own guard,
- * and a screen painting a reticle from it (STM03, STM06) has to guard too.
+ * and a screen that marks a child's keys against it (`aimedAt`) has to guard
+ * too.
  */
 export function targetIndex(state: StormState): number | null {
   const { letters } = state.wave;
@@ -605,7 +660,10 @@ export function tick(state: StormState, dtMs: number): StormState {
   let clock = timeMs;
 
   for (const { letter, index } of landings) {
-    resolved[index] = { outcome: "landed", atMs: letter.landMs };
+    // Combo 0 on the outcome as well as on the run: a letter that got through
+    // was shot on no streak at all, and `stormXp` pays nothing for it either
+    // way — it looks only at what was shot.
+    resolved[index] = { outcome: "landed", atMs: letter.landMs, combo: 0 };
     combo = 0;
 
     if (shield[letter.finger] <= 0) {
@@ -655,12 +713,17 @@ export function tick(state: StormState, dtMs: number): StormState {
  * thing and the game is pure reaction. With three, taking the bottom one first
  * is an act of prioritising under time pressure — reading ahead, which is the
  * thing that separates a typist from a hunter — and it is a skill precisely
- * because getting the order wrong costs something: the streak here, and the
- * score STM06 hangs on the same number.
+ * because getting the order wrong costs something: the streak, and with it the
+ * multiplier every later hit would have been paid at, plus `MISS_POINTS` off
+ * the score there and then.
  *
  * A shot at an empty field is a miss for the same reason. It is exactly the
  * spray this rule exists to make unprofitable, and a child who could keep
- * their streak through it has found the strategy again by another route.
+ * their streak through it has found the strategy again by another route. The
+ * screen owes them an answer to it that the board can tell the truth with:
+ * a stroke that costs points must not light `--lime` for "that was right", so
+ * the keyboard flares every key while the gun is live and has no target
+ * (`StormField`, decision 43).
  */
 export function fire(state: StormState, code: string): StormState {
   if (state.ending !== null) return state;
@@ -670,16 +733,30 @@ export function fire(state: StormState, code: string): StormState {
   // holding cannot make the shot miss (decision 2).
   const index = targetIndex(state);
   if (index === null || state.wave.letters[index].code !== code)
-    return { ...state, combo: 0 }; // A miss: the streak, and nothing else.
+    // A miss: the streak, the score and a mark against the run. Nothing on the
+    // field moves — the letter the child should have shot is still falling,
+    // which is the other half of the cost.
+    return {
+      ...state,
+      combo: 0,
+      score: state.score - MISS_POINTS,
+      misses: state.misses + 1,
+    };
 
   const resolved = state.resolved.slice();
-  resolved[index] = { outcome: "shot", atMs: state.timeMs };
   const combo = state.combo + 1;
+  resolved[index] = { outcome: "shot", atMs: state.timeMs, combo };
 
   return settled({
     ...state,
     resolved,
     combo,
+    // Paid at the multiplier the hit LANDS on, not the one before it: the
+    // fifth hit in a row is worth ×1.5, and it is the number the HUD is
+    // already showing by the time a child looks at it. Same convention as
+    // `cardXp(ms, streakAfter)`, which is what pays the same hit in XP —
+    // one streak, one multiplier, two currencies (§8.6).
+    score: state.score + Math.round(HIT_POINTS * comboMultiplier(combo)),
     shield: repaired(state.shield, state.wave.spec, combo),
   });
 }

--- a/src/games/flashcards/race/CardFace.tsx
+++ b/src/games/flashcards/race/CardFace.tsx
@@ -1,4 +1,4 @@
-import { comboMultiplier } from "@/engine/progress";
+import { comboMultiplier } from "@/engine/combo";
 import type { Card, InputMode } from "@/engine/types";
 import { WordPrompt } from "./WordPrompt";
 import type { Feedback } from "@/games/race/types";

--- a/src/games/typing/keyboard/LiveKeyboard.tsx
+++ b/src/games/typing/keyboard/LiveKeyboard.tsx
@@ -32,6 +32,7 @@ import type { KeyboardMode } from "@/engine/types";
 export function LiveKeyboard({
   mode,
   next,
+  emptyIsWrong = false,
 }: {
   /**
    * How much board to draw. "off" is absent because that decision belongs to
@@ -43,6 +44,15 @@ export function LiveKeyboard({
    * on one — before the countdown clears, and once the run is over.
    */
   next: string | null;
+  /**
+   * What a `null` `next` means for a key that was struck anyway.
+   *
+   * A passage leaves it alone: the beat between two words is not a mistake.
+   * Hailstorm sets it while the gun is live, because there a stroke with
+   * nothing to shoot at is a miss that costs score, and a key that costs a
+   * child points must not light `--lime` (§8.4, decision 43).
+   */
+  emptyIsWrong?: boolean;
 }) {
   /**
    * The expectation is the real next character in BOTH modes, and only the
@@ -54,7 +64,7 @@ export function LiveKeyboard({
    * that is the rung of the ladder they are on. Passing `null` here to match
    * the hint would turn every wrong key green.
    */
-  const { down, wrong } = useKeyEcho({ expect: next });
+  const { down, wrong } = useKeyEcho({ expect: next, emptyIsWrong });
 
   return (
     <Keyboard down={down} wrong={wrong} next={mode === "guide" ? next : null} />

--- a/src/games/typing/keyboard/useKeyEcho.test.ts
+++ b/src/games/typing/keyboard/useKeyEcho.test.ts
@@ -149,6 +149,30 @@ describe("createKeyEcho", () => {
     expect(keys.wrong()).toEqual([]);
   });
 
+  it("blames everything when the caller says nothing is right", () => {
+    // Hailstorm's empty sky (§8.4, decision 43). The same `null` a lesson
+    // means "there is nothing to judge" by, the storm means "there is nothing
+    // that COULD be right" — the stroke was a shot, it hit nothing, and it
+    // cost points. A key that costs a child points must not light `--lime`.
+    const keys = board();
+    keys.press("KeyQ", null, true);
+    expect(keys.down()).toEqual(["KeyQ"]);
+    expect(keys.wrong()).toEqual(["KeyQ"]);
+
+    // Held keys are still never wrong, whatever the caller says: reaching for
+    // the far shift is the technique, not the mistake, and in the storm it is
+    // not a shot either (`useStormClock`).
+    keys.press("ShiftRight", null, true);
+    expect(keys.wrong()).toEqual(["KeyQ"]);
+
+    // And a real target still marks against itself rather than against the
+    // flag — which is what stops the storm flaring every key it is aimed with.
+    keys.press("KeyF", "f", true);
+    expect(keys.wrong()).toEqual(["KeyQ"]);
+    keys.press("KeyD", "f", true);
+    expect(keys.wrong()).toEqual(["KeyD", "KeyQ"]);
+  });
+
   it("clears a wrong key's flare when that key is struck correctly", () => {
     const keys = board();
     keys.press("KeyD", "f");

--- a/src/games/typing/keyboard/useKeyEcho.ts
+++ b/src/games/typing/keyboard/useKeyEcho.ts
@@ -42,6 +42,12 @@ const SILENT: KeyEcho = { down: new Set(), wrong: new Set() };
 /**
  * The keys that are HELD rather than typed, and so are never wrong.
  *
+ * Exported because Hailstorm's gun has to agree with the board about what a
+ * stroke even is: the same set decides which keys never flare here and which
+ * keys are never a shot there (`useStormClock`). Two lists would be a shift
+ * that flared red without costing anything, or cost something without saying
+ * so.
+ *
  * Shift is the reason this set exists. Shift is not a mistake, it is the
  * technique: a capital is right-shift plus a left-hand letter (§3.3), and the
  * child who reaches for the far shift a beat before the letter — the thing
@@ -56,7 +62,7 @@ const SILENT: KeyEcho = { down: new Set(), wrong: new Set() };
  * the mistake that wants pointing out — before it turns the next line into
  * SHOUTING nobody can explain.
  */
-const HELD = new Set([
+export const HELD = new Set([
   "ShiftLeft",
   "ShiftRight",
   "ControlLeft",
@@ -81,16 +87,31 @@ const HELD = new Set([
  * Nothing is wrong when there is nothing to be wrong about: free play between
  * words has no expected character, and a character this layout cannot produce
  * (a curly quote that escaped the passage filter) has no key to blame.
+ *
+ * `emptyIsWrong` is the caller saying that its own nothing means the opposite:
+ * not "there is nothing to judge" but "there is nothing that could be right".
+ * Hailstorm is the case — a stroke at a sky with no letter in it is a miss
+ * that costs score (§8.4), and a key that costs a child points must not light
+ * `--lime` at them, because `--lime` means "that was right" everywhere else on
+ * this site (decision 43). A lesson never passes it: the pause between two
+ * words is not a mistake.
  */
-function isWrong(code: string, expect: string | null): boolean {
+function isWrong(
+  code: string,
+  expect: string | null,
+  emptyIsWrong: boolean,
+): boolean {
   if (HELD.has(code)) return false;
   const stroke = expect === null ? null : strokeFor(expect);
-  return stroke !== null && code !== stroke.code;
+  return stroke === null ? emptyIsWrong : code !== stroke.code;
 }
 
 export type KeyEchoBoard = {
-  /** Light `code`, flaring it if it wasn't the key `expect` needed. */
-  press: (code: string, expect: string | null) => void;
+  /**
+   * Light `code`, flaring it if it wasn't the key `expect` needed — or, with
+   * nothing expected and `emptyIsWrong`, flaring it for being a stroke at all.
+   */
+  press: (code: string, expect: string | null, emptyIsWrong?: boolean) => void;
   /** Drop every pending release. What unmounting does. */
   stop: () => void;
 };
@@ -116,9 +137,9 @@ export function createKeyEcho(emit: (echo: KeyEcho) => void): KeyEchoBoard {
   const publish = () => emit({ down: new Set(down), wrong: new Set(wrong) });
 
   return {
-    press(code, expect) {
+    press(code, expect, emptyIsWrong = false) {
       down.add(code);
-      if (isWrong(code, expect)) wrong.add(code);
+      if (isWrong(code, expect, emptyIsWrong)) wrong.add(code);
       else wrong.delete(code);
 
       // One release per code, re-armed rather than stacked: every keydown for
@@ -164,7 +185,14 @@ export function createKeyEcho(emit: (echo: KeyEcho) => void): KeyEchoBoard {
  * costs nothing next to the race clock already re-rendering this screen
  * sixteen times a second.
  */
-export function useKeyEcho({ expect }: { expect: string | null }): KeyEcho {
+export function useKeyEcho({
+  expect,
+  emptyIsWrong = false,
+}: {
+  expect: string | null;
+  /** See `isWrong`. Hailstorm's empty sky; never a lesson's. */
+  emptyIsWrong?: boolean;
+}): KeyEcho {
   const [echo, setEcho] = useState<KeyEcho>(SILENT);
 
   /**
@@ -184,10 +212,19 @@ export function useKeyEcho({ expect }: { expect: string | null }): KeyEcho {
   const expected = useRef(expect);
   expected.current = expect;
 
+  /**
+   * Read by the listener for the same reason `expected` is, and it moves for
+   * the same kind of reason: Hailstorm turns it off the moment a run ends, and
+   * a listener bound to the old value would go on flaring at a child whose
+   * storm is over.
+   */
+  const blame = useRef(emptyIsWrong);
+  blame.current = emptyIsWrong;
+
   useEffect(() => {
     const board = createKeyEcho(setEcho);
     const onKeyDown = (event: KeyboardEvent) =>
-      board.press(event.code, expected.current);
+      board.press(event.code, expected.current, blame.current);
 
     // Capture, not bubble — the third argument is load-bearing.
     //

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -372,12 +372,13 @@ describe("StormField", () => {
 
   it("borrows exactly the two telemetry colours it has something to say with", () => {
     // The field itself borrows none of the five — a hailstone in `--lime`
-    // would be saying something was right about it. The shield borrows two,
-    // and only where they already mean what they mean everywhere else on this
-    // site: `--flare` is a wrong, and damage and a hole are the two wrongs
-    // this game has; `--lime` is a right, and a repair is bought with a run of
-    // them (§8.5). The other three would each be a lie about what happened —
-    // nothing on this screen is a ghost, a record or a badge.
+    // would be saying something was right about it. The shield and the HUD
+    // borrow two, and only where they already mean what they mean everywhere
+    // else on this site: `--flare` is a wrong, and damage, a hole and a wrong
+    // key are the three wrongs this game has; `--lime` is a right, and both a
+    // repair and a live combo are bought with a run of them (§8.5, §8.6). The
+    // other three would each be a lie about what happened — nothing on this
+    // screen is a ghost, a record or a badge.
     const rules = [...storm.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(
       ([, selector, body]) => ({ selector: selector.trim(), body }),
     );
@@ -389,9 +390,13 @@ describe("StormField", () => {
 
     expect(drawnWith("--flare")).toEqual([
       ".storm__hit",
+      ".storm__miss",
       ".storm__zone[data-hole]",
     ]);
-    expect(drawnWith("--lime")).toEqual([".storm__mend"]);
+    expect(drawnWith("--lime")).toEqual([
+      ".storm__combo[data-hot]",
+      ".storm__mend",
+    ]);
     for (const name of ["--sky", "--gold", "--grape"])
       expect(storm).not.toContain(`var(${name})`);
   });

--- a/src/games/typing/storm/StormField.tsx
+++ b/src/games/typing/storm/StormField.tsx
@@ -2,6 +2,7 @@ import { isAirborne, progressAt, targetIndex } from "@/engine/typing/storm";
 
 import { LiveKeyboard } from "../keyboard/LiveKeyboard";
 
+import { StormHud } from "./StormHud";
 import { StormShield } from "./StormShield";
 
 import type { StormState } from "@/engine/typing/storm";
@@ -52,13 +53,17 @@ import type { CSSProperties } from "react";
  * which letter each one is. A rendered index rather than the loop counting
  * children, for the same reason the React key is the index (§8.3): a filtered
  * list renumbers itself the instant something in the middle of it is shot.
- * The shield is in the sky beside them and carries no such attribute, which is
- * what makes the loop skip it: `Number(undefined)` is `NaN`, which indexes no
- * letter. An EMPTY one would not — `Number("")` is `0` — and the shield would
- * be written the first letter's fall, sixty times a second, as though it were
- * the stone.
+ * The HUD and the shield are in the sky beside them and carry no such
+ * attribute, which is what makes the loop skip both: `Number(undefined)` is
+ * `NaN`, which indexes no letter. An EMPTY one would not — `Number("")` is
+ * `0` — and whichever of them held it would be written the first letter's
+ * fall, sixty times a second, as though it were the stone.
  *
- * Firing and its reticle are STM06.
+ * The trigger is not here either. A press has to be answered against the run
+ * as the last FRAME left it, and what this component is handed is the last
+ * frame whose picture changed — which can be several behind — so the gun is in
+ * `useStormClock` beside the loop, and the rules it fires are in the engine
+ * (§8.6, §8.9).
  */
 
 /**
@@ -106,9 +111,9 @@ export function aimedAt(state: StormState): string | null {
 }
 
 /**
- * The field, as markup: the sky, whatever is falling through it, and the board
- * at the bottom. A pure function of one `StormState` — see the file header for
- * why, and for what the next three stories hang off it.
+ * The field, as markup: the HUD, the sky, whatever is falling through it, the
+ * shield they land on and the board at the bottom. A pure function of one
+ * `StormState` — see the file header for why.
  */
 export function StormField({
   state,
@@ -133,6 +138,13 @@ export function StormField({
         keys is told so honestly, and that is STM09's story.
       */}
       <div className="storm__sky" ref={skyRef} aria-hidden="true">
+        {/* First in the sky, so every stone paints over the numbers rather
+            than under them: a score must never hide a letter that has to be
+            shot. It is in here rather than in a row of its own because the sky
+            is the only track `.storm` can take a row FROM, and on a short
+            viewport it has nothing left to give (decision 45, `StormHud`). */}
+        <StormHud state={state} />
+
         {state.wave.letters.map((letter, index) => {
           if (!isDrawn(state, index)) return null;
 
@@ -166,7 +178,20 @@ export function StormField({
         <StormShield state={state} />
       </div>
 
-      <LiveKeyboard mode="keys" next={aimedAt(state)} />
+      {/*
+        `emptyIsWrong` while the run is live, which is the honest answer to
+        firing at an empty sky (§8.4, decision 43). The reducer charges that
+        stroke `MISS_POINTS` and breaks the streak, so the board cannot be
+        allowed to light it `--lime` for "that was right" — with nothing in the
+        air there is nothing that could be right, and every key flares. Once
+        the run is over the gun is dead and so is the marking: `aimedAt` is
+        null for both reasons, and this is what tells them apart.
+      */}
+      <LiveKeyboard
+        mode="keys"
+        next={aimedAt(state)}
+        emptyIsWrong={state.ending === null}
+      />
     </main>
   );
 }

--- a/src/games/typing/storm/StormHud.test.tsx
+++ b/src/games/typing/storm/StormHud.test.tsx
@@ -1,0 +1,135 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { comboMultiplier } from "@/engine/combo";
+import { stormXp } from "@/engine/progress";
+import { buildWave, fire, startStorm, tick } from "@/engine/typing/storm";
+
+import { StormHud } from "./StormHud";
+
+import type { StormState, WaveSpec } from "@/engine/typing/storm";
+
+/**
+ * The HUD, as a child reads it: what the run is worth, what the next hit is
+ * worth, and one flash of red when a wrong key takes points off
+ * (docs/typing.md §8.6).
+ *
+ * Everything here is a rendering of numbers the reducer already holds, and
+ * that is the property this file is really defending: not one of these
+ * assertions computes what a hit was worth. `storm.test.ts` decides that a
+ * fifth hit is worth fifteen points; this decides only that fifteen is what
+ * ends up on the screen.
+ */
+
+const only = (ch: string, over: Partial<WaveSpec> = {}): WaveSpec => ({
+  keys: [ch],
+  count: 4,
+  gap: [200, 200],
+  fall: [4000, 4000],
+  shield: 3,
+  repairAt: 0,
+  ...over,
+});
+
+/** A run with `hits` letters shot and `misses` wrong keys, in that order. */
+const played = (hits: number, misses = 0, spec = only("f")): StormState => {
+  let state = tick(startStorm(buildWave(spec, 7)), 900);
+  for (let i = 0; i < hits; i++) state = fire(state, "KeyF");
+  for (let i = 0; i < misses; i++) state = fire(state, "KeyZ");
+  return state;
+};
+
+const hud = (state: StormState) =>
+  renderToStaticMarkup(<StormHud state={state} />);
+
+/** The HUD's text, with the markup taken out. */
+const readOut = (state: StormState) => hud(state).replace(/<[^>]+>/g, " ");
+
+const flashes = (state: StormState) =>
+  (hud(state).match(/class="storm__miss"/g) ?? []).length;
+
+describe("StormHud", () => {
+  it("shows the score the reducer is holding, negative included", () => {
+    expect(readOut(played(0))).toContain("0");
+    expect(readOut(played(3))).toContain(String(played(3).score));
+
+    // Score can fall (§8.6), and a score that fell below zero has to read as
+    // one — a HUD that clamped it would be hiding the consequence the wrong
+    // key was supposed to have.
+    const sprayed = played(0, 3);
+    expect(sprayed.score).toBeLessThan(0);
+    expect(readOut(sprayed)).toContain(String(sprayed.score));
+  });
+
+  it("shows the multiplier the next hit will be paid at", () => {
+    // The same `comboMultiplier` that scales the score and `cardXp` — one
+    // streak, one multiplier, so the figure a child watches climb is the
+    // figure their XP is worth.
+    expect(readOut(played(0))).toContain("×1.0");
+    expect(readOut(played(3))).toContain("×1.3");
+    expect(readOut(played(3))).toContain(
+      `×${comboMultiplier(played(3).combo).toFixed(1)}`,
+    );
+
+    // And it goes back to nothing the moment a wrong key breaks the streak,
+    // which is what "immediately and visibly" means for the half of the cost
+    // that is not points.
+    expect(readOut(played(3, 1))).toContain("×1.0");
+  });
+
+  it("marks the multiplier as earned only while a streak is running", () => {
+    // `data-hot` is what `--lime` hangs off in the stylesheet: at ×1 the
+    // number is a fact about the rules, at ×1.3 it is a thing a child earned.
+    expect(hud(played(0))).not.toContain("data-hot");
+    expect(hud(played(3))).toContain("data-hot");
+    expect(hud(played(3, 1))).not.toContain("data-hot");
+  });
+
+  it("flashes once per miss, and mounts nothing before the first one", () => {
+    // The no-strobe mechanism, at the altitude a unit test can hold it: the
+    // flash is one element keyed by a counter that only goes up (§8.10,
+    // decision 42), so an unchanged count is the same node and cannot restart
+    // the animation. A run starts with no element at all, or every HUD would
+    // flash red on its first frame.
+    expect(flashes(played(0))).toBe(0);
+    expect(flashes(played(2))).toBe(0);
+    expect(flashes(played(2, 1))).toBe(1);
+    expect(flashes(played(2, 4)), "one element, not one per miss").toBe(1);
+  });
+
+  it("carries no `data-stone`, so the fall loop steps over it", () => {
+    // `useStormClock` walks the sky's children and reads `data-stone` off each
+    // one; the HUD is one of the two that are not stones. Absent, that is
+    // `Number(undefined)` — `NaN`, which indexes no letter. An EMPTY one would
+    // be `Number("")`, which is 0, and the HUD would be written the first
+    // letter's fall sixty times a second.
+    expect(hud(played(1))).not.toContain("data-stone");
+  });
+
+  it("says what the run paid only once it is over", () => {
+    // XP is computed once at the end and floored at zero (§8.6), so there is
+    // nothing to show mid-run — and a live XP counter would be a second score
+    // beside the first, moving on different rules.
+    const running = played(2);
+    expect(running.ending).toBeNull();
+    expect(readOut(running)).not.toContain("XP");
+
+    const cleared = played(4, 0, only("f", { count: 2 }));
+    expect(cleared.ending).toEqual({ kind: "cleared" });
+    expect(stormXp(cleared)).toBeGreaterThan(0);
+    expect(readOut(cleared)).toContain(`+${stormXp(cleared)} XP`);
+  });
+
+  it("pays nothing rather than something negative on a run that went badly", () => {
+    // The pair §8.6 exists to keep apart, on one screen: a score deep in the
+    // red, and a payout of zero. A child's level does not go backwards because
+    // they had a bad five minutes.
+    // Six wrong keys, and then the one letter of the wave through a shield
+    // that was never there — a run that ends with nothing shot at all.
+    const beaten = tick(played(0, 6, only("f", { count: 1, shield: 0 })), 5000);
+
+    expect(beaten.ending?.kind).toBe("breached");
+    expect(beaten.score).toBeLessThan(0);
+    expect(readOut(beaten)).toContain("+0 XP");
+  });
+});

--- a/src/games/typing/storm/StormHud.test.tsx
+++ b/src/games/typing/storm/StormHud.test.tsx
@@ -10,8 +10,8 @@ import { StormHud } from "./StormHud";
 import type { StormState, WaveSpec } from "@/engine/typing/storm";
 
 /**
- * The HUD, as a child reads it: what the run is worth, what the next hit is
- * worth, and one flash of red when a wrong key takes points off
+ * The HUD, as a child reads it: what the run is worth, what the last clean hit
+ * was paid at, and one flash of red when a wrong key takes points off
  * (docs/typing.md §8.6).
  *
  * Everything here is a rendering of numbers the reducer already holds, and
@@ -61,10 +61,13 @@ describe("StormHud", () => {
     expect(readOut(sprayed)).toContain(String(sprayed.score));
   });
 
-  it("shows the multiplier the next hit will be paid at", () => {
-    // The same `comboMultiplier` that scales the score and `cardXp` — one
-    // streak, one multiplier, so the figure a child watches climb is the
-    // figure their XP is worth.
+  it("shows the multiplier the last hit was paid at", () => {
+    // `comboMultiplier(state.combo)`: what the hit that just landed was paid
+    // at — the third hit paid 13 and the HUD reads ×1.3 — which is also the
+    // streak the next hit builds on, so a fourth would pay ×1.4. A run with
+    // nothing shot yet rests at ×1.0. The same `comboMultiplier` scales the
+    // score and `cardXp`: one streak, one multiplier, so the figure a child
+    // watches climb is the figure their XP is worth.
     expect(readOut(played(0))).toContain("×1.0");
     expect(readOut(played(3))).toContain("×1.3");
     expect(readOut(played(3))).toContain(

--- a/src/games/typing/storm/StormHud.tsx
+++ b/src/games/typing/storm/StormHud.tsx
@@ -1,0 +1,81 @@
+import { comboMultiplier } from "@/engine/combo";
+import { stormXp } from "@/engine/progress";
+
+import type { StormState } from "@/engine/typing/storm";
+
+/**
+ * The two numbers a run keeps, over the sky it is being played in
+ * (docs/typing.md §8.6).
+ *
+ * ── Score, and the multiplier it is paid at ──────────────────────────────────
+ * The multiplier is the prominent half on purpose. A score is a number that
+ * has already happened; `×1.7` is a number about the NEXT letter, and it is
+ * the whole of what this screen is trying to teach — that a run of clean hits
+ * is worth more than the same hits scattered. It is `comboMultiplier`, the
+ * same curve `cardXp` pays a flash card at, so the figure a child watches
+ * climb here is the figure their XP is worth (`stormXp`). One streak, one
+ * multiplier, two currencies.
+ *
+ * Nothing here decides any of that. `score`, `combo` and `misses` are read off
+ * the reducer, which is where every rule about them lives (§8.9): a HUD that
+ * worked out what a hit was worth would be a second opinion about it at sixty
+ * frames a second, and the one on screen is the one a child would believe.
+ *
+ * ── In the sky, not beside it (decision 45) ──────────────────────────────────
+ * `.storm` is a two-track grid — the sky, and the board that never gives — and
+ * the sky is what gives: about 78px of it at 1280×360, and about 21px at
+ * 1280×250 (§8.2). A HUD row would be taken out of the one track with nothing
+ * left to give, so this is drawn INSIDE the sky instead, and costs it no
+ * height at all. It is first in the sky so the stones paint over it rather
+ * than under it: a number must never hide a letter that has to be shot, which
+ * is also why the score sits in the HUD's dim ink rather than in `--chalk`.
+ *
+ * That puts it inside the sky's `aria-hidden`, which is the right side of that
+ * trade and worth saying out loud. Hailstorm is a physical keyboard and a
+ * reaction time — a child who cannot see the falling letters cannot play it at
+ * all (§8.8 and STM09 are where that is answered honestly) — and a live region
+ * reciting a score that moves every 300ms is a denial of service rather than
+ * an accommodation (§4.4).
+ *
+ * ── One flash per miss, and never a sequence ─────────────────────────────────
+ * The `--flare` wash over the score is a child element keyed by `misses`, a
+ * counter that only ever goes up — the mechanism the shield's damage tint
+ * already uses (§8.10, decision 42). A fresh node runs its animation once, an
+ * unchanged key is the same node and does not restart it, and there is no
+ * timer here to be left mid-flash by a screen that unmounted. The gun ignores
+ * key auto-repeat (decision 44), so the fastest this can mount is a child's
+ * own keystrokes.
+ */
+export function StormHud({ state }: { state: StormState }) {
+  const { combo, ending, misses, score } = state;
+
+  return (
+    <div className="storm__hud">
+      <p className="storm__score u-mono">
+        {score}
+        {/* Mounted by the counter — see the header. Only above zero, so a run
+            does not start with a flash of red over a score of nothing. */}
+        {misses > 0 && <span key={`miss${misses}`} className="storm__miss" />}
+      </p>
+
+      {/* `--lime` only once there is a streak to be paid for: at ×1 this is a
+          fact about the rules, and at ×1.6 it is a thing a child earned. */}
+      <p
+        className="storm__combo u-mono"
+        data-hot={combo > 0 ? "" : undefined}
+      >{`×${comboMultiplier(combo).toFixed(1)}`}</p>
+
+      {/*
+        The payout, once the storm is over — the run's XP, computed at the end
+        from its hits and floored at zero, which is the whole of §8.6's second
+        half. It is here rather than on a screen of its own because there is no
+        screen of its own yet: STM07 puts a proper ending in front of a child,
+        names the finger that let the storm through and offers the drill for
+        it, and this line is what tells them what they earned until it does.
+      */}
+      {ending !== null && (
+        <p className="storm__xp u-mono">{`+${stormXp(state)} XP`}</p>
+      )}
+    </div>
+  );
+}

--- a/src/games/typing/storm/StormHud.tsx
+++ b/src/games/typing/storm/StormHud.tsx
@@ -8,13 +8,21 @@ import type { StormState } from "@/engine/typing/storm";
  * (docs/typing.md §8.6).
  *
  * ── Score, and the multiplier it is paid at ──────────────────────────────────
- * The multiplier is the prominent half on purpose. A score is a number that
- * has already happened; `×1.7` is a number about the NEXT letter, and it is
- * the whole of what this screen is trying to teach — that a run of clean hits
- * is worth more than the same hits scattered. It is `comboMultiplier`, the
- * same curve `cardXp` pays a flash card at, so the figure a child watches
- * climb here is the figure their XP is worth (`stormXp`). One streak, one
- * multiplier, two currencies.
+ * `comboMultiplier(state.combo)` is the multiplier the hit that JUST LANDED
+ * was paid at, and not a forecast for the next one. `fire` sets `combo` to
+ * `state.combo + 1` and pays that hit at the streak it lands on, so this is
+ * the figure the score has already moved by — measured in a browser, the HUD
+ * reads ×1.4 the instant after a fourth clean hit, and that hit paid 14. The
+ * next one is a step higher, ×0.1 more until the ×2 cap, which is the same
+ * fact said forwards: this is the streak the next hit builds on.
+ *
+ * It is the prominent half on purpose all the same. The score is a running
+ * total and says nothing about how the run is going now; `×1.7` says seven
+ * clean hits in a row and still climbing, and that is the whole of what this
+ * screen is trying to teach — that a run of clean hits is worth more than the
+ * same hits scattered. It is `comboMultiplier`, the same curve `cardXp` pays a
+ * flash card at, so the figure a child watches climb here is the figure their
+ * XP is worth (`stormXp`). One streak, one multiplier, two currencies.
  *
  * Nothing here decides any of that. `score`, `combo` and `misses` are read off
  * the reducer, which is where every rule about them lives (§8.9): a HUD that

--- a/src/games/typing/storm/StormRun.tsx
+++ b/src/games/typing/storm/StormRun.tsx
@@ -12,12 +12,11 @@ import type { WaveSpec } from "@/engine/typing/storm";
 /**
  * The Hailstorm route (docs/typing.md §9), playing one wave.
  *
- * The screen is two things joined: a field that draws a `StormState`, and a
- * clock that produces one per animation frame. It is still deliberately not a
- * whole game — nothing fires, so every letter lands, and when the last one has
- * the field simply empties and the loop stops. STM05 draws the shield on the
- * line they land on, STM06 gives the screen its trigger, its HUD and its way
- * out, STM07 the death screen, and STM10 replaces this stand-in wave with the
+ * The screen is three things joined: a field that draws a `StormState`, a
+ * clock that produces one per animation frame, and a keyboard that shoots. It
+ * is still not a whole game — a run that ends leaves the field standing with
+ * its score on it, because STM07 owns the death screen, the finger it names
+ * and the drill it offers, and STM10 replaces this stand-in wave with the
  * twenty the ladder actually names.
  *
  * Unlinked on purpose. Nothing on the ladder points here until STM10 puts the

--- a/src/games/typing/storm/useStormClock.test.ts
+++ b/src/games/typing/storm/useStormClock.test.ts
@@ -135,16 +135,26 @@ describe("redrawn", () => {
     expect(redrawn(before, fire(before, "KeyF"))).toBe(true);
   });
 
-  it("says yes when a miss breaks a streak, and no when there was none", () => {
+  it("says yes to a miss, streak or no streak", () => {
     const hit = fire(run(999), "KeyF");
     expect(hit.combo).toBe(1);
     expect(redrawn(hit, fire(hit, "KeyQ"))).toBe(true);
 
-    // A miss on an unbroken nothing changes nothing a screen can see — and
-    // `fire` still hands back a different object, which is the trap.
+    // And to a miss on an unbroken nothing, which changes no combo at all:
+    // the score fell, and the HUD flashes a `--flare` over it (§8.6). Before
+    // scoring landed this was the case that changed nothing a screen could
+    // see — the one where `fire` hands back a fresh object saying "different"
+    // and means it about the clock. Now the only thing left in that shape is
+    // a miss on a run that has already ended, which `fire` refuses outright.
     const cold = run(120);
-    expect(fire(cold, "KeyQ")).not.toBe(cold);
-    expect(redrawn(cold, fire(cold, "KeyQ"))).toBe(false);
+    const missed = fire(cold, "KeyQ");
+    expect(missed.combo, "there was no streak to break").toBe(cold.combo);
+    expect(missed.score).toBeLessThan(cold.score);
+    expect(redrawn(cold, missed)).toBe(true);
+
+    const dead = { ...cold, ending: { kind: "cleared" } as const };
+    expect(fire(dead, "KeyQ")).toBe(dead);
+    expect(redrawn(dead, fire(dead, "KeyQ"))).toBe(false);
   });
 
   it("says yes when the target changes mid-air with nothing else", () => {
@@ -166,7 +176,7 @@ describe("the shape the clock is watching", () => {
    *
    * The type is what makes this catch an OPTIONAL field. `Object.keys` of a
    * fresh run can only see what `startStorm` actually sets, so a
-   * `readonly score?: number` added for STM06 would be invisible to a list of
+   * `readonly score?: number` added for a HUD would be invisible to a list of
    * key strings — and `redrawn` would go on never comparing it. A
    * `Record<keyof StormState, true>` will not compile without a line for that
    * field, and being an object literal it will not compile with a line for one
@@ -175,18 +185,20 @@ describe("the shape the clock is watching", () => {
   const FIELDS: Record<keyof StormState, true> = {
     combo: true,
     ending: true,
+    misses: true,
     resolved: true,
+    score: true,
     shield: true,
     timeMs: true,
     wave: true,
   };
 
   it("pins the shape of a StormState, so a new field is decided about here", () => {
-    // `redrawn` compares four of these by identity, derives two more from the
-    // clock, and leaves `wave` out because a run's wave is fixed. A story that
-    // adds a seventh — STM06's score, STM07's tally — has to come here and say
-    // which of those three it is; the alternative is finding out from a HUD
-    // that quietly stopped updating.
+    // `redrawn` compares six of these — `score` and `misses` arrived with the
+    // HUD and are drawn in it — derives two more from the clock, and leaves
+    // `wave` out because a run's wave is fixed. A story that adds a ninth
+    // (STM07's tally) has to come here and say which of those three it is; the
+    // alternative is finding out from a HUD that quietly stopped updating.
     expect(Object.keys(startStorm(buildWave(spec, 7))).sort()).toEqual(
       Object.keys(FIELDS).sort(),
     );

--- a/src/games/typing/storm/useStormClock.ts
+++ b/src/games/typing/storm/useStormClock.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 
-import { progressAt, startStorm, tick } from "@/engine/typing/storm";
+import { keyX } from "@/engine/keyboard";
+import { fire, progressAt, startStorm, tick } from "@/engine/typing/storm";
+
+import { HELD } from "../keyboard/useKeyEcho";
 
 import { aimedAt, isDrawn } from "./StormField";
 
@@ -14,13 +17,23 @@ import type { StormState, Wave } from "@/engine/typing/storm";
  * All it does per frame is measure the delta, hand it to `tick`, write each
  * drawn stone's `--drop`, and re-render when the picture — rather than the
  * clock — has changed. Which letters exist, where they are, what a landing
- * costs and when a run is over were all settled in `engine/typing/storm.ts`
- * before the first frame. That is what makes the shield's rules answerable by
- * a unit test in a millisecond instead of by somebody watching and hoping, so
- * a rule that migrates into this file is a rule that has stopped being
- * testable. The two engine predicates called here — `progressAt` for where a
- * stone is, `isDrawn` for whether it is on the field — are asked, never
- * restated.
+ * costs, what a hit is worth, what a wrong key costs and when a run is over
+ * were all settled in `engine/typing/storm.ts` before the first frame. That is
+ * what makes the shield's rules answerable by a unit test in a millisecond
+ * instead of by somebody watching and hoping, so a rule that migrates into
+ * this file is a rule that has stopped being testable. The two engine
+ * predicates called here — `progressAt` for where a stone is, `isDrawn` for
+ * whether it is on the field — are asked, never restated.
+ *
+ * ── The trigger is here because the clock is ─────────────────────────────────
+ * A shot is fired at `live.current` — the run as this frame left it — and not
+ * at the state React last rendered. The rendered one is the last frame whose
+ * PICTURE changed, which can be a long way behind: a wave with nothing
+ * spawning, landing or being shot re-renders nothing at all, and this
+ * stand-in's letters are 300ms apart. Fire from it and a shot resolves against
+ * a target read at a stale clock, on a state with every tick since thrown
+ * away. So the keydown listener is armed and cancelled with the loop, in the
+ * same effect, and hands `fire` the ref.
  *
  * ── DOM, not canvas ──────────────────────────────────────────────────────────
  * Twelve absolutely-positioned `<span>`s moved with a transform, not a canvas,
@@ -116,12 +129,20 @@ function onField(state: StormState): number {
  * an empty tick and a missed shot both return a fresh object, so `===` on the
  * state says "changed" sixty times a second and means nothing. What the screen
  * is actually a function of is every field of a run except the clock and the
- * wave — so `resolved`, `shield`, `combo` and `ending`, compared here — plus
- * the two things the clock alone moves: a letter appearing (no field of
- * `StormState` records a spawn; it is a time crossing) and the target
- * changing, which two letters at different speeds can do mid-air with nothing
- * else happening at all (decision 32). Miss that one and the board goes on
- * marking a child's keys against a letter that is no longer the lowest.
+ * wave — so `resolved`, `shield`, `combo`, `score`, `misses` and `ending`,
+ * compared here — plus the two things the clock alone moves: a letter
+ * appearing (no field of `StormState` records a spawn; it is a time crossing)
+ * and the target changing, which two letters at different speeds can do
+ * mid-air with nothing else happening at all (decision 32). Miss that one and
+ * the board goes on marking a child's keys against a letter that is no longer
+ * the lowest.
+ *
+ * `score` and `misses` move together on every miss and would each be covered
+ * by the other today; both are compared anyway, because "the score happens to
+ * change whenever the flash does" is a coincidence of two constants in
+ * `storm.ts` rather than a property of the screen. A `MISS_POINTS` of zero
+ * would leave the HUD's `--flare` flash undrawn, which is a bug nobody would
+ * think to look for here.
  *
  * `wave` is the field left out, and deliberately: a run's wave is fixed for
  * its whole life, so it cannot change under a running loop, and a screen
@@ -143,6 +164,8 @@ export function redrawn(drawn: StormState, next: StormState): boolean {
     drawn.resolved !== next.resolved ||
     drawn.shield !== next.shield ||
     drawn.combo !== next.combo ||
+    drawn.score !== next.score ||
+    drawn.misses !== next.misses ||
     drawn.ending !== next.ending ||
     aimedAt(drawn) !== aimedAt(next) ||
     onField(drawn) !== onField(next)
@@ -154,10 +177,10 @@ export function redrawn(drawn: StormState, next: StormState): boolean {
  *
  * The state handed back is the last frame whose *picture* differed, not the
  * live one — the live one advances every frame and is the loop's own business.
- * Anything that needs the clock to the millisecond (a press, when STM06 gives
- * the storm a trigger) has to be answered from inside the loop rather than
- * from a render, which is the same reason `useRaceClock` keeps its marks in
- * refs.
+ * Anything that needs the clock to the millisecond is answered from inside the
+ * effect against `live.current` — the trigger below is exactly that — rather
+ * than from a render, which is the same reason `useRaceClock` keeps its marks
+ * in refs.
  */
 export function useStormClock(wave: Wave): {
   state: StormState;
@@ -183,6 +206,55 @@ export function useStormClock(wave: Wave): {
     let frame = 0;
     let last: number | null = null;
 
+    /** Show React the run, if this changed anything it draws. */
+    const publish = (next: StormState) => {
+      if (!redrawn(drawn.current, next)) return;
+      drawn.current = next;
+      setState(next);
+    };
+
+    /**
+     * The gun (§8.6). Every stroke is a shot at the lowest letter; the rules
+     * for what that is worth are `fire`'s, and none of them are here.
+     *
+     * Three keydowns are not strokes, and each is left out for a reason the
+     * board already agrees with:
+     *
+     *   - **`HELD`** — shift, ctrl, alt and the cmd keys. It is the very set
+     *     `useKeyEcho` never flares, imported rather than restated: a capital
+     *     is a shift and a letter (§3.3), and a game that charged a child for
+     *     reaching for the far shift would be charging them for doing it
+     *     right.
+     *   - **`event.repeat`** — the OS repeating a key that is being held down,
+     *     which is one stroke and not thirty a second (decision 44). Firing on
+     *     it would let a child spray by leaning on a key, drain a score they
+     *     never pressed for, and flash the HUD's miss at 30Hz, which is the
+     *     strobe §8.10 forbids.
+     *   - A **browser chord** — ctrl or cmd held. Reloading the page is not a
+     *     shot at a hailstone, and cmd+`r` is how a child restarts a storm
+     *     that is going badly. This is the one place the gun and the board
+     *     part company: `useKeyEcho` judges the code alone, so that `r` still
+     *     flares. A flare is 120ms and costs nothing; a shot costs ten points
+     *     and a streak, and the two are not worth the same benefit of the
+     *     doubt.
+     *
+     * The default is taken for the keys the board draws, and only those: this
+     * screen has no input to swallow a space that would otherwise scroll the
+     * page, or a `/` that opens Firefox's quick-find mid-run. `keyX` answers
+     * "is this key on the board" without a second list of codes. Anything else
+     * — F5, F12, the browser's own — is left alone, because a game screen that
+     * ate the reload key would be a screen with no way out.
+     */
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat || event.ctrlKey || event.metaKey) return;
+      if (HELD.has(event.code)) return;
+      if (!event.altKey && keyX(event.code) !== null) event.preventDefault();
+
+      const next = fire(live.current, event.code);
+      live.current = next;
+      publish(next);
+    };
+
     const loop = (now: number) => {
       // Cleared before anything else, so `frame` never holds a handle that has
       // already been delivered. It is what the cleanup cancels, and on the
@@ -200,7 +272,9 @@ export function useStormClock(wave: Wave): {
         for (let i = 0; i < sky.children.length; i++) {
           const stone = sky.children[i] as HTMLElement;
           // Anything in the sky that is not a stone is skipped rather than
-          // assumed away — the shield lands on this line in STM05.
+          // assumed away, and there are two of them: the HUD at the top of the
+          // sky and the shield at the bottom. Neither carries `data-stone`, so
+          // `Number(undefined)` is `NaN` and indexes no letter.
           const letter = next.wave.letters[Number(stone.dataset.stone)];
           if (letter)
             stone.style.setProperty(
@@ -209,10 +283,7 @@ export function useStormClock(wave: Wave): {
             );
         }
 
-      if (redrawn(drawn.current, next)) {
-        drawn.current = next;
-        setState(next);
-      }
+      publish(next);
 
       // Death and the last letter both stop the clock here, in the frame that
       // ended the run, rather than one render later: `tick` on an ended run is
@@ -222,13 +293,27 @@ export function useStormClock(wave: Wave): {
     };
 
     frame = requestAnimationFrame(loop);
+    // Capture, and on the window, exactly as `useKeyEcho` binds: this screen
+    // has no focused element for a stroke to land on, and capture runs ahead
+    // of anything that might stop propagation on the way up.
+    window.addEventListener("keydown", onKeyDown, true);
 
     // The only exit there is, and every way out runs it. Quitting is one of
-    // them today: this screen has no quit control (STM06), so leaving it is a
+    // them today: this screen has no quit control, so leaving it is a
     // navigation, and a navigation unmounts the route. A quit that instead
     // kept the field on screen would be a pause, and a pause is a thing this
     // effect has to be told about — an input, not an omission.
-    return () => cancelAnimationFrame(frame);
+    //
+    // The listener goes with the frame, for a plainer reason than the loop's:
+    // one left on the window outlives the screen. It would hold this run's
+    // state alive, call `setState` on a component that has gone, and stack a
+    // second copy of itself the next time the route is entered. What it would
+    // not do is move a score — `fire` refuses an ended run — so the leak would
+    // be invisible until the third or fourth storm.
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
   }, [wave]);
 
   return { state, skyRef };

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -2260,6 +2260,121 @@ label.segmented__btn {
   color: var(--chalk);
 }
 
+/* ── Hailstorm: the HUD ──────────────────────────────────────────────────
+   The two numbers a run keeps: the score, and the multiplier the next hit
+   will be paid at (docs/typing.md §8.6, decision 45).
+
+   **It is drawn inside the sky, and takes none of it.** `.storm` is a
+   two-track grid — a sky that gives and a board that never does — and the sky
+   is what gives: about 78px of it at 1280×360, and about 21px at 1280×250
+   (see the shield below). A HUD row would be taken out of the only track with
+   anything left, so this is absolutely positioned over the sky instead: no
+   track, no height, and no fall shortened by the height of a number.
+
+   The cost of that is an overlap, and the order settles it. The HUD is the
+   FIRST child of the sky, so every hailstone paints over it — a number must
+   never hide a letter that has to be shot — and it is drawn in `--chalk-dim`
+   rather than `--chalk` so a stone crossing it reads as the thing in front.
+
+   Two of the telemetry five are borrowed here, both meaning exactly what they
+   mean everywhere else on this site. `--flare` washes the score for one 220ms
+   pass when a wrong key takes points off it, because that is a wrong. `--lime`
+   colours the multiplier while a streak is running, because that is a run of
+   rights and it is what the streak IS. The other three would each be a lie:
+   nothing on this screen is a ghost, a record or a badge.
+
+   Everything here is a multiple of `--key`, like the lanes and the caps, so
+   the numbers grow and shrink with the board they are being shot from.     */
+
+.storm__hud {
+  position: absolute;
+  inset: 0;
+
+  /* Two columns and two rows: the score and the multiplier along the top, and
+     the payout centred in what is left once the storm is over. `1fr` on the
+     second row rather than `auto` is what gives the XP line somewhere to be
+     centred IN — with two auto rows it would sit just under the score. */
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto 1fr;
+  align-items: start;
+  padding: calc(var(--key) * 0.12) calc(var(--key) * 0.1);
+
+  font-size: calc(var(--key) * 0.5);
+  line-height: 1;
+  color: var(--chalk-dim);
+}
+
+/* The run's own score, which may be negative — a wrong key takes points off
+   it (§8.6). Positioned, because the miss flash below is drawn over exactly
+   this box and nothing wider: the thing that went down is the thing that
+   lights up. */
+.storm__score {
+  position: relative;
+  justify-self: start;
+  padding: calc(var(--key) * 0.08) calc(var(--key) * 0.16);
+  border-radius: calc(var(--key) * 0.14);
+}
+
+/* One wash of `--flare` per wrong key, and never a sequence: a single pass on
+   an element `StormHud` mounts from a counter that only goes up, exactly as
+   the shield's damage tint is (§8.10, decision 42). It rests at zero and
+   animates down to it, so `prefers-reduced-motion` — which clamps every
+   animation to one 0.001ms pass — leaves the score exactly as it found it, and
+   what a child who asked for less motion still gets is the number itself,
+   which has already fallen. */
+.storm__miss {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--flare);
+  opacity: 0;
+  animation: storm-miss 220ms var(--ease-out);
+}
+
+@keyframes storm-miss {
+  from {
+    opacity: 0.75;
+  }
+}
+
+/* The multiplier, and the prominent half of the HUD on purpose: a score is a
+   number about what has happened, and `×1.7` is a number about the next
+   letter. Bigger than the score for that reason, and green only while there is
+   a streak to be paid for — at ×1 it is a fact about the rules, at ×1.6 it is
+   a thing a child earned.
+
+   The step up is a transition and not an animation: it happens when a combo
+   starts and when one breaks, which is twice a run and not once a hit, so
+   there is nothing here that could become a flash sequence. */
+.storm__combo {
+  justify-self: end;
+  scale: 1;
+
+  font-size: calc(var(--key) * 0.8);
+  font-weight: 700;
+  transition:
+    color 200ms var(--ease-out),
+    scale 200ms var(--ease-out);
+}
+
+.storm__combo[data-hot] {
+  scale: 1.12;
+  color: var(--lime);
+}
+
+/* What the run paid the profile, once it is over (§8.6). Centred in the sky
+   the storm has just emptied, in `--chalk` rather than the HUD's dim, because
+   at that moment it is the only thing on the field worth reading. STM07 puts a
+   real ending in front of a child; until then this is the payout. */
+.storm__xp {
+  grid-column: 1 / -1;
+  place-self: center;
+
+  font-size: calc(var(--key) * 0.7);
+  color: var(--chalk);
+}
+
 /* ── Hailstorm: the shield ───────────────────────────────────────────────
    The eight segments the letters land on, one per finger (docs/typing.md
    §8.5, decisions 21 and 41).

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -2261,8 +2261,9 @@ label.segmented__btn {
 }
 
 /* ── Hailstorm: the HUD ──────────────────────────────────────────────────
-   The two numbers a run keeps: the score, and the multiplier the next hit
-   will be paid at (docs/typing.md §8.6, decision 45).
+   The two numbers a run keeps: the score, and the multiplier the last clean
+   hit was paid at — which is also the streak the next one builds on
+   (docs/typing.md §8.6, decision 45).
 
    **It is drawn inside the sky, and takes none of it.** `.storm` is a
    two-track grid — a sky that gives and a board that never does — and the sky
@@ -2338,11 +2339,11 @@ label.segmented__btn {
   }
 }
 
-/* The multiplier, and the prominent half of the HUD on purpose: a score is a
-   number about what has happened, and `×1.7` is a number about the next
-   letter. Bigger than the score for that reason, and green only while there is
-   a streak to be paid for — at ×1 it is a fact about the rules, at ×1.6 it is
-   a thing a child earned.
+/* The multiplier, and the prominent half of the HUD on purpose: the score is a
+   running total, and `×1.7` is the streak behind it — what the last clean hit
+   was paid at, and the step the next one builds on. Bigger than the score for
+   that reason, and green only while there is a streak to be paid for — at ×1
+   it is a fact about the rules, at ×1.6 it is a thing a child earned.
 
    The step up is a transition and not an animation: it happens when a combo
    starts and when one breaks, which is twice a run and not once a hit, so


### PR DESCRIPTION
## What this does

Hailstorm keeps a score and a combo, and both live entirely in the reducer. `fire` now writes `score` and `misses` beside `combo`:

- **A hit pays `HIT_POINTS × comboMultiplier`** — a clean streak is worth more than the same letters hit scattered.
- **A wrong key costs points and breaks the streak** — the multiplier drops back to ×1.0.
- **A letter that gets through costs the shield but not the score** (decision 46). Missing a letter is already punished by the shield; charging it twice would make the score a second health bar.

`comboMultiplier` moved to a new leaf module, `src/engine/combo.ts`, so the storm and `cardXp` share one curve. The storm cannot simply import `progress.ts` — that reaches `decks/index.ts`, dragging the whole deck registry into the typing island. Verified two ways: a module-graph walk shows `storm.ts` reaches exactly four modules, and measurement shows the typing island grew **+1.4 KB**, the shared chunk **+127 B**, and the flashcards island is **byte-identical**.

**`cardXp` is reused unchanged** — confirmed identical to `develop` over 25k×26 argument pairs. A Hailstorm hit and a flash-card answer of the same ms and streak pay the same XP.

### Score can fall, XP cannot

`stormXp` folds once at the end as `max(0, Σ cardXp(atMs − spawnMs, outcome.combo))`. `LetterOutcome` gains `combo` because a wrong key resolves no letter, so the streak a hit landed on is otherwise unrecoverable by the time the fold runs.

Firing at an empty sky stays a miss. `useKeyEcho` gains `emptyIsWrong` so a stroke that costs ten points flares `--flare` instead of lighting `--lime` (decision 43). Auto-repeat is not a shot (decision 44).

Decisions 43–46 are recorded in `docs/typing.md`.

## Measurements

| Scenario | Result |
| --- | --- |
| 5 clean hits | 65 at ×1.5 |
| one wrong key | 55 at ×1.0, cap carries `is-wrong` |
| 8 wrong keys | score −15, drawn negative |
| run ends | **+164 XP with the score still −15** |

XP verified non-negative and non-`NaN` under 500 and 1000 wrong keys, zero hits, and a first-letter death.

**No strobe:** 30 wrong keys in 22ms mount 30 elements and fire **one** `animationstart` — peak opacity 0.75 with zero rises. Under `prefers-reduced-motion: reduce`, peak opacity is 0.

Lessons and free play drove identically on this build and a `develop` build, so `emptyIsWrong` changed nothing outside Hailstorm.

## Review pass

Two findings, both comment accuracy, no behaviour change.

1. Five statements called the HUD figure "the multiplier the next hit will be paid at" when it is the multiplier **the hit that just landed** was paid at — one combo step lower, measured as HUD ×1.0–×1.5 before hits paying ×1.1–×1.6. The rendered value was left alone and the wording corrected, including a test renamed to what its body actually asserts.
2. A smoke comment claimed eight back-to-back wrong keys drew seven flashes; they draw **one** (8 mounts, 1 `animationstart` in 10ms). The comment now carries the mechanism and the numbers that reproduce it.

The `stormXp` floor's comment was also promoted from "currently unreachable" to an explicit do-not-remove rule. No input can drive it, and a refactor could otherwise read "unreachable" as licence to delete the one line guarding a child's level running backwards.

## CI smoke flake

The earlier CI failure on this branch was the smoke script, not the game. Its shooting loop read the lowest letter and then pressed it; on a starved driver the letter landed in between, so the run connected four times instead of five and three assertions that hard-coded totals failed.

The loop now waits in-page for the lowest stone to reach `--drop <= 0.7` — 1.2s of margin on any hardware, since `MAX_STEP_MS` only ever makes wave time run slower than the clock — confirms each press against the HUD before taking the next, restarts on a fresh wave up to three times, and reports a short count as its own named check rather than as an arithmetic failure. Later expectations are derived (`combo.score - MISSES * 10`, `12 - shot.length`, strictly-ascending indices) instead of hard-coded.

**The photosensitivity assertions were left byte-identical** — the tint census `=== 12` twice, `nothing else animated === 0`, and both `>= 150` rhythm floors. The failure reproduces pre-fix under `SMOKE_LAG=1400` with the exact CI signature; post-fix it passes 4/4 with CPU throttling combined with injected lag, plus eleven clean unthrottled runs.

Closes #152
