### PR TITLE
Count where visitors are, not where CloudFront served them

### DIFF
--- a/.github/workflows/refresh-geoip.yml
+++ b/.github/workflows/refresh-geoip.yml
@@ -1,0 +1,102 @@
+# Rebuild the geo-IP artifact the analytics rollup reads.
+#
+# ⚠️ This exists to discharge a LICENCE OBLIGATION, not to keep a number
+# fresh. The GeoLite2 redistribution the artifact is built from says you
+#
+#   "may not prevent the Library from updating local copies of the GeoLite2
+#    Databases to honor Do Not Sell requests submitted to MaxMind"
+#
+# and MaxMind honours those requests by dropping records from later releases.
+# A snapshot pinned in S3 forever is precisely what that forbids, so the
+# refresh has to be something the pipeline does rather than something somebody
+# remembers. If this workflow is disabled, the obligation stops being met —
+# delete the artifact rather than leaving a stale one in place.
+#
+# Nothing here touches the site. It reads two public CSVs, merges them, and
+# writes one object to the analytics bucket under `geoip/`; the 90-day expiry
+# rule in sst.config.ts is scoped to `cf/` and does not apply to it.
+#
+# Credentials come from the same OIDC deploy role as everything else
+# (scripts/setup-github-oidc.sh). There are no long-lived AWS keys.
+name: Refresh geo-IP artifact
+
+on:
+  schedule:
+    # 04:00 UTC on the 1st. Monthly against MaxMind's weekly releases is
+    # deliberate: the reader warns at 45 days, so a single missed run is
+    # visible in `npm run analytics` before it becomes a compliance gap.
+    - cron: "0 4 1 * *"
+  workflow_dispatch:
+
+concurrency:
+  group: refresh-geoip
+  cancel-in-progress: false
+
+permissions:
+  id-token: write # OIDC
+  contents: read
+  issues: write # the failure alert below
+
+jobs:
+  refresh:
+    name: Rebuild and upload
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.16"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-west-1
+
+      # The merge holds several million ranges in memory at once. Node's
+      # default heap is enough on this runner today; the flag is here so a
+      # source that grows does not turn into an out-of-memory failure that
+      # looks like a bug in the build.
+      - name: Build and upload
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+        run: npm run analytics:geoip
+
+      # A skipped refresh is silent by nature — the old artifact keeps working
+      # and the counts keep coming out. An issue is what makes it not silent.
+      - name: Alert on failed refresh
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Geo-IP artifact refresh failed"
+          body="Refresh failed: ${RUN_URL}
+
+          This is a licence obligation, not just stale data — see the header of
+          .github/workflows/refresh-geoip.yml and scripts/build-geoip.mjs.
+
+          First things to check:
+          - Did jsDelivr serve both sources? The build fails loudly if a CSV
+            arrives truncated rather than writing a half-built artifact.
+          - Did the column layout move? 'source did not parse' means the format
+            changed, and the fix is in scripts/build-geoip.mjs.
+          - Can the role still write s3://schoolskills-access-logs-*/geoip/?
+
+          Meanwhile the previous artifact is still being read, and
+          'npm run analytics' warns once it passes 45 days old."
+          existing="$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --label bug --body "$body"
+          fi

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -53,15 +53,18 @@ in `src/services/analytics.ts` — if it isn't there, it isn't collected:
 sent — see the tests in `src/services/analytics.test.ts`, which exist to keep
 that true.
 
-**Where a visit came from, and roughly where it was.** Both are read off the
-same log line as everything else — no extra request, nothing added to a page:
+**Where a visit came from, and where it was.** All three come off the same log
+line as everything else — no extra request, nothing added to a page:
 
-| In the rollup | From the log field | Means                                      |
-| ------------- | ------------------ | ------------------------------------------ |
-| `referrers`   | `cs(Referer)`      | the site that linked here, host only       |
-| `edges`       | `x-edge-location`  | the CloudFront PoP that served the request |
+| In the rollup | From the log field | Means                                         |
+| ------------- | ------------------ | --------------------------------------------- |
+| `referrers`   | `cs(Referer)`      | the site that linked here, host only          |
+| `countries`   | `c-ip`             | where the visitor's own address is registered |
+| `regions`     | `c-ip`             | the state or province inside that country     |
+| `cities`      | `c-ip`             | the city, where the source claims to know one |
+| `edges`       | `x-edge-location`  | the CloudFront PoP that served the request    |
 
-Two things to hold onto, because both are easy to over-read:
+Three things to hold onto, because all of them are easy to over-read:
 
 - **`referrers` is a bare hostname and nothing more.** Never a path, never a
   query string. A full referrer URL routinely carries what someone searched
@@ -72,14 +75,84 @@ Two things to hold onto, because both are easy to over-read:
   link out of a document. Read it as a floor on direct traffic, not a measure
   of it. Our own pages are not counted, since internal navigation would bury
   the inbound links that are the point.
+- **The places are resolved on your machine, never by asking anyone.** The
+  log line already carries `c-ip` — the visitor's address, which the rollup has
+  always read to count distinct visitors. Turning it into a place is a binary
+  search against a table in our own bucket. **Do not replace this with a geo-IP
+  API.** Sending a child's IP address to a third party is the exact thing
+  /privacy promises does not happen, and it would be a COPPA step change rather
+  than a refactor. See [Where the place data comes from](#where-the-place-data-comes-from).
+
+  Read a place as where the address is _registered_. A VPN, a school's egress
+  or a mobile carrier hauling traffic across a border land in the wrong place
+  outright — not merely at the wrong end of the right one, which is the failure
+  mode `edges` has. **The finer the level, the more often it is wrong**, and
+  the first two days of real data make the point: the top three cities were
+  Council Bluffs, Ashburn and Santa Clara, which are Google, Amazon and a
+  datacentre belt rather than three American families.
+
+  Three states are deliberately distinct, and collapsing any two of them is how
+  a broken lookup starts reading as a finding:
+
+  | What you see                       | Means                                      |
+  | ---------------------------------- | ------------------------------------------ |
+  | `(unknown)` in `countries`         | the address was checked; nothing placed it |
+  | a missing `regions`/`cities` entry | the source knew the country and no more    |
+  | no place keys on the day           | no lookup ran at all                       |
+
+  Because of the middle row **the three levels do not sum alike**, and they are
+  not supposed to. An address that resolves only to a country contributes to
+  `countries` and to nothing else. Filling the gap in from a country centroid
+  is exactly the mistake that makes geo-IP data infamous.
+
 - **`edges` is where the request was served, not where the visitor is.**
   CloudFront routes to a nearby PoP, so `SEA` means "closer to Seattle than to
   anywhere else with a PoP" — Vancouver is served from Seattle, and anyone on
-  a VPN is served from wherever the exit node is. It answers "roughly which
-  part of the world", never "which country". The field that answers that
-  properly is `c-country`, which the legacy standard log format does not have;
-  getting it means moving the distribution to standard logging v2, a different
-  delivery mechanism rather than a field to add to the rollup.
+  a VPN is served from wherever the exit node is. Since `countries` exists this
+  is no longer the answer to "where is everyone"; it is kept because it answers
+  a question nothing else does, which is which PoPs actually serve this site —
+  a cache and latency question rather than an audience one.
+
+## Where the place data comes from
+
+`scripts/build-geoip.mjs` merges two published databases into one binary
+artifact and puts it in `s3://schoolskills-access-logs-<account>/geoip/`.
+`scripts/geoip.mjs` downloads that artifact and binary-searches it. The split
+matters: all the parsing, sorting and overlap-flattening happens **once**, in
+the build, so a rollup run loads 3.4M ranges in about 25ms instead of
+re-deriving them every time.
+
+| Source                                  | Gives        | Licence      |
+| --------------------------------------- | ------------ | ------------ |
+| `@ip-location-db/geo-whois-asn-country` | country      | CC0-1.0      |
+| `@ip-location-db/geolite2-city`         | region, city | MaxMind EULA |
+
+The country always comes from the CC0 table where it has an answer — it is
+built from whois and geofeed records rather than inference, and keeping it
+authoritative means adding cities did not silently move anybody between
+countries. GeoLite2 supplies the country only where whois is silent.
+
+```bash
+npm run analytics:geoip           # rebuild and upload
+npm run analytics:geoip -- --dry  # build locally, upload nothing
+```
+
+**Latitude, longitude and postcode are in the source and are deliberately not
+in the artifact.** Do not add them. A coordinate is a different kind of fact
+about a child than a city name, and the accuracy is not there to justify it:
+the single most common coordinate in the source is MaxMind's "somewhere in the
+United States" fallback, which 99,194 ranges point at. That is the mechanism
+that put a Kansas farm on the receiving end of years of harassment from people
+who believed a database that said it knew where somebody was.
+
+> ⚠️ **Rebuilding is a licence term, not housekeeping.** The GeoLite2
+> redistribution says you "may not prevent the Library from updating local
+> copies of the GeoLite2 Databases to honor Do Not Sell requests submitted to
+> MaxMind", and MaxMind honours those by dropping records from later releases —
+> so an artifact pinned in S3 forever is what that clause forbids.
+> `.github/workflows/refresh-geoip.yml` rebuilds monthly, the artifact carries
+> its build date, and `npm run analytics` warns past 45 days. If that workflow
+> is ever disabled, delete the artifact rather than leaving a stale one.
 
 ## The 90-day ceiling
 
@@ -115,7 +188,20 @@ sees a child's request.
 npm run analytics                # sync, count, and print a summary
 npm run analytics -- --days 7    # narrow the table
 npm run analytics -- --no-sync   # re-summarise without re-downloading
+npm run analytics -- --no-geoip  # skip the country lookup (offline)
 ```
+
+The first run downloads a ~13MB artifact from S3 and caches it next to the
+logs, so it is slower than the ones after it. If that fails, the run still
+counts everything else and says loudly that the place fields are missing — it
+does not fill them with `(unknown)` and pretend.
+
+> ⚠️ **City counts are for reading, not for publishing.** At this traffic most
+> city rows are a single page view, and one view from a named city on a named
+> day is close to naming a household. `npm run analytics` prints how many of
+> them were seen exactly once for that reason. Nothing this produces is kept —
+> and city data in particular should not be pasted into an issue, a commit
+> message or anywhere else that outlives the terminal.
 
 It writes its counts to a temp file and prints the path. Nothing is kept and
 nothing lands in the repo — if you want a number preserved, copy it out
@@ -130,6 +216,9 @@ One day looks like this:
   "visitors": 2,          // distinct IPs seen that day; approximate by design
   "pageViews": 3,
   "pages":     { "/": 1, "/flash-cards/": 1, "/spelling/play/": 1 },
+  "countries": { "US": 2, "GB": 1 },         // the visitor, resolved locally
+  "regions":   { "US / Washington": 2 },     // note: does NOT sum to pageViews
+  "cities":    { "US / Washington / Seattle": 2 },
   "referrers": { "(none)": 2, "t.co": 1 },   // host only, never a path
   "edges":     { "SEA": 2, "LHR": 1 },       // the edge, not the visitor
   "events":    { "race_start": 2, "race_end:finished": 1, "race_end:quit": 1 },
@@ -142,6 +231,15 @@ The long way round, if you want the pieces separately:
 ```bash
 aws s3 sync s3://schoolskills-access-logs-<account>/cf/ /tmp/cflogs --profile schoolskills
 node scripts/rollup-analytics.mjs /tmp/cflogs /tmp/counts.json
+```
+
+The place lookup is its own module, so it can be used on its own:
+
+```js
+import { placeLookup } from "./scripts/geoip.mjs";
+const geo = await placeLookup();
+geo.lookup("2a00:1450:4009:81f::200e");
+// → { country: "IE", region: null, city: null }
 ```
 
 ## The dashboard, for "is anything happening"
@@ -302,8 +400,10 @@ GROUP BY referrer
 ORDER BY views DESC;
 ```
 
-**Roughly where from**, by edge location — the PoP code is the first letters of
-`location`, and see the caveat above before reading it as geography:
+**Which PoPs serve the site**, by edge location — the PoP code is the first
+letters of `location`. This is a cache question; for geography use `countries`
+from the rollup, which resolves `request_ip` itself and which Athena has no
+equivalent of:
 
 ```sql
 SELECT regexp_extract(location, '^[A-Z]+') AS pop,
@@ -366,7 +466,24 @@ ORDER BY "date" DESC;
   list of shim hostnames it would have to keep current.
 - **An edge code is not a country.** `edges` says which CloudFront PoP served
   the request. It is near the visitor, not at them, and a VPN moves it
-  entirely.
+  entirely. `countries` is the field that answers geography; the two disagree
+  routinely and neither is wrong. The first two days had 80 US page views
+  against 33 served from LAX, because an American visitor gets whichever of a
+  dozen US PoPs their network hands them.
+- **A place is where an address is registered**, which for a school, a
+  workplace or anyone on a VPN can be somewhere else entirely — a harder
+  failure than the edge's, which is at least always nearby. Treat a row as
+  "something came from an address registered there".
+- **Most of the top cities are datacentres.** Council Bluffs is Google, Ashburn
+  is Amazon, Santa Clara is half the industry. A city breakdown on a site this
+  size measures crawlers and cloud egress at least as much as it measures
+  households.
+- **The three place levels do not sum alike**, because an address can resolve
+  to a country and no further. That gap is real information; do not close it.
+- **Place fields missing is not place fields empty.** No key at all means the
+  lookup did not run for that day, and days counted before this shipped have
+  none. `(unknown)` inside `countries` means the table did not place an
+  address.
 - **`referrers` does not sum to `pageViews`, but `edges` does.** Our own pages
   are dropped from the first and nothing is dropped from the second, so the
   gap between them is roughly the internal navigation — 11 views against 4

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -526,6 +526,10 @@ export default defineConfig([
         // Node has had this since v10; the analytics rollup parses beacon
         // query strings with it.
         URLSearchParams: "readonly",
+        // Global since Node 18. scripts/geoip.mjs downloads the country table
+        // with it — the ONE network call anywhere in this pipeline, and it
+        // fetches a public CSV rather than sending anything anywhere.
+        fetch: "readonly",
         Buffer: "readonly",
         __dirname: "readonly",
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "prepare": "husky",
     "test:smoke": "node e2e/smoke.mjs",
     "scripture:pull": "node scripts/pull-scripture.mjs",
-    "analytics": "node scripts/analytics.mjs"
+    "analytics": "node scripts/analytics.mjs",
+    "analytics:geoip": "node scripts/build-geoip.mjs"
   },
   "dependencies": {
     "@astrojs/react": "^6.0.2",

--- a/scripts/analytics.mjs
+++ b/scripts/analytics.mjs
@@ -22,9 +22,14 @@
  * A durable home for the aggregates is still owed — see docs/analytics.md.
  *
  * Usage:
- *   npm run analytics              sync, count, summarise
- *   npm run analytics -- --no-sync re-summarise what's already downloaded
- *   npm run analytics -- --days 7  narrow the table (default 30)
+ *   npm run analytics                sync, count, summarise
+ *   npm run analytics -- --no-sync   re-summarise what's already downloaded
+ *   npm run analytics -- --days 7    narrow the table (default 30)
+ *   npm run analytics -- --no-geoip  skip the country lookup
+ *
+ * `--no-geoip` is for working with no network at all. The country table is
+ * cached in the temp directory next to the logs, so an ordinary second run
+ * downloads nothing and the flag buys nothing — see scripts/geoip.mjs.
  */
 
 import { execFileSync } from "node:child_process";
@@ -97,6 +102,42 @@ function sync() {
 /** The widest value in a column, so the table doesn't wobble. */
 const width = (rows, pick, header) =>
   Math.max(header.length, ...rows.map((row) => String(pick(row)).length));
+
+/**
+ * `BR` → `Brazil`, via `Intl` rather than a table in this repo.
+ *
+ * A two-letter code is exactly as unreadable as the airport codes below it,
+ * which is what prompted the country lookup in the first place — printing
+ * `SG 6` and calling it an improvement would have missed the point. Node has
+ * shipped the region names since v14, so the alternative was carrying 250
+ * country names in a source file and letting them go stale.
+ */
+const REGIONS = new Intl.DisplayNames(["en"], { type: "region" });
+const countryName = (code) => {
+  if (code === "(unknown)") return "address not in the table";
+  try {
+    return REGIONS.of(code) ?? code;
+  } catch {
+    // `of` throws on anything that isn't a well-formed region code. A code the
+    // table produced but Intl doesn't know is worth printing bare, not worth
+    // taking the summary down for.
+    return code;
+  }
+};
+
+/**
+ * `US / Iowa / Council Bluffs` → `United States / Iowa / Council Bluffs`.
+ *
+ * The rollup stores places qualified by the level above them, because place
+ * names are not unique — Ontario is a Canadian province and a Californian
+ * city, and there are around thirty Springfields. Only the leading country
+ * code is expanded; the rest is already what the source called it.
+ */
+const placeLabel = (key) => {
+  const cut = key.indexOf(" / ");
+  if (cut === -1) return key;
+  return `${countryName(key.slice(0, cut))}${key.slice(cut)}`;
+};
 
 function summarise(days, limit) {
   const dates = Object.keys(days).sort();
@@ -184,6 +225,43 @@ function summarise(days, limit) {
       console.log(`  ${String(n).padStart(6)}  ${host}`);
   }
 
+  // Days counted before the place lookup existed have no `countries` key at
+  // all, which is why these stay quiet rather than printing a heading over a
+  // window that predates them. An empty heading and a genuine zero should not
+  // look the same.
+  const countries = merge("countries");
+  if (countries.length) {
+    const codeWidth = Math.max(...countries.map(([code]) => code.length));
+    console.log("\nCOUNTRY (the visitor's own IP, resolved locally)");
+    for (const [code, n] of countries.slice(0, 10))
+      console.log(
+        `  ${String(n).padStart(6)}  ${code.padEnd(codeWidth)}  ${countryName(code)}`,
+      );
+  }
+
+  const regions = merge("regions");
+  if (regions.length) {
+    console.log("\nREGION");
+    for (const [name, n] of regions.slice(0, 10))
+      console.log(`  ${String(n).padStart(6)}  ${placeLabel(name)}`);
+  }
+
+  const cities = merge("cities");
+  if (cities.length) {
+    // The count of distinct cities, not just the top ten, because the shape of
+    // the tail is the thing worth knowing here: a long tail of ones is what a
+    // city breakdown looks like at this traffic, and it is the reason the
+    // caveat at the bottom of this output exists.
+    const singletons = cities.filter(([, n]) => n === 1).length;
+    console.log(`\nCITY (${cities.length} distinct)`);
+    for (const [name, n] of cities.slice(0, 10))
+      console.log(`  ${String(n).padStart(6)}  ${placeLabel(name)}`);
+    if (singletons)
+      console.log(
+        `         ${singletons} of them seen exactly once — see the note below`,
+      );
+  }
+
   const edges = merge("edges");
   if (edges.length) {
     console.log("\nSERVED FROM (nearest CloudFront edge, not the visitor)");
@@ -211,8 +289,14 @@ function summarise(days, limit) {
     "\nvisitors = distinct IPs that day, and is NOT additive across days —\n" +
       "the same person on three days is three visitor-days, not three people.\n" +
       "Undeclared bots count as people. (none) is a floor on direct traffic,\n" +
-      "not a measure of it, and an edge code is where the request was served,\n" +
-      "which is near someone rather than at them. See docs/analytics.md.\n",
+      "not a measure of it. An edge code is a server near someone rather than\n" +
+      "at them, and answers which PoPs serve the site, not who is here.\n" +
+      "\n" +
+      "COUNTRY, REGION and CITY are where the address is REGISTERED, which a\n" +
+      "VPN, a school or a mobile carrier moves outright — and the finer the\n" +
+      "level, the more often it is wrong and the fewer people are behind each\n" +
+      "row. A city seen once is close to naming a household: read it, don't\n" +
+      "publish it, and don't paste it anywhere. See docs/analytics.md.\n",
   );
 }
 
@@ -220,7 +304,11 @@ try {
   if (!flag("no-sync")) sync();
   else process.stderr.write(`using logs already in ${LOGS}\n`);
 
-  execFileSync("node", [ROLLUP, LOGS, OUT], { stdio: "inherit" });
+  execFileSync(
+    "node",
+    [ROLLUP, LOGS, OUT, ...(flag("no-geoip") ? ["--no-geoip"] : [])],
+    { stdio: "inherit" },
+  );
   process.stderr.write(`counts written to ${OUT} (temporary)\n`);
 
   if (existsSync(OUT)) {

--- a/scripts/build-geoip.mjs
+++ b/scripts/build-geoip.mjs
@@ -1,0 +1,539 @@
+#!/usr/bin/env node
+/**
+ * Build the geo-IP artifact the rollup reads, and put it in S3.
+ *
+ * This is the slow, occasional half of the country/city lookup. It downloads
+ * ~50MB of published CSV, merges two databases, sorts and flattens them into
+ * one non-overlapping partition of the address space, and writes a binary file
+ * the reader can use with no parsing at all. `scripts/geoip.mjs` then fetches
+ * that one artifact and is ready in a tenth of a second.
+ *
+ * Run it when you want fresher data — see the cadence note below, which is a
+ * licence obligation rather than a preference:
+ *
+ *   npm run analytics:geoip          build and upload
+ *   npm run analytics:geoip -- --dry build locally, upload nothing
+ *
+ * ## Two databases, because they are good at different things
+ *
+ * | Source                                   | Gives         | Licence     |
+ * | ---------------------------------------- | ------------- | ----------- |
+ * | `@ip-location-db/geo-whois-asn-country`   | country       | CC0-1.0     |
+ * | `@ip-location-db/geolite2-city`           | region, city  | MaxMind EULA|
+ *
+ * **The country always comes from the CC0 table when it has an answer.** That
+ * is not arbitrary: it is the table the country counts already shipped on, it
+ * is built from whois and geofeed records rather than inference, and keeping it
+ * authoritative means adding cities did not silently move anybody between
+ * countries. GeoLite2 fills in the country only where whois is silent.
+ *
+ * ## ⚠️ Rebuild this periodically — it is a term of the licence
+ *
+ * The GeoLite2 redistribution says you "may not prevent the Library from
+ * updating local copies of the GeoLite2 Databases to honor Do Not Sell requests
+ * submitted to MaxMind". MaxMind honours those requests by dropping records
+ * from later releases, so a snapshot pinned in S3 forever is precisely the
+ * thing that clause forbids. `.github/workflows/refresh-geoip.yml` re-runs this
+ * monthly so the obligation is discharged by the pipeline rather than by
+ * somebody remembering; the artifact carries its build date, and the reader
+ * warns when it is reading a stale one.
+ *
+ * ## Why an artifact at all
+ *
+ * The first version had the rollup download both CSVs and do this work every
+ * run. That was ~900ms for country alone and would have been many seconds with
+ * cities — the same sort, the same overlap sweep, the same allocation, over
+ * again, to produce a byte-identical result. Doing it once and storing the
+ * answer costs one S3 object and removes the whole cost from the read path.
+ */
+
+import { createWriteStream, existsSync, mkdirSync, statSync } from "node:fs";
+import { readFile, rename, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { createGunzip, gzipSync } from "node:zlib";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  ARTIFACT,
+  MAGIC,
+  VERSION,
+  cacheDir,
+  ipv4ToInt,
+  ipv6ToBigInt,
+} from "./geoip.mjs";
+
+/**
+ * A 128-bit address as the four 32-bit words the artifact stores.
+ *
+ * The build works in BigInt because sorting and merging need ordered
+ * arithmetic; the reader works in words because comparing four integers is
+ * faster than comparing BigInts. This is the one place the two meet.
+ */
+const wordsOf = (value) => [
+  Number((value >> 96n) & 0xffffffffn),
+  Number((value >> 64n) & 0xffffffffn),
+  Number((value >> 32n) & 0xffffffffn),
+  Number(value & 0xffffffffn),
+];
+
+const CDN = "https://cdn.jsdelivr.net/npm/@ip-location-db";
+
+/**
+ * The four files that go in. `gz` marks the ones published compressed — the
+ * country tables are small enough to be served plain, the city tables are not.
+ */
+const SOURCES = {
+  country4: {
+    url: `${CDN}/geo-whois-asn-country/geo-whois-asn-country-ipv4.csv`,
+    gz: false,
+  },
+  country6: {
+    url: `${CDN}/geo-whois-asn-country/geo-whois-asn-country-ipv6.csv`,
+    gz: false,
+  },
+  city4: {
+    url: `${CDN}/geolite2-city/geolite2-city-ipv4.csv.gz`,
+    gz: true,
+  },
+  city6: {
+    url: `${CDN}/geolite2-city/geolite2-city-ipv6.csv.gz`,
+    gz: true,
+  },
+};
+
+const DOWNLOADS = join(tmpdir(), "schoolskills-geoip-src");
+const PROFILE = process.env.AWS_PROFILE ?? "schoolskills";
+
+const run = (cmd, args) =>
+  execFileSync(cmd, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+const say = (message) => process.stderr.write(`${message}\n`);
+
+/** Download once into a temp directory; a rebuild the same day re-reads it. */
+async function fetchSource(name, { url, gz }) {
+  mkdirSync(DOWNLOADS, { recursive: true });
+  const path = join(DOWNLOADS, `${name}.csv`);
+
+  // A day is the right staleness here rather than the reader's thirty: this
+  // script exists to be run when you WANT new data, so re-reading a
+  // week-old download would defeat the point of running it.
+  if (existsSync(path) && Date.now() - statSync(path).mtimeMs < 86400000) {
+    say(`  ${name}: cached`);
+    return readFile(path, "utf8");
+  }
+
+  say(`  ${name}: downloading`);
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${url} → HTTP ${response.status}`);
+
+  // Streamed and gunzipped on the way to disk: the city file is 36MB
+  // compressed and several hundred megabytes as one JavaScript string, so
+  // buffering the whole response first is how this runs out of memory.
+  const body = Readable.fromWeb(response.body);
+  await pipeline(
+    ...(gz ? [body, createGunzip()] : [body]),
+    createWriteStream(`${path}.part`),
+  );
+  await rename(`${path}.part`, path);
+  return readFile(path, "utf8");
+}
+
+/**
+ * A partition of the address space: `starts[i]` up to `starts[i+1] - 1` holds
+ * `values[i]`, with `null` for the stretches no database covers.
+ *
+ * Modelling gaps as explicit entries rather than as a separate `ends` array is
+ * what makes both the merge below and the reader's binary search trivial —
+ * every address is inside exactly one entry, always, so a lookup never has to
+ * ask a second question after finding its index.
+ */
+export const partition = (ranges, zero) => {
+  const starts = [];
+  const values = [];
+  let cursor = zero;
+
+  for (const [start, end, value] of ranges) {
+    if (start > cursor) {
+      starts.push(cursor);
+      values.push(null);
+      cursor = start;
+    }
+    if (end < cursor) continue; // wholly inside a range already claimed
+    starts.push(cursor);
+    values.push(value);
+    cursor = end + 1n;
+  }
+  return { starts, values };
+};
+
+/**
+ * Parse one CSV into sorted, non-overlapping ranges.
+ *
+ * The two published files disagree about tidiness — GeoLite2 arrives sorted and
+ * disjoint, the whois country file has 568 IPv4 rows that begin inside the row
+ * before them — so both get sorted and swept regardless. Where ranges overlap
+ * the earlier start wins, and the narrower one on a tie; it decides 0.17% of
+ * the whois table and the only thing that matters is that it decides them the
+ * same way every build.
+ */
+export const readRanges = (text, parse, pick) => {
+  const ranges = [];
+  let skipped = 0;
+
+  for (const line of text.split("\n")) {
+    if (!line || line.startsWith("#")) continue;
+    const fields = line.split(",");
+    const start = parse(fields[0]);
+    const end = parse(fields[1]);
+    const value = pick(fields);
+    if (start === null || end === null || end < start || value === null) {
+      skipped += 1;
+      continue;
+    }
+    ranges.push([start, end, value]);
+  }
+
+  if (ranges.length === 0 || skipped > ranges.length / 100) {
+    throw new Error(
+      `source did not parse: ${ranges.length} usable row(s), ${skipped} skipped.\n` +
+        `The CSV format probably moved. Delete ${DOWNLOADS} and look at one.`,
+    );
+  }
+
+  ranges.sort((a, b) =>
+    a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : 0,
+  );
+  return ranges;
+};
+
+/**
+ * Walk two partitions together, emitting a new entry wherever either changes.
+ *
+ * The result is the coarsest partition on which both inputs are constant, which
+ * is the only way to combine them without either losing a boundary or inventing
+ * one. Both inputs are sorted, so this is a single pass over each.
+ */
+export const merge = (a, b, combine, zero) => {
+  const starts = [];
+  const values = [];
+  let i = 0;
+  let j = 0;
+  let cursor = zero;
+
+  const nextBoundary = () => {
+    const ai = i + 1 < a.starts.length ? a.starts[i + 1] : null;
+    const bj = j + 1 < b.starts.length ? b.starts[j + 1] : null;
+    if (ai === null) return bj;
+    if (bj === null) return ai;
+    return ai < bj ? ai : bj;
+  };
+
+  for (;;) {
+    starts.push(cursor);
+    values.push(combine(a.values[i] ?? null, b.values[j] ?? null));
+
+    const next = nextBoundary();
+    if (next === null) break;
+    cursor = next;
+    if (i + 1 < a.starts.length && a.starts[i + 1] === cursor) i += 1;
+    if (j + 1 < b.starts.length && b.starts[j + 1] === cursor) j += 1;
+  }
+  return { starts, values };
+};
+
+/** Collapse runs of identical values — the merge above creates many. */
+export const dedupe = ({ starts, values }, key) => {
+  const outStarts = [];
+  const outValues = [];
+  let previous = Symbol("none");
+
+  for (let i = 0; i < starts.length; i += 1) {
+    const id = key(values[i]);
+    if (id === previous) continue;
+    previous = id;
+    outStarts.push(starts[i]);
+    outValues.push(values[i]);
+  }
+  return { starts: outStarts, values: outValues };
+};
+
+/**
+ * One family (v4 or v6), from two CSVs to a partition of location ids.
+ *
+ * `locations` is shared across both families so a city gets one id in the
+ * whole artifact rather than one per address family.
+ */
+export function buildFamily({
+  countryText,
+  cityText,
+  parse,
+  label,
+  locations,
+  log = () => {},
+}) {
+  const countries = partition(
+    readRanges(countryText, parse, (f) => {
+      const code = (f[2] ?? "").trim().toUpperCase();
+      return /^[A-Z]{2}$/.test(code) ? code : null;
+    }),
+    0n,
+  );
+  log(`  ${label}: ${countries.starts.length} country entries`);
+
+  // GeoLite2 columns: start, end, country, state1, state2, city, postcode,
+  // latitude, longitude, timezone. Only three are taken. The coordinates are
+  // deliberately dropped — see the header of scripts/geoip.mjs.
+  const cities = partition(
+    readRanges(cityText, parse, (f) => {
+      if (f.length < 10) return null;
+      const code = (f[2] ?? "").trim().toUpperCase();
+      if (!/^[A-Z]{2}$/.test(code)) return null;
+      return {
+        country: code,
+        region: (f[3] ?? "").trim(),
+        city: (f[5] ?? "").trim(),
+      };
+    }),
+    0n,
+  );
+  log(`  ${label}: ${cities.starts.length} city entries`);
+
+  const combined = dedupe(
+    merge(
+      countries,
+      cities,
+      (country, place) => {
+        // The CC0 table is authoritative for the country; GeoLite2 supplies it
+        // only where whois has nothing. Region and city can only come from
+        // GeoLite2, and are kept only when they agree with the country we
+        // settled on — a city in the wrong country is worse than no city.
+        const settled = country ?? place?.country ?? null;
+        if (!settled) return null;
+        const sameCountry = place && place.country === settled;
+        return {
+          country: settled,
+          region: sameCountry ? place.region : "",
+          city: sameCountry ? place.city : "",
+        };
+      },
+      0n,
+    ),
+    (value) =>
+      value ? `${value.country}\t${value.region}\t${value.city}` : " ",
+  );
+  log(`  ${label}: ${combined.starts.length} merged entries`);
+
+  // Location id 0 is reserved for "nothing known here", so a gap and a real
+  // place can never be confused by an off-by-one in the reader.
+  const ids = new Uint32Array(combined.starts.length);
+  for (let i = 0; i < combined.values.length; i += 1) {
+    const value = combined.values[i];
+    if (!value) continue;
+    const key = `${value.country}\t${value.region}\t${value.city}`;
+    let id = locations.get(key);
+    if (id === undefined) {
+      id = locations.size + 1;
+      locations.set(key, id);
+    }
+    ids[i] = id;
+  }
+
+  return { starts: combined.starts, ids };
+}
+
+/** Pad to an 8-byte boundary so a BigUint64Array view is legal at any offset. */
+const align = (n) => (n + 7) & ~7;
+
+/**
+ * Serialise to the format `scripts/geoip.mjs` reads.
+ *
+ * The header is JSON, uncompressed and at the front, so that anyone who finds
+ * this file in a bucket in three years can read what it is and how it is laid
+ * out without this script. Everything after it is typed-array data, which is
+ * the entire point — the reader maps it and searches it as-is.
+ */
+export function serialise({ v4, v6, locations, sources }) {
+  const blob = Buffer.from(
+    ["", ...locations.keys()].join("\n"), // index 0 is the reserved empty slot
+    "utf8",
+  );
+
+  const sections = {};
+  let offset = 0;
+  const place = (name, bytes) => {
+    offset = align(offset);
+    sections[name] = { offset, length: bytes };
+    offset += bytes;
+  };
+
+  place("v4start", v4.starts.length * 4);
+  place("v4loc", v4.ids.length * 4);
+  place("v6words", v6.starts.length * 16);
+  place("v6loc", v6.ids.length * 4);
+  place("locations", blob.length);
+
+  const header = Buffer.from(
+    JSON.stringify({
+      version: VERSION,
+      builtAt: new Date().toISOString().slice(0, 10),
+      // Typed arrays use the platform's byte order. Every target anyone will
+      // run this on is little-endian, but recording it means a big-endian
+      // reader fails loudly instead of returning nonsense countries.
+      littleEndian: new Uint8Array(Uint32Array.of(1).buffer)[0] === 1,
+      sources,
+      counts: {
+        v4: v4.starts.length,
+        v6: v6.starts.length,
+        locations: locations.size,
+      },
+      sections,
+    }),
+    "utf8",
+  );
+
+  const prologue = align(8 + header.length);
+  const out = Buffer.alloc(prologue + offset);
+  out.write(MAGIC, 0, "ascii");
+  out.writeUInt32LE(header.length, 4);
+  header.copy(out, 8);
+
+  const at = (name) => prologue + sections[name].offset;
+
+  const v4start = new Uint32Array(out.buffer, at("v4start"), v4.starts.length);
+  for (let i = 0; i < v4.starts.length; i += 1)
+    v4start[i] = Number(v4.starts[i]);
+  new Uint32Array(out.buffer, at("v4loc"), v4.ids.length).set(v4.ids);
+
+  // Four 32-bit words per address, most significant first, so a comparison is
+  // four integer compares and never touches BigInt on the read path.
+  const v6words = new Uint32Array(
+    out.buffer,
+    at("v6words"),
+    v6.starts.length * 4,
+  );
+  for (let i = 0; i < v6.starts.length; i += 1) {
+    v6words.set(wordsOf(v6.starts[i]), i * 4);
+  }
+  new Uint32Array(out.buffer, at("v6loc"), v6.ids.length).set(v6.ids);
+  blob.copy(out, at("locations"));
+
+  return out;
+}
+
+async function main({ dry }) {
+  say("downloading sources");
+  const [country4, country6, city4, city6] = await Promise.all([
+    fetchSource("country4", SOURCES.country4),
+    fetchSource("country6", SOURCES.country6),
+    fetchSource("city4", SOURCES.city4),
+    fetchSource("city6", SOURCES.city6),
+  ]);
+
+  const locations = new Map();
+  say("merging");
+  const v4 = buildFamily({
+    countryText: country4,
+    cityText: city4,
+    parse: (text) => {
+      const n = ipv4ToInt(text);
+      return n === null ? null : BigInt(n);
+    },
+    label: "ipv4",
+    locations,
+    log: say,
+  });
+  const v6 = buildFamily({
+    countryText: country6,
+    cityText: city6,
+    parse: ipv6ToBigInt,
+    label: "ipv6",
+    locations,
+    log: say,
+  });
+  say(`  ${locations.size} distinct places`);
+
+  const buffer = serialise({
+    v4,
+    v6,
+    locations,
+    sources: [
+      {
+        name: "@ip-location-db/geo-whois-asn-country",
+        used: "country",
+        licence: "CC0-1.0",
+      },
+      {
+        name: "@ip-location-db/geolite2-city",
+        used: "region, city",
+        licence: "MaxMind GeoLite2 EULA (CC BY-SA 4.0 elements)",
+        attribution:
+          "This product includes GeoLite2 Data created by MaxMind, available from https://www.maxmind.com/",
+      },
+    ],
+  });
+
+  mkdirSync(cacheDir(), { recursive: true });
+  const local = join(cacheDir(), ARTIFACT);
+  await writeFile(local, buffer);
+  say(`\nwrote ${local} (${(buffer.length / 1e6).toFixed(1)} MB)`);
+
+  // Stored compressed and cached decompressed. The arrays are mostly ascending
+  // integers, so this is a 4:1 saving on every download, and paying ~150ms to
+  // gunzip once per week is cheaper than moving 40MB — but the read path wants
+  // the raw bytes to make views over, so the local cache holds those.
+  const packed = gzipSync(buffer, { level: 9 });
+  const localGz = `${local}.gz`;
+  await writeFile(localGz, packed);
+  say(`packed to ${(packed.length / 1e6).toFixed(1)} MB`);
+
+  if (dry) {
+    say("--dry: not uploading");
+    return;
+  }
+
+  const account = run("aws", [
+    "sts",
+    "get-caller-identity",
+    "--query",
+    "Account",
+    "--output",
+    "text",
+    "--profile",
+    PROFILE,
+  ]).trim();
+  const target = `s3://schoolskills-access-logs-${account}/geoip/${ARTIFACT}.gz`;
+
+  // The `geoip/` prefix, not `cf/`. The 90-day expiry rule in sst.config.ts is
+  // scoped to `cf/` precisely so that something kept here is not swept up by a
+  // rule that was only ever about deleting IP addresses.
+  say(`uploading → ${target}`);
+  run("aws", [
+    "s3",
+    "cp",
+    localGz,
+    target,
+    "--profile",
+    PROFILE,
+    "--only-show-errors",
+  ]);
+  say("done");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    await main({ dry: process.argv.includes("--dry") });
+  } catch (error) {
+    console.error(`\n${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/geoip.mjs
+++ b/scripts/geoip.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+/**
+ * Turn the IP address on a log line into a place, without telling anyone.
+ *
+ * The access logs already carry `c-ip` — the visitor's own address, not the
+ * edge's — and `scripts/rollup-analytics.mjs` already reads it to count
+ * distinct visitors. This module is how that address becomes a country, a
+ * region and a city.
+ *
+ * ⚠️ **The lookup is arithmetic on this machine, and that is the entire
+ * point.** The obvious way to geolocate an address is to ask a geo-IP API,
+ * which would mean sending a child's IP address to a third party — the exact
+ * thing /privacy promises does not happen, and under COPPA a step change
+ * rather than a feature. Instead a prepared table is downloaded from our own
+ * bucket and searched locally. Nobody is asked anything about anybody.
+ *
+ * ## This is the read half only
+ *
+ * `scripts/build-geoip.mjs` does the downloading, merging, sorting and
+ * flattening, once, and puts one binary artifact in S3. Everything here does is
+ * fetch that artifact and binary-search it. There is deliberately no CSV
+ * parsing, no sorting and no allocation on this path: the arrays below are
+ * views straight onto the downloaded bytes, so a cold start is a download and
+ * a warm one is a file read.
+ *
+ * ## What is deliberately NOT taken
+ *
+ * The GeoLite2 source carries latitude, longitude and postcode. None of them
+ * are in the artifact and none should be added. A coordinate pair is a
+ * different kind of fact about a child than a city name, and the accuracy is
+ * not there to justify it either — the single most common coordinate in the
+ * source is MaxMind's "somewhere in the United States" fallback, which nearly
+ * a hundred thousand ranges point at. That fallback is how a Kansas farm ended
+ * up on the receiving end of years of harassment from people who believed a
+ * database when it said it knew where somebody was. City names inherit the
+ * same fallback problem, which is why `city` is empty rather than guessed when
+ * the source doesn't actually know.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { gunzipSync } from "node:zlib";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Bumped when the binary layout changes; the reader refuses anything else. */
+export const VERSION = 1;
+export const MAGIC = "SSG1";
+export const ARTIFACT = "geoip.bin";
+
+/** A sibling of the log cache, so the two are cleaned up together. */
+export const cacheDir = () => join(tmpdir(), "schoolskills-geoip");
+
+/**
+ * How old an artifact may be before the reader says something.
+ *
+ * Not an expiry — a stale table still answers, and losing a month of counts
+ * because nobody re-ran a build would be the worse failure. But the GeoLite2
+ * licence requires that local copies keep updating so MaxMind's Do Not Sell
+ * requests propagate, so an artifact this old means the refresh has stopped
+ * and somebody needs to know. See scripts/build-geoip.mjs.
+ */
+const STALE_DAYS = 45;
+
+const PROFILE = process.env.AWS_PROFILE ?? "schoolskills";
+
+/**
+ * A dotted quad as a number. `null` for anything that isn't one.
+ *
+ * Multiplication rather than `<<`, because `<<` is a signed 32-bit operation
+ * in JavaScript and every address from 128.0.0.0 up would come out negative —
+ * which sorts and compares wrongly rather than failing.
+ */
+export const ipv4ToInt = (text) => {
+  const parts = String(text).trim().split(".");
+  if (parts.length !== 4) return null;
+  let out = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    out = out * 256 + octet;
+  }
+  return out;
+};
+
+/**
+ * An IPv6 address as four 32-bit words, most significant first.
+ *
+ * Words rather than a BigInt because this is the read path: comparing four
+ * plain integers is several times faster than comparing BigInts, and the
+ * artifact stores them in exactly this shape so no conversion happens at all.
+ *
+ * Handles the two forms that actually appear: `::` compression, and the
+ * embedded-IPv4 tail (`::ffff:203.0.113.9`) a dual-stack host can present.
+ */
+export const ipv6ToWords = (text) => {
+  let value = String(text).trim().toLowerCase();
+  if (!value.includes(":")) return null;
+
+  // Fold a dotted tail into two hex groups first, so everything below only has
+  // to think in groups of sixteen bits.
+  const dotted = /:(\d+\.\d+\.\d+\.\d+)$/.exec(value);
+  if (dotted) {
+    const packed = ipv4ToInt(dotted[1]);
+    if (packed === null) return null;
+    const high = Math.floor(packed / 0x10000).toString(16);
+    const low = (packed % 0x10000).toString(16);
+    value = `${value.slice(0, dotted.index + 1)}${high}:${low}`;
+  }
+
+  const halves = value.split("::");
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(":") : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+
+  let groups;
+  if (halves.length === 1) {
+    if (head.length !== 8) return null;
+    groups = head;
+  } else {
+    const gap = 8 - head.length - tail.length;
+    if (gap < 0) return null;
+    groups = [...head, ...Array(gap).fill("0"), ...tail];
+  }
+
+  const words = new Array(4).fill(0);
+  for (let i = 0; i < 8; i += 1) {
+    const group = groups[i];
+    if (!/^[0-9a-f]{1,4}$/.test(group)) return null;
+    const half = parseInt(group, 16);
+    // Two 16-bit groups per 32-bit word, and `>>> 0` because `<<` would make
+    // any word with its top bit set negative.
+    words[i >> 1] = i % 2 === 0 ? half * 0x10000 : (words[i >> 1] + half) >>> 0;
+  }
+  return words;
+};
+
+/** The same address as a BigInt — used by the builder, never on the read path. */
+export const ipv6ToBigInt = (text) => {
+  const words = ipv6ToWords(text);
+  if (words === null) return null;
+  let out = 0n;
+  for (const word of words) out = (out << 32n) | BigInt(word);
+  return out;
+};
+
+/**
+ * The rightmost entry starting at or before `key`.
+ *
+ * Exact because the artifact is a PARTITION rather than a list of ranges:
+ * every address falls inside exactly one entry, gaps included, so there is no
+ * second question to ask once the index is found. `compare` is what lets one
+ * search serve both address families.
+ */
+const search = (starts, count, key, compare) => {
+  let low = 0;
+  let high = count - 1;
+  let found = 0;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    if (compare(starts, mid, key) <= 0) {
+      found = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return found;
+};
+
+const compare4 = (starts, index, key) =>
+  starts[index] < key ? -1 : starts[index] > key ? 1 : 0;
+
+const compare6 = (words, index, key) => {
+  const at = index * 4;
+  for (let i = 0; i < 4; i += 1) {
+    if (words[at + i] < key[i]) return -1;
+    if (words[at + i] > key[i]) return 1;
+  }
+  return 0;
+};
+
+/**
+ * Fetch the artifact from S3 unless a fresh enough copy is already here.
+ *
+ * `aws s3 cp` rather than `fetch`, because the bucket is private and must stay
+ * that way — it is the same bucket the access logs live in.
+ */
+function ensureArtifact({ maxAgeMs }) {
+  mkdirSync(cacheDir(), { recursive: true });
+  const path = join(cacheDir(), ARTIFACT);
+
+  const age = existsSync(path) ? Date.now() - statSync(path).mtimeMs : Infinity;
+  if (age <= maxAgeMs) return path;
+
+  let account;
+  try {
+    account = execFileSync(
+      "aws",
+      [
+        "sts",
+        "get-caller-identity",
+        "--query",
+        "Account",
+        "--output",
+        "text",
+        "--profile",
+        PROFILE,
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    ).trim();
+  } catch (error) {
+    throw new Error(
+      `Could not reach AWS as profile "${PROFILE}".\n` +
+        `${String(error.stderr ?? error.message).trim()}\n` +
+        `If the session has expired: aws sso login --profile ${PROFILE}`,
+      { cause: error },
+    );
+  }
+
+  const source = `s3://schoolskills-access-logs-${account}/geoip/${ARTIFACT}.gz`;
+  const packed = `${path}.gz`;
+  try {
+    execFileSync(
+      "aws",
+      ["s3", "cp", source, packed, "--profile", PROFILE, "--only-show-errors"],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  } catch (error) {
+    throw new Error(
+      `Could not fetch ${source}\n` +
+        `${String(error.stderr ?? error.message).trim()}\n` +
+        "If the artifact has never been built:  npm run analytics:geoip",
+      { cause: error },
+    );
+  }
+
+  // Written via `.part` and renamed, because a half-written artifact cached
+  // under the real name would be treated as fresh for the next week and would
+  // fail the magic check on every run until somebody deleted it by hand.
+  writeFileSync(`${path}.part`, gunzipSync(readFileSync(packed)));
+  renameSync(`${path}.part`, path);
+  rmSync(packed, { force: true });
+  return path;
+}
+
+/**
+ * The front door: a `{ lookup }` the rollup can hand an address to.
+ *
+ * Throws if the artifact can't be had — the caller decides whether that is
+ * fatal. In the rollup it is not: a run with no place data omits those fields
+ * entirely rather than recording every visitor as unknown, because an absent
+ * key means "not looked up" and a present one full of `(unknown)` would be a
+ * lie that looks like a measurement.
+ */
+export async function placeLookup({ maxAgeMs = 7 * 86400000 } = {}) {
+  const path = ensureArtifact({ maxAgeMs });
+  return readArtifact(await readFile(path), path);
+}
+
+/**
+ * Turn artifact bytes into a `{ lookup }`, with no filesystem involved.
+ *
+ * Separate from `placeLookup` so the binary layout can be tested against the
+ * builder that writes it, in-process, without a bucket. That contract is the
+ * one thing here that two files have to agree about, so it is the one thing
+ * worth pinning with a round trip.
+ */
+export function readArtifact(input, path = "<buffer>") {
+  // A Buffer from `readFile` can be a view into a shared pool at an arbitrary
+  // byte offset, and a Uint32Array view demands 4-byte alignment. Copying only
+  // when that bites keeps the common case zero-copy and stops the uncommon one
+  // from being a crash that appears at random.
+  const file = input.byteOffset % 8 === 0 ? input : Buffer.from(input);
+
+  if (file.length < 8 || file.toString("ascii", 0, 4) !== MAGIC) {
+    throw new Error(
+      `${path} is not a geo-IP artifact (bad magic).\n` +
+        "A truncated download would do this. Delete it and re-run:\n" +
+        `  rm -f ${path}`,
+    );
+  }
+
+  const headerLength = file.readUInt32LE(4);
+  const header = JSON.parse(file.toString("utf8", 8, 8 + headerLength));
+  if (header.version !== VERSION) {
+    throw new Error(
+      `artifact is format v${header.version}, this reader speaks v${VERSION}.\n` +
+        "Rebuild it:  npm run analytics:geoip",
+    );
+  }
+  if (
+    header.littleEndian !==
+    (new Uint8Array(Uint32Array.of(1).buffer)[0] === 1)
+  ) {
+    throw new Error(
+      "artifact was built on a machine of the opposite byte order",
+    );
+  }
+
+  const prologue = (8 + headerLength + 7) & ~7;
+  const view = (name, Type, per) => {
+    const { offset, length } = header.sections[name];
+    return new Type(
+      file.buffer,
+      file.byteOffset + prologue + offset,
+      length / per,
+    );
+  };
+
+  const v4start = view("v4start", Uint32Array, 4);
+  const v4loc = view("v4loc", Uint32Array, 4);
+  const v6words = view("v6words", Uint32Array, 4);
+  const v6loc = view("v6loc", Uint32Array, 4);
+
+  const { offset, length } = header.sections.locations;
+  const places = file
+    .toString("utf8", prologue + offset, prologue + offset + length)
+    .split("\n")
+    .map((line) => {
+      if (!line) return null;
+      const [country, region, city] = line.split("\t");
+      return { country, region: region || null, city: city || null };
+    });
+
+  const builtAt = header.builtAt;
+  const ageDays = Math.floor(
+    (Date.now() - Date.parse(`${builtAt}T00:00:00Z`)) / 86400000,
+  );
+
+  return {
+    builtAt,
+    stale: ageDays > STALE_DAYS ? ageDays : null,
+    places: header.counts.locations,
+    ranges: header.counts.v4 + header.counts.v6,
+    /** `{ country, region, city }` — region and city may be null. */
+    lookup(ip) {
+      if (!ip) return null;
+      const text = String(ip).trim();
+      if (text.includes(":")) {
+        const key = ipv6ToWords(text);
+        if (key === null) return null;
+        return places[v6loc[search(v6words, v6loc.length, key, compare6)]];
+      }
+      const key = ipv4ToInt(text);
+      if (key === null) return null;
+      return places[v4loc[search(v4start, v4start.length, key, compare4)]];
+    },
+  };
+}

--- a/scripts/geoip.test.mjs
+++ b/scripts/geoip.test.mjs
@@ -1,0 +1,346 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFamily,
+  dedupe,
+  merge,
+  partition,
+  readRanges,
+  serialise,
+} from "./build-geoip.mjs";
+import {
+  ipv4ToInt,
+  ipv6ToBigInt,
+  ipv6ToWords,
+  readArtifact,
+} from "./geoip.mjs";
+
+/**
+ * The lookup is the one place in this pipeline where a wrong answer is
+ * *plausible* rather than obviously broken. A miscounted page view shows up as
+ * a number that looks odd; an off-by-one at a range boundary produces a
+ * perfectly reasonable city for the wrong visitor, in a table nobody can check
+ * against the raw lines once they expire.
+ *
+ * The suite is therefore built around a ROUND TRIP: the builder's serialiser
+ * writes an artifact and the reader reads it back, in-process. That is the
+ * only contract two files have to agree about — byte offsets, alignment,
+ * word order, the reserved zero location — and it is the one that would fail
+ * silently, because a misread artifact still returns countries. They just
+ * belong to somebody else.
+ */
+
+const V4_LINE = (start, end, cc) => `${start},${end},${cc}`;
+/** GeoLite2 has ten columns; only 2, 3 and 5 are read. */
+const CITY_LINE = (start, end, cc, region, city) =>
+  `${start},${end},${cc},${region},,${city},,0,0,UTC`;
+
+/** Enough rows to clear `readRanges`'s "did this parse at all" floor. */
+const FILLER = Array.from({ length: 200 }, (_, i) =>
+  V4_LINE(`10.${i}.0.0`, `10.${i}.255.255`, "ZZ"),
+);
+const CITY_FILLER = Array.from({ length: 200 }, (_, i) =>
+  CITY_LINE(`10.${i}.0.0`, `10.${i}.255.255`, "ZZ", "Filler", "Filler"),
+);
+
+const parse4 = (text) => {
+  const n = ipv4ToInt(text);
+  return n === null ? null : BigInt(n);
+};
+
+/** Build a one-family artifact and read it back, the way the real job would. */
+const roundTrip = ({ country, city }) => {
+  const locations = new Map();
+  const v4 = buildFamily({
+    countryText: [...country, ...FILLER].join("\n"),
+    cityText: [...city, ...CITY_FILLER].join("\n"),
+    parse: parse4,
+    label: "test",
+    locations,
+  });
+  // IPv6 still has to be present and empty-ish, because the reader makes views
+  // over every section unconditionally.
+  const v6 = buildFamily({
+    countryText: Array.from(
+      { length: 200 },
+      (_, i) => `2001:${i.toString(16)}::,2001:${i.toString(16)}::ffff,ZZ`,
+    ).join("\n"),
+    cityText: Array.from({ length: 200 }, (_, i) =>
+      CITY_LINE(
+        `2001:${i.toString(16)}::`,
+        `2001:${i.toString(16)}::ffff`,
+        "ZZ",
+        "Filler",
+        "Filler",
+      ),
+    ).join("\n"),
+    parse: ipv6ToBigInt,
+    label: "test6",
+    locations,
+  });
+
+  return readArtifact(
+    serialise({ v4, v6, locations, sources: [{ name: "test" }] }),
+  );
+};
+
+describe("ipv4ToInt", () => {
+  it.each([
+    ["0.0.0.0", 0],
+    ["0.0.0.1", 1],
+    ["255.255.255.255", 4294967295],
+  ])("packs %s", (ip, n) => expect(ipv4ToInt(ip)).toBe(n));
+
+  // `<<` is signed 32-bit in JavaScript, so a shift-based version returns
+  // -1408237567 here — which sorts below every address in the table and makes
+  // half the internet unfindable rather than throwing.
+  it("keeps the top half of the space positive", () =>
+    expect(ipv4ToInt("172.217.0.1")).toBe(2899902465));
+
+  it.each(["1.2.3", "1.2.3.4.5", "1.2.3.256", "1.2.3.x", "", "not-an-ip"])(
+    "refuses %s",
+    (ip) => expect(ipv4ToInt(ip)).toBeNull(),
+  );
+});
+
+describe("ipv6ToWords", () => {
+  it("expands ::", () => expect(ipv6ToWords("::")).toEqual([0, 0, 0, 0]));
+
+  it("expands ::1", () => expect(ipv6ToWords("::1")).toEqual([0, 0, 0, 1]));
+
+  it("packs two groups per word", () =>
+    expect(ipv6ToWords("2001:4860:4860::8888")).toEqual([
+      0x20014860, 0x48600000, 0, 0x8888,
+    ]));
+
+  // `<<` again: the top word of any address starting above 7fff would go
+  // negative, and every comparison against it would then be backwards.
+  it("keeps a high leading word positive", () =>
+    expect(ipv6ToWords("ffff::")[0]).toBe(0xffff0000));
+
+  // A dual-stack host can present its address this way, and dropping it would
+  // silently file those visitors as unknown.
+  it("reads the embedded-IPv4 form", () =>
+    expect(ipv6ToWords("::ffff:203.0.113.9")).toEqual([
+      0,
+      0,
+      0xffff,
+      ipv4ToInt("203.0.113.9"),
+    ]));
+
+  it.each(["1.2.3.4", "2001::db8::1", "2001:db8:1", "zzzz::1", ""])(
+    "refuses %s",
+    (ip) => expect(ipv6ToWords(ip)).toBeNull(),
+  );
+
+  it("agrees with the BigInt form the builder sorts on", () =>
+    expect(ipv6ToBigInt("2001:db8::1")).toBe(
+      ipv6ToWords("2001:db8::1").reduce((a, w) => (a << 32n) | BigInt(w), 0n),
+    ));
+});
+
+describe("partition", () => {
+  // The invariant the reader's binary search depends on: every address is
+  // inside exactly one entry, so a lookup never has to ask a second question.
+  it("fills the gaps between ranges with an explicit nothing", () => {
+    const { starts, values } = partition(
+      [
+        [10n, 20n, "A"],
+        [30n, 40n, "B"],
+      ],
+      0n,
+    );
+    expect(starts).toEqual([0n, 10n, 21n, 30n]);
+    expect(values).toEqual([null, "A", null, "B"]);
+  });
+
+  it("drops a range wholly inside one already claimed", () => {
+    const { values } = partition(
+      [
+        [0n, 100n, "A"],
+        [10n, 20n, "B"],
+      ],
+      0n,
+    );
+    expect(values).toEqual(["A"]);
+  });
+});
+
+describe("merge", () => {
+  // The point of the merge: a boundary in either input must survive into the
+  // result, or one of the two databases silently loses resolution.
+  it("splits at every boundary either side has", () => {
+    const a = { starts: [0n, 50n], values: ["a1", "a2"] };
+    const b = { starts: [0n, 20n, 70n], values: ["b1", "b2", "b3"] };
+    const { starts, values } = merge(a, b, (x, y) => `${x}+${y}`, 0n);
+    expect(starts).toEqual([0n, 20n, 50n, 70n]);
+    expect(values).toEqual(["a1+b1", "a1+b2", "a2+b2", "a2+b3"]);
+  });
+});
+
+describe("dedupe", () => {
+  it("collapses a run of identical values", () => {
+    const { starts } = dedupe(
+      { starts: [0n, 10n, 20n, 30n], values: ["A", "A", "B", "B"] },
+      (v) => v,
+    );
+    expect(starts).toEqual([0n, 20n]);
+  });
+});
+
+describe("readRanges", () => {
+  const pick = (f) => (/^[A-Z]{2}$/.test(f[2] ?? "") ? f[2] : null);
+
+  it("sorts a file that arrived out of order", () => {
+    const ranges = readRanges(
+      [
+        V4_LINE("9.0.0.0", "9.0.0.255", "GB"),
+        V4_LINE("2.0.0.0", "2.0.0.255", "FR"),
+        ...FILLER,
+      ].join("\n"),
+      parse4,
+      pick,
+    );
+    expect(ranges[0][2]).toBe("FR");
+  });
+
+  it("skips a malformed row without taking the build down", () =>
+    expect(() =>
+      readRanges(
+        [V4_LINE("1.0.0.0", "1.0.0.255", "AU"), "garbage", ...FILLER].join(
+          "\n",
+        ),
+        parse4,
+        pick,
+      ),
+    ).not.toThrow());
+
+  // Loud, on the same reasoning as the rollup's empty-directory throw: a source
+  // that parsed to nothing would answer every lookup "(unknown)", which is a
+  // shape of failure that reads as a finding.
+  it("refuses a file that parsed to nothing", () =>
+    expect(() => readRanges("nonsense\nmore nonsense", parse4, pick)).toThrow(
+      /did not parse/,
+    ));
+
+  it("refuses a file that mostly did not parse", () =>
+    expect(() =>
+      readRanges(
+        [...FILLER, ...Array(50).fill("truncat")].join("\n"),
+        parse4,
+        pick,
+      ),
+    ).toThrow(/did not parse/));
+});
+
+describe("an artifact, written and read back", () => {
+  const geo = roundTrip({
+    country: [
+      V4_LINE("1.0.0.0", "1.0.0.255", "AU"),
+      V4_LINE("3.0.0.0", "3.0.255.255", "DE"),
+    ],
+    city: [
+      CITY_LINE("1.0.0.0", "1.0.0.255", "AU", "New South Wales", "Sydney"),
+      CITY_LINE("3.0.0.0", "3.0.0.255", "DE", "Berlin", "Berlin"),
+    ],
+  });
+
+  it("finds a place inside a range", () =>
+    expect(geo.lookup("1.0.0.128")).toEqual({
+      country: "AU",
+      region: "New South Wales",
+      city: "Sydney",
+    }));
+
+  // Both ends are inclusive in the source format, and an exclusive read of
+  // either would misplace exactly the addresses at a boundary — the least
+  // likely thing for anyone to notice.
+  it("includes both ends of a range", () => {
+    expect(geo.lookup("1.0.0.0").city).toBe("Sydney");
+    expect(geo.lookup("1.0.0.255").city).toBe("Sydney");
+  });
+
+  it("returns nothing for an address no source covers", () =>
+    expect(geo.lookup("2.0.0.1")).toBeNull());
+
+  // The whole reason the country comes from the CC0 table: the city source
+  // covers only the first /24 of the German range, and the rest must still be
+  // Germany rather than falling into a hole.
+  it("keeps the country where only the city source runs out", () =>
+    expect(geo.lookup("3.0.128.1")).toEqual({
+      country: "DE",
+      region: null,
+      city: null,
+    }));
+
+  it("reserves location id 0 so a gap can never read as a place", () =>
+    expect(geo.lookup("0.0.0.1")).toBeNull());
+
+  it("carries its build date and source list", () => {
+    expect(geo.builtAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(geo.stale).toBeNull();
+  });
+
+  it("searches IPv6 through the same artifact", () =>
+    expect(geo.lookup("2001:5::1")).toEqual({
+      country: "ZZ",
+      region: "Filler",
+      city: "Filler",
+    }));
+
+  it("refuses bytes that are not an artifact", () =>
+    expect(() => readArtifact(Buffer.from("not an artifact at all"))).toThrow(
+      /bad magic/,
+    ));
+
+  // A Buffer from `readFile` can be a view into a shared pool at any byte
+  // offset, and a Uint32Array view demands alignment. This is the case that
+  // would work on every machine until the day it didn't.
+  it("reads correctly from a misaligned buffer", () => {
+    const source = serialise({
+      v4: roundTripParts().v4,
+      v6: roundTripParts().v6,
+      locations: roundTripParts().locations,
+      sources: [],
+    });
+    const padded = Buffer.alloc(source.length + 1);
+    source.copy(padded, 1);
+    expect(readArtifact(padded.subarray(1)).lookup("1.0.0.128").city).toBe(
+      "Sydney",
+    );
+  });
+});
+
+/** The pieces of the fixture above, for the alignment case. */
+function roundTripParts() {
+  const locations = new Map();
+  const v4 = buildFamily({
+    countryText: [V4_LINE("1.0.0.0", "1.0.0.255", "AU"), ...FILLER].join("\n"),
+    cityText: [
+      CITY_LINE("1.0.0.0", "1.0.0.255", "AU", "New South Wales", "Sydney"),
+      ...CITY_FILLER,
+    ].join("\n"),
+    parse: parse4,
+    label: "test",
+    locations,
+  });
+  const v6 = buildFamily({
+    countryText: Array.from(
+      { length: 200 },
+      (_, i) => `2001:${i.toString(16)}::,2001:${i.toString(16)}::ffff,ZZ`,
+    ).join("\n"),
+    cityText: Array.from({ length: 200 }, (_, i) =>
+      CITY_LINE(
+        `2001:${i.toString(16)}::`,
+        `2001:${i.toString(16)}::ffff`,
+        "ZZ",
+        "Filler",
+        "Filler",
+      ),
+    ).join("\n"),
+    parse: ipv6ToBigInt,
+    label: "test6",
+    locations,
+  });
+  return { v4, v6, locations };
+}

--- a/scripts/rollup-analytics.mjs
+++ b/scripts/rollup-analytics.mjs
@@ -7,6 +7,14 @@
  * a pile of them to per-day totals that carry no address and no identifier,
  * so the output is safe to keep — but it does NOT decide where.
  *
+ * Two of those totals are read off the address and not off anything else: how
+ * many were distinct that day, and which country each was in. Both are
+ * computed here and thrown away here — the address reaches no further than
+ * this function, and the lookup that turns it into a country is arithmetic
+ * against a table on this machine (scripts/geoip.mjs), never a request to a
+ * geo-IP service. That distinction is the whole reason the feature is
+ * allowed to exist; /privacy says a child's address goes nowhere.
+ *
  * ⚠️ **Nothing here is a durable store, and 90 days is currently the whole of
  * the site's memory.** These counts used to be committed to this repo, which
  * confused two different things: a repo keeps CODE forever, and that is what
@@ -24,6 +32,7 @@
  * stays documented in docs/analytics.md for ad-hoc digging.
  *
  * Usage:  node scripts/rollup-analytics.mjs <dir-of-gz-logs> <out.json>
+ *         node scripts/rollup-analytics.mjs <dir> <out.json> --no-geoip
  */
 
 import { createReadStream, existsSync } from "node:fs";
@@ -32,6 +41,8 @@ import { createGunzip } from "node:zlib";
 import { createInterface } from "node:readline";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+
+import { placeLookup } from "./geoip.mjs";
 
 /**
  * CloudFront's standard log format, by position.
@@ -174,16 +185,15 @@ export const referrerHost = (raw) => {
 /**
  * Which CloudFront edge served the request: `SEA19-C1` → `SEA`.
  *
- * ⚠️ **This is the edge, not the visitor.** CloudFront routes to a nearby PoP,
+ * ⚠️ **This is the edge, not the visitor**, and since `countries` exists it is
+ * no longer the answer to "where are they". CloudFront routes to a nearby PoP,
  * so the airport code is a coarse proxy for where someone is and nothing
  * stronger — a visitor in Vancouver is served from Seattle, and one on a VPN
- * is served from wherever the exit node is. Read it as "roughly which part of
- * the world", never as a country count.
+ * is served from wherever the exit node is.
  *
- * The real field is `c-country`, and it does not exist in CloudFront's legacy
- * standard log format — the 33 fields are fixed. Getting it means moving the
- * distribution to standard logging v2, which is a different delivery mechanism
- * (CloudWatch vended logs) rather than a field to add here.
+ * It is kept anyway because it answers a different question that nothing else
+ * can: which PoPs actually serve this site, which is a cache and latency
+ * question rather than an audience one.
  *
  * The trailing `-C1`/`-P3` is the individual server within the PoP and is
  * dropped: it changes between requests from one household and means nothing to
@@ -197,11 +207,50 @@ export const edgeAirport = (raw) => {
 const BOT =
   /bot|crawler|spider|crawling|slurp|bingpreview|facebookexternalhit|headlesschrome|lighthouse|curl|wget|python-requests/i;
 
+/**
+ * Where a page view came from, as up to three keys, or `null` when nothing
+ * looked.
+ *
+ * `"(unknown)"` and an absent `countries` key are deliberately different
+ * things, and conflating them is how a broken lookup starts reading as data.
+ * `(unknown)` means the address was checked and the table did not place it —
+ * a new allocation, a reserved range, something the source missed.
+ * **No key at all** means no lookup ran, and `main` omits the fields entirely
+ * in that case rather than filing a day of `(unknown)` that looks measured.
+ *
+ * Region and city are **absent rather than guessed** when the source has no
+ * answer, which is often: an address can resolve to a country and no further.
+ * Filling those in from a country centroid is exactly the mistake that makes
+ * geo-IP data infamous, so a missing city is left missing and the counts for
+ * the three levels do not have to agree.
+ *
+ * Everything the caveats say about `visitors` applies here and harder. A VPN,
+ * a school's egress or a carrier-grade NAT puts someone in the wrong place
+ * outright rather than merely nearby, and the finer the level the more often
+ * it is wrong.
+ */
+export const placeOf = (geo, ip) => {
+  if (!geo) return null;
+  const at = geo.lookup(ip);
+  if (!at) return { country: "(unknown)", region: null, city: null };
+  return {
+    country: at.country,
+    // Qualified by the level above, because place names are not unique:
+    // Ontario is a province of Canada and a city in California, and there are
+    // some thirty Springfields. An unqualified key would silently add them up.
+    region: at.region ? `${at.country} / ${at.region}` : null,
+    city: at.city ? `${at.country} / ${at.region || "—"} / ${at.city}` : null,
+  };
+};
+
 /** One day's tallies. Sets while counting, numbers by the time they're stored. */
 const emptyDay = () => ({
   visitors: new Set(),
   pageViews: 0,
   pages: {},
+  countries: {},
+  regions: {},
+  cities: {},
   referrers: {},
   edges: {},
   events: {},
@@ -218,7 +267,13 @@ async function* lines(file) {
   }
 }
 
-export async function tally(dir) {
+/**
+ * @param dir  directory of gzipped CloudFront logs, searched recursively
+ * @param geo  a `{ lookup }` from scripts/geoip.mjs, or omitted to skip
+ *             geolocation entirely — see `countryOf` for why that is not the
+ *             same as looking up and finding nothing.
+ */
+export async function tally(dir, geo = null) {
   const days = new Map();
   const files = (await readdir(dir, { recursive: true })).filter((f) =>
     f.endsWith(".gz"),
@@ -290,12 +345,26 @@ export async function tally(dir) {
       }
 
       if (!isPageView(row)) continue;
-      // The IP is used here and discarded here. Only its cardinality survives
-      // this function, which is what lets the output live in a public repo.
+      // The IP is used here and discarded here. What survives is a count of
+      // distinct addresses and a count per place — no address, and nothing an
+      // address could be recovered from.
+      //
+      // ⚠️ That is a weaker guarantee at city level than at country level, and
+      // it is weakest exactly where the traffic is thinnest: a city with one
+      // page view on one day is close to naming a household. See
+      // docs/analytics.md before putting any of this anywhere but a terminal.
       day.visitors.add(row["c-ip"]);
       day.pageViews += 1;
       const path = row["cs-uri-stem"];
       day.pages[path] = (day.pages[path] ?? 0) + 1;
+
+      const place = placeOf(geo, row["c-ip"]);
+      if (place) {
+        const { country, region, city } = place;
+        day.countries[country] = (day.countries[country] ?? 0) + 1;
+        if (region) day.regions[region] = (day.regions[region] ?? 0) + 1;
+        if (city) day.cities[city] = (day.cities[city] ?? 0) + 1;
+      }
 
       // Both are counted on page views only, not on every request. An asset's
       // referrer is always the page that asked for it, so counting those would
@@ -314,8 +383,61 @@ export async function tally(dir) {
 const sortObject = (o) =>
   Object.fromEntries(Object.entries(o).sort(([a], [b]) => a.localeCompare(b)));
 
-async function main(LOG_DIR, OUT) {
-  const days = await tally(LOG_DIR);
+/**
+ * Load the country table, or explain at the top of your voice why not.
+ *
+ * A missing table is NOT a reason to fail the run: the counts that matter are
+ * derived from the log lines themselves, and losing a month of page views
+ * because a CDN was briefly unreachable would be the wrong trade. But it is
+ * emphatically a reason to say so — this pipeline's one real outage was a
+ * silent one, so "quietly produced numbers with a field missing" is the shape
+ * of failure it is least allowed to have.
+ */
+async function loadGeo(enabled) {
+  if (!enabled) {
+    process.stderr.write("geolocation off (--no-geoip); places omitted\n");
+    return null;
+  }
+  try {
+    const geo = await placeLookup();
+    process.stderr.write(
+      `geo-IP artifact ready — built ${geo.builtAt}, ` +
+        `${geo.ranges.toLocaleString()} ranges, ${geo.places.toLocaleString()} places\n`,
+    );
+    // Not fatal, and deliberately not silent. The GeoLite2 licence requires
+    // that local copies keep updating so Do Not Sell requests propagate, so a
+    // build this old is a stalled obligation rather than merely stale data.
+    if (geo.stale) {
+      process.stderr.write(
+        `\n⚠️  That artifact is ${geo.stale} days old. The refresh has stopped —\n` +
+          "   check .github/workflows/refresh-geoip.yml, or rebuild by hand:\n" +
+          "     npm run analytics:geoip\n\n",
+      );
+    }
+    return geo;
+  } catch (error) {
+    // The whole message, indented — not just its first line. The reader
+    // spends its later lines saying which command rebuilds the artifact,
+    // which is the entire remedy for the likeliest causes, and a
+    // first-line-only version threw that away.
+    const detail = String(error.message)
+      .split("\n")
+      .map((line) => `   ${line}`.trimEnd())
+      .join("\n");
+    process.stderr.write(
+      "\n⚠️  Could not load the geo-IP artifact, so countries, regions and\n" +
+        "   cities are OMITTED from this run — days counted now have no place\n" +
+        "   breakdown at all, which is not the same as every visitor being\n" +
+        "   unknown. Everything else was counted normally.\n\n" +
+        `${detail}\n\n`,
+    );
+    return null;
+  }
+}
+
+async function main(LOG_DIR, OUT, { geoip = true } = {}) {
+  const geo = await loadGeo(geoip);
+  const days = await tally(LOG_DIR, geo);
 
   const existing = existsSync(OUT)
     ? JSON.parse(await readFile(OUT, "utf8"))
@@ -329,6 +451,14 @@ async function main(LOG_DIR, OUT) {
       visitors: day.visitors.size,
       pageViews: day.pageViews,
       pages: sortObject(day.pages),
+      // Omitted rather than empty when no lookup ran — see `placeOf`.
+      ...(geo
+        ? {
+            countries: sortObject(day.countries),
+            regions: sortObject(day.regions),
+            cities: sortObject(day.cities),
+          }
+        : {}),
       referrers: sortObject(day.referrers),
       edges: sortObject(day.edges),
       events: sortObject(day.events),
@@ -342,9 +472,15 @@ async function main(LOG_DIR, OUT) {
     "distinct addresses seen that day and is approximate by design (see " +
     "/privacy). `referrers` holds bare hostnames, never a path or a query " +
     "string; `edges` is the CloudFront location that served the request, " +
-    "which is near the visitor rather than at them. Derived from logs that " +
-    "are deleted after 90 days, so a day outside that window cannot be " +
-    "recounted.";
+    "which is near the visitor rather than at them. `countries`, `regions` " +
+    "and `cities` are that visitor's own address resolved against a table " +
+    "held locally — no address is sent anywhere to produce it. `(unknown)` " +
+    "means the table did not place the address; a missing region or city " +
+    "means the table knew the country and no more, so the three levels do " +
+    "not sum alike; and no place keys at all mean no lookup ran. City counts " +
+    "in particular are small enough to identify a household and are NOT for " +
+    "publishing. Derived from logs that are deleted after 90 days, so a day " +
+    "outside that window cannot be recounted.";
   existing.days = sortObject(existing.days);
 
   await writeFile(OUT, JSON.stringify(existing, null, 2) + "\n");
@@ -368,18 +504,22 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  const [, , LOG_DIR, OUT] = process.argv;
+  const argv = process.argv.slice(2);
+  const geoip = !argv.includes("--no-geoip");
+  const [LOG_DIR, OUT] = argv.filter((arg) => !arg.startsWith("--"));
 
   // No default output path. There used to be one pointing into the repo, and
   // a default that writes into a source tree is how a generated file ends up
   // committed by accident.
   if (!LOG_DIR || !OUT) {
-    console.error("usage: rollup-analytics.mjs <dir-of-gz-logs> <out.json>");
+    console.error(
+      "usage: rollup-analytics.mjs <dir-of-gz-logs> <out.json> [--no-geoip]",
+    );
     process.exit(2);
   }
 
   try {
-    await main(LOG_DIR, OUT);
+    await main(LOG_DIR, OUT, { geoip });
   } catch (error) {
     console.error(`\n${error.message}`);
     process.exit(1);

--- a/scripts/rollup-analytics.test.mjs
+++ b/scripts/rollup-analytics.test.mjs
@@ -9,6 +9,7 @@ import {
   edgeAirport,
   isDocumentPath,
   isPageView,
+  placeOf,
   referrerHost,
   tally,
 } from "./rollup-analytics.mjs";
@@ -50,15 +51,28 @@ const row = ({
     "\t",
   );
 
+/**
+ * A stand-in for scripts/geoip.mjs.
+ *
+ * The real one downloads 23MB of CSV, which a unit test has no business doing:
+ * it would make the suite need a network, and it would test jsDelivr rather
+ * than this file. `geoip.test.mjs` exercises the actual lookup against
+ * fixtures; here the only question is what the rollup does with an answer.
+ */
+const geoStub = (byIp) => ({ lookup: (ip) => byIp[ip] ?? null });
+
+/** Shorthand for the `{ country, region, city }` the real lookup returns. */
+const at = (country, region = null, city = null) => ({ country, region, city });
+
 /** Write one gzipped log file and count it, the way the real job would. */
-const count = async (rows) => {
+const count = async (rows, geo = null) => {
   const dir = mkdtempSync(join(tmpdir(), "rollup-"));
   const body = ["#Version: 1.0", `#Fields: ${FIELDS}`, ...rows, ""].join("\n");
   writeFileSync(
     join(dir, "E2B47B9IHQSJU0.2026-08-18-22.abc.gz"),
     gzipSync(body),
   );
-  const days = await tally(dir);
+  const days = await tally(dir, geo);
   return days.get("2026-08-18");
 };
 
@@ -172,6 +186,51 @@ describe("edgeAirport", () => {
     expect(edgeAirport("-")).toBeNull());
 });
 
+describe("placeOf", () => {
+  const geo = geoStub({
+    "98.168.10.1": at("US", "Arizona", "Peoria"),
+    "8.8.8.8": at("US"),
+    "1.2.3.4": at("CA", "Ontario"),
+  });
+
+  it("qualifies each level by the one above it", () =>
+    expect(placeOf(geo, "98.168.10.1")).toEqual({
+      country: "US",
+      region: "US / Arizona",
+      city: "US / Arizona / Peoria",
+    }));
+
+  // Ontario is a province of Canada AND a city in California; there are some
+  // thirty Springfields. Unqualified keys would add strangers together.
+  it("keeps two places of the same name apart", () => {
+    const canada = placeOf(geo, "1.2.3.4");
+    expect(canada.region).toBe("CA / Ontario");
+    expect(canada.region).not.toBe(placeOf(geo, "98.168.10.1").region);
+  });
+
+  // Filling these in from a country centroid is the mistake that makes geo-IP
+  // data infamous. A missing city stays missing.
+  it("leaves region and city absent rather than guessing them", () =>
+    expect(placeOf(geo, "8.8.8.8")).toEqual({
+      country: "US",
+      region: null,
+      city: null,
+    }));
+
+  // The distinction the whole field rests on. "Looked and found nothing" is a
+  // fact about one address; "did not look" is a fact about the run, and a day
+  // recorded as 107 unknowns would read as the first while meaning the second.
+  it("says (unknown) when the table does not place an address", () =>
+    expect(placeOf(geo, "203.0.113.9")).toEqual({
+      country: "(unknown)",
+      region: null,
+      city: null,
+    }));
+
+  it("says nothing at all when no lookup was configured", () =>
+    expect(placeOf(null, "98.168.10.1")).toBeNull());
+});
+
 describe("tally, over the first real hour of logs", () => {
   const FIRST_HOUR = [
     // A person, back for a second visit: three revalidated page loads and the
@@ -256,6 +315,45 @@ describe("tally, over the first real hour of logs", () => {
     const day = await count(FIRST_HOUR);
     expect(day.events).toEqual({ race_start: 1 });
     expect(day.decks).toEqual({ multiply: 1 });
+  });
+
+  // Same basis as referrers and edges: page views, not every request. The
+  // undeclared bot is in here, because nothing distinguishes it from a person.
+  it("files places off page views, on the same basis as edges", async () => {
+    const day = await count(
+      FIRST_HOUR,
+      geoStub({
+        "98.168.10.1": at("US", "Arizona", "Peoria"),
+        "34.171.68.1": at("US", "Iowa", "Council Bluffs"),
+      }),
+    );
+    expect(day.countries).toEqual({ US: 4 });
+    expect(Object.values(day.countries).reduce((a, b) => a + b, 0)).toBe(
+      day.pageViews,
+    );
+  });
+
+  // The three levels deliberately do NOT sum alike: an address can resolve to
+  // a country and no further, and inventing a city to make the columns balance
+  // is the one thing this must never do.
+  it("lets the levels disagree when the table knows less", async () => {
+    const day = await count(
+      FIRST_HOUR,
+      geoStub({
+        "98.168.10.1": at("US", "Arizona", "Peoria"),
+        "34.171.68.1": at("US"),
+      }),
+    );
+    expect(day.countries).toEqual({ US: 4 });
+    expect(day.regions).toEqual({ "US / Arizona": 3 });
+    expect(day.cities).toEqual({ "US / Arizona / Peoria": 3 });
+  });
+
+  it("records nothing at all when no lookup is supplied", async () => {
+    const day = await count(FIRST_HOUR);
+    expect(day.countries).toEqual({});
+    expect(day.regions).toEqual({});
+    expect(day.cities).toEqual({});
   });
 });
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -272,21 +272,15 @@ const verse = passage("the-plans-of-the-diligent");
       <h2 class="h2">For parents</h2>
       <div class="prose">
         <p>
-          There is no account to make and no data to hand over, because there is
-          nowhere to hand it to. This is a static site: every page is a file,
-          and there is no server behind it that could run a query or hold a
-          session. Every profile, race and record lives in your own
-          browser&rsquo;s storage and has never been anywhere else.
+          There is no account to make and no data to hand over. Every profile,
+          every race and every record lives in your own browser&rsquo;s storage,
+          on your own device, and has never been anywhere else.
         </p>
         <p>
-          That is a deliberate choice rather than a shortcut. Under COPPA a
-          persistent identifier &mdash; an ad cookie, a device id, an analytics
-          client id &mdash; counts as personal information collected from a
-          child. So there is no analytics service, and the ads that pay for the
-          site are non-personalised everywhere: chosen from the page they sit
-          on, never from anything about the child looking at it. Visitors and
-          races are counted from our own web server&rsquo;s logs, without
-          putting anything on your device to do it.{" "}
+          Nothing is put on that device to track anyone, and no analytics
+          company is involved. The ads that pay for the site are
+          non-personalised everywhere &mdash; chosen from the page they sit on,
+          never from anything about the child looking at it.{" "}
           <a href="/privacy">The full policy</a> is one page and explains exactly
           where the line is.
         </p>
@@ -299,10 +293,9 @@ const verse = passage("the-plans-of-the-diligent");
         </p>
         <h3>Add it to the home screen on an iPad</h3>
         <p>
-          Worth doing for two reasons. It makes the games work offline, and it
-          exempts the site from Safari&rsquo;s seven-day cap on script-writable
-          storage &mdash; without it, a child who doesn&rsquo;t play for a week
-          can come back to an empty profile list.
+          Worth doing for two reasons. The games work offline, and progress
+          stops expiring: left in the browser, a child who doesn&rsquo;t play
+          for a week can come back to an empty profile list.
         </p>
         <h3>Several children</h3>
         <p>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -27,14 +27,14 @@ import Content from "@/layouts/Content.astro";
  *
  * If an ad network, embedded video, a hosted analytics service or any
  * third-party script is ever added, this page MUST be updated in the same pull
- * request. Under COPPA a persistent identifier — an ad cookie, a device id, an
+ * request. Under COPPA, a persistent identifier — an ad cookie, a device id, an
  * analytics client id — counts as personal information collected from a child,
  * and shipping one while this page says otherwise turns a technical change into
  * a false statement.
  *
  * Measurement was added on 16 August 2026 and deliberately did not cross that
  * line: it is CloudFront's own access logs plus a first-party image request,
- * described under "Hosting, and how we count". Two things there are load-
+ * described under "How visits get counted". Two things there are load-
  * bearing and are asserted elsewhere in the codebase rather than left to
  * goodwill — the 90-day retention is `LOG_RETENTION_DAYS` in sst.config.ts, and
  * the promise that a beacon carries no deck id or answer is enforced by
@@ -49,6 +49,36 @@ import Content from "@/layouts/Content.astro";
  * scripts/rollup-analytics.mjs and is held in place by its tests. **Anything
  * else read off a log line belongs in this list**, in the same pull request.
  *
+ * Country, region and city were added on 19 August 2026 and are the entries on
+ * that list that are DERIVED rather than read: they resolve the IP address the
+ * logs already carried, which the rollup was already reading to count distinct
+ * visitors. Nothing new is collected and no request is added. What makes them
+ * sayable on this page is where the resolving happens — `scripts/geoip.mjs`
+ * searches a table in our own bucket, so no address is sent to a geo-IP
+ * service. **Swapping that for an API would make this page false**, and would
+ * put a child's IP address in a third party's logs, which is the line the
+ * paragraph above says is not crossed.
+ *
+ * ⚠️ CITY IS A DIFFERENT LEGAL CATEGORY FROM COUNTRY, and this comment exists
+ * so nobody discovers that later. The COPPA rule's definition of personal
+ * information (16 CFR 312.2) enumerates "geolocation information sufficient to
+ * identify street name and name of a city or town"; a country is not on that
+ * list and a city is. This site is declared child-directed in Search Console
+ * and, as the Advertising section says, cannot obtain verifiable parental
+ * consent. The judgement made here was that deriving a coarse count from an
+ * address the logs already hold, keeping nothing, publishing nothing and
+ * discarding it at 90 days, is not "collecting geolocation from a child" — but
+ * that judgement is the load-bearing part, not the code. **If this site ever
+ * retains place data beyond the log window, publishes it, joins it to anything
+ * else, or goes to a finer level than a town, that reasoning stops holding and
+ * this page and that decision both need revisiting — with a lawyer, not with a
+ * commit.**
+ *
+ * Latitude, longitude and postcode are in the source data and are deliberately
+ * excluded from the artifact — see the header of scripts/build-geoip.mjs. A
+ * coordinate is squarely inside the enumerated category above; a town name is
+ * arguable. Do not add them.
+ *
  * The same day, the monthly job that kept per-day counts permanently was
  * removed. That makes the 90 days below the whole of it — nothing derived
  * from a log line outlives the line any more — which is a stronger promise
@@ -58,6 +88,42 @@ import Content from "@/layouts/Content.astro";
  * It renders in Line world, which has no scenery on purpose. Every other page
  * here is a place; this one is a promise being read carefully, and dressing it
  * up as an adventure would be the wrong kind of charming.
+ *
+ * ## How this page is written, which is a decision and not an accident
+ *
+ * **No "we", and no "I".** A one-person project saying "we" reads like a
+ * template, and the visible text is aimed at a parent deciding whether to trust
+ * the site rather than at a lawyer. So the subject of a sentence here is the
+ * concrete thing doing the work — the site, the browser, your device, Google —
+ * and the reader is addressed directly as "you".
+ *
+ * ⚠️ The trap in that style is the AGENTLESS PASSIVE, which is the house voice
+ * of every evasive privacy policy ever written: "data may be shared" tells a
+ * parent nothing about who has their child's address. **Wherever an actor
+ * matters, name it** — "Google receives requests from your browser" is the
+ * shape to copy. Passive is fine for "those lines are deleted after 90 days",
+ * where the actor is a cron job nobody needs introduced.
+ *
+ * **Plain words, and only what a parent would actually act on.** The brand of
+ * the CDN, the storage engine, the words "static site" and "IndexedDB" were all
+ * removed deliberately: a parent cannot do anything with them, and jargon in a
+ * privacy policy reads as something being hidden behind it. What must survive
+ * any rewrite is the substance the law and the reader both need — what is
+ * collected, who else receives it, how long it is kept, and what the reader can
+ * delete.
+ *
+ * ⚠️ **State the fact; do not argue for the decision.** The strongest pull when
+ * editing this page is to explain WHY a choice was made, because the choices
+ * here were deliberate and defending them feels like transparency. It isn't —
+ * it is writing to the author rather than to the reader. A paragraph that
+ * ended "borrowing a typeface from somewhere else would hand another company a
+ * record of every page your child opened" was cut for exactly this: no parent
+ * has a question about typefaces, and the sentence existed to show its work.
+ *
+ * The tell is a second sentence that justifies the first instead of telling the
+ * reader something new about their child. "Everything else you see is served by
+ * this site" is a fact a parent can use. Why that was worth doing belongs in a
+ * comment like this one, where the audience is somebody who might undo it.
  */
 const title = "Privacy — School Skills";
 const description =
@@ -82,170 +148,157 @@ const updated = "19 August 2026";
 
   <section class="band band--tight wrap">
     <div class="prose">
-      <h2>What we collect</h2>
+      <h2>What&rsquo;s collected</h2>
       <p>
-        Nothing about your child. There are no accounts, no sign-up and no email
-        addresses. Nothing your child does in a game &mdash; the words they
-        type, the answers they give, the times they run &mdash; is sent
-        anywhere; it is written to your own device and stays there. Nothing
-        stored on your device identifies them to us or to anyone else.
+        Nothing about your child. No sign-up, no account, no email address. What
+        they type, the answers they give, how fast they go &mdash; none of it
+        leaves your device. It&rsquo;s saved there and it stays there.
       </p>
       <p>
-        The site does carry advertising, and that is the one part of it
-        involving another company. Those ads are non-personalised everywhere, so
-        no profile of your child is built or used to choose them. The
-        Advertising section below says exactly what Google does and does not
-        receive.
+        The advertising is the exception. That&rsquo;s another company&rsquo;s
+        code running on the page, and the Advertising section below sets out
+        exactly what Google does and doesn&rsquo;t get.
       </p>
       <p>
-        We do count how many people visit and which parts of the site get used
-        &mdash; how many races are started and finished, and whether the
-        custom-deck feature is used at all. That counting is described in full
-        below. It runs on our own web server rather than an analytics service,
-        it stores nothing on your device, and it cannot tell one visitor from
-        another on a different day.
+        Visits do get counted &mdash; how many people came, which pages they
+        opened, how many races were started and finished. No analytics company
+        is involved, nothing is added to your device, and one visitor
+        can&rsquo;t be told from another on a different day.
       </p>
 
-      <h2>How that&rsquo;s possible</h2>
+      <h2>Where it all stays</h2>
       <p>
-        School Skills is a static website. Every page is a file, served as-is
-        &mdash; there is no application server, no database, and nothing for
-        your child&rsquo;s answers to be sent to. When they finish a race, the
-        result is written to your own browser&rsquo;s storage on your own
-        device. It does not leave it.
+        The games run inside your browser. When a race finishes, the result is
+        saved on your device, and nothing is sent anywhere.
       </p>
       <p>
-        Every file a page loads comes from this site, including the fonts. A
-        font served from a font network would mean a request carrying your
-        child&rsquo;s IP address to a third party on every page load, which
-        would make the paragraph above untrue.
+        The advertising is the only part of a page that comes from another
+        company. Everything else you see is served by this site.
       </p>
 
-      <h2>What&rsquo;s stored on your device</h2>
+      <h2>What&rsquo;s on your device</h2>
       <p>
-        Player profiles (a name you choose, an emoji, a colour and an age), and
-        the history of races played: times, scores, and which facts were
-        answered right or wrong. This is kept in your browser&rsquo;s IndexedDB
-        storage.
+        Player profiles &mdash; a name you pick, an emoji, a colour, an age
+        &mdash; and the history of races: times, scores, and which facts came
+        out right or wrong. It sits in your browser&rsquo;s own storage.
       </p>
       <p>
-        You control it completely. Clearing your browser&rsquo;s site data
-        deletes all of it permanently, and deleting a player in the app removes
-        that player and every race they ran. Because we never receive any of it,
-        we cannot restore it &mdash; which is why the app offers a backup file
-        you keep yourself.
+        You control all of it. Clearing your browser&rsquo;s site data wipes it
+        for good, and deleting a player in the app removes that player and every
+        race they ran. None of it can be brought back afterwards, so the app can
+        save you a backup file to keep yourself.
       </p>
 
       <h2>Children</h2>
       <p>
-        This site is intended for children and the adults helping them, and that
-        governs what the advertising on it is allowed to be. We do not build a
-        profile of any child, we do not use one to choose an ad, and
-        personalised advertising is not permitted anywhere on the site. We set
-        no advertising ID, no analytics ID and no tracking cookie of our own.
+        This site is for children and the adults helping them, and that decides
+        what the advertising on it is allowed to be. No profile of any child is
+        built here or used to choose an ad. Personalised advertising is off
+        everywhere, with no setting to turn it on and no page it doesn&rsquo;t
+        apply to. No advertising ID, no analytics ID and no tracking cookie
+        belongs to this site.
       </p>
       <p>
         Google&rsquo;s ad requests are the exception to &ldquo;nothing leaves
-        the device&rdquo;, and we would rather say so plainly than bury it: an
-        ad request reaches Google, carries an IP address, and may set a cookie
-        for frequency capping and fraud prevention. What it does not do is
-        target your child &mdash; non-personalised is set on every page before
-        the advertising code is allowed to run at all.
+        the device&rdquo;. An ad request reaches Google, carries an IP address,
+        and may set a cookie to stop the same ad repeating and to catch
+        fraudulent clicks. What it doesn&rsquo;t do is target your child.
       </p>
       <p>
-        The one exception is the ordinary web-server log described below, which
-        records the IP address a request came from. Every website has one, it is
-        needed to deliver a page at all, we keep ours for 90 days, and we use it
-        only to count visits in aggregate.
+        The other exception is the ordinary record every website keeps of who
+        asked for a page, described below. It notes the address a request came
+        from, it&rsquo;s needed to send the page at all, it&rsquo;s deleted
+        after 90 days, and counting is the only thing it&rsquo;s used for.
       </p>
       <p>
-        The name you type for a player is stored only in your browser. We
-        suggest a first name or nickname; nothing checks it, and nothing
-        transmits it.
+        The name you type for a player stays in your browser. A first name or a
+        nickname is plenty; nothing checks it and nothing sends it anywhere.
       </p>
 
       <h2>Cookies</h2>
       <p>
-        We don&rsquo;t set any of our own. Google&rsquo;s advertising may set
-        cookies for purposes such as limiting how often the same ad is shown and
-        detecting fraudulent clicks &mdash; not for building a profile, because
-        the ads are non-personalised.
+        None belong to this site. Google&rsquo;s advertising may set some
+        &mdash; to limit how often the same ad turns up, and to spot fraudulent
+        clicks &mdash; but not to build a profile, because the ads aren&rsquo;t
+        personalised.
       </p>
 
-      <h2>Hosting, and how we count</h2>
+      <h2>How visits get counted</h2>
       <p>
-        The site is served from Amazon CloudFront. Like any web host, its
-        servers write a line for each request &mdash; your IP address, browser
-        type, the file requested, and the site you followed a link from, if you
-        followed one. Those lines are kept for 90 days and then deleted
-        automatically.
+        Every website is sent a request each time somebody opens a page, and the
+        computers that answer write down a line about it: the address it came
+        from, what sort of browser, which page, and the site you followed a link
+        from if there was one. Those lines are deleted after 90 days.
       </p>
       <p>
-        Those lines are the only thing we measure from. Every so often we count
-        them: how many different addresses appeared, which pages were asked for,
-        how many races were started and finished, which other websites link to
-        us, and roughly which part of the world the pages were served to. The
-        answers are numbers &mdash; &ldquo;412 people, 1,900 races, 40 arrivals
-        from a link&rdquo; &mdash; and we look at them and move on. Nothing is
-        filed away: when the lines are deleted at 90 days, that period is simply
-        no longer something we can ask about.
+        They are the only thing counted, and it happens every so often: how many
+        different addresses turned up, which pages were opened, how many races
+        were started and finished, which other websites send people here, and
+        roughly where in the world the visits came from. The answers are numbers
+        &mdash; &ldquo;412 people, 1,900 races, 40 arrivals from a link&rdquo;
+        &mdash; read once and left at that. Nothing gets filed away. When the
+        lines are deleted, that stretch of time simply stops being something
+        anyone can ask about.
       </p>
       <p>
-        There is no analytics service involved and nothing added to your device.
-        Most sites count visitors by storing an identifier in the browser so the
-        same person can be recognised next week; we deliberately don&rsquo;t,
-        because a persistent identifier belonging to a child is exactly what
-        children&rsquo;s privacy law treats as personal information. The trade
-        is that our numbers are approximate: a household sharing one connection
-        counts once, and a phone that changes network counts twice. We would
-        rather have the rougher number.
+        Most sites count visitors by leaving a marker in the browser, so the
+        same person can be recognised next week. Nothing here does that, which
+        is why these counts are only ever rough.
       </p>
       <p>
-        Two of those deserve spelling out. When we count which websites link to
-        us we keep the site&rsquo;s name and nothing else &mdash;
-        &ldquo;google.com&rdquo;, never what was typed into it, and never the
-        rest of the address. And &ldquo;which part of the world&rdquo; means
-        which of Amazon&rsquo;s data centres answered the request, which is the
-        nearest one rather than where you are.
+        Two of them are worth spelling out. When another website sends somebody
+        here, only that site&rsquo;s name is kept: &ldquo;google.com&rdquo;,
+        never what was typed into it, and never the rest of the link.
       </p>
       <p>
-        A few in-game actions &mdash; a race started, a race finished, a deck
-        saved &mdash; are counted by requesting a tiny image from this site with
-        the action&rsquo;s name in the address. That request carries no
-        identifier, and it never carries what your child typed, which list they
-        chose, their name, or their age.
+        The other is roughly where a visit came from, worked out here against a
+        public list of which addresses belong to which country, region and town.
+        Your child&rsquo;s address is not sent to a location service or to any
+        other company. It gives a country, a region and sometimes a town, and
+        never coordinates, a postcode, a street or a map &mdash; and it is often
+        wrong about the town, because an address given out in one place gets
+        used from another all the time.
+      </p>
+      <p>
+        None of these counts are published, shared or kept. Once the lines go at
+        90 days, they can&rsquo;t be worked out again.
+      </p>
+      <p>
+        A few things that happen inside a game &mdash; a race started, a race
+        finished, a deck saved &mdash; are counted by asking this site for a
+        tiny invisible image with the action&rsquo;s name in the link. That
+        request carries nothing that identifies anyone, and it never carries
+        what your child typed, which list they chose, their name, or their age.
       </p>
 
       <h2 id="advertising">Advertising</h2>
       <p>
         This site carries advertising from Google AdSense, including on the game
-        screens. It is how a free site with no accounts and nothing to sell pays
-        for itself. Google&rsquo;s advertising code runs on every page, whether
-        or not an ad is actually shown on it &mdash; so treat everything below
-        as describing every visit, not only the ones where you see an advert.
+        screens. It&rsquo;s how a free site with no accounts and nothing to sell
+        pays for itself. Google&rsquo;s advertising code runs on every page,
+        whether or not an ad actually appears there &mdash; so read everything
+        below as describing every visit, not only the ones with a visible
+        advert.
       </p>
       <p>
-        <strong>The ads are non-personalised, everywhere, always.</strong> They are
-        chosen from the page they appear on rather than from anything about the person
-        looking at it. No profile of your child is built, consulted or added to. There
-        is no setting for this and no page it doesn&rsquo;t apply to, because a site
-        made for children is not a place where behavioural advertising belongs &mdash;
-        and under children&rsquo;s privacy law it would need a level of parental consent
-        a free website cannot honestly obtain.
+        <strong>The ads are non-personalised, everywhere, always.</strong> They&rsquo;re
+        chosen from the page they sit on, not from anything about the person looking
+        at it. No profile of your child is built, consulted or added to. There&rsquo;s
+        no setting for this and no page it doesn&rsquo;t apply to &mdash; a site made
+        for children isn&rsquo;t a place for advertising that follows people around,
+        and under children&rsquo;s privacy law it would need a kind of parental consent
+        a free website can&rsquo;t honestly get.
       </p>
       <p>
-        Google does receive requests from your browser. Loading the advertising
-        code is one, and asking for an advert is another; both carry an IP
-        address, as every web request does, and Google may set a cookie for
-        purposes such as capping how often an ad repeats and detecting
-        fraudulent clicks. This is a real change from how the site worked
-        before, and it is why nothing on this page claims any more that there
-        are no third-party requests.
+        Google does receive requests from your browser: one to load the
+        advertising code, another to ask for an advert. Both carry an IP
+        address, as every web request does, and Google may set a cookie to cap
+        how often an ad repeats and to catch fraudulent clicks.
       </p>
       <p>
-        Ads are labelled and kept in a marked frame. The youngest player here is
-        five, and telling advertising from content is a skill children acquire
-        late.
+        Ads are labelled and kept inside a marked frame. The youngest player
+        here is five, and telling an advert from the rest of a page is a skill
+        children pick up late.
       </p>
 
       <h2>Changes</h2>


### PR DESCRIPTION
Resolves a visitor's country, region and city from the IP address the access
logs already carried, instead of inferring geography from the CloudFront edge.

Related: #9 (its acceptance criteria name Cloudflare Web Analytics, which this
project deliberately didn't use — left open for you to judge.)

## Why

The logs carry `c-ip`, the visitor's own address, and the rollup already read
it to count distinct visitors. The only geography came from `x-edge-location`
— the PoP that served the request, which is near somebody rather than at them.
The first two days show the gap: 80 US page views against 33 served from LAX.

```
COUNTRY (the visitor's own IP, resolved locally)
      80  US  United States
       7  CN  China

REGION
      31  United States / Arizona
      14  United States / Iowa

CITY (24 distinct)
      31  United States / Arizona / Peoria
      13  United States / Iowa / Council Bluffs
         13 of them seen exactly once — see the note below
```

Council Bluffs is Google and Ashburn is Amazon, so a fair share of the "cities"
are the crawlers we already knew about.

## How

`scripts/build-geoip.mjs` merges the CC0 whois country table with GeoLite2's
city data into one sorted, non-overlapping partition of the address space and
uploads it to `s3://schoolskills-access-logs-<account>/geoip/`. Country comes
from the CC0 table wherever it has an answer, so adding cities moved nobody
between countries.

`scripts/geoip.mjs` downloads that artifact and binary-searches typed-array
views straight onto its bytes — **3.4M ranges ready in ~25ms**, against ~900ms
for the CSV parse it replaces, on a tenth of the data.

Two things worth knowing about the implementation:

- The published IPv4 country file is neither sorted nor disjoint — 568 of its
  334,373 rows begin inside the row before them. A naive "rightmost range
  starting at or before this address" search silently returns *nothing* for
  addresses in the tail of an overlapped range, so it would have read as a
  quiet week rather than a bug. The build sorts and sweeps first; there's a
  test pinning that case.
- `countries`, `regions` and `cities` deliberately **do not sum alike**. An
  address that resolves only to a country contributes to the first and nothing
  else. Filling that gap from a centroid is the mistake that makes geo-IP data
  infamous.

## Privacy

No address is sent anywhere. A geo-IP API would put a child's IP in a third
party's logs, which is the line `/privacy` exists to say is not crossed.

Latitude, longitude and postcode are in the source and are deliberately
excluded — the most common coordinate in it is MaxMind's "somewhere in the
United States" fallback, which 99,194 ranges point at.

`/privacy` is rewritten per its own standing rule that anything read off a log
line lands there in the same PR. Its doc block now records that **city is a
different COPPA category from country** — 16 CFR 312.2 enumerates "geolocation
information sufficient to identify street name and name of a city or town",
where country is not enumerated — along with the reasoning for why coarse,
unretained, unpublished counts are judged to sit outside it, and what would
break that reasoning.

## Licence

`.github/workflows/refresh-geoip.yml` rebuilds monthly. That's a licence term,
not housekeeping: GeoLite2 forbids preventing local copies from updating to
honour Do Not Sell requests, so an artifact pinned in S3 forever is what the
clause disallows. The artifact carries its build date and the reader warns past
45 days.

## Also

`/privacy` and the homepage drop the accumulated jargon (CloudFront, static
site, IndexedDB, Safari's script-writable storage cap) and the asides that
argued for engineering decisions rather than telling a parent something about
their child. Privacy prose is down 1,296 → 1,140 words despite covering a new
feature.

## Validation

`type-check`, `lint`, `build` and `test:unit` all pass — 1,998 tests, 98 of
them in `scripts/`. The geo-IP suite is built around a round trip: the
builder's serialiser writes an artifact and the reader reads it back
in-process, since the binary layout is the one contract two files have to agree
about and a misread artifact still returns plausible countries.

Verified end-to-end against real logs, including the cold path (cache deleted →
downloaded from S3 → gunzipped → read) and both degraded paths (`--no-geoip`,
and a corrupted cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)