### PR TITLE
Don't name an AWS profile where the credentials are already in the env

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -137,6 +137,16 @@ npm run analytics:geoip           # rebuild and upload
 npm run analytics:geoip -- --dry  # build locally, upload nothing
 ```
 
+**How these scripts authenticate**, because it differs by where they run and
+getting it wrong is invisible until it isn't. `scripts/aws.mjs` decides: an
+explicit `AWS_PROFILE` always wins; otherwise, if credentials are already in
+the environment — which is what `aws-actions/configure-aws-credentials` leaves
+behind after the OIDC exchange — **no `--profile` is passed at all**; and
+failing both, it falls back to the local `schoolskills` profile. A runner has
+no `~/.aws/config`, so naming a profile there replaces working credentials with
+a pointer to a file that does not exist. The first scheduled refresh failed on
+exactly that, after building a perfectly good artifact it then discarded.
+
 **Latitude, longitude and postcode are in the source and are deliberately not
 in the artifact.** Do not add them. A coordinate is a different kind of fact
 about a child than a city name, and the accuracy is not there to justify it:

--- a/scripts/analytics.mjs
+++ b/scripts/analytics.mjs
@@ -37,6 +37,8 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { awsAuthHint, awsIdentityLabel, awsProfileArgs } from "./aws.mjs";
+
 // Temp, deliberately. See the header: nothing this produces is kept, and
 // writing into the repo is what this stopped doing.
 const OUT = join(tmpdir(), "schoolskills-counts.json");
@@ -44,7 +46,6 @@ const ROLLUP = "scripts/rollup-analytics.mjs";
 // Stable rather than a fresh mkdtemp: `aws s3 sync` is incremental, so keeping
 // the directory between runs turns the second run into a no-op download.
 const LOGS = join(tmpdir(), "schoolskills-cflogs");
-const PROFILE = process.env.AWS_PROFILE ?? "schoolskills";
 
 const argv = process.argv.slice(2);
 const flag = (name) => argv.includes(`--${name}`);
@@ -69,15 +70,14 @@ function bucket() {
       "Account",
       "--output",
       "text",
-      "--profile",
-      PROFILE,
+      ...awsProfileArgs(),
     ]).trim();
     return `schoolskills-access-logs-${account}`;
   } catch (error) {
     const detail = String(error.stderr ?? error.message).trim();
     throw new Error(
-      `Could not reach AWS as profile "${PROFILE}".\n${detail}\n\n` +
-        `If the session has expired: aws sso login --profile ${PROFILE}`,
+      `Could not reach AWS as ${awsIdentityLabel()}.\n${detail}\n\n` +
+        awsAuthHint(),
       { cause: error },
     );
   }
@@ -92,8 +92,7 @@ function sync() {
     "sync",
     `s3://${name}/cf/`,
     LOGS,
-    "--profile",
-    PROFILE,
+    ...awsProfileArgs(),
     "--no-progress",
     "--only-show-errors",
   ]);

--- a/scripts/aws.mjs
+++ b/scripts/aws.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * How the analytics scripts talk to the AWS CLI.
+ *
+ * One job: decide whether to pass `--profile`, which is not the same question
+ * on a laptop as it is on a CI runner.
+ *
+ * ⚠️ **Never hardcode `--profile` again.** The first version of the geo-IP
+ * builder did — `AWS_PROFILE ?? "schoolskills"`, passed unconditionally — and
+ * it worked perfectly on a developer machine and failed on the very first
+ * scheduled run in GitHub Actions:
+ *
+ *     aws: [ERROR]: The config profile (schoolskills) could not be found
+ *
+ * A named profile is a lookup into `~/.aws/config`. A runner has no such file.
+ * It has AMBIENT credentials instead: `aws-actions/configure-aws-credentials`
+ * exchanges the OIDC token and exports `AWS_ACCESS_KEY_ID` and friends into the
+ * environment, where the CLI's default credential chain finds them without
+ * being told anything. Passing `--profile` there does not add information — it
+ * overrides working credentials with a pointer to a file that does not exist.
+ *
+ * So the rule is: name a profile only when nothing else has already supplied
+ * credentials.
+ */
+
+/**
+ * The profile to use locally, when nobody has said otherwise.
+ *
+ * Matches the profile name in docs/analytics.md and the one `aws sso login`
+ * is run against. `AWS_PROFILE` overrides it for anyone whose local config
+ * calls it something else.
+ */
+const LOCAL_PROFILE = "schoolskills";
+
+/**
+ * True when the environment has already handed the CLI credentials.
+ *
+ * Covers the two shapes that actually occur: exported static/session keys
+ * (what `configure-aws-credentials` leaves behind, and what `AWS_PROFILE=…
+ * aws sso export` style setups produce), and the web-identity variables a
+ * container or pod-identity setup exports instead.
+ */
+export const hasAmbientCredentials = (env = process.env) =>
+  Boolean(
+    env.AWS_ACCESS_KEY_ID ||
+    env.AWS_SESSION_TOKEN ||
+    env.AWS_WEB_IDENTITY_TOKEN_FILE ||
+    env.AWS_CONTAINER_CREDENTIALS_FULL_URI ||
+    env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,
+  );
+
+/**
+ * The `--profile …` pair to splice into an `aws` argument list, or nothing.
+ *
+ * Returned as an array so a caller can spread it unconditionally:
+ *
+ *     execFileSync("aws", ["s3", "cp", from, to, ...awsProfileArgs()])
+ *
+ * An explicit `AWS_PROFILE` always wins — somebody who set it meant it, and it
+ * is also how you point this at a second account without editing code.
+ */
+export const awsProfileArgs = (env = process.env) => {
+  if (env.AWS_PROFILE) return ["--profile", env.AWS_PROFILE];
+  if (hasAmbientCredentials(env)) return [];
+  return ["--profile", LOCAL_PROFILE];
+};
+
+/**
+ * How to describe the current credentials in an error message.
+ *
+ * "Could not reach AWS as profile schoolskills" is exactly the wrong thing to
+ * print on a runner that never used a profile — it sends whoever is reading
+ * the failed job off looking for a config file rather than at the role.
+ */
+export const awsIdentityLabel = (env = process.env) => {
+  const [, profile] = awsProfileArgs(env);
+  return profile
+    ? `profile "${profile}"`
+    : "the credentials in the environment";
+};
+
+/**
+ * What to suggest when the CLI cannot authenticate.
+ *
+ * Different advice for the two worlds, for the same reason as above: an
+ * expired SSO session is a laptop problem, and a role that cannot be assumed
+ * is a workflow problem.
+ */
+export const awsAuthHint = (env = process.env) => {
+  const [, profile] = awsProfileArgs(env);
+  return profile
+    ? `If the session has expired:  aws sso login --profile ${profile}`
+    : "Check that the workflow's OIDC step ran and that AWS_DEPLOY_ROLE_ARN is set.";
+};

--- a/scripts/aws.test.mjs
+++ b/scripts/aws.test.mjs
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  awsAuthHint,
+  awsIdentityLabel,
+  awsProfileArgs,
+  hasAmbientCredentials,
+} from "./aws.mjs";
+
+/**
+ * These exist because of a real failure, not a hypothetical one.
+ *
+ * The geo-IP builder shipped with `--profile schoolskills` passed
+ * unconditionally. It worked on a laptop and died on the first scheduled run
+ * in GitHub Actions with "The config profile (schoolskills) could not be
+ * found" — after spending four minutes downloading and merging 50MB of source
+ * data, which it then threw away.
+ *
+ * The shape of the bug is what makes it worth pinning: it is invisible in
+ * every environment where anyone would notice it, and only appears where a
+ * profile is exactly the wrong way to authenticate.
+ */
+
+/** GitHub Actions after `aws-actions/configure-aws-credentials` has run. */
+const RUNNER = {
+  AWS_ACCESS_KEY_ID: "ASIAEXAMPLE",
+  AWS_SECRET_ACCESS_KEY: "secret",
+  AWS_SESSION_TOKEN: "token",
+  AWS_REGION: "us-west-1",
+  GITHUB_ACTIONS: "true",
+};
+
+/** A developer machine with an SSO profile and nothing exported. */
+const LAPTOP = { HOME: "/Users/someone" };
+
+describe("awsProfileArgs", () => {
+  // The regression. A runner has no ~/.aws/config, so naming a profile is not
+  // extra information — it replaces credentials that already work with a
+  // pointer to a file that does not exist.
+  it("names no profile when the environment already has credentials", () =>
+    expect(awsProfileArgs(RUNNER)).toEqual([]));
+
+  it("names the local profile when nothing else has supplied any", () =>
+    expect(awsProfileArgs(LAPTOP)).toEqual(["--profile", "schoolskills"]));
+
+  // Somebody who set AWS_PROFILE meant it, and it is how you point this at a
+  // second account without editing code.
+  it("lets an explicit AWS_PROFILE win over both", () => {
+    expect(awsProfileArgs({ ...LAPTOP, AWS_PROFILE: "other" })).toEqual([
+      "--profile",
+      "other",
+    ]);
+    expect(awsProfileArgs({ ...RUNNER, AWS_PROFILE: "other" })).toEqual([
+      "--profile",
+      "other",
+    ]);
+  });
+
+  it.each([
+    ["AWS_ACCESS_KEY_ID", { AWS_ACCESS_KEY_ID: "AKIA" }],
+    ["AWS_SESSION_TOKEN", { AWS_SESSION_TOKEN: "t" }],
+    ["AWS_WEB_IDENTITY_TOKEN_FILE", { AWS_WEB_IDENTITY_TOKEN_FILE: "/f" }],
+    [
+      "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+      { AWS_CONTAINER_CREDENTIALS_FULL_URI: "http://x" },
+    ],
+    [
+      "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+      { AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/x" },
+    ],
+  ])("treats %s as ambient credentials", (_name, env) =>
+    expect(hasAmbientCredentials(env)).toBe(true),
+  );
+
+  it("does not mistake an empty environment for credentials", () =>
+    expect(hasAmbientCredentials({})).toBe(false));
+});
+
+describe("the message when authentication fails", () => {
+  // "Could not reach AWS as profile schoolskills" on a runner that never used
+  // a profile sends whoever opens the failed job looking for a config file
+  // instead of at the role.
+  it("does not claim a profile on a runner", () => {
+    expect(awsIdentityLabel(RUNNER)).toBe("the credentials in the environment");
+    expect(awsAuthHint(RUNNER)).toMatch(/OIDC/);
+    expect(awsAuthHint(RUNNER)).not.toMatch(/sso login/);
+  });
+
+  it("suggests an SSO login on a laptop", () => {
+    expect(awsIdentityLabel(LAPTOP)).toBe('profile "schoolskills"');
+    expect(awsAuthHint(LAPTOP)).toMatch(/aws sso login --profile schoolskills/);
+  });
+});

--- a/scripts/build-geoip.mjs
+++ b/scripts/build-geoip.mjs
@@ -57,6 +57,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { awsAuthHint, awsIdentityLabel, awsProfileArgs } from "./aws.mjs";
 import {
   ARTIFACT,
   MAGIC,
@@ -106,7 +107,6 @@ const SOURCES = {
 };
 
 const DOWNLOADS = join(tmpdir(), "schoolskills-geoip-src");
-const PROFILE = process.env.AWS_PROFILE ?? "schoolskills";
 
 const run = (cmd, args) =>
   execFileSync(cmd, args, {
@@ -498,16 +498,30 @@ async function main({ dry }) {
     return;
   }
 
-  const account = run("aws", [
-    "sts",
-    "get-caller-identity",
-    "--query",
-    "Account",
-    "--output",
-    "text",
-    "--profile",
-    PROFILE,
-  ]).trim();
+  let account;
+  try {
+    account = run("aws", [
+      "sts",
+      "get-caller-identity",
+      "--query",
+      "Account",
+      "--output",
+      "text",
+      ...awsProfileArgs(),
+    ]).trim();
+  } catch (error) {
+    // Named, rather than left as a raw execFileSync dump. The build takes
+    // minutes and has already written a good artifact by this point; whoever
+    // reads the failed job needs to know it fell over at the upload and which
+    // credentials it was using, not to reverse-engineer that from a stack.
+    throw new Error(
+      `Built the artifact, but could not reach AWS as ${awsIdentityLabel()} to upload it.\n` +
+        `${String(error.stderr ?? error.message).trim()}\n` +
+        awsAuthHint(),
+      { cause: error },
+    );
+  }
+
   const target = `s3://schoolskills-access-logs-${account}/geoip/${ARTIFACT}.gz`;
 
   // The `geoip/` prefix, not `cf/`. The 90-day expiry rule in sst.config.ts is
@@ -519,8 +533,7 @@ async function main({ dry }) {
     "cp",
     localGz,
     target,
-    "--profile",
-    PROFILE,
+    ...awsProfileArgs(),
     "--only-show-errors",
   ]);
   say("done");

--- a/scripts/geoip.mjs
+++ b/scripts/geoip.mjs
@@ -52,6 +52,8 @@ import { gunzipSync } from "node:zlib";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { awsAuthHint, awsIdentityLabel, awsProfileArgs } from "./aws.mjs";
+
 /** Bumped when the binary layout changes; the reader refuses anything else. */
 export const VERSION = 1;
 export const MAGIC = "SSG1";
@@ -70,8 +72,6 @@ export const cacheDir = () => join(tmpdir(), "schoolskills-geoip");
  * and somebody needs to know. See scripts/build-geoip.mjs.
  */
 const STALE_DAYS = 45;
-
-const PROFILE = process.env.AWS_PROFILE ?? "schoolskills";
 
 /**
  * A dotted quad as a number. `null` for anything that isn't one.
@@ -214,16 +214,15 @@ function ensureArtifact({ maxAgeMs }) {
         "Account",
         "--output",
         "text",
-        "--profile",
-        PROFILE,
+        ...awsProfileArgs(),
       ],
       { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     ).trim();
   } catch (error) {
     throw new Error(
-      `Could not reach AWS as profile "${PROFILE}".\n` +
+      `Could not reach AWS as ${awsIdentityLabel()}.\n` +
         `${String(error.stderr ?? error.message).trim()}\n` +
-        `If the session has expired: aws sso login --profile ${PROFILE}`,
+        awsAuthHint(),
       { cause: error },
     );
   }
@@ -233,7 +232,7 @@ function ensureArtifact({ maxAgeMs }) {
   try {
     execFileSync(
       "aws",
-      ["s3", "cp", source, packed, "--profile", PROFILE, "--only-show-errors"],
+      ["s3", "cp", source, packed, ...awsProfileArgs(), "--only-show-errors"],
       {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
Fixes #189.

## What broke

The first scheduled geo-IP refresh failed at the upload:

```
aws: [ERROR]: The config profile (schoolskills) could not be found
```

`AWS_PROFILE ?? "schoolskills"` was passed to every `aws` call
unconditionally. That's right on a laptop and wrong on a runner — a named
profile is a lookup into `~/.aws/config`, which GitHub Actions doesn't have. It
has *ambient* credentials instead: `configure-aws-credentials` exchanges the
OIDC token and exports `AWS_ACCESS_KEY_ID` and friends, where the CLI's default
chain finds them unaided. Naming a profile there doesn't add information — it
replaces working credentials with a pointer to a file that doesn't exist.

Worth noting the build itself was fine. It merged all 3.4M ranges and packed a
12.9MB artifact, then threw it away four minutes in because it couldn't
authenticate to upload.

## The fix

`scripts/aws.mjs` decides once, for all three callers:

| Situation | `--profile` passed |
| --- | --- |
| `AWS_PROFILE` set explicitly | that profile |
| Credentials already in the environment (CI/OIDC) | **none** |
| Neither | `schoolskills` |

`scripts/analytics.mjs` had the same latent bug and is fixed alongside, though
only the builder runs in CI today.

The error messages move with the same decision. "Could not reach AWS as profile
schoolskills" on a runner that never used a profile sends whoever opens the
failed job looking for a config file rather than at the role, so the identity
and the suggested fix are both derived from `awsProfileArgs`.

The builder also names its own upload failure now — it has a good artifact in
hand by then, and "built it, couldn't upload it" is a different problem from
"couldn't build it".

## Tests

`scripts/aws.test.mjs` pins the real failure, not a hypothetical: a runner-shaped
environment must produce **no** `--profile`, a laptop-shaped one must produce
the local default, and an explicit `AWS_PROFILE` must beat both. Also that the
runner-side error text doesn't mention SSO login.

This is the kind of bug worth a test precisely because it's invisible in every
environment where anyone would notice it.

## Validation

`type-check`, `lint`, `build`, `test:unit` — 2,029 tests pass. Verified the
local path still authenticates (`npm run analytics -- --no-sync` loads the
artifact from S3 as before), and confirmed the resolved arguments for all three
environments.

The workflow itself still needs a real run to confirm end-to-end; I'd trigger
it manually after merge rather than wait for the 1st.

🤖 Generated with [Claude Code](https://claude.com/claude-code)