### PR TITLE
STM08 · A storm run is a Session (#154)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1175,8 +1175,10 @@ the colour can be read as a mark for the child rather than a report of what the
 weather did. The one hue a breach adds is the named finger's own, which is
 identity and not judgement: the same colour as the block that broke and the
 keys under it. `--lime` appears exactly once, on the XP, where it means
-what it means everywhere else on this site — this is what you earned, and it
-could not have gone down (§8.6).
+what it means everywhere else on this site — this is what the letters paid,
+and it could not have gone down (§8.6). A cleared wave that let nothing through
+earns the site's standard "No mistakes" bonus on top of it, which the profile
+takes and this panel does not restate (§8.7).
 
 **A zone is its finger's home-row span** (`FINGER_ZONES` in
 `engine/keyboard.ts`, decision 41). That is a choice between four rows rather
@@ -1308,6 +1310,59 @@ XP and badges accrue, per-character trouble spots feed the drill builder, and
 The one thing that is different: a run can **end early**. Dying at letter 18 of
 40 saves a session with 18 cards. `correct`, `incorrect` and `durationMs` are
 all honest; the pass criterion (`survive`) is simply not met.
+
+The mapping is `stormSession.ts`, beside the screen that plays a wave and for
+the same two reasons `lessonRun.ts` sits beside the screen that runs a lesson:
+it needs `stormXp`, which is in `progress.ts`, which reaches `decks/index.ts` —
+and `storm.ts` is kept a hop clear of the deck layer (§5.3) — and what a run is
+filed as is the island's answer to give. The write itself is `useRaceFinish`,
+unchanged: `summariseRun` scores it, the session service pays its XP into the
+profile, and `SaveFailed` offers the retry when IndexedDB refuses.
+
+**A card is a letter's outcome, never a keystroke** (decision 48). A wrong key
+resolves no letter, so it is not a card, and `incorrect` counts what got
+through rather than what was mistyped. That is not a detail: `survived` is
+`cards.length >= wordCount`, so a card per keystroke would hand a pass to a run
+that died at letter three and sprayed forty keys — and the `unbroken` badge
+reads "nothing marked wrong" as "nothing got through" (§6.7), which counting
+wrong keys would silently re-tune into "flawless run". It is also the bargain
+decision 13 already struck for the lessons, where a key backspaced away costs
+nothing because what ended up on the line is right. What a miss cost is still
+in the saved run: it broke the streak, and `bestStreak` is the run's longest
+combo, which is the one the miss ended.
+
+**A letter that got through is a `timedOut` card** (decision 49). That is what
+the flag has always meant — the clock ran out before an answer arrived — and
+the clock here is the fall. `troubleFacts` weights a timeout above a wrong
+answer, so the keys a child never reaches rank straight to the top of the drill
+the record book offers.
+
+**No ghost, and no personal best** (decision 50). `compareRuns` ranks runs on
+time, and a run that ended at letter three took less of it than one that
+cleared the wave — so a personal best would go to dying early and pay 150 XP
+for it, which is XP rewarding the one thing the game is against (§8.6). The run
+still carries its `configKey`, so a later story that wants to rank storms has
+every run it needs. `durationMs` is then the sum of the letters' own air time
+rather than a wall clock, because a storm's letters overlap in the sky; the two
+agree only on a wave that never puts two up at once.
+
+The XP on the ending panel is the run's own `stormXp` — what its letters paid
+(§8.5). A wave cleared with nothing through also earns the site's standard
+"No mistakes" bonus, which goes into the profile like any other run's and is
+not restated on the panel: the four figures there are about the weather, and a
+bonus line is a results screen's business.
+
+`configKey` is `typing|L39|12` — the lesson, and the **wave's** length, never
+the letters that were survived. Retries of a level therefore compare with each
+other, which is the whole point of the key (§5.4).
+
+**Saved exactly once, and a retry is a new run** (decision 51). The run is
+written on the frame `ending` appears, which the reducer sets once and never
+touches again. "Try this wave again" remounts the screen rather than swapping a
+wave under it, so the second attempt gets its own finish guard, its own history
+snapshot — the first attempt included — and a clock that starts at zero. The
+wave is rebuilt from the same `(spec, seed)`, so it is the same twelve letters:
+a different run of the same storm.
 
 ### 8.8 · Hailstorm never gates the ladder
 
@@ -1483,11 +1538,20 @@ Almost nothing, and that is the design working.
 | `TypingConfig`    | `lessonId?: string` — optional, and the ghost-key discriminator       |
 | `TypingConfig`    | `keyboard?: KeyboardMode` — the brief's choice; inert in `configKey`  |
 | `configKey`       | unchanged for every config already saved (§5.4)                       |
+| A Hailstorm run   | a `Session` with a `TypingConfig` — no new field either side (§8.7)   |
 | Lesson progress   | derived from sessions; stored nowhere (§6.5)                          |
 
 Two existing runs saved before any of this must keep resolving, and the tests
 that pin that (`decks/typing.test.ts`, `migrate.test.ts`) are the ones to run
 first when either optional field is added.
+
+A Hailstorm run costs nothing here either, and that is the shape being right
+rather than a coincidence. Its cards are already the current shape — a string
+`answer` and a string `factId` — so `migrate.ts` passes them straight through
+and has nothing to widen; its config is a `TypingConfig` carrying the same
+optional `lessonId` a ladder run already writes; and `configKey`'s format is
+untouched, which `configkey.test.ts` freezes. No new store, no `DB_VERSION`
+bump, no backfill.
 
 ---
 
@@ -1542,6 +1606,10 @@ first when either optional field is added.
 | 45  | The HUD is drawn inside the sky, not as a row of its own | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give              |
 | 46  | A wrong key costs score; a letter through costs shield   | One failure, one cost — the landing has already taken the thing that ends runs                              |
 | 47  | The ending stands where the board did                    | The gun is dead, and the sky it leaves whole is the shield with the hole in it that the sentence is about   |
+| 48  | A storm's cards are its letters, not its keystrokes      | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both   |
+| 49  | A letter that got through is a `timedOut` card           | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped    |
+| 50  | A storm has no ghost and no personal best                | `compareRuns` ranks on time, so the record would go to dying at letter three — and pay 150 XP for it        |
+| 51  | A retry is a new run, so it is a remount                 | The finish guard, the history snapshot and the clock all have to start again; one instance is one run       |
 
 ---
 

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1337,14 +1337,43 @@ the clock here is the fall. `troubleFacts` weights a timeout above a wrong
 answer, so the keys a child never reaches rank straight to the top of the drill
 the record book offers.
 
-**No ghost, and no personal best** (decision 50). `compareRuns` ranks runs on
-time, and a run that ended at letter three took less of it than one that
-cleared the wave — so a personal best would go to dying early and pay 150 XP
-for it, which is XP rewarding the one thing the game is against (§8.6). The run
-still carries its `configKey`, so a later story that wants to rank storms has
-every run it needs. `durationMs` is then the sum of the letters' own air time
-rather than a wall clock, because a storm's letters overlap in the sky; the two
-agree only on a wave that never puts two up at once.
+**No ghost, and no record of any kind** (decision 50). `compareRuns` ranks runs
+on time, and a run that ended at letter three took less of it than one that
+cleared the wave — so a best would go to dying early and pay 150 XP for it,
+which is XP rewarding the one thing the game is against (§8.6). The run still
+carries its `configKey`, so a later story that wants to rank storms on
+something other than time has every run it needs. `durationMs` is then the sum
+of the letters' own air time rather than a wall clock, because a storm's
+letters overlap in the sky; the two agree only on a wave that never puts two up
+at once.
+
+**That takes two things, not one, and the XP half is the smaller.** The screen
+hands `useRaceFinish` a `previousBest` of `null`, which is what makes
+`summariseRun.personalRecord` false and the 150 XP unpayable — but it decides
+this run's own panel and nothing else. Every _other_ "best" on the site is
+`bestRun`, which groups a player's runs by `configKey` and picks on
+`compareRuns`, and a storm's key is a lesson's key: without a second signal the
+record book's "your best" column, the house best beside it, and — the moment
+STM10 gives lesson 39 a `WaveSpec` and `lessonKey` starts returning
+`typing|L39|12` — the lesson brief's best and its rival list would all rank
+storms against each other on time, and hand the record to the shortest life.
+
+So the run says what it is. `stormConfig` writes **`storm: true`** into its
+`TypingConfig`, `isRanked` in `decks/index.ts` reads it, and `bestRun` drops
+those runs before it compares anything — one rule, at the single door every
+best on the site comes through, inherited by the screens that do not exist yet.
+The flag is on the run rather than derived from `lessonById(lessonId)` because
+a saved run outlives the ladder it was played on (§5.4): re-tune lesson 39 out
+of a Hailstorm and a derived rule would quietly start ranking every storm
+already in the record book. It is optional, never `false`, and inert in
+`configKey` — a storm and its lesson still key identically, which they must, or
+STM10 would orphan every storm already saved.
+
+A run that holds no record is still a run in every other way: the record book
+_lists_ it, it pays its XP, it earns badges, and its letters feed the drill
+builder. `bestRun` returning `null` for a player whose every run at a
+configuration is a storm is therefore an ordinary answer — the record table
+drops the row rather than inventing a record for it.
 
 The XP on the ending panel is the run's own `stormXp` — what its letters paid
 (§8.5). A wave cleared with nothing through also earns the site's standard
@@ -1538,7 +1567,8 @@ Almost nothing, and that is the design working.
 | `TypingConfig`    | `lessonId?: string` — optional, and the ghost-key discriminator       |
 | `TypingConfig`    | `keyboard?: KeyboardMode` — the brief's choice; inert in `configKey`  |
 | `configKey`       | unchanged for every config already saved (§5.4)                       |
-| A Hailstorm run   | a `Session` with a `TypingConfig` — no new field either side (§8.7)   |
+| `TypingConfig`    | `storm?: true` — optional, set only by a storm, inert in `configKey`  |
+| A Hailstorm run   | a `Session` with a `TypingConfig`; no new store, no bump (§8.7)       |
 | Lesson progress   | derived from sessions; stored nowhere (§6.5)                          |
 
 Two existing runs saved before any of this must keep resolving, and the tests
@@ -1549,9 +1579,12 @@ A Hailstorm run costs nothing here either, and that is the shape being right
 rather than a coincidence. Its cards are already the current shape — a string
 `answer` and a string `factId` — so `migrate.ts` passes them straight through
 and has nothing to widen; its config is a `TypingConfig` carrying the same
-optional `lessonId` a ladder run already writes; and `configKey`'s format is
-untouched, which `configkey.test.ts` freezes. No new store, no `DB_VERSION`
-bump, no backfill.
+optional `lessonId` a ladder run already writes, plus the one field that is new
+— `storm?: true` (§8.7) — which is optional and never `false`, exactly like
+`lessonId` and `keyboard` beside it; and `configKey`'s format is untouched,
+which `configkey.test.ts` freezes. No new store, no `DB_VERSION` bump, no
+backfill: a config without the field reads as a config that is not a storm,
+which is what every run saved before this is.
 
 ---
 
@@ -1608,7 +1641,7 @@ bump, no backfill.
 | 47  | The ending stands where the board did                    | The gun is dead, and the sky it leaves whole is the shield with the hole in it that the sentence is about   |
 | 48  | A storm's cards are its letters, not its keystrokes      | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both   |
 | 49  | A letter that got through is a `timedOut` card           | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped    |
-| 50  | A storm has no ghost and no personal best                | `compareRuns` ranks on time, so the record would go to dying at letter three — and pay 150 XP for it        |
+| 50  | A storm has no ghost and holds no record                 | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it          |
 | 51  | A retry is a new run, so it is a remount                 | The finish guard, the history snapshot and the clock all have to start again; one instance is one run       |
 
 ---

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -1223,6 +1223,128 @@ try {
       `closest pair ${rhythm(flashes, () => "hud")}ms apart`,
   );
 
+  /*
+   * A storm is a `Session`, and a retry is a second one (docs/typing.md §8.7).
+   *
+   * The mapping is pure and `stormSession.test.ts` proves every field of it
+   * without a browser. What only a browser can answer is whether the write
+   * happens at all, exactly once, and again for the next attempt: the save is
+   * an effect fired on the frame `ending` appears, the guard against a second
+   * one is a component instance, and a retry is a remount — none of which
+   * exist in the unit suite. So this counts what actually reached IndexedDB.
+   *
+   * Two runs have FINISHED by now and they are deliberately different shapes:
+   * the census run above was played with nothing pressed, so all twelve
+   * letters got through it, and the one after it was played with a child's
+   * hands on it. The first is the honest-numbers case (§8.7's "correct,
+   * incorrect and durationMs are all honest") and the second is the one that
+   * pays XP. Every other storm this file entered was left mid-fall, and a run
+   * with no ending writes nothing — which is why "two" is the number here even
+   * though `storm()` has been called four or five times.
+   */
+  log("\n10. A storm is a session, and a retry is a second one");
+  const stormRuns = async () =>
+    (await readStore("sessions")).filter((s) => s.mode === "typing:L39");
+
+  /**
+   * Waits — in the page, against the same database the app writes to — until
+   * exactly `want` storm runs are stored. `false` if it never got there, which
+   * says "too few, or the count went past it and stayed".
+   */
+  const storedRuns = (want) =>
+    page
+      .waitForFunction(
+        (target) =>
+          new Promise((res) => {
+            const open = indexedDB.open("schoolskills");
+            open.onerror = () => res(false);
+            open.onsuccess = () => {
+              const all = open.result
+                .transaction("sessions", "readonly")
+                .objectStore("sessions")
+                .getAll();
+              all.onsuccess = () =>
+                res(
+                  all.result.filter((s) => s.mode === "typing:L39").length ===
+                    target,
+                );
+            };
+          }),
+        want,
+        { timeout: 8000 },
+      )
+      .then(() => true)
+      .catch(() => false);
+
+  const twoRuns = await storedRuns(2);
+  const saved = await stormRuns();
+  const untouched = saved.find((s) => s.correct === 0);
+  const handsOn = saved.find((s) => s.correct > 0);
+  check(
+    "both finished storms are in the record book, filed under their lesson",
+    twoRuns &&
+      saved.length === 2 &&
+      saved.every(
+        (s) =>
+          s.configKey === "typing|L39|12" &&
+          s.config.lessonId === "L39" &&
+          s.seed === 353 &&
+          s.cards.length === 12,
+      ),
+    `${saved.length} run(s): ${saved.map((s) => `${s.mode} ${s.configKey} ${s.correct}/${s.cards.length}`).join(", ")}`,
+  );
+  check(
+    "a wave nobody pressed at saves twelve letters that all got through",
+    untouched?.correct === 0 &&
+      untouched?.incorrect === 12 &&
+      // Twelve four-second falls. `ms` is the letter's own time in the air,
+      // so the total is the wave's letters and not the wall clock.
+      untouched?.durationMs === 48000 &&
+      untouched?.cards.every(
+        (c) =>
+          c.prompt === c.answer &&
+          c.factId === c.answer &&
+          c.given === null &&
+          c.ok === false &&
+          c.timedOut === true &&
+          c.ms === 4000,
+      ),
+    `${untouched?.correct}/${untouched?.incorrect} in ${untouched?.durationMs}ms`,
+  );
+  check(
+    "the run that was played saves what was shot, and pays for it",
+    handsOn?.correct === shot.length &&
+      handsOn?.incorrect === 12 - shot.length &&
+      handsOn?.xpEarned > 0 &&
+      handsOn?.bestStreak === shot.length &&
+      handsOn?.cards.filter((c) => c.ok).every((c) => c.given === c.answer) &&
+      // A shot letter was caught before it landed, so its time in the air is
+      // less than the fall — which is what makes it worth XP (§8.6).
+      handsOn?.cards.filter((c) => c.ok).every((c) => c.ms < 4000),
+    `${handsOn?.correct} shot, ${handsOn?.incorrect} through, ` +
+      `${handsOn?.xpEarned} XP, best combo ${handsOn?.bestStreak}`,
+  );
+
+  // And the same wave again. "Try this wave again" is a new run rather than
+  // the old one rewound (decision 51), so it owes the record book exactly one
+  // more session — where a screen that kept its finish guard across the retry
+  // would write none, and one that re-fired the old one would write two.
+  await page.getByRole("button", { name: /try this wave again/i }).click();
+  await page.waitForSelector(".storm__letter", { timeout: 8000 });
+  await page
+    .waitForFunction(() => document.querySelector(".storm__over") !== null, {
+      timeout: 20000,
+    })
+    .catch(() => {});
+  const threeRuns = await storedRuns(3);
+  const retried = await stormRuns();
+  check(
+    "a retry writes one more run, and only one",
+    threeRuns && retried.length === 3,
+    `${retried.length} run(s) after the retry: ` +
+      retried.map((s) => `${s.correct}/${s.cards.length}`).join(", "),
+  );
+
   log(
     `\nconsole errors: ${errors.length ? errors.slice(0, 5).join(" | ") : "none"}`,
   );

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -89,17 +89,29 @@ export default function Progress() {
     ];
   }, [mine]);
 
-  /** Best time per configuration, with whoever in the house holds it. */
+  /**
+   * Best time per configuration, with whoever in the house holds it.
+   *
+   * A configuration with no ranked run of mine gets no row at all. That is not
+   * an empty group — I have run it — it is a group of runs that may not hold a
+   * record, which today means Hailstorm: a storm ends when the shield does, so
+   * ranking it on time would put the child who died first at the top of both
+   * columns (`isRanked`, docs/typing.md §8.7). Those runs are still in the
+   * history below; they just set nothing. Once `myBest` exists the house best
+   * does too, because mine is one of the runs it is chosen from.
+   */
   const records = useMemo(() => {
     if (!profile) return [];
     const keys = [...new Set(mine.map((s) => s.configKey))];
     return keys
       .map((key) => {
-        const myBest = bestRun(sessionsFor(sessions, profile.id, key))!;
+        const myBest = bestRun(sessionsFor(sessions, profile.id, key));
+        if (!myBest) return null;
         const houseBest = bestRun(sessions.filter((s) => s.configKey === key))!;
         const holder = profiles.find((p) => p.id === houseBest.profileId);
         return { key, myBest, houseBest, holder };
       })
+      .filter((row) => row !== null)
       .sort((a, b) => raceTimeMs(a.myBest) - raceTimeMs(b.myBest));
   }, [mine, sessions, profiles, profile]);
 

--- a/src/engine/decks/configkey.test.ts
+++ b/src/engine/decks/configkey.test.ts
@@ -155,6 +155,28 @@ const FROZEN: Frozen[] = [
     },
     "typing|home-row|10|wadd,ask",
   ],
+  // The ladder's two run shapes. Both key on the LESSON and on the length the
+  // rung declares — never on the words a passage came out with, and never on
+  // how much of a wave was survived (§5.4, §8.7). The lesson below carries
+  // both of the fields that have to stay inert: the passage it generated, and
+  // the board the child chose to type it under.
+  [
+    "typing, a lesson from the ladder",
+    {
+      kind: "typing",
+      levelId: "L07",
+      lessonId: "L07",
+      words: ["fff", "jjj", "fjfj"],
+      keyboard: "off",
+      wordCount: 25,
+    },
+    "typing|L07|25",
+  ],
+  [
+    "typing, a Hailstorm wave",
+    { kind: "typing", levelId: "L39", lessonId: "L39", wordCount: 12 },
+    "typing|L39|12",
+  ],
 ];
 
 describe("the keys already saved", () => {

--- a/src/engine/decks/index.ts
+++ b/src/engine/decks/index.ts
@@ -84,6 +84,36 @@ export function buildDeck(config: RaceConfig, seed: number): Card[] {
   return buildFlashDeck(config, seed);
 }
 
+/**
+ * Whether this run may hold a record — a personal best, the house best, or a
+ * place in a rival list.
+ *
+ * Every "best" on the site is `compareRuns`, which decides on time. That is
+ * safe for a race, where the only way to stop the clock is to answer every
+ * card, and wrong for a run that can **end early**: a Hailstorm run stops when
+ * the shield does, so a child who died at letter three took less time than one
+ * who cleared the wave and would be handed the record for it (docs/typing.md
+ * §8.7, decision 50).
+ *
+ * The judgement is made here, at the front door, and enforced in exactly one
+ * place — `bestRun` in `engine/records.ts` — rather than filtered at each
+ * screen, so every consumer inherits it: the record book's "your best" and
+ * "house best" columns, the `previousBest` a results screen pays the
+ * personal-best bonus on, and `ghostsFor`, which is where every rival a setup
+ * screen offers comes from. That matters most for the consumers that do not
+ * exist yet. STM10 gives lesson 39 a `WaveSpec`, at which point
+ * `lessonKey(lesson)` is `typing|L39|12` — the same string `stormConfig`
+ * already writes — and `TypingSetup`'s brief and rival list would start
+ * reading storms as lesson runs without a line of them changing.
+ *
+ * An unranked run is still a run in every other way: the record book lists it,
+ * it pays its XP, it earns badges and its cards feed the drill builder. It
+ * just never holds a "best". Only a storm answers false today, and this is the
+ * only place to widen if a second kind of run ever can end early.
+ */
+export const isRanked = (config: RaceConfig): boolean =>
+  !(isTyping(config) && config.storm === true);
+
 /** Two runs may only race each other as ghosts if they share this. */
 export function configKey(config: RaceConfig): string {
   if (isWords(config)) return wordConfigKey(config);

--- a/src/engine/progress.ts
+++ b/src/engine/progress.ts
@@ -425,10 +425,14 @@ function courseBadges(
 
      "Shield untouched" is read as **no letter reached the bottom**, which is
      what takes a point off a segment (§8.5). A storm's cards are its falling
-     letters (§8.7), so a run with nothing marked wrong is a run where nothing
-     got through. That errs strict — a letter fired at twice and then hit may
-     cost a card without costing the shield — and strict is the right direction
-     for a badge that, once in `Profile.badges`, is not taken back.
+     letters and nothing else (§8.7, decision 48), so a run with nothing marked
+     wrong is exactly a run where nothing got through: a wrong key resolves no
+     letter and so costs no card, and the one letter that lands without costing
+     a shield point is the fatal one, which is itself a card marked wrong. So
+     this is the badge's own sentence rather than an approximation of it —
+     which is worth saying out loud, because counting a storm's wrong KEYS into
+     `incorrect` would quietly re-tune it from "untouched shield" to "flawless
+     run" without a line of this file changing.
 
      `correct > 0` cannot change the answer, and is kept on purpose. A run with
      no cards at all has an accuracy of 0 (`accuracyOf` returns 0 rather than

--- a/src/engine/records.test.ts
+++ b/src/engine/records.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { factStats, factsToDrill, masteryOf, troubleFacts } from "./records";
-import type { CardResult, Session } from "./types";
+import {
+  bestRun,
+  factStats,
+  factsToDrill,
+  ghostsFor,
+  masteryOf,
+  troubleFacts,
+} from "./records";
+import type { CardResult, Profile, Session } from "./types";
 
 /**
  * What counts as "the same fact" is now the deck's answer, not this module's.
@@ -43,6 +50,85 @@ const session = (mode: string, cards: CardResult[]): Session => ({
   ghostSessionId: null,
   beatGhost: null,
   cards,
+});
+
+describe("bestRun", () => {
+  /**
+   * A run that may not hold a record is dropped before anything is compared.
+   *
+   * `isRanked` is the judgement and this is the only place it is enforced, so
+   * these two cases are what every "best" on the site inherits: the record
+   * book's columns, the `previousBest` a personal-best bonus is paid on, and
+   * `ghostsFor` below it. Today only a Hailstorm answers false — it ends when
+   * the shield does, so ranking it on time gives the record to whoever quit
+   * first (docs/typing.md §8.7, decision 50).
+   */
+  const typing = (over: Partial<Session>): Session => ({
+    ...session("typing:L39", [card()]),
+    configKey: "typing|L39|12",
+    config: { kind: "typing", levelId: "L39", lessonId: "L39", wordCount: 12 },
+    ...over,
+  });
+
+  const PLAYER: Profile = {
+    id: "p1",
+    name: "Ada",
+    emoji: "🦊",
+    color: "#4ade80",
+    age: 8,
+    soundOn: false,
+    xp: 0,
+    badges: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("returns null when every run is one that may not be ranked", () => {
+    const storm = typing({
+      id: "storm",
+      config: {
+        kind: "typing",
+        levelId: "L39",
+        lessonId: "L39",
+        storm: true,
+        wordCount: 12,
+      },
+      durationMs: 1000,
+    });
+
+    // Not the empty-list null: there is a run here, and it is still a run in
+    // every other way. It just sets no record.
+    expect(bestRun([storm])).toBeNull();
+    expect(ghostsFor([storm], [PLAYER], storm.configKey, PLAYER.id)).toEqual(
+      [],
+    );
+  });
+
+  it("picks the slowest ranked run over a faster unranked one", () => {
+    const storm = typing({
+      id: "storm",
+      config: {
+        kind: "typing",
+        levelId: "L39",
+        lessonId: "L39",
+        storm: true,
+        wordCount: 12,
+      },
+      durationMs: 1000,
+    });
+    const lesson = typing({ id: "lesson", durationMs: 90_000 });
+
+    expect(bestRun([storm, lesson])?.id).toBe("lesson");
+  });
+
+  it("still ranks two ordinary runs on time", () => {
+    const slow = { ...session("multiply", [card()]), id: "slow" };
+    const fast = { ...session("multiply", [card()]), id: "fast" };
+    slow.durationMs = 9000;
+    fast.durationMs = 4000;
+
+    expect(bestRun([slow, fast])?.id).toBe("fast");
+    expect(bestRun([])).toBeNull();
+  });
 });
 
 describe("factStats", () => {

--- a/src/engine/records.ts
+++ b/src/engine/records.ts
@@ -6,7 +6,7 @@ import type {
   Session,
 } from "@/engine/types";
 
-import { deckSpec } from "@/engine/decks";
+import { deckSpec, isRanked } from "@/engine/decks";
 
 export const accuracyOf = (session: Pick<Session, "correct" | "incorrect">) => {
   const total = session.correct + session.incorrect;
@@ -52,9 +52,26 @@ export function compareRuns(a: Scored, b: Scored) {
   return raceTimeMs(a) - raceTimeMs(b);
 }
 
+/**
+ * The best of these runs, or null if none of them may hold a record.
+ *
+ * Runs `isRanked` refuses are dropped before anything is compared, and this is
+ * the one place that happens. It is the single door every "best" on the site
+ * comes through — the record book's two columns, the `previousBest` a results
+ * screen pays the personal-best bonus on, and `ghostsFor` below, which every
+ * rival list is built from — so putting the rule here is what makes a run that
+ * must not be ranked unrankable everywhere at once, including in the screens
+ * that have not been written yet (see `isRanked`).
+ *
+ * **Null is an ordinary answer, not only the empty-list one.** A player whose
+ * every run at a configuration is a Hailstorm has no best at it, and a caller
+ * has to say what it shows instead: `Progress.tsx` drops the row rather than
+ * inventing a record, and `PlayerHub` already renders "No runs yet".
+ */
 export function bestRun(sessions: Session[]): Session | null {
-  if (sessions.length === 0) return null;
-  return sessions.reduce((best, s) => (compareRuns(s, best) < 0 ? s : best));
+  const ranked = sessions.filter((session) => isRanked(session.config));
+  if (ranked.length === 0) return null;
+  return ranked.reduce((best, s) => (compareRuns(s, best) < 0 ? s : best));
 }
 
 export const sessionsFor = (

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -147,6 +147,34 @@ export type TypingConfig = {
    * from them the first time they turned the guide off.
    */
   keyboard?: KeyboardMode;
+  /**
+   * Set only by a Hailstorm run (docs/typing.md §8.7, decision 50).
+   *
+   * A storm is not ranked, and this is the field that says so. Every "best" on
+   * the site is `compareRuns`, which decides on time — and a storm run ends
+   * when the shield does, so a child who died at letter three took less time
+   * than one who cleared the wave and would hold the record for it. `isRanked`
+   * (`decks/index.ts`) reads this and `bestRun` (`engine/records.ts`) refuses
+   * those runs, so the record book's two columns, the `previousBest` that pays
+   * the personal-best bonus and every ghost a setup screen offers all inherit
+   * one judgement.
+   *
+   * ── On the run, not derived from the lesson ─────────────────────────────
+   * `lessonById(lessonId)?.kind.type === "storm"` would answer the same
+   * question today without a field. It is not used, because a saved run
+   * outlives the ladder it was played on (§5.4, and `UNKNOWN_DECK`): re-tune
+   * lesson 39 out of a Hailstorm — or retire the id — and a derived rule would
+   * quietly start ranking every storm already in the record book, awarding the
+   * record to the shortest life. What a run *was* is a fact about the run, and
+   * facts about a run travel with it.
+   *
+   * Optional and never `false`, exactly like `lessonId` and `keyboard` above,
+   * so it costs no `DB_VERSION` bump and no migration. Inert in `configKey`
+   * (`decks/typing.ts#typingConfigKey`): that key decides which runs may race
+   * each other as ghosts, and changing its format orphans every personal best
+   * already saved (CLAUDE.md, §10).
+   */
+  storm?: true;
   /** An explicit set, for a drill of the words a player keeps fumbling. */
   words?: string[];
   wordCount: number;

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -403,13 +403,16 @@ export type StormEnding =
  * `resolved` is parallel to `wave.letters` and indexed by the letter's
  * identity (§8.3). Indexed rather than appended to, because resolution is
  * **not** in spawn order: shoot the middle one of three and the array gets a
- * hole in it. That indexing is also what makes the run a `Session` later with
- * no bookkeeping — card _i_ is letter _i_, so `prompt`, `answer` and `factId`
- * are its character and `ms` is `atMs - spawnMs` (§8.7, STM08).
+ * hole in it. That indexing is also what makes the run a `Session` with no
+ * bookkeeping: card _i_ is built from letter _i_ and outcome _i_ together, so
+ * `prompt`, `answer` and `factId` are the letter's character and `ms` is
+ * `atMs - spawnMs` (§8.7, `stormSession.ts`). It is a card **per resolved
+ * letter**, not per index — a run that ended early leaves holes in here, and
+ * they are the letters that never happened.
  *
- * What the next story adds, and why nothing here is in its way: STM07 reads
- * `ending` for the finger and counts `resolved` by finger for "let three
- * through". It wants no different shape.
+ * Two stories read this and neither wanted a different shape: STM07 takes the
+ * finger off `ending` and counts `resolved` by finger for "let three through",
+ * and STM08 walks it in order for the cards.
  */
 export type StormState = {
   /** The storm being played. Decided before the run; never changes during it. */
@@ -453,11 +456,18 @@ export type StormState = {
   /**
    * Wrong keys — shots that hit nothing, including shots at an empty sky.
    *
-   * A count and not a list, because the two things that read it want a number:
-   * the HUD mounts one `--flare` flash per miss off it (a counter that only
-   * goes up cannot restart an animation, §8.10, decision 42), and STM08 owes a
-   * saved session an `incorrect` that counts what a child got wrong rather
-   * than only what the shield paid for.
+   * A count and not a list, because what reads it wants a number: the HUD
+   * mounts one `--flare` flash per miss off it, and a counter that only goes
+   * up cannot restart an animation (§8.10, decision 42).
+   *
+   * **It is the run's own number and does not reach the record book.** STM08
+   * weighed giving a saved session an `incorrect` that counted wrong keys as
+   * well as letters that got through, and did not: a card is a letter's
+   * outcome, a wrong key resolves no letter, and two things downstream read
+   * "nothing marked wrong" as "nothing got through" — `survived`, which is
+   * `cards.length >= wordCount`, and the `unbroken` badge (§8.7, decision 48).
+   * What a miss cost is still saved, in the streak it broke: `bestStreak` is
+   * `bestCombo`, and the combo a wrong key ended is one the maximum never saw.
    */
   readonly misses: number;
   /** How the run finished, or `null` while it is live. */

--- a/src/games/typing/storm/StormRun.tsx
+++ b/src/games/typing/storm/StormRun.tsx
@@ -158,12 +158,18 @@ export default function StormRun() {
  * What it is handed that a race is not:
  *
  *   - **No ghost, and no previous best.** Nothing chases a storm, and a storm
- *     has no personal record: `compareRuns` ranks runs on time, and a run that
- *     ended at letter three took less of it than one that cleared the wave —
- *     so the record would go to dying early, and pay a personal-best bonus for
- *     it. XP must never reward the thing the game is against (§8.6, decision
- *     50). The run is still filed under its `configKey`, so a later story that
- *     wants to rank storms has every run it needs.
+ *     holds no record: `compareRuns` ranks runs on time, and a run that ended
+ *     at letter three took less of it than one that cleared the wave — so a
+ *     best would go to dying early, and pay a personal-best bonus for it. XP
+ *     must never reward the thing the game is against (§8.6, decision 50).
+ *
+ *     `previousBest: null` is only half of that, and the smaller half: it
+ *     buys this run's own 150 XP bonus and its `personalRecord` flag, and
+ *     nothing else. What stops the record book, the house best and every
+ *     future rival list from ranking the run is `config.storm`, which
+ *     `stormConfig` sets and `isRanked` reads — the run is still filed under
+ *     its `configKey`, so a later story that wants to rank storms on
+ *     something other than time has every run it needs.
  *   - **A results path that is the screen it is already on.** The ending
  *     stands where the board did (decision 47) and IS this run's results
  *     screen, so the navigation `useRaceFinish` performs on a good save is a

--- a/src/games/typing/storm/StormRun.tsx
+++ b/src/games/typing/storm/StormRun.tsx
@@ -1,28 +1,33 @@
-import { useState } from "react";
-import { Navigate, useParams } from "react-router-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
 
-import { usePlayer } from "@/components/state/HubContext";
+import { useHub, usePlayer } from "@/components/state/HubContext";
+import { useRace } from "@/components/state/RaceContext";
 import { typingMode } from "@/engine/decks/typing";
+import { sessionsFor } from "@/engine/records";
 import { unlockedAt } from "@/engine/typing/keys";
 import { buildWave } from "@/engine/typing/storm";
+import { SaveFailed, useRaceFinish } from "@/games/race";
 
 import { StormField } from "./StormField";
 import { StormOver } from "./StormOver";
+import { stormConfig, stormTally } from "./stormSession";
 import { useStormClock } from "./useStormClock";
 
 import type { WaveSpec } from "@/engine/typing/storm";
+import type { Profile } from "@/engine/types";
 
 /**
  * The Hailstorm route (docs/typing.md §9), playing one wave.
  *
- * The screen is four things joined: a field that draws a `StormState`, a clock
- * that produces one per animation frame, a keyboard that shoots, and — once
- * the storm stops — the ending that says which finger let it through and
- * offers a drill of that finger's keys (`StormOver`).
+ * The screen is five things joined: a field that draws a `StormState`, a clock
+ * that produces one per animation frame, a keyboard that shoots, the ending
+ * that says which finger let it through and offers a drill of that finger's
+ * keys (`StormOver`), and — the moment the storm stops — the run written to
+ * the record book as a `Session` (§8.7, `stormSession.ts`).
  *
  * What it is still not is a whole game. STM10 replaces the stand-in wave below
- * with the twenty the ladder actually names, and STM08 saves the run as a
- * `Session`; until then nothing that happens here is written down anywhere.
+ * with the twenty the ladder actually names.
  *
  * Unlinked on purpose. Nothing on the ladder points here until STM10 puts the
  * storm tiles on it, so the only way in is the URL — which is exactly what a
@@ -33,13 +38,21 @@ import type { WaveSpec } from "@/engine/typing/storm";
  * Which lesson this stand-in stands in for: 39, "Hailstorm · Shift under
  * fire" — the last of block 4's two storm levels.
  *
- * One number for the pool AND the mode, so the two cannot drift. The wave
- * draws on the alphabet lesson 39 is played at, and the run files itself under
- * `typing:L39` exactly as a lesson run does (§8.7) — which is what the ending
- * screen builds its drill through. STM10 replaces all of this with the lesson
- * the ladder tile named.
+ * One number for the pool AND the id, so the two cannot drift: the wave draws
+ * on the alphabet lesson 39 is played at, and the run files itself under
+ * `typing:L39` exactly as a lesson run does (§8.7). STM10 replaces all of this
+ * with the lesson the ladder tile named.
  */
 const PREVIEW_LESSON = 39;
+
+/**
+ * The id that identifies the run — in `Session.mode`, in `configKey`, and in
+ * the config the run is saved with. Written once here and read by both
+ * `typingMode` and `stormConfig`, because a mode and a config that disagreed
+ * about which lesson this is would file the run in one place and look for it
+ * in another.
+ */
+const PREVIEW_LESSON_ID = `L${PREVIEW_LESSON}`;
 
 /**
  * A stand-in storm: everything a child has met by lesson 39, falling one after
@@ -82,30 +95,162 @@ const PREVIEW_SPEC: WaveSpec = {
 const PREVIEW_SEED = 353;
 
 /** The mode a run of it files under, and the drill's family (§8.7). */
-const PREVIEW_MODE = typingMode(`L${PREVIEW_LESSON}`);
+const PREVIEW_MODE = typingMode(PREVIEW_LESSON_ID);
 
+/**
+ * The route, which owns nothing but which attempt is being played.
+ *
+ * **A retry is a new run, not the same one rewound** (decision 51), and that is
+ * why it is a remount rather than a fresh wave handed to a component that stays
+ * put. Three things a second go has to get right come free from starting the
+ * component again, and every one of them would have to be undone by hand
+ * otherwise:
+ *
+ *   - **It has not been saved.** `useRaceFinish` guards its own double-finish
+ *     with a ref that latches for the life of the hook, so a screen that kept
+ *     that hook across a retry would write the first run and silently never
+ *     write another. A new instance is a new latch — which is the guard, said
+ *     structurally rather than kept in step by a second flag.
+ *   - **Its history includes the run before it.** `history` is snapshotted at
+ *     mount so the run being saved cannot alter its own scoring; a second
+ *     attempt badged against the first attempt's snapshot would be counting a
+ *     record book that no longer exists.
+ *   - **Its clock starts at zero.** `useStormClock` starts a fresh run when it
+ *     is handed a different wave, and a remount is the plainest way to hand it
+ *     one.
+ *
+ * The wave itself is rebuilt from the same `(spec, seed)`, so "try this wave
+ * again" means the same twelve letters in the same lanes at the same speeds
+ * (§8.3) — a different run of the same storm, which is the only version of
+ * beating it that means a child got better.
+ */
 export default function StormRun() {
   const { profileId } = useParams();
   const profile = usePlayer(profileId);
-
-  /**
-   * The wave, rebuilt on retry.
-   *
-   * `useStormClock` starts a fresh run whenever it is handed a different wave
-   * OBJECT, so building a second one from the same `(spec, seed)` is both the
-   * retry and the promise the retry makes: same twelve letters, same lanes,
-   * same speeds, from zero. Held in state rather than at module scope for that
-   * reason alone — a constant could not change identity, and a child would
-   * press "try this wave again" and watch nothing happen.
-   */
-  const [wave, setWave] = useState(() => buildWave(PREVIEW_SPEC, PREVIEW_SEED));
-  const { state, skyRef } = useStormClock(wave);
+  const [attempt, setAttempt] = useState(0);
 
   // Same guard as the other run screens: a URL naming a player who isn't on
   // this device goes back to the picker rather than rendering half a game.
-  // Below the hooks, so the clock is armed and cancelled in the same order on
-  // every render — the redirect unmounts this, which is what stops it.
+  // Below the hooks, so they are called in the same order on every render.
   if (!profile) return <Navigate to="/" replace />;
+
+  return (
+    <StormPlay
+      key={attempt}
+      profile={profile}
+      onRetry={() => setAttempt((n) => n + 1)}
+    />
+  );
+}
+
+/**
+ * One attempt: the wave, the clock, the field, and the write at the end of it.
+ *
+ * ── Saved through the race's own finish ──────────────────────────────────────
+ * `useRaceFinish` and not a second save path, because a storm is a `Session`
+ * and every hard part of writing one has already been solved there: scoring
+ * through `summariseRun`, the badges, the XP into the profile, and the failure
+ * that matters — IndexedDB refusing a write on a full disk or in private
+ * browsing — held in state so the answers are still in memory and `SaveFailed`
+ * can offer to try again (§8.7's "no new code downstream", from the other
+ * side).
+ *
+ * What it is handed that a race is not:
+ *
+ *   - **No ghost, and no previous best.** Nothing chases a storm, and a storm
+ *     has no personal record: `compareRuns` ranks runs on time, and a run that
+ *     ended at letter three took less of it than one that cleared the wave —
+ *     so the record would go to dying early, and pay a personal-best bonus for
+ *     it. XP must never reward the thing the game is against (§8.6, decision
+ *     50). The run is still filed under its `configKey`, so a later story that
+ *     wants to rank storms has every run it needs.
+ *   - **A results path that is the screen it is already on.** The ending
+ *     stands where the board did (decision 47) and IS this run's results
+ *     screen, so the navigation `useRaceFinish` performs on a good save is a
+ *     replace onto the current route: it commits the history entry a race
+ *     would, and moves nothing.
+ */
+function StormPlay({
+  profile,
+  onRetry,
+}: {
+  profile: Profile;
+  /** Play the same storm again, as a new run. See `StormRun`. */
+  onRetry: () => void;
+}) {
+  const { sessions, saveSession, notify } = useHub();
+  const { finish } = useRace();
+  const navigate = useNavigate();
+
+  /**
+   * This attempt's wave, and the config the run will be filed under.
+   *
+   * Built once per mount and never rebuilt: a run's wave is fixed for its
+   * whole life (`StormState.wave`), and the config is its length and its
+   * lesson, both of which are decided before the first letter falls.
+   */
+  const [wave] = useState(() => buildWave(PREVIEW_SPEC, PREVIEW_SEED));
+  const config = useMemo(() => stormConfig(PREVIEW_LESSON_ID, wave), [wave]);
+  const { state, skyRef } = useStormClock(wave);
+
+  // Snapshotted at mount so the run we're about to save can't affect it.
+  const [history] = useState(() => sessionsFor(sessions, profile.id));
+
+  const { saveError, complete, retry } = useRaceFinish({
+    profile,
+    config,
+    seed: wave.seed,
+    ghost: null,
+    history,
+    previousBest: null,
+    // Read at save time, off the frame that ended the run — which is the
+    // frame this render is of, because `useStormClock` publishes an ending
+    // and the effect below fires on it.
+    readTally: () => stormTally(state),
+    saveSession,
+    finish,
+    notify,
+    navigate,
+    resultsPath: `/p/${profile.id}/storm`,
+    // Nothing to disarm. The gun dies with the run inside `useStormClock` and
+    // the field is frozen where the clock stopped, so there is no phase a
+    // saving storm is in that it is not in already.
+    onSaving: () => {},
+  });
+
+  /**
+   * Save the run, once, on the frame it ends.
+   *
+   * Through a ref for the reason `TypingTrack` uses one: `complete` is a fresh
+   * closure on every render, so naming it as a dependency would re-run this on
+   * every re-render — and the ending screen re-renders whenever the hub's
+   * sessions change, which the save itself does. The dependency is
+   * `state.ending`, which the reducer replaces exactly once per run and then
+   * leaves alone, so this fires on the ending frame and on no other.
+   *
+   * `complete` refuses a second call for the life of this component anyway;
+   * across attempts, a retry is a new component (`StormRun`).
+   */
+  const completeRef = useRef<() => Promise<void>>(async () => {});
+  completeRef.current = complete;
+
+  useEffect(() => {
+    if (state.ending === null) return;
+    void completeRef.current();
+  }, [state.ending]);
+
+  // The same screen a race shows, and for the same reason: the run is over,
+  // the answers are still in memory, and nothing is lost until the player
+  // leaves. It stands in for the whole field rather than beside it, because a
+  // storm that could not be written down is not a storm to go on looking at.
+  if (saveError)
+    return (
+      <SaveFailed
+        message={saveError}
+        onRetry={retry}
+        onDiscard={() => navigate(`/p/${profile.id}`)}
+      />
+    );
 
   return (
     <StormField
@@ -118,7 +263,7 @@ export default function StormRun() {
           state={state}
           mode={PREVIEW_MODE}
           profileId={profile.id}
-          onRetry={() => setWave(buildWave(PREVIEW_SPEC, PREVIEW_SEED))}
+          onRetry={onRetry}
         />
       }
     />

--- a/src/games/typing/storm/stormSession.test.ts
+++ b/src/games/typing/storm/stormSession.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it } from "vitest";
 import { buildDrill, configKey, deckSpec, modeOf } from "@/engine/decks";
 import { keyX, strokeFor } from "@/engine/keyboard";
 import { stormXp } from "@/engine/progress";
-import { troubleFacts } from "@/engine/records";
+import {
+  bestRun,
+  compareRuns,
+  ghostsFor,
+  raceTimeMs,
+  troubleFacts,
+} from "@/engine/records";
 import { summariseRun } from "@/engine/run";
 import { lessonById } from "@/engine/typing/lessons";
 import { fire, startStorm, stormReport, tick } from "@/engine/typing/storm";
@@ -251,6 +257,10 @@ describe("what a storm files itself as", () => {
       kind: "typing",
       levelId: LESSON,
       lessonId: LESSON,
+      // The one field a `lessonConfig` at this rung does not write, and the
+      // whole of what keeps the run out of the record book's ranking — see
+      // "a storm holds no record" below.
+      storm: true,
       wordCount: 12,
     });
     // The rung itself still says 0 — a storm level's `wordCount` is its wave's
@@ -265,6 +275,106 @@ describe("what a storm files itself as", () => {
       "Lesson 39 · Hailstorm · Shift under fire",
     );
     expect(deckSpec(MODE).world).toBe("ice");
+  });
+});
+
+describe("a storm holds no record", () => {
+  /**
+   * **Decision 50, as the record book actually reaches it.**
+   *
+   * `previousBest: null` on the playing screen buys one thing: this run's own
+   * `personalRecord` flag and the 150 XP behind it. Every OTHER best on the
+   * site — the record book's "your best" column, the house best beside it, the
+   * `previousBest` a lesson's results screen is handed, and every rival a
+   * setup screen offers — is `bestRun`, which groups runs by `configKey` and
+   * picks with `compareRuns`, i.e. on time. A storm ends when the shield does,
+   * so on that rule the child who died first wins.
+   *
+   * These are the reviewer's two runs, played by the reducer rather than
+   * hand-built: one twelve-letter wave cleared, and the same wave with nothing
+   * pressed at all. Both file under `typing|L39|12`, which is the point of the
+   * key (§5.4) and therefore also the trap.
+   */
+  const WAVE = Array.from({ length: 12 }, (_, i) => at("f", i * 100, 3000));
+
+  /** Every letter shot 200ms before it would have landed. */
+  const cleared: Session = (() => {
+    let state = fire(tick(runOf(WAVE), 2800), "KeyF");
+    for (let i = 1; i < WAVE.length; i++)
+      state = fire(tick(state, 100), "KeyF");
+    return { ...asSaved(state), id: "cleared" };
+  })();
+
+  /** Nothing pressed: the shield takes three, and the fourth ends the run. */
+  const died: Session = {
+    ...asSaved(tick(runOf(WAVE), 60_000)),
+    id: "died",
+  };
+
+  /**
+   * A lesson run at the identical key — STM10's trap, dry-run.
+   *
+   * Once lesson 39 carries a `WaveSpec`, `lessonKey(lesson)` is
+   * `typing|L39|12`: the exact string `stormConfig` already writes, because
+   * `storm` is inert in `configKey` and must stay so. `TypingSetup`'s brief and
+   * its rival list then read this run and the two storms as one group. It is
+   * SLOWER than either storm and still has to be the best of the three, which
+   * it can only be if the other two are refused.
+   */
+  const lessonRun: Session = {
+    ...died,
+    id: "lesson",
+    config: {
+      kind: "typing",
+      levelId: LESSON,
+      lessonId: LESSON,
+      wordCount: WAVE.length,
+    },
+    durationMs: 40_000,
+    correct: 12,
+    incorrect: 0,
+  };
+
+  it("would lose its own wave to the run that died, if it were ranked", () => {
+    // The premise, and the only reason any of this is needed. Asserted so the
+    // guards below cannot pass because the two runs happen to tie or because
+    // the wrong-answer penalty happens to cover the difference.
+    expect(cleared.cards).toHaveLength(12);
+    expect(died.cards).toHaveLength(4);
+    expect(cleared.configKey).toBe(died.configKey);
+    expect(cleared.configKey).toBe("typing|L39|12");
+    // Twelve letters, 2.8s in the air each, and nothing through.
+    expect(raceTimeMs(cleared)).toBe(33_600);
+    // Four letters through: 3s each in the air, and 3s of penalty apiece.
+    expect(raceTimeMs(died)).toBe(24_000);
+    expect(compareRuns(died, cleared)).toBeLessThan(0);
+  });
+
+  it("is refused a best, so the run that died holds nothing", () => {
+    expect(bestRun([cleared, died])).toBeNull();
+    expect(bestRun([died, cleared])).toBeNull();
+    expect(bestRun([died])).toBeNull();
+  });
+
+  it("is offered as nobody's ghost", () => {
+    expect(ghostsFor([cleared, died], [PLAYER], died.configKey, PLAYER.id)) //
+      .toEqual([]);
+  });
+
+  it("never takes a best off the lesson it shares a key with", () => {
+    expect(configKey(lessonRun.config)).toBe(died.configKey);
+    // Slower than the storm that died AND slower than the one that cleared.
+    expect(raceTimeMs(lessonRun)).toBeGreaterThan(raceTimeMs(cleared));
+
+    expect(bestRun([cleared, died, lessonRun])?.id).toBe("lesson");
+    expect(
+      ghostsFor(
+        [cleared, died, lessonRun],
+        [PLAYER],
+        died.configKey,
+        PLAYER.id,
+      ).map((ghost) => ghost.session.id),
+    ).toEqual(["lesson"]);
   });
 });
 
@@ -421,9 +531,12 @@ describe("nothing downstream needs a line of new code", () => {
     expect(summary.draft.seed).toBe(353);
     expect(summary.draft.ghostSessionId).toBeNull();
     expect(summary.draft.beatGhost).toBeNull();
-    // A storm is never a personal best (decision 50): `previousBest` is null,
-    // so a run that ended at letter three can never be ranked above one that
-    // cleared the wave on the strength of having taken less time.
+    // `previousBest` is null, so this run's own results can never call
+    // themselves a personal record or pay the 150 XP for one (decision 50).
+    // That is ALL it decides — it is a fact about this summary and about
+    // nothing else in storage. What keeps a run that died early from taking
+    // a record off one that cleared the wave is `config.storm`, which the
+    // block below is about.
     expect(summary.personalRecord).toBe(false);
   });
 

--- a/src/games/typing/storm/stormSession.test.ts
+++ b/src/games/typing/storm/stormSession.test.ts
@@ -1,0 +1,477 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDrill, configKey, deckSpec, modeOf } from "@/engine/decks";
+import { keyX, strokeFor } from "@/engine/keyboard";
+import { stormXp } from "@/engine/progress";
+import { troubleFacts } from "@/engine/records";
+import { summariseRun } from "@/engine/run";
+import { lessonById } from "@/engine/typing/lessons";
+import { fire, startStorm, stormReport, tick } from "@/engine/typing/storm";
+import { verdictFor } from "@/engine/typing/verdict";
+
+import { stormCards, stormConfig, stormTally } from "./stormSession";
+
+import type { StormLetter, StormState, WaveSpec } from "@/engine/typing/storm";
+import type { Profile, Session } from "@/engine/types";
+
+/**
+ * A storm, as a `Session` (docs/typing.md §8.7, decision 23).
+ *
+ * What is on trial here is the MAPPING, because the run itself is already
+ * decided: `storm.test.ts` proves what was shot, what got through and on what
+ * streak, and this file asks only whether the record book is told the truth
+ * about it. Four of its claims are acceptance criteria in their own right —
+ * a letter is a `CardResult`, a run that ends early saves honestly, `configKey`
+ * keys on the lesson rather than on how far a child got, and nothing
+ * downstream needs a line of new code.
+ */
+
+const LESSON = "L39";
+const MODE = modeOf({
+  kind: "typing",
+  levelId: LESSON,
+  lessonId: LESSON,
+  wordCount: 1,
+});
+
+/** One letter, placed by hand, off the same board the game is played on. */
+const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
+  const stroke = strokeFor(ch);
+  if (!stroke || stroke.finger === "thumb")
+    throw new Error(`${ch} cannot fall`);
+  return {
+    ch,
+    code: stroke.code,
+    finger: stroke.finger,
+    lane: keyX(stroke.code) ?? 0,
+    spawnMs,
+    fallMs,
+    landMs: spawnMs + fallMs,
+  };
+};
+
+const runOf = (letters: StormLetter[], over: Partial<WaveSpec> = {}) =>
+  startStorm({
+    spec: {
+      keys: ["f", "o", "l", "j"],
+      count: letters.length,
+      gap: [100, 100],
+      fall: [1000, 1000],
+      shield: 3,
+      repairAt: 0,
+      ...over,
+    },
+    seed: 353,
+    letters,
+    durationMs: letters.reduce((last, l) => Math.max(last, l.landMs), 0),
+  });
+
+/** `n` letters of `f`, one every 100ms, each a second in the air. */
+const drumbeat = (n: number, over: Partial<WaveSpec> = {}) =>
+  runOf(
+    Array.from({ length: n }, (_, i) => at("f", i * 100, 1000)),
+    over,
+  );
+
+const PLAYER: Profile = {
+  id: "p1",
+  name: "Smoke",
+  emoji: "🐢",
+  color: "#4ade80",
+  age: 8,
+  soundOn: false,
+  xp: 0,
+  badges: [],
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+/** The run as `useRaceFinish` would hand it to the session service. */
+const draftOf = (state: StormState, history: Session[] = []) =>
+  summariseRun({
+    profile: PLAYER,
+    config: stormConfig(LESSON, state.wave),
+    seed: state.wave.seed,
+    ghost: null,
+    history,
+    previousBest: null,
+    tally: stormTally(state),
+  });
+
+/** A draft, given the id and time the session service would give it. */
+const asSaved = (state: StormState): Session => ({
+  ...draftOf(state).draft,
+  id: "s1",
+  finishedAt: "2026-08-19T10:00:00.000Z",
+});
+
+describe("a falling letter is a CardResult", () => {
+  it("is its own character, and what was pressed at it", () => {
+    // Shot 300ms into a one-second fall.
+    const shot = fire(tick(runOf([at("f", 0, 1000)]), 300), "KeyF");
+    const [card] = stormCards(shot);
+
+    expect(card).toEqual({
+      prompt: "f",
+      answer: "f",
+      given: "f",
+      ok: true,
+      ms: 300,
+      factId: "f",
+    });
+    // A letter that was hit is not a timeout, and carries no such field at all
+    // — `toEqual` above would pass on an explicit `undefined`.
+    expect("timedOut" in card).toBe(false);
+  });
+
+  it("is a timeout with nothing pressed at it when it gets through", () => {
+    const through = tick(runOf([at("f", 0, 1000)]), 60_000);
+    const [card] = stormCards(through);
+
+    expect(card).toEqual({
+      prompt: "f",
+      answer: "f",
+      given: null,
+      ok: false,
+      // The fall, not the sixty seconds the tick was handed.
+      ms: 1000,
+      factId: "f",
+      // The clock a falling letter runs out is its own fall (§8.7), which is
+      // what puts it above a wrong answer in `troubleFacts`.
+      timedOut: true,
+    });
+  });
+
+  it("times the fall, not the tick that noticed it", () => {
+    // A backgrounded tab hands back seconds, and `tick` resolves every landing
+    // inside the interval it is given (decision 35). A card timed off the
+    // clock would put nine seconds in a child's record book for a letter that
+    // was in the air for one.
+    const stalled = tick(runOf([at("f", 0, 1000)]), 9_000);
+    expect(stalled.timeMs).toBe(9_000);
+    expect(stormCards(stalled)[0].ms).toBe(1000);
+  });
+
+  it("counts what `resolved` says, and never what `hasLanded` does", () => {
+    // The letter at index 2 lands on the same millisecond as the one that
+    // breaches, so the clock reads it as landed while the run ended before it.
+    // Counting the clock would put a card in the record book for a letter this
+    // child never faced.
+    const state = tick(
+      runOf([at("f", 0, 1000), at("f", 0, 2000), at("f", 0, 2000)], {
+        shield: 1,
+      }),
+      60_000,
+    );
+
+    expect(state.ending).toEqual({
+      kind: "breached",
+      finger: "l-index",
+      index: 1,
+    });
+    expect(state.timeMs).toBe(2000);
+    expect(state.resolved[2]).toBeNull();
+    expect(stormCards(state)).toHaveLength(2);
+  });
+});
+
+describe("a run that ends early", () => {
+  /**
+   * §8.7's own example: dying at letter 18 of 40 saves a session with 18
+   * cards, `correct`, `incorrect` and `durationMs` all honest, and the
+   * `survive` criterion simply not met.
+   *
+   * Four shot at the front, then thirteen landings empty the zone and the
+   * fourteenth is the one nothing was left to stop.
+   */
+  const died = (() => {
+    let state = drumbeat(40, { shield: 13 });
+    for (let i = 0; i < 4; i++) state = fire(tick(state, 100), "KeyF");
+    return tick(state, 60_000);
+  })();
+
+  it("saves the letters it faced and no more", () => {
+    expect(died.ending).toMatchObject({ kind: "breached", index: 17 });
+    expect(stormCards(died)).toHaveLength(18);
+  });
+
+  it("is honest about all four numbers", () => {
+    const { draft } = draftOf(died);
+
+    expect(draft.cards).toHaveLength(18);
+    expect(draft.correct).toBe(4);
+    expect(draft.incorrect).toBe(14);
+    // Four shots a tenth of a second in, and fourteen full falls.
+    expect(draft.durationMs).toBe(4 * 100 + 14 * 1000);
+  });
+
+  it("does not pass the lesson it did not survive", () => {
+    const lesson = lessonById(LESSON);
+    if (!lesson) throw new Error("lesson 39 is missing");
+
+    const verdict = verdictFor(asSaved(died), lesson);
+    expect(lesson.pass.kind).toBe("storm");
+    expect(verdict.passed).toBe(false);
+  });
+
+  it("passes the same lesson on a wave it cleared", () => {
+    const lesson = lessonById(LESSON);
+    if (!lesson) throw new Error("lesson 39 is missing");
+
+    // Every letter shot, so the wave is cleared and the accuracy bar is full.
+    let state = drumbeat(6);
+    for (let i = 0; i < 6; i++) state = fire(tick(state, 100), "KeyF");
+
+    expect(state.ending).toEqual({ kind: "cleared" });
+    expect(verdictFor(asSaved(state), lesson).passed).toBe(true);
+  });
+});
+
+describe("what a storm files itself as", () => {
+  it("keys on the lesson, not on how many letters were survived", () => {
+    // The acceptance criterion, as two runs of one wave: a child who cleared
+    // it and a child who died at letter four have to land in the same bucket,
+    // or a retry could never be compared with the run it is a retry of.
+    let cleared = drumbeat(6);
+    for (let i = 0; i < 6; i++) cleared = fire(tick(cleared, 100), "KeyF");
+    const died = tick(drumbeat(6, { shield: 3 }), 60_000);
+
+    expect(stormCards(cleared)).toHaveLength(6);
+    expect(stormCards(died)).toHaveLength(4);
+
+    const key = configKey(stormConfig(LESSON, cleared.wave));
+    expect(key).toBe(configKey(stormConfig(LESSON, died.wave)));
+    // The wave's own length, and the lesson's id. Neither moves with the run.
+    expect(key).toBe("typing|L39|6");
+  });
+
+  it("carries the wave's length rather than the ladder's placeholder", () => {
+    const config = stormConfig(LESSON, drumbeat(12).wave);
+
+    expect(config).toEqual({
+      kind: "typing",
+      levelId: LESSON,
+      lessonId: LESSON,
+      wordCount: 12,
+    });
+    // The rung itself still says 0 — a storm level's `wordCount` is its wave's
+    // `count` (§8.3) and the twenty `WaveSpec`s land in STM10 — so the wave in
+    // hand is the only honest place to read a run's length from today.
+    expect(lessonById(LESSON)?.wordCount).toBe(0);
+  });
+
+  it("names itself in a record book years later", () => {
+    expect(modeOf(stormConfig(LESSON, drumbeat(3).wave))).toBe("typing:L39");
+    expect(deckSpec(MODE).label).toBe(
+      "Lesson 39 · Hailstorm · Shift under fire",
+    );
+    expect(deckSpec(MODE).world).toBe("ice");
+  });
+});
+
+describe("what `incorrect` counts", () => {
+  /**
+   * **Letters that got through, and not keys that missed** (decision 48).
+   *
+   * A wrong key resolves no letter, so it is not a card — the same bargain
+   * decision 13 struck for the lessons, where a keystroke backspaced away
+   * costs nothing because what ended up on the line is right. Two things hang
+   * on it, and both would break if a miss were given a card of its own:
+   * `survived` is `cards.length >= wordCount`, so a run that died at letter
+   * three and sprayed forty wrong keys would read as having faced the whole
+   * wave; and the `unbroken` badge reads "nothing marked wrong" as "nothing
+   * got through", which is the sentence its own description makes.
+   */
+  it("is not moved by a wrong key", () => {
+    let state = drumbeat(3);
+    // Three hits, with two wrong keys in the middle of them. `j` is on the
+    // board and on no letter in this wave.
+    state = fire(tick(state, 100), "KeyF");
+    state = fire(state, "KeyJ");
+    state = fire(state, "KeyJ");
+    state = fire(tick(state, 100), "KeyF");
+    state = fire(tick(state, 100), "KeyF");
+
+    expect(state.misses).toBe(2);
+    expect(state.ending).toEqual({ kind: "cleared" });
+
+    const { draft } = draftOf(state);
+    expect(draft.cards).toHaveLength(3);
+    expect(draft.correct).toBe(3);
+    expect(draft.incorrect).toBe(0);
+  });
+
+  it("is exactly what the ending screen calls got through", () => {
+    // `stormReport.through` is the number the panel says out loud, and "the
+    // shield came through untouched" is that number being zero (§8.5). So a
+    // saved run's `incorrect` and the sentence a child just read are the same
+    // fact, which is what keeps the `unbroken` badge's promise honest.
+    const runs = [
+      tick(drumbeat(6, { shield: 3 }), 60_000),
+      tick(drumbeat(3), 60_000),
+      // Every letter shot, so nothing got through and nothing is marked wrong.
+      ["KeyF", "KeyF"].reduce(
+        (state) => fire(tick(state, 100), "KeyF"),
+        drumbeat(2),
+      ),
+    ];
+
+    for (const state of runs) {
+      const report = stormReport(state);
+      if (!report) throw new Error("a finished run has a report");
+      expect(draftOf(state).draft.incorrect).toBe(report.through);
+    }
+  });
+
+  it("keeps a wrong key's cost in the streak it broke", () => {
+    // Nothing about a miss is thrown away: the combo it cost is a combo
+    // `bestStreak` never sees, which is how a saved run remembers it.
+    let clean = drumbeat(4);
+    for (let i = 0; i < 4; i++) clean = fire(tick(clean, 100), "KeyF");
+
+    let broken = drumbeat(4);
+    broken = fire(tick(broken, 100), "KeyF");
+    broken = fire(tick(broken, 100), "KeyF");
+    broken = fire(broken, "KeyJ");
+    broken = fire(tick(broken, 100), "KeyF");
+    broken = fire(tick(broken, 100), "KeyF");
+
+    expect(stormTally(clean).bestStreak).toBe(4);
+    expect(stormTally(broken).bestStreak).toBe(2);
+    expect(draftOf(broken).draft.bestStreak).toBe(2);
+  });
+});
+
+describe("the `unbroken` badge, over a wave the reducer really played", () => {
+  /**
+   * "Clear a Hailstorm wave with the shield untouched" is read in
+   * `progress.ts` as `incorrect === 0`, and the mapping above is what decides
+   * which of two badges that sentence describes. Counting wrong keys into
+   * `incorrect` would have re-tuned it from **untouched shield** to
+   * **flawless run** — a behaviour change invisible in a diff that never
+   * touches `progress.ts`. These two pin the meaning that shipped.
+   *
+   * The rung's own `wordCount` is lent for the length of the test, exactly as
+   * `progress.test.ts` does: the badge is guarded on the wave having a length
+   * (decision 29) and the twenty `WaveSpec`s land in STM10, so nothing can
+   * earn it today.
+   */
+  const withWave = (count: number, body: () => void) => {
+    const of = lessonById(LESSON);
+    if (!of) throw new Error("lesson 39 is missing");
+    const was = of.wordCount;
+    of.wordCount = count;
+    try {
+      body();
+    } finally {
+      of.wordCount = was;
+    }
+  };
+
+  /** Ten letters, all shot, with three wrong keys scattered through them. */
+  const sprayed = (() => {
+    let state = drumbeat(10);
+    for (let i = 0; i < 10; i++) {
+      state = fire(tick(state, 100), "KeyF");
+      if (i % 4 === 0) state = fire(state, "KeyJ");
+    }
+    return state;
+  })();
+
+  /** The same ten with the first one let through, and the rest shot. */
+  const holed = (() => {
+    let state = tick(drumbeat(10), 1000);
+    for (let i = 1; i < 10; i++) state = fire(state, "KeyF");
+    return state;
+  })();
+
+  it("is earned by a run full of wrong keys that let nothing through", () => {
+    expect(sprayed.misses).toBe(3);
+    expect(sprayed.ending).toEqual({ kind: "cleared" });
+    expect(draftOf(sprayed).draft.incorrect).toBe(0);
+
+    withWave(10, () => {
+      expect(draftOf(sprayed).earnedBadges).toContain("unbroken");
+    });
+  });
+
+  it("is refused by a clean run that let one letter through", () => {
+    // Nine of ten is exactly the storm accuracy bar, so this run passes the
+    // lesson and is refused the badge on the letter alone — which is the half
+    // of the rule the mapping decides.
+    expect(holed.ending).toEqual({ kind: "cleared" });
+    expect(draftOf(holed).draft.incorrect).toBe(1);
+
+    withWave(10, () => {
+      const lesson = lessonById(LESSON);
+      if (!lesson) throw new Error("lesson 39 is missing");
+      expect(verdictFor(asSaved(holed), lesson).passed).toBe(true);
+      expect(draftOf(holed).earnedBadges).not.toContain("unbroken");
+    });
+  });
+});
+
+describe("nothing downstream needs a line of new code", () => {
+  it("scores through `summariseRun` like any other run", () => {
+    let state = drumbeat(5);
+    for (let i = 0; i < 5; i++) state = fire(tick(state, 100), "KeyF");
+
+    const summary = draftOf(state);
+    expect(summary.draft.mode).toBe("typing:L39");
+    expect(summary.draft.configKey).toBe("typing|L39|5");
+    expect(summary.draft.seed).toBe(353);
+    expect(summary.draft.ghostSessionId).toBeNull();
+    expect(summary.draft.beatGhost).toBeNull();
+    // A storm is never a personal best (decision 50): `previousBest` is null,
+    // so a run that ended at letter three can never be ranked above one that
+    // cleared the wave on the strength of having taken less time.
+    expect(summary.personalRecord).toBe(false);
+  });
+
+  it("pays the run's own XP, plus whatever a flawless run is worth", () => {
+    let state = drumbeat(5);
+    for (let i = 0; i < 5; i++) state = fire(tick(state, 100), "KeyF");
+
+    const summary = draftOf(state);
+    const bonus = summary.bonuses.reduce((sum, b) => sum + b.xp, 0);
+
+    expect(stormXp(state)).toBeGreaterThan(0);
+    expect(summary.draft.xpEarned).toBe(stormXp(state) + bonus);
+    // The one bonus a storm can reach, and only by letting nothing through.
+    expect(summary.bonuses.map((b) => b.label)).toEqual(["No mistakes"]);
+  });
+
+  it("earns badges through the evaluator every race goes through", () => {
+    let state = drumbeat(5);
+    for (let i = 0; i < 5; i++) state = fire(tick(state, 100), "KeyF");
+
+    expect(draftOf(state).earnedBadges).toContain("green-light");
+    expect(draftOf(state).earnedBadges).toContain("clean-sheet");
+  });
+
+  it("feeds the drill builder one trouble spot per character", () => {
+    // The letters that got through, ranked worst-first and handed to the same
+    // front door the record book's drill button uses. A fact id in a typing
+    // deck is a character, so the drill comes back as a passage of the keys a
+    // child keeps losing letters on.
+    const state = tick(
+      runOf([at("o", 0, 1000), at("l", 100, 1000), at("f", 200, 1000)]),
+      60_000,
+    );
+    const trouble = troubleFacts([asSaved(state)], MODE);
+
+    expect(trouble.map((fact) => fact.factId).sort()).toEqual(["f", "l", "o"]);
+    expect(trouble.every((fact) => fact.timeouts === 1)).toBe(true);
+
+    const drill = buildDrill(
+      trouble.map((fact) => fact.factId),
+      MODE,
+      { inputMode: "type", timeLimitMs: null },
+    );
+    expect(drill.kind).toBe("typing");
+    expect(drill.kind === "typing" && drill.words?.sort()).toEqual([
+      "f",
+      "l",
+      "o",
+    ]);
+  });
+});

--- a/src/games/typing/storm/stormSession.ts
+++ b/src/games/typing/storm/stormSession.ts
@@ -1,0 +1,149 @@
+import { stormXp } from "@/engine/progress";
+import { bestCombo } from "@/engine/typing/storm";
+
+import type { RunTally } from "@/engine/run";
+import type { StormState, Wave } from "@/engine/typing/storm";
+import type { CardResult, TypingConfig } from "@/engine/types";
+
+/**
+ * A storm, as the record book holds it (docs/typing.md §8.7, decision 23).
+ *
+ * A falling letter maps onto a `CardResult` with nothing forced — `prompt` and
+ * `answer` are the character, `given` is what was pressed, `ms` is how long it
+ * was in the air, `factId` is the character — so a Hailstorm run **is** a
+ * `Session`, filed under `typing:L39` exactly as the lesson at that rung is.
+ * Everything downstream then works with no new code at all: the record book
+ * lists it, `sessionService.record` pays its XP into the profile, the badge
+ * evaluator asks it the same questions it asks a race, and `troubleFacts`
+ * ranks its characters for the drill builder.
+ *
+ * ── Here rather than in the engine ───────────────────────────────────────────
+ * Beside the screen that plays a storm, exactly as `lessonRun.ts` sits beside
+ * the screen that runs a lesson, and for the same two reasons. It needs
+ * `stormXp`, which lives in `progress.ts`, which imports `decks/index.ts` —
+ * and `storm.ts` is deliberately kept a hop clear of the deck layer, because
+ * STM10 puts a `WaveSpec` on each storm lesson and `lessons.ts` is reachable
+ * from `decks/index.ts` (§5.3, decision 7). And what a run of a lesson is
+ * filed as is the island's answer to give: the engine is handed a config, it
+ * does not compose one.
+ *
+ * Every function here is pure and takes a finished — or unfinished — run, so
+ * `stormSession.test.ts` can ask all of it without a browser.
+ */
+
+/**
+ * The config a storm run files itself under.
+ *
+ * `lessonId` is the identity of the run and the one field `modeOf` and
+ * `configKey` prefer (§5.4), so a storm is `typing:L39` and keys as
+ * `typing|L39|12`. `levelId` carries the same id for the same reason
+ * `lessonConfig` does: both fields are read through `lessonId` on a ladder run,
+ * and putting anything else in the level would only invite a screen to read it.
+ *
+ * **`wordCount` is the WAVE's length, never the letters that were faced.**
+ * That is the whole of the acceptance criterion about ghosts: `configKey` has
+ * to key on the lesson so that retries of a level compare with each other, and
+ * a count that moved with how far a child got would file every attempt in a
+ * bucket of one — the same failure §5.4 keeps a lesson's generated passage out
+ * of the key to avoid. It is also what `survived` reads back off a saved run
+ * (`verdict.ts`): "you faced every letter the wave had" is `cards.length >=
+ * wordCount`, which only means anything if the second number is the wave's.
+ *
+ * A storm lesson's own `wordCount` is that same figure (§8.3) but is `0` on
+ * every row until STM10 writes the `WaveSpec`s, so the wave in hand is the
+ * only place the length can honestly be read from today.
+ */
+export function stormConfig(lessonId: string, wave: Wave): TypingConfig {
+  return {
+    kind: "typing",
+    levelId: lessonId,
+    lessonId,
+    wordCount: wave.spec.count,
+  };
+}
+
+/**
+ * The run's letters, as cards — one per letter that was resolved, in wave
+ * order.
+ *
+ * ── `resolved`, and never `hasLanded` ────────────────────────────────────────
+ * The list is walked over `state.resolved` because that is the only honest
+ * account of what a run faced. After a breach the clock stops at the fatal
+ * `landMs` rather than at the end of the tick that found it, so a letter from a
+ * higher index tying that exact millisecond is left unresolved while
+ * `hasLanded(letter, state.timeMs)` reads true of it (`tick`). Counting the
+ * clock would put a card in a child's record book for a letter the run ended
+ * before — the same over-count `zoneTally` refuses on the ending screen.
+ *
+ * ── A card per letter, and not per keystroke ─────────────────────────────────
+ * A wrong key resolves no letter, so it is not a card. That is decision 13's
+ * bargain — per-key stats come from cards and not from keystrokes — kept for
+ * the storm, and it is what makes `cards.length` mean "letters faced" for
+ * `survived`. What a wrong key cost is still in the saved run: it broke the
+ * streak, and `bestStreak` is the longest one that survived (`stormTally`).
+ *
+ * ── The four fields, and why each is what it is ──────────────────────────────
+ *   - `prompt`, `answer`, `factId` — the character. One character is one fact,
+ *     so `troubleFacts` ranks per key and the drill `buildDrill` returns is a
+ *     passage of exactly the keys a child keeps losing letters on.
+ *   - `given` — the character for a letter that was shot, and `null` for one
+ *     that got through, because nothing was pressed at it. `fire` compares
+ *     `code` alone (decision 2), so a capital shot without the shift held
+ *     still records the character its key was struck for.
+ *   - `ms` — `atMs - spawnMs`: how long the letter was in the air. `atMs` is
+ *     the letter's own moment (`LetterOutcome`) — the press for a letter that
+ *     was shot and its own `landMs` for one that landed — never the tick that
+ *     noticed it, so a run played through a stalled frame is timed by the fall
+ *     rather than by the stall.
+ *   - `timedOut` — set on a letter that reached the shield. It is what the
+ *     flag has always meant: the clock ran out before an answer arrived, and
+ *     the clock here is the fall. `troubleFacts` weights a timeout above a
+ *     wrong answer, which is the right order for a key whose letter a child
+ *     never touched at all. It cannot reach `beat-the-clock`, whose gate is a
+ *     `timeLimitMs` that a typing config never carries.
+ */
+export function stormCards(state: StormState): CardResult[] {
+  const cards: CardResult[] = [];
+
+  state.resolved.forEach((outcome, index) => {
+    if (outcome === null) return;
+    const letter = state.wave.letters[index];
+    const shot = outcome.outcome === "shot";
+    cards.push({
+      prompt: letter.ch,
+      answer: letter.ch,
+      given: shot ? letter.ch : null,
+      ok: shot,
+      ms: outcome.atMs - letter.spawnMs,
+      factId: letter.ch,
+      ...(shot ? {} : { timedOut: true }),
+    });
+  });
+
+  return cards;
+}
+
+/**
+ * What the run was worth, in the shape `summariseRun` scores every run on.
+ *
+ * `cardXp` is `stormXp` — the same `cardXp(ms, streak)` a flash card is paid
+ * at, folded over the hits and floored at zero (§8.6), so a Hailstorm level
+ * and a times-table race pay into one profile on one scale. It is not
+ * accumulated here: `resolved` already says which letters were shot, when, and
+ * on what streak.
+ *
+ * `bestStreak` is `bestCombo`, which is the run's own streak and the place a
+ * wrong key's cost survives into the record book: the combo it broke is a
+ * combo the maximum never saw.
+ *
+ * `maxDeficitMs` is 0 because a storm has no ghost to fall behind. It feeds
+ * the `comeback` badge, which also wants `beatGhost`, so nothing reads it.
+ */
+export function stormTally(state: StormState): RunTally {
+  return {
+    cards: stormCards(state),
+    cardXp: stormXp(state),
+    bestStreak: bestCombo(state),
+    maxDeficitMs: 0,
+  };
+}

--- a/src/games/typing/storm/stormSession.ts
+++ b/src/games/typing/storm/stormSession.ts
@@ -52,12 +52,22 @@ import type { CardResult, TypingConfig } from "@/engine/types";
  * A storm lesson's own `wordCount` is that same figure (§8.3) but is `0` on
  * every row until STM10 writes the `WaveSpec`s, so the wave in hand is the
  * only place the length can honestly be read from today.
+ *
+ * **`storm: true` is what keeps it out of the record book's ranking**
+ * (decision 50). The key above is deliberately the lesson's, so retries
+ * compare with each other — and that is exactly what makes the flag necessary:
+ * a group of runs sharing a key is what `bestRun` ranks, and it ranks on time,
+ * so without the flag the run that died first would hold the record. It is the
+ * only thing here a `lessonConfig` does not also write, and it is inert in
+ * `configKey`, so the two configs still key identically — which they must, or
+ * STM10 would orphan every storm already saved.
  */
 export function stormConfig(lessonId: string, wave: Wave): TypingConfig {
   return {
     kind: "typing",
     levelId: lessonId,
     lessonId,
+    storm: true,
     wordCount: wave.spec.count,
   };
 }


### PR DESCRIPTION
## What this is

A Hailstorm run now lands in the record book like any other run.

**A falling letter is a `CardResult`.** `prompt`, `answer` and `factId` are all the
character; `given` is the character for a letter that was shot and `null` for one
that got through; `ms` is `atMs - spawnMs`, so the time on the card is the
letter's own air time and not a slice of the wall clock. Nothing in the card loop
learns that a storm exists.

**A storm run is a `Session`**, `mode = "typing:L39"`, saved through the existing
`useRaceFinish` path — the same clock, XP, badges and record book everything else
already uses.

**A run that ends early saves honestly.** A breach at letter 3 of 12 saves 3
cards, 0 correct, 3 incorrect, 12000ms. It saves what happened, not what a
cleared wave would have looked like.

**No migration and no `DB_VERSION` bump.** The cards are already the current
shape, and `migrate.ts` passes them straight through.

## Decision 48 — cards are letters, not keystrokes

A wrong key is not a card. Only a letter is, so `incorrect === 0` is exactly
"nothing got through", and the `unbroken` badge keeps its printed meaning of an
untouched shield. Three reasons:

1. `survived` is `cards.length >= wordCount`. A card per keystroke would hand a
   pass to a run that died at letter three and sprayed its way past the count.
2. Decision 13 already refused keystrokes-as-record for the lessons; this is the
   same call in the same place.
3. `progress.test.ts`'s pre-existing Unbroken suite already encodes a
   letter-through as `card(ch, null)` — the shape was assumed before it was
   written down.

This reverses an earlier note in `storm.ts`, which was amended rather than left
to contradict the code. The amendment is comment-only: esbuild-stripping
`progress.ts` and `storm.ts` and diffing against `develop` is byte-identical.

## Decisions 49 and 51

**49** — a letter that gets through is a `timedOut` card. The clock that ran out
is its fall, and `troubleFacts` weights a timeout (3) above a mistype (2), which
is the right ordering for a letter that reached the shield.

**51** — a retry is a remount: `<StormPlay key={attempt}>`. Without it the second
attempt reuses `useRaceFinish`'s latched `finishing` ref and a stale `history`
snapshot, and the second run never saves.

## The review found a real defect, and the fix closed it

Decision 50 says a storm has no personal best, and the first cut expressed that
as `previousBest: null` at the call site — which killed the XP bonus and the
record flag and looked done. It wasn't: the Records table groups on `configKey`
and picks `bestRun` with **no mode filter**, so a died-at-three run at 21.00 beat
a cleared run at 1:24.00 and was shown as both "Your best" and House best.

The fix went **on the run, not on the screen**:

- `TypingConfig` gains an optional `storm?: true`, written only by `stormConfig`.
- `isRanked(config)` reads it in `decks/index.ts` — the only place the
  `RaceConfig` union may be narrowed.
- `records.ts`'s `bestRun` filters unranked runs out before comparing anything.

`bestRun` is the single door every "best" comes through, so the Records table,
`previousBest`, `ghostsFor` and every rival list built from it, and the hub's
flagship all inherit one rule.

**That also closes the STM10 trap.** Once #156 writes the `WaveSpec`s,
`lessonKey` becomes `typing|L39|12` — byte-identical to `stormConfig`'s key — and
a lesson run would have started colliding with storms silently. A test now pins
that a lesson run at that same key still wins both `bestRun` and `ghostsFor`.

### Alternatives rejected

- **A mode filter in `Progress.tsx`** fixes the table and leaves the trap armed
  for `previousBest`, `ghostsFor` and every screen not yet written.
- **Deriving it from `lessonById(lessonId)?.kind.type === "storm"`** breaks
  because a saved run outlives the ladder it was played on. Re-tune lesson 39 out
  of a Hailstorm and every storm already in storage silently becomes rankable
  again, with the record going to the shortest life.

## `configKey` is untouched

Verified two ways: this branch's `configkey.test.ts` copied into a fresh clone of
clean `develop` and run against the unmodified implementation (16/16), plus 600
simulated runs (5 policies x 120 seeds) confirming the key never varies with how
many letters were survived.

## Validation

`npm run type-check`, `npm run build`, scoped lint (silent), scoped unit tests
(100 files / 2098 passing) and `npm run test:smoke` (all checks passed, no
console errors) all green.

Closes #154
