### PR TITLE
STM09 · Reduced motion, and the device with no keys (#155)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1586,6 +1586,41 @@ falling. What it can and must do:
   hits on one zone re-peak a tint that is already lit rather than blinking it
   off and on, which is the safe direction for that failure to go in.
 
+  **That re-peak only holds while the previous tint is still lit, and it is lit
+  for less time than the animation is long.** `storm-hit` is 150 ms on
+  `cubic-bezier(0.16, 1, 0.3, 1)`, which is heavily front-loaded: 40% of peak
+  opacity is gone by 20 ms and 90% of it by 50 ms. So landings within ~20 ms of
+  each other re-peak, as the 15 ms measurement above found; landings 100 ms
+  apart do not — the zone has gone dark and comes back, which is a blink.
+  Between roughly 50 ms and 333 ms is therefore a band where a zone genuinely
+  flashes, and **nothing in the generator keeps a wave out of it**. What bounds
+  the risk today is only how often it can happen: WCAG 2.3.1 counts _more than
+  three flashes in any one second_, and the stand-in wave at its fixed seed
+  peaks at **two tint starts per second on any one zone**, with at most two of
+  the eight lit at once.
+
+  The obvious fix is the wrong one and it is worth writing down before somebody
+  reaches for it. **`gap` is not the lever, and there is no `MIN_GAP_MS` to
+  mirror `MIN_FALL_MS`.** A zone's tint rate is set by how often two letters
+  _land_ on one finger, and because `fall` is a range as well, two letters
+  spawned far apart land together: `storm.test.ts`'s "capitals", at `gap`
+  600–1000 ms, already lands two letters on one zone 14 ms apart. Measured on
+  "everything falls", the lesson-93 shape: flooring its `gap` at 350 ms takes
+  one zone from four tint starts a second to three, and flooring it at 800 ms —
+  which would make the top of the ladder one letter at a time and delete
+  "whiteout" — still leaves three. A floor on `gap` buys a difficulty ceiling
+  and almost no safety.
+
+  So the rule the twenty specs have to keep is **a count of tint starts per
+  zone per second**, read off the built schedule the way `fallRange` says such
+  questions must be. Which of the two ways to keep it — shaping the specs so no
+  zone lands twice inside the band, or making the tint itself rate-insensitive
+  so no spec can — is STM10's to decide, because it is the story that writes
+  the twenty rows and the one that retires the stand-in the numbers above are
+  measured on. The same question is open for `.storm__miss`, whose cadence is
+  not a wave's at all but the rate a child can press wrong keys at, and which
+  `StormState` currently records as a bare count with no times on it.
+
 - **Fall speeds are capped** at the top of the ladder. "Whiteout" at lesson 89
   should be hard because there are many letters, not because one is a blur.
 

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1016,7 +1016,10 @@ export type WaveSpec = {
   count: number;
   /** ms between spawns — sampled per letter from this range. */
   gap: [number, number];
-  /** ms for a letter to cross the field — sampled per letter. */
+  /**
+   * ms for a letter to cross the field — sampled per letter, and floored at
+   * `MIN_FALL_MS` however low the level writes it (§8.10, decision 52).
+   */
   fall: [number, number];
   /** Shield hit points per finger zone. */
   shield: number;
@@ -1412,6 +1415,50 @@ The ladder marks them clearly — a different tile, "worth playing, not
 required" — and the tile is disabled with a reason on a device with no
 keyboard, rather than failing mysteriously.
 
+**How the tile knows** (`useKeyboardPresence`, decision 53). There is no
+browser API for "a keyboard is attached", so the answer is built out of two
+signals of very different strength, and the weak one only ever decides what the
+strong one has not:
+
+- **Proof: a key arrived.** Any `keydown` carrying a `code` is a physical
+  keyboard and no media query argues with it. It latches for the life of the
+  page. The listener is bound when the ladder first mounts and comes off only
+  when it has its answer, so a child who leaves for a lesson and types four
+  hundred characters has proved the point without the ladder being on screen
+  to watch. `code` is also exactly the field the gun reads, so what counts as
+  proof is "a key the storm could have been played with" — which is why a
+  software keyboard, whose keys have no physical position to report, is not
+  mistaken for one.
+- **A guess: the pointer.** `(any-pointer: coarse) and (any-hover: none)` —
+  every input this device has is a fingertip. A desktop with a touchscreen
+  fails the second half because its mouse hovers, and that is the false
+  negative that would have mattered most.
+
+**Everything it cannot answer is a yes**: an old browser with no `matchMedia`,
+the server rendering the markup the page ships with, a pointer that says
+nothing. The two ways of being wrong are not the same size — wrongly open is a
+tile that does nothing when a child presses it, wrongly shut is a child locked
+out with no way to argue — and the way back from wrongly shut is the proof
+above. The legend says so in as many words, once, where there is room for it
+rather than on each of twenty tiles: _press any key if you have one_.
+
+User-agent sniffing is deliberately not a signal. It goes stale, it cannot see
+a keyboard plugged in after the page loaded, and it would answer "can this
+child press a key" with a fact about who made the device.
+
+Nothing is stored, either. A device is shared and a keyboard is unplugged, so a
+remembered "yes" from March is exactly the stale fact that would lock the
+honest answer out; re-proving it costs one keystroke and a child at a keyboard
+makes hundreds.
+
+**And the route is not gated by any of it.** A wrong guess costs a child a
+tile, never the game — `#/p/:id/storm` opens and plays whatever the guess was,
+with the way out drawn on it (§8.11). Measured in a browser (`e2e/smoke.mjs`
+§13): on a touch-only context all twenty storm tiles are `aria-disabled` and
+name the keyboard, the other eighty rungs are untouched, the storm route still
+opens, and one keystroke flips every tile back with nothing reloaded and the
+pointer still reporting a tablet.
+
 ### 8.9 · DOM, not canvas
 
 Ten falling letters, a shield and a keyboard, at 60fps, in DOM elements with
@@ -1487,7 +1534,36 @@ A falling-letter game cannot honour `prefers-reduced-motion` by removing the
 falling. What it can and must do:
 
 - **No screen shake, no parallax, no particles** under reduced motion. Those
-  are decoration and they come off.
+  are decoration and they come off — and the honest report is that this screen
+  never grew any of the three. Nothing translates but the stones, the sky is
+  one flat box rather than layers at different speeds, and the only thing here
+  resembling a particle is a hailstone, which is the game. So the guarantee is
+  kept by not having built them, and it is checked as what it looks like:
+  `e2e/smoke.mjs` reads the computed transform of the field, the sky and the
+  shield under the setting and finds `none` on all three while the stone
+  carries a `matrix`, which is the fall.
+
+  **The fall stays, and stays at frame rate.** That is why it was never written
+  as an animation: the loop writes `--drop` onto each stone and the stylesheet
+  multiplies it by the height of the sky, so base.css's blanket clamp — every
+  animation and transition to one 0.001ms pass — has none of the storm's motion
+  to reach. Measured under the setting: 24 distinct positions in 24 readings
+  over 600ms, monotonically down, and a whole fall still takes the 4000ms its
+  wave asked for.
+
+  What the setting does take off is the three tints, and they are switched off
+  rather than left to the clamp — `animation: none` on `.storm__hit`,
+  `.storm__mend` and `.storm__miss`. The difference between those two is one
+  `animationstart` per event, because a clamped animation still starts.
+  Measured both ways on the same wave: with the tints left to the clamp, twelve
+  landings fire twelve `animationstart` events at a duration of 1e-06s; with
+  `animation: none` they fire **zero**, which is the number the smoke suite
+  holds it to. Nothing is lost by it. Both damage tints rest at `opacity: 0`
+  and animate DOWN to it, so what a child who asked for less motion still gets
+  is the block's own height — the damage itself rather than a report of it —
+  and a score that has already fallen. The same run still empties three zones
+  and draws all three as holes.
+
 - **No strobe, ever, in any mode.** Damage is one 150 ms tint, not a flash
   sequence. A hail of red flashes at 60fps is a photosensitivity risk and this
   site's youngest player is five.
@@ -1512,6 +1588,77 @@ falling. What it can and must do:
 
 - **Fall speeds are capped** at the top of the ladder. "Whiteout" at lesson 89
   should be hard because there are many letters, not because one is a blur.
+
+  The cap is `MIN_FALL_MS` in `buildWave`, and it is there rather than in the
+  levels because the twenty `WaveSpec`s are a table and a table gets tightened
+  one row at a time until a level nobody can read ships (decision 52). 800ms is
+  a judgement rather than a measured reaction time, and it is anchored to this
+  epic's own level shapes: the fastest fall any of them declares is 800ms, so
+  the floor is the fastest the ladder ever _means_ to be. At the 1280×1000
+  viewport the smoke suite runs at, a fall crosses 615px of sky — 154px/s at
+  the stand-in wave's four seconds, and 769px/s at the floor.
+
+  It is a backstop and not a difficulty knob: `fallRange(spec)` is the spec's
+  own range with both ends raised to the floor, so a wave written entirely
+  above it comes out byte-identical, and a spec asking for 40–200ms falls
+  produces 800ms letters at every seed. Two consequences worth writing down.
+  The range is clamped rather than each sample, because flooring samples would
+  pile a too-fast level's letters onto the floor exactly — a metronome wearing
+  a range's clothes. And the "one letter at a time" guarantee is read against
+  the effective range: a floor can only ever raise a fall, so a level that
+  declared `gap[0] >= fall[1]` with falls under the floor gets overlap. That is
+  the right way for it to go — the alternative is a level keeping its spacing
+  promise by dropping letters nobody could read.
+
+### 8.11 · The way out, mid-wave
+
+A storm is one viewport tall with `overflow: hidden` and no site chrome over it
+(CLAUDE.md), so until the run ends there is nothing on screen that leaves it.
+That is a dead end for the child §8.8 is about — the one whose device cannot
+press a key at all — and merely rude for everybody else. So the run has two
+doors, and they are two because neither reaches everyone:
+
+- **A `Quit` control in the HUD** (decision 54), between the score and the
+  multiplier. Those are the two corners already taken, and the middle of the
+  HUD is the part of the sky a child is least often reading — the letters that
+  matter are the low ones. It is the one thing in the sky that gets
+  `pointer-events` back, because the sky refuses them so that a drag cannot
+  select a hailstorm and a tap cannot land on a letter. It goes when the gun
+  does: after an ending the panel standing where the board did carries the way
+  out (§8.5), and two exits on one screen are two answers to one question.
+- **`Escape`** (decision 55), because the button cannot be tabbed to: `Tab` is
+  a key the board carries and the gun swallows it while the run is live. It is
+  taken inside the gun's own listener and **before the trigger** — every other
+  keydown while a run is live is a shot, so a way out handled by a second
+  listener beside it would still be fired at as a miss on the way past, and a
+  child reaching for the door would be charged ten points and their streak for
+  reaching. `Escape` is the key to spend on it precisely because the board does
+  not carry it: `keyX` says so, which is also what keeps it out of the
+  `preventDefault` and out of every letter a wave can draw.
+
+Both open the same sheet — the race's `QuitSheet`, with three words changed —
+and **the sheet is the storm's pause**. `useStormClock` takes it as `paused`
+and tears the effect down: no frame is requested, so no wave time passes, and
+no listener is bound, so no key fires or is swallowed. Both matter. A wave
+falling behind the sheet would break a child's shield while they read "it won't
+be saved", and a gun still listening would fire `Space` and `Enter` at the
+letters instead of at the two buttons in front of them. Resuming re-arms with
+`last` at `null`, which is a first frame worth nothing (`stepMs`), so however
+long the sheet was up costs the run exactly zero.
+
+**Quitting saves nothing, and no code makes that true.** A run is written by an
+effect on the `ending` the reducer stamps; a wave abandoned halfway has none,
+so leaving is a navigation and the route unmounts with the run still only in
+memory. It is worth stating because it is the kind of guarantee somebody later
+adds a "save the partial run" line against. Measured by counting rows in
+IndexedDB rather than by watching the screen — a partial run written and then
+hidden would look identical from the outside — and the count does not move.
+
+Because the way out lives in the HUD, the sky is no longer `aria-hidden` as a
+whole. The attribute sits on each of its churning parts instead — the two HUD
+numbers, every stone, the shield — for the reason the board carries one (§4.4).
+A screen whose only exit sat inside a hidden subtree would be a trap for
+exactly the child least able to get out of it.
 
 ---
 
@@ -1590,59 +1737,63 @@ which is what every run saved before this is.
 
 ## 11 · Decisions, recorded
 
-|     | Decision                                                 | Because                                                                                                     |
-| --- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| 1   | The keyboard layout is engine, not view                  | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture       |
-| 2   | `code`, not `key`                                        | Shift+`4` produces `$` and there is no `$` key to light up                                                  |
-| 3   | Keys release on a timer, not `keyup`                     | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                             |
-| 4   | The board is `aria-hidden`                               | Sixty announcing spans is not accessibility; the passage already carries the state                          |
-| 5   | The visual keyboard is never tappable                    | A tappable board is a hunt-and-peck trainer, which is the thing this is against                             |
-| 6   | Lesson text is generated, not written                    | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                         |
-| 7   | The lexicon must not be reachable from `decks/index.ts`  | The same import took the shared chunk 46 KB → 222 KB once already                                           |
-| 8   | Ghost identity is the lesson, not the passage            | Every run generates different words; keying on them buckets every run alone                                 |
-| 9   | Three pass bars, not one score                           | A single number says you failed; three say what to fix                                                      |
-| 10  | Accuracy is flat and high; speed scales                  | An accuracy bar you can hammer past teaches hammering                                                       |
-| 11  | The speed bar dips when a key arrives                    | You have just got slower and you should have                                                                |
-| 12  | The new-key gate                                         | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                          |
-| 13  | Per-key stats come from cards, not keystrokes            | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven         |
-| 14  | Progress is derived, never stored                        | No migration, self-heals when criteria change, cannot disagree with the record book                         |
-| 15  | Unlock is `max(cleared) + 1`                             | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                             |
-| 16  | Any checkpoint, any time                                 | It is a placement test, a skip-ahead and an ordering rule in one sentence                                   |
-| 17  | A lesson has no ghost and no time penalty                | A penalty double-counts accuracy and makes the wpm number a lie                                             |
-| 18  | Hailstorm is a route in the typing island                | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard    |
-| 19  | Letters fall down their key's column                     | The lane is a spatial hint — the game teaches the layout the whole time it is played                        |
-| 20  | Only the lowest letter can be shot                       | Otherwise spraying the keyboard is a winning strategy                                                       |
-| 21  | The shield is eight finger zones                         | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise           |
-| 22  | Score can fall, XP cannot                                | XP is cumulative across years and four games; a bad five minutes must not lower a level                     |
-| 23  | A Hailstorm run is a `Session`                           | Record book, XP, badges and the drill builder all work with no new code                                     |
-| 24  | Hailstorm never gates the ladder                         | A tablet has no keys, and a reward that blocks you is not a reward                                          |
-| 25  | DOM, not canvas                                          | Eleven custom properties change the whole app's biome; a canvas is a hole in that                           |
-| 26  | US ANSI only, and say so                                 | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                               |
-| 27  | A lesson's keyboard seeds; it does not overrule          | All hundred name a mode, so an override beats the player's own setting on every rung                        |
-| 28  | `eyes-up` reads the board the run was typed under        | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory          |
-| 29  | `unbroken` is gated on the wave having a length          | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete     |
-| 30  | A falling letter is on the field on `[spawn, land)`      | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two         |
-| 31  | A letter carries its key, finger and lane                | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift          |
-| 32  | The target is the greatest fall progress, not `landMs`   | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen              |
-| 33  | An exact tie goes to the earlier spawn                   | The index is the letter's identity, so a replay resolves the same dead heat the same way                    |
-| 34  | A repair never lifts a zone above `spec.shield`          | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                    |
-| 35  | A tick resolves every landing inside it                  | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's               |
-| 36  | The field's lanes step back half a `--key-gap`           | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference  |
-| 37  | `--key` is declared once, at the root                    | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key      |
-| 38  | A frame is clamped to 100ms of wave time                 | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield      |
-| 39  | The loop writes `--drop`; the stylesheet owns the fall   | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either   |
-| 40  | The field re-renders on the picture, not on the frame    | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal        |
-| 41  | A shield segment is its finger's home-row span           | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on |
-| 42  | A tint is an element keyed by a counter, not a class     | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe   |
-| 43  | A stroke at an empty sky flares the whole board          | It costs ten points and the streak, and a key that costs a child points must not light `--lime`             |
-| 44  | Key auto-repeat is not a shot                            | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                   |
-| 45  | The HUD is drawn inside the sky, not as a row of its own | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give              |
-| 46  | A wrong key costs score; a letter through costs shield   | One failure, one cost — the landing has already taken the thing that ends runs                              |
-| 47  | The ending stands where the board did                    | The gun is dead, and the sky it leaves whole is the shield with the hole in it that the sentence is about   |
-| 48  | A storm's cards are its letters, not its keystrokes      | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both   |
-| 49  | A letter that got through is a `timedOut` card           | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped    |
-| 50  | A storm has no ghost and holds no record                 | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it          |
-| 51  | A retry is a new run, so it is a remount                 | The finish guard, the history snapshot and the clock all have to start again; one instance is one run       |
+|     | Decision                                                 | Because                                                                                                      |
+| --- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| 1   | The keyboard layout is engine, not view                  | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture        |
+| 2   | `code`, not `key`                                        | Shift+`4` produces `$` and there is no `$` key to light up                                                   |
+| 3   | Keys release on a timer, not `keyup`                     | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                              |
+| 4   | The board is `aria-hidden`                               | Sixty announcing spans is not accessibility; the passage already carries the state                           |
+| 5   | The visual keyboard is never tappable                    | A tappable board is a hunt-and-peck trainer, which is the thing this is against                              |
+| 6   | Lesson text is generated, not written                    | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                          |
+| 7   | The lexicon must not be reachable from `decks/index.ts`  | The same import took the shared chunk 46 KB → 222 KB once already                                            |
+| 8   | Ghost identity is the lesson, not the passage            | Every run generates different words; keying on them buckets every run alone                                  |
+| 9   | Three pass bars, not one score                           | A single number says you failed; three say what to fix                                                       |
+| 10  | Accuracy is flat and high; speed scales                  | An accuracy bar you can hammer past teaches hammering                                                        |
+| 11  | The speed bar dips when a key arrives                    | You have just got slower and you should have                                                                 |
+| 12  | The new-key gate                                         | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                           |
+| 13  | Per-key stats come from cards, not keystrokes            | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven          |
+| 14  | Progress is derived, never stored                        | No migration, self-heals when criteria change, cannot disagree with the record book                          |
+| 15  | Unlock is `max(cleared) + 1`                             | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                              |
+| 16  | Any checkpoint, any time                                 | It is a placement test, a skip-ahead and an ordering rule in one sentence                                    |
+| 17  | A lesson has no ghost and no time penalty                | A penalty double-counts accuracy and makes the wpm number a lie                                              |
+| 18  | Hailstorm is a route in the typing island                | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard     |
+| 19  | Letters fall down their key's column                     | The lane is a spatial hint — the game teaches the layout the whole time it is played                         |
+| 20  | Only the lowest letter can be shot                       | Otherwise spraying the keyboard is a winning strategy                                                        |
+| 21  | The shield is eight finger zones                         | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise            |
+| 22  | Score can fall, XP cannot                                | XP is cumulative across years and four games; a bad five minutes must not lower a level                      |
+| 23  | A Hailstorm run is a `Session`                           | Record book, XP, badges and the drill builder all work with no new code                                      |
+| 24  | Hailstorm never gates the ladder                         | A tablet has no keys, and a reward that blocks you is not a reward                                           |
+| 25  | DOM, not canvas                                          | Eleven custom properties change the whole app's biome; a canvas is a hole in that                            |
+| 26  | US ANSI only, and say so                                 | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                                |
+| 27  | A lesson's keyboard seeds; it does not overrule          | All hundred name a mode, so an override beats the player's own setting on every rung                         |
+| 28  | `eyes-up` reads the board the run was typed under        | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory           |
+| 29  | `unbroken` is gated on the wave having a length          | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete      |
+| 30  | A falling letter is on the field on `[spawn, land)`      | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two          |
+| 31  | A letter carries its key, finger and lane                | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift           |
+| 32  | The target is the greatest fall progress, not `landMs`   | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen               |
+| 33  | An exact tie goes to the earlier spawn                   | The index is the letter's identity, so a replay resolves the same dead heat the same way                     |
+| 34  | A repair never lifts a zone above `spec.shield`          | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                     |
+| 35  | A tick resolves every landing inside it                  | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's                |
+| 36  | The field's lanes step back half a `--key-gap`           | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference   |
+| 37  | `--key` is declared once, at the root                    | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key       |
+| 38  | A frame is clamped to 100ms of wave time                 | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield       |
+| 39  | The loop writes `--drop`; the stylesheet owns the fall   | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either    |
+| 40  | The field re-renders on the picture, not on the frame    | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal         |
+| 41  | A shield segment is its finger's home-row span           | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on  |
+| 42  | A tint is an element keyed by a counter, not a class     | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe    |
+| 43  | A stroke at an empty sky flares the whole board          | It costs ten points and the streak, and a key that costs a child points must not light `--lime`              |
+| 44  | Key auto-repeat is not a shot                            | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                    |
+| 45  | The HUD is drawn inside the sky, not as a row of its own | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give               |
+| 46  | A wrong key costs score; a letter through costs shield   | One failure, one cost — the landing has already taken the thing that ends runs                               |
+| 47  | The ending stands where the board did                    | The gun is dead, and the sky it leaves whole is the shield with the hole in it that the sentence is about    |
+| 48  | A storm's cards are its letters, not its keystrokes      | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both    |
+| 49  | A letter that got through is a `timedOut` card           | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped     |
+| 50  | A storm has no ghost and holds no record                 | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it           |
+| 51  | A retry is a new run, so it is a remount                 | The finish guard, the history snapshot and the clock all have to start again; one instance is one run        |
+| 52  | Fall time has a floor, in the generator                  | The twenty specs are a table, and a table gets tightened a row at a time until a level nobody can read ships |
+| 53  | A keystroke proves a keyboard; the pointer only guesses  | Every proxy is wrong about somebody, and wrongly shut is a child locked out where wrongly open is a dud tile |
+| 54  | The quit sheet is the storm's pause                      | A wave falling behind it would break a shield while a child read "it won't be saved"                         |
+| 55  | `Escape` leaves, and is taken before the trigger         | Every other key while a run is live is a shot, so a way out on a second listener would cost ten points       |
 
 ---
 

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -1345,6 +1345,310 @@ try {
       retried.map((s) => `${s.correct}/${s.cards.length}`).join(", "),
   );
 
+  /*
+   * The setting a falling-letter game cannot honour by removing the falling
+   * (docs/typing.md §8.10, #155).
+   *
+   * Two claims, and neither can be read off the stylesheet. **The fall stays**
+   * — it is a custom property written from a rAF loop rather than an
+   * animation, so base.css's blanket clamp has nothing of it to reach, and the
+   * only proof of that is a stone moving on a page that asked for less motion.
+   * **The flashing comes off** — the three tints are switched to
+   * `animation: none` rather than left to the clamp's 0.001ms pass, and the
+   * difference between those two is exactly one `animationstart` per event: a
+   * clamped animation still starts. So the census below is of a whole run, and
+   * the number it may equal is zero.
+   *
+   * Screen shake, parallax and particles are the rest of §8.10's list, and the
+   * honest answer is that this screen has never had any of them. That is not a
+   * claim a count can carry, so it is checked as what it looks like: nothing
+   * on this screen is transformed but the stones.
+   */
+  log("\n11. Under reduced motion the fall stays and the flashing goes");
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.evaluate(() => (window.__tints = []));
+  await storm();
+
+  const calm = await page.evaluate(async () => {
+    // The same measurement as the fall at the top of section 9, on a page that
+    // has asked for less motion: distinct positions are what a re-render alone
+    // cannot fake, because without the loop a stone climbs a 300ms staircase.
+    const stone = document.querySelector(".storm__letter");
+    const tops = [];
+    for (let i = 0; i < 24; i++) {
+      tops.push(stone.getBoundingClientRect().top);
+      await new Promise((done) => window.setTimeout(done, 25));
+    }
+    const transformOf = (selector) => {
+      const el = document.querySelector(selector);
+      return el ? window.getComputedStyle(el).transform : "missing";
+    };
+    return {
+      distinct: new Set(tops.map((top) => Math.round(top))).size,
+      forwards: tops.every((top, i) => i === 0 || top >= tops[i - 1]),
+      travelled: Math.round(tops[tops.length - 1] - tops[0]),
+      // Nothing but the stones moves. A shake would be on one of the first
+      // three; a parallax layer would be a fourth thing with a transform.
+      still: [".storm", ".storm__sky", ".storm__shield"].map(transformOf),
+      stone: transformOf(".storm__letter"),
+      particles: document.querySelectorAll(".confetti, .confetti__bit").length,
+    };
+  });
+  check(
+    "a stone still falls, frame by frame, for a child who asked for less motion",
+    calm.distinct >= 12 && calm.forwards && calm.travelled > 0,
+    `${calm.distinct} distinct positions in 24 readings over 600ms, ` +
+      `${calm.travelled}px travelled`,
+  );
+  check(
+    "and nothing but the stones is moved at all",
+    calm.still.every((value) => value === "none") &&
+      calm.stone.startsWith("matrix") &&
+      calm.particles === 0,
+    `field/sky/shield ${calm.still.join()}, stone ${calm.stone}, ` +
+      `${calm.particles} particles`,
+  );
+
+  // The whole wave, untouched, exactly as the census run in section 9 was —
+  // so the number below is over twelve landings and not over a quiet moment.
+  await page
+    .waitForFunction(() => window.__pendingFrames() === 0, null, {
+      timeout: 15000,
+    })
+    .catch(() => {});
+  await page.waitForTimeout(300);
+  const quiet = await page.evaluate(() => ({
+    tints: window.__tints,
+    zones: document.querySelectorAll(".storm__zone[data-hole]").length,
+  }));
+  check(
+    "twelve letters land and not one animation runs",
+    quiet.tints.length === 0 && quiet.zones === 3,
+    `${quiet.tints.length} storm animations over a whole wave, ` +
+      `${quiet.zones} zones emptied (the damage still happened)`,
+  );
+  await page.emulateMedia({ reducedMotion: null });
+
+  /*
+   * The keys the gun swallows, the key that leaves, and what quitting costs
+   * the record book (§8.8, #155).
+   *
+   * `preventDefault` is invisible to every other kind of test: the storm is
+   * exactly one viewport tall with `overflow: hidden`, so a `Space` that
+   * scrolled would move nothing HERE and everything on a shorter screen or
+   * behind a taller ad. What can be asked is whether the default was taken,
+   * which a listener on the way back up can see — so the checks below read
+   * `defaultPrevented` rather than a scroll position, and read the scroll
+   * position too because it costs nothing.
+   *
+   * The pair matters as much as the members: `Space`, `/` and `Tab` are keys
+   * the board carries and are swallowed; `ArrowDown` and `Escape` are not on
+   * it and are left alone, which is what keeps a browser's own keys working on
+   * a screen a child has to be able to get out of.
+   */
+  log("\n12. The keys a storm swallows, and the one that leaves it");
+  const runsBeforeQuit = (await stormRuns()).length;
+  await storm();
+  await page.evaluate(() => {
+    window.__keys = [];
+    // Bubble phase, so this runs after the gun's capture listener and sees
+    // whatever it decided.
+    window.addEventListener("keydown", (event) =>
+      window.__keys.push({
+        code: event.code,
+        prevented: event.defaultPrevented,
+      }),
+    );
+  });
+  for (const key of ["Space", "/", "Tab", "ArrowDown"]) {
+    await press(key);
+    await page.waitForTimeout(120);
+  }
+  const swallowed = await page.evaluate(() => ({
+    keys: window.__keys,
+    scrollY: window.scrollY,
+  }));
+  const took = (code) => swallowed.keys.find((k) => k.code === code)?.prevented;
+  check(
+    "the gun reads event.code, and swallows the keys that would scroll",
+    swallowed.keys.length === 4 &&
+      took("Space") === true &&
+      took("Slash") === true &&
+      took("Tab") === true &&
+      took("ArrowDown") === false &&
+      swallowed.scrollY === 0,
+    swallowed.keys.map((k) => `${k.code}:${k.prevented}`).join(" "),
+  );
+
+  // And the way out. `Escape` is not a key the board carries, so it is neither
+  // swallowed nor fired at the lowest letter — a way out that cost ten points
+  // and a streak would be a trap.
+  const scoreAtQuit = await page.evaluate(() =>
+    Number(document.querySelector(".storm__score").textContent),
+  );
+  await press("Escape");
+  await page.waitForSelector('[aria-label="Quit the storm"]', {
+    timeout: 4000,
+  });
+  const asked = await page.evaluate(async () => {
+    const lowest = () => {
+      const stones = [...document.querySelectorAll(".storm__letter")];
+      let low = stones[0];
+      for (const stone of stones)
+        if (Number(stone.dataset.stone) < Number(low.dataset.stone))
+          low = stone;
+      return low
+        ? Number(window.getComputedStyle(low).getPropertyValue("--drop"))
+        : null;
+    };
+    const before = lowest();
+    await new Promise((done) => window.setTimeout(done, 900));
+    return {
+      before,
+      after: lowest(),
+      // No frame is requested while the sheet is up, which is what makes the
+      // pause cost the wave nothing rather than merely look like it.
+      pending: window.__pendingFrames(),
+      escaped: window.__keys.at(-1),
+      score: Number(document.querySelector(".storm__score").textContent),
+    };
+  });
+  check(
+    "Escape asks rather than fires, and the storm stops where it stood",
+    asked.escaped.code === "Escape" &&
+      asked.escaped.prevented === false &&
+      asked.score === scoreAtQuit &&
+      asked.before !== null &&
+      asked.after === asked.before &&
+      asked.pending === 0,
+    `--drop ${asked.before} → ${asked.after} over 900ms, ` +
+      `${asked.pending} frames pending, score ${scoreAtQuit} → ${asked.score}`,
+  );
+
+  // Then confirm it. A quit mid-wave is a run with no ending, and the save is
+  // an effect on the ending — so the record book must not move. Counted in
+  // IndexedDB rather than watched on screen: a partial run written and then
+  // hidden would look identical from here.
+  await page.locator(".modal__actions button", { hasText: /^quit$/i }).click();
+  await page.waitForFunction(
+    () => document.querySelector(".ladder__tile") !== null,
+    null,
+    { timeout: 8000 },
+  );
+  const runsAfterQuit = await stormRuns();
+  check(
+    "quitting mid-wave saves nothing at all",
+    runsAfterQuit.length === runsBeforeQuit &&
+      (await page.evaluate(
+        () => document.querySelectorAll(".storm").length,
+      )) === 0,
+    `${runsBeforeQuit} run(s) before, ${runsAfterQuit.length} after`,
+  );
+
+  /*
+   * The tablet (§4.5, §8.8, #155).
+   *
+   * A second context, because `hasTouch` is fixed when one is created — and it
+   * is what makes `(any-pointer: coarse) and (any-hover: none)` match, which
+   * is the guess `useKeyboardPresence` makes. Only a browser can be asked
+   * whether that query really matches on a device with no mouse; the unit
+   * suite can only be told.
+   *
+   * Both halves of the story are here, and the second is the one that matters:
+   * the guess is a guess, so a child in a keyboard folio has to be able to
+   * overturn it — with one keystroke, live, on the same page.
+   */
+  log("\n13. A device with no keyboard is told so, and is not locked out");
+  const tabletCtx = await browser.newContext({
+    viewport: { width: 1024, height: 768 },
+    hasTouch: true,
+  });
+  const tablet = await tabletCtx.newPage();
+  tablet.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
+  await tablet.goto(`${BASE}/typing`, { waitUntil: "networkidle" });
+  await tablet
+    .getByRole("button", { name: /add a player/i })
+    .first()
+    .click();
+  await tablet.waitForSelector(".modal__panel", { timeout: 8000 });
+  await tablet.locator(".modal__panel input").first().fill("Tablet");
+  await tablet.getByRole("button", { name: /^add player$/i }).click();
+  await tablet.waitForSelector(".modal__panel", {
+    state: "detached",
+    timeout: 8000,
+  });
+  await tablet.getByText("Tablet", { exact: false }).first().click();
+  await tablet.waitForSelector(".ladder__tile", { timeout: 8000 });
+
+  /** The ladder as this device draws it: the storms, and the legend's line. */
+  const ladder = () =>
+    tablet.evaluate(() => {
+      const rung = (extra) => [
+        ...document.querySelectorAll(`.ladder__row .ladder__tile${extra}`),
+      ];
+      const storms = rung(".is-storm");
+      return {
+        storms: storms.length,
+        shut: storms.filter((t) => t.getAttribute("aria-disabled") === "true")
+          .length,
+        said: storms.filter((t) =>
+          t.textContent.includes("Hailstorm needs a keyboard"),
+        ).length,
+        // The rest of the ladder is untouched: a passage is typed on the
+        // software keyboard like anything else (§4.5), so a child on an iPad
+        // still has the whole course.
+        lessonsOpen: rung(":not(.is-storm):not([aria-disabled])").length,
+        legend: [...document.querySelectorAll(".ladder__keyitem")]
+          .map((li) => li.textContent.trim())
+          .find((text) => text.startsWith("Hailstorm")),
+        touchOnly: window.matchMedia(
+          "(any-pointer: coarse) and (any-hover: none)",
+        ).matches,
+      };
+    });
+
+  const guessed = await ladder();
+  check(
+    "every storm tile is shut, with the reason on it",
+    guessed.touchOnly === true &&
+      guessed.storms === 20 &&
+      guessed.shut === 20 &&
+      guessed.said === 20 &&
+      guessed.lessonsOpen > 0 &&
+      guessed.legend.includes("Press any key if you have one"),
+    `${guessed.said}/${guessed.storms} storms say why, ` +
+      `${guessed.lessonsOpen} lessons still open: "${guessed.legend}"`,
+  );
+
+  // And the route itself is not gated by any of it. A wrong guess must cost a
+  // child a tile, never the game — so a URL still opens a playable storm, with
+  // the way out drawn on it.
+  await tablet.evaluate(() => (location.hash = `${location.hash}/storm`));
+  await tablet.waitForSelector(".storm__letter", { timeout: 8000 });
+  const reachable = await tablet.evaluate(() => ({
+    stones: document.querySelectorAll(".storm__letter").length,
+    quit: document.querySelectorAll(".storm__quit").length,
+  }));
+  await tablet.goBack();
+  await tablet.waitForSelector(".ladder__tile", { timeout: 8000 });
+
+  // One keystroke, and the guess is over. Nothing is reloaded and the pointer
+  // still says tablet — which is the point: proof beats a proxy.
+  await tablet.keyboard.press("k");
+  await tablet.waitForTimeout(250);
+  const proved = await ladder();
+  check(
+    "and one keystroke lets a keyboard in, with nothing reloaded",
+    reachable.stones > 0 &&
+      reachable.quit === 1 &&
+      proved.touchOnly === true &&
+      proved.said === 0 &&
+      proved.legend.includes("Coming soon"),
+    `the route opened ${reachable.stones} stone(s) either way; ` +
+      `after one key ${proved.said}/${proved.storms} still name a keyboard`,
+  );
+  await tabletCtx.close();
+
   log(
     `\nconsole errors: ${errors.length ? errors.slice(0, 5).join(" | ") : "none"}`,
   );

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -469,9 +469,10 @@ try {
   const storm = async () => {
     // Out to the ladder first, so this is a fresh mount every time it is
     // called: a hash set to the one it already holds fires no navigation, and
-    // the run below it would be whatever the last one finished as. Leaving is
-    // also the only way out of the storm there is, so this is the same exit a
-    // child takes between two goes at it.
+    // the run below it would be whatever the last one finished as. A hash
+    // navigation is the exit THIS helper uses; it is not the only one a child
+    // has — the HUD's Quit button and `Escape` both open the sheet (§8.11),
+    // and section 12 leaves that way on purpose.
     await page.evaluate((id) => (location.hash = `#/p/${id}`), player);
     await page.evaluate((id) => (location.hash = `#/p/${id}/storm`), player);
     await page.waitForSelector(".storm__letter", { timeout: 8000 });
@@ -587,8 +588,11 @@ try {
       .join(" "),
   );
 
-  // Leaving is what quitting is on this screen (there is no quit control), and
-  // it has to take the loop with it — and, since the gun landed, the keydown
+  // Leaving the route is one of the three ways a run ends — route-left,
+  // run-ended, paused (§8.11) — and no longer the only one, now that the HUD
+  // carries a Quit and `Escape` opens the same sheet (section 12 uses both).
+  // The point being made here is still the one only a navigation can make: it
+  // has to take the loop with it, and — since the gun landed — the keydown
   // listener beside it.
   await page.evaluate((id) => (location.hash = `#/p/${id}`), player);
   await page.waitForTimeout(500);
@@ -1379,18 +1383,29 @@ try {
       tops.push(stone.getBoundingClientRect().top);
       await new Promise((done) => window.setTimeout(done, 25));
     }
-    const transformOf = (selector) => {
-      const el = document.querySelector(selector);
-      return el ? window.getComputedStyle(el).transform : "missing";
-    };
     return {
       distinct: new Set(tops.map((top) => Math.round(top))).size,
       forwards: tops.every((top, i) => i === 0 || top >= tops[i - 1]),
       travelled: Math.round(tops[tops.length - 1] - tops[0]),
-      // Nothing but the stones moves. A shake would be on one of the first
-      // three; a parallax layer would be a fourth thing with a transform.
-      still: [".storm", ".storm__sky", ".storm__shield"].map(transformOf),
-      stone: transformOf(".storm__letter"),
+      // Nothing but the stones moves — and that is asked of the whole screen
+      // rather than of a list of selectors somebody has to remember to grow.
+      // A shake would be a transform on the field, the sky or the shield; a
+      // parallax layer would be a transform on something none of those three
+      // names. Enumerating every descendant catches all of them, including
+      // the one nobody thought of, which is the only kind worth checking for.
+      // `.storm__combo` reports `scale: 1` rather than a transform, so it is
+      // `none` here like everything else that is not a falling stone. The
+      // field itself is in the list as well as its descendants, because a
+      // shake would most naturally be put on the thing that holds them.
+      // Read as an attribute rather than `className`, which is an
+      // `SVGAnimatedString` and not a string on an SVG node — and an icon
+      // somebody transforms is exactly the kind of thing this is here to
+      // find, so the one case it must not choke on is the new one.
+      moved: [...document.querySelectorAll("main.storm, main.storm *")]
+        .filter((el) => window.getComputedStyle(el).transform !== "none")
+        .map((el) => el.getAttribute("class") ?? el.tagName),
+      stone: window.getComputedStyle(document.querySelector(".storm__letter"))
+        .transform,
       particles: document.querySelectorAll(".confetti, .confetti__bit").length,
     };
   });
@@ -1402,10 +1417,11 @@ try {
   );
   check(
     "and nothing but the stones is moved at all",
-    calm.still.every((value) => value === "none") &&
+    calm.moved.every((name) => name.split(" ").includes("storm__letter")) &&
       calm.stone.startsWith("matrix") &&
       calm.particles === 0,
-    `field/sky/shield ${calm.still.join()}, stone ${calm.stone}, ` +
+    `${calm.moved.length} transformed element(s) in the storm, all stones: ` +
+      `${[...new Set(calm.moved)].join() || "none"}; stone ${calm.stone}, ` +
       `${calm.particles} particles`,
   );
 
@@ -1596,7 +1612,10 @@ try {
         ).length,
         // The rest of the ladder is untouched: a passage is typed on the
         // software keyboard like anything else (§4.5), so a child on an iPad
-        // still has the whole course.
+        // still has the whole course. Counted exactly, because "some are
+        // open" would pass with seventy-nine of the eighty wrongly shut —
+        // which is the failure this is here to catch, and the one a floor of
+        // zero cannot see.
         lessonsOpen: rung(":not(.is-storm):not([aria-disabled])").length,
         legend: [...document.querySelectorAll(".ladder__keyitem")]
           .map((li) => li.textContent.trim())
@@ -1614,7 +1633,12 @@ try {
       guessed.storms === 20 &&
       guessed.shut === 20 &&
       guessed.said === 20 &&
-      guessed.lessonsOpen > 0 &&
+      // Eleven of the eighty non-storm rungs, which is what FRESH progress
+      // opens on any device: lesson 1, and the ten checkpoints a placement
+      // test may be taken at from a standing start (§6.6). A desktop draws
+      // the same eleven — the keyboard guess reaches storm tiles and nothing
+      // else — so a drift either way is the bug this names.
+      guessed.lessonsOpen === 11 &&
       guessed.legend.includes("Press any key if you have one"),
     `${guessed.said}/${guessed.storms} storms say why, ` +
       `${guessed.lessonsOpen} lessons still open: "${guessed.legend}"`,

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -6,8 +6,10 @@ import { keyX, strokeFor } from "@/engine/keyboard";
 import { cardXp, stormXp } from "@/engine/progress";
 import { unlockedAt } from "./keys";
 import {
+  MIN_FALL_MS,
   SHIELD_FINGERS,
   buildWave,
+  fallRange,
   fire,
   hasLanded,
   isAirborne,
@@ -334,7 +336,18 @@ describe("gap and fall are sampled per letter", () => {
     // This is the assertion an exclusive bound fails: a generator that never
     // reached `max` would make every level fractionally easier than written,
     // and nothing else here would notice.
-    const s = spec({ keys: HOME, count: 40, gap: [10, 12], fall: [5, 7] });
+    //
+    // The fall range sits just above `MIN_FALL_MS` rather than at any three
+    // numbers, because the floor would flatten a range under it (below) — and
+    // a range flattened to a constant is exactly what this assertion is here
+    // to catch. Sitting one millisecond above the floor also says the floor
+    // does not disturb a range that clears it.
+    const s = spec({
+      keys: HOME,
+      count: 40,
+      gap: [10, 12],
+      fall: [MIN_FALL_MS + 1, MIN_FALL_MS + 3],
+    });
     const gaps = new Set<number>();
     const falls = new Set<number>();
     for (const seed of SEEDS) {
@@ -343,7 +356,79 @@ describe("gap and fall are sampled per letter", () => {
       for (const letter of wave.letters) falls.add(letter.fallMs);
     }
     expect([...gaps].sort()).toEqual([10, 11, 12]);
-    expect([...falls].sort()).toEqual([5, 6, 7]);
+    expect([...falls].sort((a, b) => a - b)).toEqual([
+      MIN_FALL_MS + 1,
+      MIN_FALL_MS + 2,
+      MIN_FALL_MS + 3,
+    ]);
+  });
+});
+
+describe("no letter is ever a blur", () => {
+  /*
+   * The cap at the top of the ladder (§8.10, decision 52). "Whiteout" is meant
+   * to be hard because there are many letters, not because one of them cannot
+   * be read — and the only place that can be guaranteed is the generator,
+   * because the twenty specs are a table and a table is edited a row at a time.
+   */
+
+  it("floors every fall a too-fast spec asks for", () => {
+    const blur = spec({ count: 40, gap: [200, 300], fall: [40, 200] });
+    for (const seed of SEEDS)
+      for (const letter of buildWave(blur, seed).letters)
+        expect(letter.fallMs, `@ ${seed}`).toBe(MIN_FALL_MS);
+  });
+
+  it("holds for every spec and seed in this file, capped or not", () => {
+    // The universal form of it: whatever a level declares, nothing crosses the
+    // sky faster than the floor. The specs above all clear it, so this is the
+    // assertion that keeps clearing it true of a table somebody re-tunes.
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS)
+        for (const letter of buildWave(s, seed).letters)
+          expect(letter.fallMs, `${name} @ ${seed}`).toBeGreaterThanOrEqual(
+            MIN_FALL_MS,
+          );
+  });
+
+  it("leaves a spec that clears the floor exactly as it was written", () => {
+    // A cap that quietly re-tuned the levels that were already fine would be a
+    // difficulty knob wearing a safety rail's clothes.
+    for (const [name, s] of SPECS) {
+      expect(fallRange(s), name).toEqual(s.fall);
+      for (const seed of SEEDS)
+        for (const letter of buildWave(s, seed).letters) {
+          expect(letter.fallMs, `${name} @ ${seed}`).toBeGreaterThanOrEqual(
+            s.fall[0],
+          );
+          expect(letter.fallMs, `${name} @ ${seed}`).toBeLessThanOrEqual(
+            s.fall[1],
+          );
+        }
+    }
+  });
+
+  it("raises a range rather than flattening it", () => {
+    // Clamping each sample would pile every letter of a too-fast spec onto the
+    // floor exactly; clamping the range keeps the draw a draw. Only the half
+    // of the range under the floor moves.
+    const half = spec({ count: 40, fall: [MIN_FALL_MS - 400, 2000] });
+    expect(fallRange(half)).toEqual([MIN_FALL_MS, 2000]);
+
+    const falls = new Set<number>();
+    for (const seed of SEEDS)
+      for (const letter of buildWave(half, seed).letters)
+        falls.add(letter.fallMs);
+    expect(Math.min(...falls)).toBeGreaterThanOrEqual(MIN_FALL_MS);
+    expect(falls.size).toBeGreaterThan(5);
+  });
+
+  it("still builds the same storm twice under the cap", () => {
+    // The floor is part of what a seed means, and a cap applied anywhere but
+    // in the build would make a replay a different wave.
+    const blur = spec({ count: 20, fall: [10, 100] });
+    for (const seed of SEEDS)
+      expect(buildWave(blur, seed), `@ ${seed}`).toEqual(buildWave(blur, seed));
   });
 });
 
@@ -375,7 +460,14 @@ describe("the schedule the wave hands the reducer", () => {
         );
       }
 
-    const overtaking = spec({ count: 20, gap: [10, 10], fall: [100, 2000] });
+    // Written above `MIN_FALL_MS` so the range is the one the letters get: the
+    // floor would raise a 100ms fall to 800 anyway, and a spec that says one
+    // thing while the wave does another is a fixture nobody can reason from.
+    const overtaking = spec({
+      count: 20,
+      gap: [10, 10],
+      fall: [MIN_FALL_MS, 2000],
+    });
     const waves = SEEDS.map((seed) => buildWave(overtaking, seed));
     expect(
       waves.some((w) => w.durationMs !== w.letters.at(-1)!.landMs),

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -213,6 +213,53 @@ function fallable(ch: string): Fallable | null {
 }
 
 /**
+ * The fastest a letter may ever cross the sky, in ms (§8.10, decision 52).
+ *
+ * **"Whiteout" is hard because there are many letters, not because one is a
+ * blur.** That is a promise about the top of the ladder, and the only place it
+ * can be kept is here: twenty `WaveSpec`s are a table somebody writes, and a
+ * table is exactly the kind of thing a difficulty pass tightens one row at a
+ * time until a level nobody can read ships. A floor in the generator cannot be
+ * forgotten by a row.
+ *
+ * 800ms is a judgement and worth being honest about that — it is not a
+ * measured reaction time. What it is anchored to is the epic's own level
+ * shapes: the fastest fall any of them declares is 800ms (`storm.test.ts`'s
+ * "capitals under fire", lesson 44), so the floor is the fastest the ladder
+ * ever *means* to be. Under it a letter stops being a thing to read, find and
+ * press and becomes a streak going past — which is the failure §8.10 names,
+ * and the one a five-year-old cannot tell from the game being broken.
+ *
+ * It is a backstop, not a difficulty knob: it bites only on a spec that asked
+ * for something faster than the ladder ever intends, and a wave built entirely
+ * above it is untouched.
+ */
+export const MIN_FALL_MS = 800;
+
+/**
+ * The fall times a spec can actually produce — its own range, floored at
+ * `MIN_FALL_MS`.
+ *
+ * Exported because two questions are asked of it and neither should re-derive
+ * the clamp: `buildWave` samples from it, and anything asking whether a level
+ * is "one letter at a time" has to read the schedule the wave was built with
+ * rather than the one it was written with. `gap[0] >= fall[1]` is that
+ * property (see `buildWave`), and a fall the floor has raised is a fall that
+ * can overlap where the declaration said it would not.
+ *
+ * The range is clamped rather than each sample, so the draw stays uniform over
+ * what a letter can be. Flooring the sample instead would pile every letter of
+ * a too-fast spec onto the floor exactly, which is a metronome wearing a
+ * range's clothes.
+ */
+export function fallRange(spec: WaveSpec): [number, number] {
+  return [
+    Math.max(MIN_FALL_MS, spec.fall[0]),
+    Math.max(MIN_FALL_MS, spec.fall[1]),
+  ];
+}
+
+/**
  * The whole wave, from a seed.
  *
  * Deterministic in `(spec, seed)` and in nothing else: no clock is read and
@@ -235,9 +282,17 @@ function fallable(ch: string): Fallable | null {
  * letter on screen, because the interval is half-open — the outgoing letter
  * lands on the same millisecond the next one spawns, and landing is the tick
  * that takes it off the field.
+ *
+ * That arithmetic is read against `fallRange(spec)` and not against
+ * `spec.fall`: the fall a letter gets is floored at `MIN_FALL_MS`, and a floor
+ * can only ever raise a fall — so a spec that declared "one at a time" with
+ * falls under the floor gets letters that overlap. Which is the right way for
+ * that to go: the alternative is a level that keeps its spacing promise by
+ * dropping letters nobody could read.
  */
 export function buildWave(spec: WaveSpec, seed: number): Wave {
   const rand = mulberry32(seed);
+  const fall = fallRange(spec);
 
   // Filtered once, up front. An empty pool — a spec naming only characters
   // this board cannot type — yields an empty wave rather than an exception:
@@ -256,7 +311,7 @@ export function buildWave(spec: WaveSpec, seed: number): Wave {
     // because a draw nobody uses is still part of what the seed means.
     if (i > 0) spawnMs += between(spec.gap[0], spec.gap[1], rand);
     const from = pool[between(0, pool.length - 1, rand)];
-    const fallMs = between(spec.fall[0], spec.fall[1], rand);
+    const fallMs = between(fall[0], fall[1], rand);
     letters.push({ ...from, spawnMs, fallMs, landMs: spawnMs + fallMs });
   }
 

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -225,14 +225,27 @@ function fallable(ch: string): Fallable | null {
  * 800ms is a judgement and worth being honest about that — it is not a
  * measured reaction time. What it is anchored to is the epic's own level
  * shapes: the fastest fall any of them declares is 800ms (`storm.test.ts`'s
- * "capitals under fire", lesson 44), so the floor is the fastest the ladder
- * ever *means* to be. Under it a letter stops being a thing to read, find and
- * press and becomes a streak going past — which is the failure §8.10 names,
- * and the one a five-year-old cannot tell from the game being broken.
+ * "home row", lesson 9), so the floor is the fastest the ladder ever *means*
+ * to be. Under it a letter stops being a thing to read, find and press and
+ * becomes a streak going past — which is the failure §8.10 names, and the one
+ * a five-year-old cannot tell from the game being broken.
  *
  * It is a backstop, not a difficulty knob: it bites only on a spec that asked
  * for something faster than the ladder ever intends, and a wave built entirely
  * above it is untouched.
+ *
+ * **There is deliberately no `MIN_GAP_MS` beside it, and the symmetry is a
+ * trap.** The thing a gap floor looks like it would buy is §8.10's "no strobe,
+ * ever" — a zone tinting over and over. But a zone tints when two letters
+ * *land* on one finger, and `fall` is a range too, so letters spawned a second
+ * apart land together: `storm.test.ts`'s "capitals", at `gap` 600–1000ms,
+ * already lands two on one zone 14ms apart. Measured on its "everything
+ * falls", the lesson-93 shape: flooring its
+ * `gap` at 350ms takes one zone from four tint starts a second to three, and
+ * flooring it at 800ms — which would make the top of the ladder one letter at
+ * a time — still leaves three. The floor would cost the density knob the top
+ * of the ladder is built out of and buy almost no safety, so the rule STM10
+ * has to keep is a count per zone per second and not a floor here (§8.10).
  */
 export const MIN_FALL_MS = 800;
 

--- a/src/games/race/QuitSheet.tsx
+++ b/src/games/race/QuitSheet.tsx
@@ -3,33 +3,51 @@ import { Button, Scrim } from "@/components/ui/kit";
 /**
  * Confirmation before abandoning a run.
  *
- * While this is up the race clock is paused — see `useRaceClock`. Backing out
- * neither costs the player time nor buys them any.
+ * While this is up the run's clock is paused — `useRaceClock` for a race,
+ * `useStormClock`'s `paused` for a hailstorm. Backing out neither costs the
+ * player time nor buys them any, and in the storm's case it also disarms the
+ * gun, which is what leaves `Space` and `Enter` free to press the two buttons
+ * below.
+ *
+ * ── Three words are the caller's ─────────────────────────────────────────────
+ * The sheet itself is the same in every game — the same pause, the same
+ * warning, the same pair of buttons — and only the noun changes. That is worth
+ * a prop rather than a second component: "Keep racing" over a hailstorm is a
+ * sentence about a screen the child is not on, and a copy of this file to fix
+ * it would be a second place for "it won't be saved" to stop being true.
+ *
+ * The body copy is not a prop, deliberately. "It won't be saved and no XP is
+ * earned" is the same promise everywhere it is shown, and it is the one thing
+ * on this sheet a child is being asked to weigh.
  */
 export function QuitSheet({
   onQuit,
   onKeepRacing,
+  title = "Quit this race?",
+  keep = "Keep racing",
+  label = "Quit the race",
 }: {
   onQuit: () => void;
   onKeepRacing: () => void;
+  /** The question, as a heading. */
+  title?: string;
+  /** The way back into the run — the button label and the scrim's name. */
+  keep?: string;
+  /** The dialog's own accessible name. */
+  label?: string;
 }) {
   return (
-    <div
-      className="modal"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Quit the race"
-    >
-      <Scrim onClose={onKeepRacing} label="Keep racing" />
+    <div className="modal" role="dialog" aria-modal="true" aria-label={label}>
+      <Scrim onClose={onKeepRacing} label={keep} />
       <div className="modal__panel panel anim-pop">
-        <h2 className="panel__title">Quit this race?</h2>
+        <h2 className="panel__title">{title}</h2>
         <p className="muted">It won&apos;t be saved and no XP is earned.</p>
         <div className="modal__actions">
           <Button variant="danger" size="sm" onClick={onQuit}>
             Quit
           </Button>
           <Button variant="accent" onClick={onKeepRacing}>
-            Keep racing
+            {keep}
           </Button>
         </div>
       </div>

--- a/src/games/typing/LessonLadder.test.tsx
+++ b/src/games/typing/LessonLadder.test.tsx
@@ -41,9 +41,21 @@ const STORMS = LESSONS.filter((lesson) => lesson.kind.type === "storm");
 
 type Tile = { classes: string; label: string; shut: boolean };
 
-/** Every tile the ladder drew, in the order it drew them. */
-const tiles = (progress: LadderProgress): Tile[] =>
-  renderToStaticMarkup(<LessonLadder progress={progress} onOpen={() => {}} />)
+/**
+ * Every tile the ladder drew, in the order it drew them.
+ *
+ * `hasKeyboard` defaults to true because that is what every device this suite
+ * is not about reports, and what the hook answers when it cannot tell
+ * (`useKeyboardPresence`). The tablet is a case, not the baseline.
+ */
+const tiles = (progress: LadderProgress, hasKeyboard = true): Tile[] =>
+  renderToStaticMarkup(
+    <LessonLadder
+      progress={progress}
+      hasKeyboard={hasKeyboard}
+      onOpen={() => {}}
+    />,
+  )
     .split("<button")
     .slice(1)
     .map((chunk) => ({
@@ -97,7 +109,7 @@ describe("tileState", () => {
 describe("LessonLadder", () => {
   it("draws the hundred as ten rows of ten, named", () => {
     const html = renderToStaticMarkup(
-      <LessonLadder progress={FRESH} onOpen={() => {}} />,
+      <LessonLadder progress={FRESH} hasKeyboard onOpen={() => {}} />,
     );
     expect(tiles(FRESH)).toHaveLength(LESSONS.length);
     expect(html.match(/class="ladder__row"/g)).toHaveLength(10);
@@ -125,7 +137,7 @@ describe("LessonLadder", () => {
 
   it("says a checkpoint is always open, on the tile and in the copy", () => {
     const html = renderToStaticMarkup(
-      <LessonLadder progress={FRESH} onOpen={() => {}} />,
+      <LessonLadder progress={FRESH} hasKeyboard onOpen={() => {}} />,
     );
     expect(html).toContain("every checkpoint is open from the start");
     for (const tile of tiles(FRESH).filter((t) =>
@@ -143,7 +155,7 @@ describe("LessonLadder", () => {
    */
   it("keeps every tile in the tab order, locked ones included", () => {
     const html = renderToStaticMarkup(
-      <LessonLadder progress={FRESH} onOpen={() => {}} />,
+      <LessonLadder progress={FRESH} hasKeyboard onOpen={() => {}} />,
     );
     expect(html).not.toContain('disabled=""');
     expect(tiles(FRESH).filter((tile) => tile.shut).length).toBeGreaterThan(0);
@@ -159,5 +171,54 @@ describe("LessonLadder", () => {
     const storms = drawn.filter((tile) => tile.classes.includes("is-storm"));
     expect(storms).toHaveLength(STORMS.length);
     for (const storm of storms) expect(storm.shut).toBe(true);
+  });
+
+  /**
+   * The tablet (docs/typing.md §8.8, #155). Hailstorm needs raw `keydown` with
+   * a `code` and there is no software keyboard on screen during it, so a
+   * device with no keys is told which of these tiles is not for it and why —
+   * rather than being given a tile that does nothing when it is pressed.
+   *
+   * Every other rung is unaffected, and that is half the claim: a passage is
+   * typed on the software keyboard like anything else, so a child on an iPad
+   * still has the whole course.
+   */
+  it("says why a storm tile is shut on a device with no keyboard", () => {
+    const drawn = tiles(at(99, 100), false);
+    const storms = drawn.filter((tile) => tile.classes.includes("is-storm"));
+
+    expect(storms).toHaveLength(STORMS.length);
+    for (const storm of storms) {
+      expect(storm.shut).toBe(true);
+      expect(storm.label).toContain("Hailstorm needs a keyboard");
+    }
+
+    const lessons = drawn.filter((tile) => !tile.classes.includes("is-storm"));
+    expect(lessons).toHaveLength(LESSONS.length - STORMS.length);
+    for (const lesson of lessons) {
+      expect(lesson.shut).toBe(false);
+      expect(lesson.label).not.toContain("keyboard");
+    }
+  });
+
+  /**
+   * And the way out of a wrong guess, said once where there is room for it.
+   * Detection is a guess (`useKeyboardPresence`), so the legend has to carry
+   * the instruction that overturns it — a child in a keyboard folio reads
+   * "press any key", presses one, and the ladder redraws with no reload.
+   */
+  it("offers the keystroke that overturns the guess, in the legend only", () => {
+    const shut = renderToStaticMarkup(
+      <LessonLadder progress={FRESH} hasKeyboard={false} onOpen={() => {}} />,
+    );
+    expect(shut).toContain("Press any key if you have one");
+    // Once, in the legend — not on each of the twenty tiles.
+    expect(shut.match(/Press any key if you have one/g)).toHaveLength(1);
+
+    const open = renderToStaticMarkup(
+      <LessonLadder progress={FRESH} hasKeyboard onOpen={() => {}} />,
+    );
+    expect(open).not.toContain("Press any key");
+    expect(open).toContain("Coming soon");
   });
 });

--- a/src/games/typing/LessonLadder.tsx
+++ b/src/games/typing/LessonLadder.tsx
@@ -1,6 +1,6 @@
 import type { LadderProgress } from "@/engine/typing/ladder";
 import { LESSONS, type Lesson } from "@/engine/typing/lessons";
-import { LessonTile } from "./LessonTile";
+import { STORM_NOTE, LessonTile } from "./LessonTile";
 
 /**
  * The hundred lessons, as the ice world's own overworld (docs/typing.md §9).
@@ -61,9 +61,20 @@ const BLOCKS = BLOCK_NAMES.map((name, i) => ({
 
 export function LessonLadder({
   progress,
+  hasKeyboard,
   onOpen,
 }: {
   progress: LadderProgress;
+  /**
+   * Whether this device looks like it has a physical keyboard
+   * (`useKeyboardPresence`), which decides what the Hailstorm tiles say
+   * (§8.8).
+   *
+   * A prop rather than a hook call in here, so this screen stays a pure
+   * function of what it is handed — the same reason `progress` arrives as one.
+   * `TypingSetup` is where the browser is asked.
+   */
+  hasKeyboard: boolean;
   onOpen: (lesson: Lesson) => void;
 }) {
   return (
@@ -101,6 +112,7 @@ export function LessonLadder({
                   <LessonTile
                     lesson={lesson}
                     progress={progress}
+                    hasKeyboard={hasKeyboard}
                     onOpen={onOpen}
                   />
                 </li>
@@ -131,7 +143,15 @@ export function LessonLadder({
         </li>
         <li className="ladder__keyitem">
           <span className="ladder__tile is-open is-storm" aria-hidden="true" />
-          Hailstorm — worth playing, never required. Coming soon
+          {/* The one place the keyboard is explained rather than merely
+              enforced, and the one place the way out of a wrong guess is
+              offered (§8.8, #155). It is said once, here, because a hundred
+              tiles each carrying "press any key" is wallpaper rather than
+              advice — and it corrects itself the instant a key is pressed,
+              with nothing to reload. */}
+          {hasKeyboard
+            ? `${STORM_NOTE} Coming soon`
+            : `${STORM_NOTE} It needs a keyboard, so these stay shut here. Press any key if you have one`}
         </li>
       </ul>
     </section>

--- a/src/games/typing/LessonTile.tsx
+++ b/src/games/typing/LessonTile.tsx
@@ -60,6 +60,42 @@ export function tileState(lesson: Lesson, progress: LadderProgress): TileState {
   return "locked";
 }
 
+/**
+ * What a Hailstorm tile is, said the same way wherever it is said.
+ *
+ * The tile's accessible name and the ladder's legend both open with it, and a
+ * third copy would be one to keep in step: a legend that described a different
+ * kind of tile from the tiles it is a legend for is a legend that has quietly
+ * stopped being one.
+ */
+export const STORM_NOTE = "Hailstorm — worth playing, never required.";
+
+/**
+ * Why a Hailstorm tile cannot be entered, or `null` when it can be.
+ *
+ * **Two reasons, and the keyboard one wins** (docs/typing.md §8.8, #155). A
+ * storm tile is shut today for everybody, because there is no wave behind it
+ * yet — and shut on a tablet for a reason that will still be true long after
+ * #156 builds one. Told only "coming soon", a child on an iPad would press it
+ * again in a month and find it still doing nothing, with no more idea why. So
+ * the reason a child is given is the one that is about them and their device,
+ * and the reason about the calendar is what is left when it does not apply.
+ *
+ * #156 deletes the second arm and returns `null` there: a keyboard is then the
+ * only thing between a child and a wave, and `LessonTile` opens the tile off
+ * this same answer without knowing that anything changed.
+ *
+ * It is deliberately not "you have no keyboard" said as a fact. The detection
+ * is a guess (`useKeyboardPresence`), and a guess that has been wrong is
+ * undone by one keystroke — which is why the ladder's legend, where there is
+ * room to say it once rather than a hundred times, offers exactly that.
+ */
+export function stormReason(hasKeyboard: boolean): string | null {
+  if (!hasKeyboard)
+    return "Hailstorm needs a keyboard, so this one stays shut.";
+  return "Coming soon.";
+}
+
 /** The state, said out loud. Read after the lesson's number and title. */
 const SAID: Record<TileState, string> = {
   cleared: "Passed",
@@ -77,16 +113,19 @@ const SAID: Record<TileState, string> = {
  * see the ring around a checkpoint has no other way to learn that the tile
  * forty rungs above their own is one they are allowed to press.
  */
-function tileLabel(lesson: Lesson, state: TileState): string {
+function tileLabel(
+  lesson: Lesson,
+  state: TileState,
+  blocked: string | null,
+): string {
   const what = `Lesson ${lesson.n}, ${lesson.title}`;
 
-  // A storm level has no passage and no wave yet (#159 builds it), so its tile
-  // says what it is and that it cannot be entered — the same stand-down the
-  // lesson results screen makes for the same reason, rather than a run of
-  // nothing. Its place on the map is still worth drawing: it is what makes
-  // lesson 4 arriving before the first word look deliberate.
+  // A storm level says what it is, and — where there is one — why it cannot be
+  // entered, rather than being a tile that does nothing when pressed. Its
+  // place on the map is worth drawing either way: it is what makes lesson 4
+  // arriving before the first word look deliberate.
   if (lesson.kind.type === "storm")
-    return `${what}. Hailstorm — worth playing, never required. Coming soon.`;
+    return `${what}. ${STORM_NOTE} ${blocked ?? `${SAID[state]}.`}`;
 
   // Only worth saying while it is ahead of the child: a checkpoint they have
   // already passed is just a lesson they passed, and "always open" on it would
@@ -107,15 +146,25 @@ function tileLabel(lesson: Lesson, state: TileState): string {
 export function LessonTile({
   lesson,
   progress,
+  hasKeyboard,
   onOpen,
 }: {
   lesson: Lesson;
   progress: LadderProgress;
+  /**
+   * Whether this device looks like it has a physical keyboard
+   * (`useKeyboardPresence`). Only a Hailstorm tile reads it — every other rung
+   * of the ladder is a passage, and a passage on a tablet is typed on the
+   * software keyboard like anything else (§4.5).
+   */
+  hasKeyboard: boolean;
   onOpen: (lesson: Lesson) => void;
 }) {
   const state = tileState(lesson, progress);
   const storm = lesson.kind.type === "storm";
-  const openable = state !== "locked" && !storm;
+  // One answer, drawn twice: what stops a storm tile is also what it says.
+  const blocked = storm ? stormReason(hasKeyboard) : null;
+  const openable = state !== "locked" && blocked === null;
 
   const classes = [
     "ladder__tile",
@@ -143,7 +192,7 @@ export function LessonTile({
       <span className="ladder__n u-mono" aria-hidden="true">
         {lesson.n}
       </span>
-      <span className="u-sr">{tileLabel(lesson, state)}</span>
+      <span className="u-sr">{tileLabel(lesson, state, blocked)}</span>
     </Button>
   );
 }

--- a/src/games/typing/TypingSetup.tsx
+++ b/src/games/typing/TypingSetup.tsx
@@ -17,6 +17,7 @@ import { ladderProgress } from "@/engine/typing/ladder";
 import { RivalList } from "@/games/race";
 import { sfx } from "@/services/sound";
 import { KeyboardSetting } from "./keyboard/KeyboardSetting";
+import { useKeyboardPresence } from "./keyboard/useKeyboardPresence";
 import { LessonBrief } from "./LessonBrief";
 import { LessonLadder } from "./LessonLadder";
 import { lessonConfig, lessonKey } from "./lessonRun";
@@ -67,6 +68,16 @@ export default function TypingSetup() {
    * one that suggests something else.
    */
   const [briefing, setBriefing] = useState<Lesson | null>(null);
+
+  /**
+   * Whether this device looks like it can play Hailstorm at all (§8.8, #155).
+   *
+   * Asked here rather than inside the ladder so that screen stays a pure
+   * function of its props, and asked at all because a storm tile that opened a
+   * game a child physically cannot play is the "fails mysteriously" this is
+   * against. It is a guess that costs a keystroke to overturn — see the hook.
+   */
+  const hasKeyboard = useKeyboardPresence();
 
   const key = configKey(config);
   const rivals = useMemo(
@@ -167,7 +178,11 @@ export default function TypingSetup() {
         </Link>
       </TopBar>
 
-      <LessonLadder progress={progress} onOpen={setBriefing} />
+      <LessonLadder
+        progress={progress}
+        hasKeyboard={hasKeyboard}
+        onOpen={setBriefing}
+      />
 
       {/* Keyed by the lesson, so a second brief is a second mount: the
           keyboard control is seeded from the lesson on mount, and a component

--- a/src/games/typing/keyboard/useKeyboardPresence.test.ts
+++ b/src/games/typing/keyboard/useKeyboardPresence.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { keyboardPresent, provesKeyboard } from "./useKeyboardPresence";
+
+/**
+ * The two rules that decide whether anybody is locked out of Hailstorm
+ * (docs/typing.md §8.8, decision 53).
+ *
+ * Neither needs a browser, and that is the point of them being functions: what
+ * `useKeyboardPresence` adds around these is a listener, a media query and a
+ * `useState`, all of which a real device answers better than a fake one — the
+ * browser half is measured in `e2e/smoke.mjs`. What is *decidable* here is the
+ * asymmetry the story turns on: detection is a guess, and a guess that has
+ * gone wrong must leave a child a way in rather than a locked door.
+ */
+
+describe("what proves a keyboard", () => {
+  it("takes any keydown carrying a code", () => {
+    for (const code of ["KeyA", "Space", "Escape", "F5", "ShiftLeft", "Tab"])
+      expect(provesKeyboard({ code }), code).toBe(true);
+  });
+
+  it("takes neither of the two ways a browser says it has no idea", () => {
+    // The two values left when there is no physical key behind the event:
+    // `code` names a position on a keyboard, so it is empty when nothing on
+    // one produced the keydown, and `Unidentified` is the fallback for a key
+    // that cannot be named. Neither is proof — so a child typing their name
+    // into a text field on a tablet has not opened the storm tile by
+    // accident.
+    expect(provesKeyboard({ code: "" })).toBe(false);
+    expect(provesKeyboard({ code: "Unidentified" })).toBe(false);
+  });
+
+  it("is exactly the field the gun reads", () => {
+    // `useStormClock` fires on `event.code` and nothing else, so proof and
+    // playability are the same claim: a key that could not have shot a
+    // hailstone is not evidence that one could be shot.
+    expect(provesKeyboard({ code: undefined as unknown as string })).toBe(
+      false,
+    );
+  });
+});
+
+describe("who is allowed in", () => {
+  it("opens for a device that has proved itself, whatever the pointer says", () => {
+    // The escape hatch, and the whole of "nobody is locked out by a bad
+    // guess": a tablet in a keyboard folio reports the pointer of a tablet
+    // until the first keystroke, and then it does not matter what it reports.
+    expect(keyboardPresent(true, true)).toBe(true);
+    expect(keyboardPresent(true, false)).toBe(true);
+    expect(keyboardPresent(true, null)).toBe(true);
+  });
+
+  it("opens for anything it cannot answer", () => {
+    // No `matchMedia`, or the server rendering the markup the page ships
+    // with. Wrongly open is a tile that does nothing; wrongly shut is a child
+    // with no way to argue, and the two are not the same size.
+    expect(keyboardPresent(false, null)).toBe(true);
+  });
+
+  it("opens for a device with a pointer that hovers", () => {
+    // A laptop with a touchscreen answers `any-pointer: coarse` and would be
+    // caught by half of this query on its own.
+    expect(keyboardPresent(false, false)).toBe(true);
+  });
+
+  it("shuts only for a touch-only device that has never seen a key", () => {
+    // The one case out of six. It is the tablet, and it is still one keystroke
+    // from being reopened.
+    expect(keyboardPresent(false, true)).toBe(false);
+  });
+});

--- a/src/games/typing/keyboard/useKeyboardPresence.ts
+++ b/src/games/typing/keyboard/useKeyboardPresence.ts
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Does this device have a physical keyboard? (docs/typing.md §4.5, §8.8,
+ * decision 53.)
+ *
+ * Hailstorm is the one screen on this site that cannot be played without one:
+ * it needs raw `keydown` with a `code`, and there is no software keyboard on
+ * screen during it (§8.8). A tile that opened a game a child cannot play is
+ * the "fails mysteriously" this exists to prevent — so the ladder asks this
+ * and says so instead.
+ *
+ * ── It is a guess, and it is built to be wrong safely ────────────────────────
+ * There is no browser API for "a keyboard is attached". Everything available
+ * is a proxy, and every proxy is wrong about somebody: an iPad in a
+ * keyboard-only folio has a keyboard and reports the pointer of a tablet; a
+ * laptop with a touchscreen reports the pointer of a tablet and has always had
+ * one. So the answer is built out of two signals of very different strength,
+ * and the weak one only ever decides the case the strong one has not.
+ *
+ *   - **Proof: a key arrived.** Any `keydown` carrying a `code` is a physical
+ *     keyboard, full stop, and no media query can argue with it. This latches
+ *     for the life of the page and nothing takes it back.
+ *   - **A guess: the pointer.** `(any-pointer: coarse) and (any-hover: none)`
+ *     is "every input this device has is a fingertip" — no mouse, no trackpad,
+ *     nothing that can hover. That is a tablet or a phone. A desktop with a
+ *     touchscreen fails the second half (its mouse hovers) and is not caught
+ *     by it, which is the false negative that would have mattered most.
+ *
+ * **The default is yes.** Anything this cannot answer — an old browser with no
+ * `matchMedia`, the server, a device whose pointer says nothing — is treated
+ * as having a keyboard, because the two ways of being wrong are not the same
+ * size. Wrongly open is a tile that does nothing when a child presses it;
+ * wrongly shut is a child locked out of the game with no way to argue. And the
+ * way back from wrongly shut is the proof above: press any key and the guess
+ * is over, live, with nothing to reload.
+ *
+ * User-agent sniffing is deliberately not among the signals. It is a list of
+ * strings that goes stale, it cannot see a keyboard plugged in after the page
+ * loaded, and it would answer the one question here — "can this child press a
+ * key" — with a fact about who made the device.
+ *
+ * ── Not stored ───────────────────────────────────────────────────────────────
+ * Proof lives in this module and dies with the page. It could be written to
+ * the profile and remembered, and deliberately is not: a device is shared, a
+ * keyboard is unplugged, and a stored "yes" from March is exactly the kind of
+ * stale fact that would lock the honest answer out. Re-proving it costs one
+ * keystroke, and a child at a keyboard makes hundreds.
+ */
+
+/** Every mounted `useKeyboardPresence`, so proof reaches all of them at once. */
+const watchers = new Set<() => void>();
+
+/** Has a real key been seen on this device since the page loaded? */
+let proven = false;
+
+/**
+ * A keydown that proves a physical keyboard.
+ *
+ * `code` is the whole test, and it is the same field the gun reads
+ * (`useStormClock`) — so what counts as proof here is exactly "a key the storm
+ * could have been played with", rather than a second, looser idea of a
+ * keystroke. A software keyboard is not expected to produce one: `code` is
+ * the physical key's position, which an on-screen key does not have, and both
+ * the empty string and `"Unidentified"` are what browsers put there when they
+ * have nothing to say.
+ *
+ * Exported for its test, and because "what counts as proof" is the kind of
+ * rule that gets quietly restated at a call site.
+ */
+export function provesKeyboard(event: Pick<KeyboardEvent, "code">): boolean {
+  return (
+    typeof event.code === "string" &&
+    event.code !== "" &&
+    event.code !== "Unidentified"
+  );
+}
+
+function onKeyDown(event: KeyboardEvent) {
+  if (proven || !provesKeyboard(event)) return;
+  proven = true;
+  window.removeEventListener("keydown", onKeyDown, true);
+  for (const wake of [...watchers]) wake();
+}
+
+/**
+ * Media query for "every pointer on this device is a fingertip".
+ *
+ * `any-` rather than the primary `pointer`/`hover`, because the question is
+ * what the device HAS and not what it is being driven by at this instant — a
+ * laptop being used by touch still has its keyboard sitting there.
+ */
+const TOUCH_ONLY = "(any-pointer: coarse) and (any-hover: none)";
+
+/** The media query object, or `null` where there is no `matchMedia` to ask. */
+function touchOnly(): MediaQueryList | null {
+  if (typeof window === "undefined") return null;
+  if (typeof window.matchMedia !== "function") return null;
+  return window.matchMedia(TOUCH_ONLY);
+}
+
+/**
+ * The rule itself, as arithmetic over the two signals — proof, and what the
+ * pointer says (`true` touch-only, `false` not, `null` for a browser that
+ * cannot be asked).
+ *
+ * Separate from the browser so that the half of this story that matters can be
+ * tested without one: **nothing but a definite "every pointer here is a
+ * fingertip", with no key ever seen, closes the door.** An unanswerable
+ * device, a device with a mouse and a device that has proved itself are all
+ * open, and the asymmetry is deliberate — see the file header.
+ */
+export function keyboardPresent(
+  seenKey: boolean,
+  touchOnlyDevice: boolean | null,
+): boolean {
+  return seenKey || touchOnlyDevice !== true;
+}
+
+/** The answer right now, for this page and this device. */
+function look(): boolean {
+  return keyboardPresent(proven, touchOnly()?.matches ?? null);
+}
+
+export function useKeyboardPresence(): boolean {
+  // Server-rendered as `true` for the same reason an unanswerable device is:
+  // the markup a screen ships with must not be the one that shuts a door.
+  const [present, setPresent] = useState(look);
+
+  useEffect(() => {
+    const wake = () => setPresent(look());
+    watchers.add(wake);
+
+    // The proof listener outlives this component on purpose, and is removed
+    // only by the proof itself. A child who leaves the ladder for a lesson and
+    // types four hundred characters has proved the point, and a listener that
+    // came off with the screen would have watched none of it. It is one
+    // capture listener per page load, on the same window the gun binds to, and
+    // it takes itself off the moment it has its answer.
+    if (!proven) window.addEventListener("keydown", onKeyDown, true);
+
+    // A trackpad case being attached moves `any-hover` under a tablet, which
+    // is a device that just grew a keyboard. Nothing here waits for a
+    // keystroke to notice it.
+    const query = touchOnly();
+    query?.addEventListener("change", wake);
+
+    // The state was read before the effect ran; a key pressed in between would
+    // otherwise be a proof nothing published.
+    wake();
+
+    return () => {
+      watchers.delete(wake);
+      query?.removeEventListener("change", wake);
+    };
+  }, []);
+
+  return present;
+}

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import { RaceProvider } from "@/components/state/RaceContext";
 import { FINGER_ZONES, KEYS, keyX, strokeFor } from "@/engine/keyboard";
 import {
+  MIN_FALL_MS,
   SHIELD_FINGERS,
   buildWave,
   fire,
@@ -557,9 +558,11 @@ describe("StormField", () => {
   });
 
   it("draws what is in the air, and nothing that is spent", () => {
-    // Four letters, 300ms apart, each crossing the field in half a second: by
-    // 950ms the first two have landed and the last two are still falling.
-    const state = frameOf(only("j", 4, 500), 950);
+    // Four letters, 300ms apart, each crossing the field in the fastest fall
+    // the generator allows (`MIN_FALL_MS`, §8.10): they land at 800, 1100,
+    // 1400 and 1700, so by 1150ms the first two are spent and the last two —
+    // spawned at 600 and 900 — are still in the air.
+    const state = frameOf(only("j", 4, MIN_FALL_MS), MIN_FALL_MS + 350);
 
     expect(stones(state)).toHaveLength(2);
     expect(state.resolved[0]).not.toBeNull();
@@ -601,12 +604,51 @@ describe("StormField", () => {
     expect(aimedAt(dead)).toBeNull();
   });
 
+  it("hands the way out to the HUD, and says which key does it too", () => {
+    // Forwarding, which is all this file does with it — where the control
+    // goes and when it goes away are `StormHud`'s (§8.8, #155). What is worth
+    // pinning here is that a screen which offers a destination gets one, and
+    // that the key doing the same job is named for a child who cannot see the
+    // button: while the gun is live, `Tab` is one of the keys it swallows.
+    const live = frameOf(only("f"), 500);
+    const html = renderToStaticMarkup(
+      <StormField state={live} skyRef={{ current: null }} onQuit={() => {}} />,
+    );
+
+    expect(html).toContain("storm__quit");
+    expect(html).toContain("press Escape to leave");
+    // And a screen with nowhere to send them draws neither.
+    expect(draw(live)).not.toContain("storm__quit");
+  });
+
   it("says what the screen is, without reading out the hailstorm", () => {
     const html = draw(frameOf(only("f"), 500));
 
+    /** The opening tag of the first element carrying a class, whole. */
+    const tag = (cls: string) =>
+      new RegExp(`<[a-z0-9]+[^>]*class="[^"]*\\b${cls}\\b[^"]*"[^>]*>`).exec(
+        html,
+      )?.[0] ?? "";
+
     expect(html).toContain("Hailstorm");
-    // The sky churns sixty times a second once STM04 lands; the board is
-    // sixty spans. Neither is an announcement anybody could act on.
-    expect(html.match(/aria-hidden="true"/g)).toHaveLength(2);
+
+    // Everything that moves is hidden: the two HUD numbers, every stone, the
+    // eight shield segments and the board's sixty spans. None of it is an
+    // announcement anybody could act on, and a live region reading out a
+    // hailstorm is a denial of service rather than an accommodation (§4.4).
+    for (const cls of [
+      "storm__score",
+      "storm__combo",
+      "storm__letter",
+      "storm__shield",
+      "keyboard",
+    ])
+      expect(tag(cls), cls).toContain('aria-hidden="true"');
+
+    // The sky itself is NOT, and that is the point of putting the attribute on
+    // its parts (#155): the way out is drawn in the HUD, and a screen whose
+    // only exit sat inside a hidden subtree would be a trap for the child
+    // least able to get out of it.
+    expect(tag("storm__sky")).not.toContain("aria-hidden");
   });
 });

--- a/src/games/typing/storm/StormField.tsx
+++ b/src/games/typing/storm/StormField.tsx
@@ -124,11 +124,20 @@ export function aimedAt(state: StormState): string | null {
 export function StormField({
   state,
   skyRef,
+  onQuit,
   over,
 }: {
   state: StormState;
   /** Where `useStormClock` writes the fall, frame by frame. */
   skyRef: React.RefObject<HTMLDivElement | null>;
+  /**
+   * Ask to leave mid-run, or absent on a screen with no way out (`StormHud`).
+   *
+   * Handed to the HUD rather than drawn here, because the HUD is the row that
+   * already owns the top of the sky and its two corners — a way out placed by
+   * this file would be a second opinion about where that row is.
+   */
+  onQuit?: () => void;
   /**
    * What stands where the board does once the run is over (§8.5, STM07).
    *
@@ -146,31 +155,47 @@ export function StormField({
 }) {
   return (
     <main className="storm">
-      {/* The screen's name, for the one visitor who cannot see any of it. The
-          field itself is hidden below — see the sky. */}
+      {/* The screen's name and what it is, for the one visitor who cannot see
+          any of it. Everything that moves is hidden one level down — see the
+          sky — so this and the way out are all there is to announce, which is
+          honest: the game is a physical keyboard and a reaction time, and a
+          child who cannot see the letters cannot play it (§8.8). What they can
+          still do is leave, and while the gun is live `Tab` is a key it
+          swallows, so the key that does it is worth naming. */}
       <h1 className="u-sr">Hailstorm</h1>
+      {state.ending === null && (
+        <p className="u-sr">
+          Letters fall down the column of the key that types them. Press that
+          key to shoot the lowest one, or press Escape to leave.
+        </p>
+      )}
 
       {/*
-        `aria-hidden`, for the reason the board is (§4.4): what is in here
-        changes sixty times a second under STM04's loop, and a live region
-        reading out a hailstorm is a denial of service rather than an
-        accommodation. Nothing is announced that a child could act on anyway —
-        the game is a physical keyboard and a reaction time. The device with no
-        keys is told so honestly, and that is STM09's story.
+        Not `aria-hidden` itself, though nearly everything in it is: the way
+        out lives in the HUD (`StormHud`), and a screen whose only exit was
+        inside a hidden subtree would be a trap for exactly the child least
+        able to get out of it. So the attribute sits on each churning part —
+        the two HUD numbers, every stone, the shield — for the reason the board
+        carries one (§4.4): what is in here changes sixty times a second, and a
+        live region reading out a hailstorm is a denial of service rather than
+        an accommodation.
       */}
-      <div className="storm__sky" ref={skyRef} aria-hidden="true">
+      <div className="storm__sky" ref={skyRef}>
         {/* First in the sky, so every stone paints over the numbers rather
             than under them: a score must never hide a letter that has to be
             shot. It is in here rather than in a row of its own because the sky
             is the only track `.storm` can take a row FROM, and on a short
             viewport it has nothing left to give (decision 45, `StormHud`). */}
-        <StormHud state={state} />
+        <StormHud state={state} onQuit={onQuit} />
 
         {state.wave.letters.map((letter, index) => {
           if (!isDrawn(state, index)) return null;
 
           return (
             <span
+              // Hidden for the reason the sky's other churn is: a letter is on
+              // screen for a second and a half and is not a thing to announce.
+              aria-hidden="true"
               // The index is the letter's identity (§8.3): the wave is built
               // once and never grows, so this key cannot shift under a letter
               // mid-fall — which it would if the drawn letters were numbered

--- a/src/games/typing/storm/StormHud.test.tsx
+++ b/src/games/typing/storm/StormHud.test.tsx
@@ -39,8 +39,8 @@ const played = (hits: number, misses = 0, spec = only("f")): StormState => {
   return state;
 };
 
-const hud = (state: StormState) =>
-  renderToStaticMarkup(<StormHud state={state} />);
+const hud = (state: StormState, onQuit?: () => void) =>
+  renderToStaticMarkup(<StormHud state={state} onQuit={onQuit} />);
 
 /** The HUD's text, with the markup taken out. */
 const readOut = (state: StormState) => hud(state).replace(/<[^>]+>/g, " ");
@@ -107,6 +107,58 @@ describe("StormHud", () => {
     // be `Number("")`, which is 0, and the HUD would be written the first
     // letter's fall sixty times a second.
     expect(hud(played(1))).not.toContain("data-stone");
+  });
+
+  /*
+   * The way out (docs/typing.md §8.8, #155). A storm fills the viewport with
+   * no site chrome over it, so until the run ends this is the only exit there
+   * is — and on a tablet, where the game cannot be played at all, it is the
+   * only thing on the screen that does anything.
+   */
+
+  it("draws a way out while the gun is live", () => {
+    const html = hud(played(2), () => {});
+    expect(html).toContain("storm__quit");
+    expect(html).toContain(">Quit<");
+  });
+
+  it("draws none where a screen offers none", () => {
+    // The prop is optional so that a still frame — this suite, a future
+    // screen showing a run back — is not obliged to invent a destination.
+    expect(hud(played(2))).not.toContain("storm__quit");
+  });
+
+  it("takes it away with the gun", () => {
+    // Once the run has an ending, the panel standing where the board did
+    // carries the way out (`StormOver`), and two exits on one screen are two
+    // answers to the same question.
+    const spec = only("f", { count: 1, fall: [1000, 1000] });
+    const over = tick(startStorm(buildWave(spec, 7)), 5000);
+
+    expect(over.ending).not.toBeNull();
+    expect(hud(over, () => {})).not.toContain("storm__quit");
+  });
+
+  it("keeps the numbers where they were when it goes", () => {
+    // Both are placed by column rather than by order (`game.css`), so the
+    // multiplier does not slide into the middle of the sky on the frame the
+    // quit disappears.
+    const live = hud(played(2), () => {});
+    expect(live).toMatch(/storm__score[^>]*>[\s\S]*storm__quit/);
+    expect(live).toMatch(/storm__quit[\s\S]*storm__combo/);
+  });
+
+  it("is the one thing in the sky that is not aria-hidden", () => {
+    // The sky's moving parts are hidden one element at a time (§4.4,
+    // `StormField`), and this is why: an exit inside a hidden subtree is a
+    // trap for exactly the child least able to get out of it.
+    const html = hud(played(2), () => {});
+    const quit = /<button[^>]*class="[^"]*storm__quit[^"]*"[^>]*>/.exec(
+      html,
+    )![0];
+
+    expect(quit).not.toContain("aria-hidden");
+    expect(html.match(/aria-hidden="true"/g)).toHaveLength(2);
   });
 
   it("says nothing about XP, in a run or at the end of one", () => {

--- a/src/games/typing/storm/StormHud.tsx
+++ b/src/games/typing/storm/StormHud.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/kit";
 import { comboMultiplier } from "@/engine/combo";
 
 import type { StormState } from "@/engine/typing/storm";
@@ -37,12 +38,33 @@ import type { StormState } from "@/engine/typing/storm";
  * than under it: a number must never hide a letter that has to be shot, which
  * is also why the score sits in the HUD's dim ink rather than in `--chalk`.
  *
- * That puts it inside the sky's `aria-hidden`, which is the right side of that
- * trade and worth saying out loud. Hailstorm is a physical keyboard and a
- * reaction time — a child who cannot see the falling letters cannot play it at
- * all (§8.8 and STM09 are where that is answered honestly) — and a live region
- * reciting a score that moves every 300ms is a denial of service rather than
- * an accommodation (§4.4).
+ * The two numbers are `aria-hidden`, which is the right side of that trade and
+ * worth saying out loud. Hailstorm is a physical keyboard and a reaction time —
+ * a child who cannot see the falling letters cannot play it at all (§8.8) —
+ * and a live region reciting a score that moves every 300ms is a denial of
+ * service rather than an accommodation (§4.4). The attribute is on each of
+ * them rather than on the sky that holds them, because the way out is in here
+ * too and that is the one thing on this screen everybody needs (below).
+ *
+ * ── The way out ─────────────────────────────────────────────────────────────
+ * A storm fills the viewport and there is no site chrome over a game
+ * (CLAUDE.md), so without this a child who cannot play — the tablet §8.8 is
+ * about, or anyone who has simply had enough — is on a screen with no exit but
+ * the browser's own. It sits between the two numbers because those are the two
+ * corners already taken, and because the middle of the HUD is the part of the
+ * sky a child is least often reading: the letters that matter are the low
+ * ones.
+ *
+ * It is a real control and not a decoration: `pointer-events` are given back
+ * to it in `game.css` (the sky refuses them, so a drag cannot select a
+ * hailstorm), and it is the one thing in the sky a finger is allowed to land
+ * on. `QUIT_KEY` is the same door for a child who has a keyboard, and it has
+ * to exist separately: while the gun is live, `Tab` is one of the keys it
+ * swallows, so this button cannot be reached by tabbing to it.
+ *
+ * It goes when the gun does. Once the run has an ending, the panel that stands
+ * where the board did carries the way out (`StormOver`), and two of them would
+ * be two answers to "how do I leave" on one screen.
  *
  * ── One flash per miss, and never a sequence ─────────────────────────────────
  * The `--flare` wash over the score is a child element keyed by `misses`, a
@@ -53,22 +75,36 @@ import type { StormState } from "@/engine/typing/storm";
  * key auto-repeat (decision 44), so the fastest this can mount is a child's
  * own keystrokes.
  */
-export function StormHud({ state }: { state: StormState }) {
+export function StormHud({
+  state,
+  onQuit,
+}: {
+  state: StormState;
+  /** Ask to leave mid-run. Absent on a screen that offers no way out. */
+  onQuit?: () => void;
+}) {
   const { combo, misses, score } = state;
 
   return (
     <div className="storm__hud">
-      <p className="storm__score u-mono">
+      <p className="storm__score u-mono" aria-hidden="true">
         {score}
         {/* Mounted by the counter — see the header. Only above zero, so a run
             does not start with a flash of red over a score of nothing. */}
         {misses > 0 && <span key={`miss${misses}`} className="storm__miss" />}
       </p>
 
+      {onQuit && state.ending === null && (
+        <Button variant="bare" className="storm__quit" onClick={onQuit}>
+          Quit
+        </Button>
+      )}
+
       {/* `--lime` only once there is a streak to be paid for: at ×1 this is a
           fact about the rules, and at ×1.6 it is a thing a child earned. */}
       <p
         className="storm__combo u-mono"
+        aria-hidden="true"
         data-hot={combo > 0 ? "" : undefined}
       >{`×${comboMultiplier(combo).toFixed(1)}`}</p>
     </div>

--- a/src/games/typing/storm/StormRun.tsx
+++ b/src/games/typing/storm/StormRun.tsx
@@ -7,7 +7,7 @@ import { typingMode } from "@/engine/decks/typing";
 import { sessionsFor } from "@/engine/records";
 import { unlockedAt } from "@/engine/typing/keys";
 import { buildWave } from "@/engine/typing/storm";
-import { SaveFailed, useRaceFinish } from "@/games/race";
+import { QuitSheet, SaveFailed, useRaceFinish } from "@/games/race";
 
 import { StormField } from "./StormField";
 import { StormOver } from "./StormOver";
@@ -20,18 +20,17 @@ import type { Profile } from "@/engine/types";
 /**
  * The Hailstorm route (docs/typing.md §9), playing one wave.
  *
- * The screen is five things joined: a field that draws a `StormState`, a clock
- * that produces one per animation frame, a keyboard that shoots, the ending
- * that says which finger let it through and offers a drill of that finger's
- * keys (`StormOver`), and — the moment the storm stops — the run written to
- * the record book as a `Session` (§8.7, `stormSession.ts`).
+ * The screen is six things joined: a field that draws a `StormState`, a clock
+ * that produces one per animation frame, a keyboard that shoots, the way out
+ * (below), the ending that says which finger let it through and offers a drill
+ * of that finger's keys (`StormOver`), and — the moment the storm stops — the
+ * run written to the record book as a `Session` (§8.7, `stormSession.ts`).
  *
  * What it is still not is a whole game. STM10 replaces the stand-in wave below
  * with the twenty the ladder actually names.
  *
  * Unlinked on purpose. Nothing on the ladder points here until STM10 puts the
- * storm tiles on it, so the only way in is the URL — which is exactly what a
- * screen with no quit button should be.
+ * storm tiles on it, so the only way in is the URL.
  */
 
 /**
@@ -189,6 +188,26 @@ function StormPlay({
   const navigate = useNavigate();
 
   /**
+   * Is the quit sheet up? (§8.8, decision 54.)
+   *
+   * It is the storm's pause as well as its question, and the two are one flag
+   * because they are one moment: a wave that went on falling behind the sheet
+   * would break a child's shield while they read "it won't be saved", and a
+   * gun still listening would fire `Space` and `Enter` at the letters instead
+   * of at the two buttons in front of them. `useStormClock` takes it as
+   * `paused` and stops the loop, which costs the run nothing — wave time is
+   * measured between frames, and there are none.
+   *
+   * **Quitting saves nothing, and there is no code here that makes that true.**
+   * The run is written by the effect below, which fires on an `ending` the
+   * reducer stamps; a wave abandoned halfway has none, so leaving is a
+   * navigation and the route unmounts with the run still only in memory. That
+   * is worth stating because it is the kind of guarantee somebody later adds a
+   * "save the partial run" line against without noticing it was a promise.
+   */
+  const [quitting, setQuitting] = useState(false);
+
+  /**
    * This attempt's wave, and the config the run will be filed under.
    *
    * Built once per mount and never rebuilt: a run's wave is fixed for its
@@ -197,7 +216,14 @@ function StormPlay({
    */
   const [wave] = useState(() => buildWave(PREVIEW_SPEC, PREVIEW_SEED));
   const config = useMemo(() => stormConfig(PREVIEW_LESSON_ID, wave), [wave]);
-  const { state, skyRef } = useStormClock(wave);
+  const { state, skyRef } = useStormClock(wave, {
+    paused: quitting,
+    // The keyboard's way to the same sheet the button opens. It is taken
+    // inside the gun's own listener because every other key while the run is
+    // live is a shot, and a way out that cost ten points would be a trap
+    // (`QUIT_KEY`).
+    onQuit: () => setQuitting(true),
+  });
 
   // Snapshotted at mount so the run we're about to save can't affect it.
   const [history] = useState(() => sessionsFor(sessions, profile.id));
@@ -259,19 +285,37 @@ function StormPlay({
     );
 
   return (
-    <StormField
-      state={state}
-      skyRef={skyRef}
-      // Drawn where the board was, and only once the run is over — which is
-      // `StormField`'s call to make, off the same `ending` the gun dies on.
-      over={
-        <StormOver
-          state={state}
-          mode={PREVIEW_MODE}
-          profileId={profile.id}
-          onRetry={onRetry}
+    <>
+      <StormField
+        state={state}
+        skyRef={skyRef}
+        onQuit={() => setQuitting(true)}
+        // Drawn where the board was, and only once the run is over — which is
+        // `StormField`'s call to make, off the same `ending` the gun dies on.
+        over={
+          <StormOver
+            state={state}
+            mode={PREVIEW_MODE}
+            profileId={profile.id}
+            onRetry={onRetry}
+          />
+        }
+      />
+
+      {/* The race's sheet and not a second one, because it is the same
+          question with a different noun: the storm is paused behind it, the
+          run is not saved either way, and "it won't be saved and no XP is
+          earned" is the one thing being weighed. Quitting goes back to the
+          ladder, which is where the tile that will send a child here lives. */}
+      {quitting && (
+        <QuitSheet
+          title="Quit this storm?"
+          keep="Keep playing"
+          label="Quit the storm"
+          onQuit={() => navigate(`/p/${profile.id}`)}
+          onKeepRacing={() => setQuitting(false)}
         />
-      }
-    />
+      )}
+    </>
   );
 }

--- a/src/games/typing/storm/StormShield.test.tsx
+++ b/src/games/typing/storm/StormShield.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { FINGER_ZONES } from "@/engine/keyboard";
 import {
+  MIN_FALL_MS,
   SHIELD_FINGERS,
   buildWave,
   fire,
@@ -30,7 +31,10 @@ const only = (ch: string, over: Partial<WaveSpec> = {}): WaveSpec => ({
   keys: [ch],
   count: 4,
   gap: [300, 300],
-  fall: [500, 500],
+  // The fastest fall the generator will build (`MIN_FALL_MS`, §8.10), so the
+  // schedule below is the one a wave really gets: spawns at 0, 300, 600 and
+  // 900, landing at 800, 1100, 1400 and 1700.
+  fall: [MIN_FALL_MS, MIN_FALL_MS],
   shield: 3,
   repairAt: 0,
   ...over,
@@ -102,20 +106,20 @@ describe("StormShield", () => {
     const start = frameOf(only("f", { shield: 3 }), 0);
     expect(at(start, "l-index").vars["--hp"]).toBe(1);
 
-    // One `f` has landed by 550ms: two of three left on the left index, and
+    // One `f` has landed by 850ms: two of three left on the left index, and
     // nothing taken off any other finger.
-    const hurt = frameOf(only("f", { shield: 3 }), 550);
+    const hurt = frameOf(only("f", { shield: 3 }), 850);
     expect(at(hurt, "l-index").vars["--hp"]).toBeCloseTo(2 / 3, 10);
     expect(at(hurt, "r-index").vars["--hp"]).toBe(1);
   });
 
   it("reads a zone at zero as a hole, and nothing above it", () => {
-    const hurt = frameOf(only("f", { shield: 2 }), 550);
+    const hurt = frameOf(only("f", { shield: 2 }), 850);
     expect(at(hurt, "l-index").hole).toBe(false);
 
     // Two landings into a two-point zone: empty, and the next `f` down this
     // column ends the run.
-    const gone = frameOf(only("f", { shield: 2 }), 850);
+    const gone = frameOf(only("f", { shield: 2 }), 1150);
     expect(at(gone, "l-index").vars["--hp"]).toBe(0);
     expect(at(gone, "l-index").hole).toBe(true);
     expect(segments(gone).filter((zone) => zone.hole)).toHaveLength(1);
@@ -134,14 +138,14 @@ describe("StormShield", () => {
     // moves by two rather than a second element (§8.10). What that element
     // then does — mount once, animate once, and not restart on a frame where
     // nothing happened — is the browser's to answer, and `e2e/smoke.mjs` does.
-    const one = frameOf(only("f"), 550);
+    const one = frameOf(only("f"), 850);
     expect(at(one, "l-index").hit).toBe(1);
     expect(zoneTally(one)["l-index"].hit).toBe(1);
 
-    // 30ms of gap and a 500ms fall puts two landings inside one 16ms frame.
+    // 30ms of gap and an 800ms fall puts two landings inside one 16ms frame.
     const together = tick(
       startStorm(buildWave(only("f", { gap: [30, 30] }), 7)),
-      540,
+      830,
     );
     expect(together.resolved.filter(Boolean)).toHaveLength(2);
     expect(zoneTally(together)["l-index"].hit).toBe(2);
@@ -152,15 +156,17 @@ describe("StormShield", () => {
     // A shield of two with a repair every second hit: one letter through, then
     // two shot, and the weakest zone — the one that just took the hit — gets
     // its point back (§8.5).
-    const spec = only("f", { shield: 2, repairAt: 2 });
-    const hurt = frameOf(spec, 550);
+    // Gaps wider than the fall, so the letters come one at a time (§8.3):
+    // spawns at 0, 900 and 1800, landing at 800, 1700 and 2600.
+    const spec = only("f", { shield: 2, repairAt: 2, gap: [900, 900] });
+    const hurt = frameOf(spec, 1000);
     expect(at(hurt, "l-index").vars["--hp"]).toBe(0.5);
     expect(at(hurt, "l-index").mend).toBe(0);
 
-    // A tick between the two shots, because the second letter has not spawned
-    // at 550ms and firing at an empty field is a miss that breaks the streak
+    // A tick between the two shots, because the third letter has not spawned
+    // at 1000ms and firing at an empty field is a miss that breaks the streak
     // (§8.4) — which is the rule the repair hangs off.
-    const mended = fire(tick(fire(hurt, "KeyF"), 100), "KeyF");
+    const mended = fire(tick(fire(hurt, "KeyF"), 900), "KeyF");
     expect(mended.shield["l-index"]).toBe(2);
     expect(zoneTally(mended)["l-index"]).toEqual({ hit: 1, mend: 1 });
     expect(at(mended, "l-index").mend).toBe(1);
@@ -172,7 +178,7 @@ describe("StormShield", () => {
     // breaks before the decrement — there was nothing left to take. Counting
     // it against the hit points would leave the arithmetic one short and draw
     // a lime pulse on the frame a child died.
-    const dead = frameOf(only("f", { shield: 1 }), 900);
+    const dead = frameOf(only("f", { shield: 1 }), 1150);
 
     expect(dead.ending).toEqual({
       kind: "breached",

--- a/src/games/typing/storm/StormShield.tsx
+++ b/src/games/typing/storm/StormShield.tsx
@@ -64,7 +64,10 @@ export function StormShield({ state }: { state: StormState }) {
   const tally = zoneTally(state);
 
   return (
-    <div className="storm__shield">
+    // Hidden for the reason the rest of the sky's moving parts are (§4.4,
+    // `StormField`): eight numbers that change as letters land are not an
+    // announcement anybody could act on.
+    <div className="storm__shield" aria-hidden="true">
       {SHIELD_FINGERS.map((finger) => {
         const zone = FINGER_ZONES[finger];
         const hp = state.shield[finger];

--- a/src/games/typing/storm/useStormClock.test.ts
+++ b/src/games/typing/storm/useStormClock.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { keyX, strokeFor } from "@/engine/keyboard";
 import { buildWave, fire, startStorm, tick } from "@/engine/typing/storm";
 
-import { MAX_STEP_MS, redrawn, stepMs } from "./useStormClock";
+import { MAX_STEP_MS, QUIT_KEY, redrawn, stepMs } from "./useStormClock";
 
 import type {
   ShieldFinger,
@@ -35,6 +35,27 @@ const spec: WaveSpec = {
 
 const run = (atMs: number): StormState =>
   tick(startStorm(buildWave(spec, 7)), atMs);
+
+describe("the key that leaves a storm", () => {
+  /*
+   * `QUIT_KEY` is taken inside the gun's own listener and before the trigger,
+   * so what it must be is a key that could not have been a shot. Two ways it
+   * could stop being one, and both are decidable here.
+   */
+
+  it("is not a key the board carries", () => {
+    // A key with a lane is a key `preventDefault` swallows and a key a letter
+    // can fall down. `Escape` has neither, which is what makes it spendable.
+    expect(keyX(QUIT_KEY)).toBeNull();
+  });
+
+  it("is not a key any character is typed with", () => {
+    // The stronger half: if some character resolved to this code, a child
+    // shooting that letter would leave the game instead.
+    for (const ch of [...`abcdefghijklmnopqrstuvwxyz0123456789 ;',./[]\\-=\``])
+      expect(strokeFor(ch)?.code, ch).not.toBe(QUIT_KEY);
+  });
+});
 
 describe("stepMs", () => {
   it("is nothing on the first frame of a run", () => {

--- a/src/games/typing/storm/useStormClock.ts
+++ b/src/games/typing/storm/useStormClock.ts
@@ -95,6 +95,22 @@ import type { StormState, Wave } from "@/engine/typing/storm";
 export const MAX_STEP_MS = 100;
 
 /**
+ * The key that leaves a storm (§8.8, decision 55).
+ *
+ * `Escape` is not on the board — `keyX` says so, which is what keeps it out of
+ * the `preventDefault` below — so it is the one key on a keyboard this game
+ * has no use for, and therefore the one it can spend on the way out.
+ *
+ * It has to be known HERE and not only by the screen that acts on it. Every
+ * other keydown while the gun is live is a shot, and a shot that missed costs
+ * ten points and the streak: an `Escape` handled by a second listener beside
+ * this one would still be fired at as a miss on the way past, so a child
+ * reaching for the way out would be charged for reaching for it. One listener,
+ * one decision, and the quit is taken before the trigger.
+ */
+export const QUIT_KEY = "Escape";
+
+/**
  * How much wave time one frame is worth, given the two rAF timestamps around
  * it. `last` is `null` on the first frame of a run, which is worth nothing.
  *
@@ -182,7 +198,38 @@ export function redrawn(drawn: StormState, next: StormState): boolean {
  * than from a render, which is the same reason `useRaceClock` keeps its marks
  * in refs.
  */
-export function useStormClock(wave: Wave): {
+export function useStormClock(
+  wave: Wave,
+  {
+    paused = false,
+    onQuit,
+  }: {
+    /**
+     * Freeze the run: no frames, no wave time, no gun (§8.8, decision 54).
+     *
+     * This file's cleanup used to say that a quit which kept the field on
+     * screen would be a pause, and that a pause is an input rather than an
+     * omission. This is that input. A storm with the quit sheet up must not go
+     * on falling behind it — a child reading "this won't be saved" while their
+     * shield breaks is being charged for asking the question — and it must not
+     * go on shooting either, because `Space` and `Enter` are the keys the
+     * sheet's own buttons answer to.
+     *
+     * Both come free from tearing the effect down. rAF is what moves wave
+     * time, and `last` starts over at `null` when the loop re-arms, so however
+     * long the sheet is up is worth exactly zero to the storm. Nothing here
+     * holds a paused-at timestamp for a resume to get wrong.
+     */
+    paused?: boolean;
+    /**
+     * What `QUIT_KEY` does, or nothing where a screen offers no way out.
+     *
+     * Taken here rather than by a listener of the screen's own, because the
+     * gun is here: see `QUIT_KEY`.
+     */
+    onQuit?: () => void;
+  } = {},
+): {
   state: StormState;
   skyRef: React.RefObject<HTMLDivElement | null>;
 } {
@@ -193,6 +240,14 @@ export function useStormClock(wave: Wave): {
   const drawn = useRef(state);
   const skyRef = useRef<HTMLDivElement | null>(null);
 
+  /**
+   * Through a ref for the reason `StormRun`'s finish is: a fresh closure every
+   * render, and naming it as a dependency would re-arm the loop — and reset
+   * `last` — on every re-render of a screen that re-renders on the picture.
+   */
+  const quitRef = useRef<(() => void) | undefined>(undefined);
+  quitRef.current = onQuit;
+
   useEffect(() => {
     // A run's wave is fixed for its whole life (`StormState.wave`), so this
     // normally arms once per mount. Handed a different storm it starts that
@@ -202,6 +257,12 @@ export function useStormClock(wave: Wave): {
       drawn.current = live.current;
       setState(live.current);
     }
+
+    // Nothing is armed while the sheet is up: no frame is requested, so no
+    // wave time passes, and no listener is bound, so no key fires or is
+    // swallowed. Resuming re-runs this effect from the top with `last` null
+    // again, which is a first frame worth zero (`stepMs`).
+    if (paused) return;
 
     let frame = 0;
     let last: number | null = null;
@@ -218,9 +279,12 @@ export function useStormClock(wave: Wave): {
      * as the run is live; the rules for what that is worth are `fire`'s, and
      * none of them are here.
      *
-     * Three keydowns are not strokes even while it is, and each is left out
+     * Four keydowns are not strokes even while it is, and each is left out
      * for a reason the board already agrees with:
      *
+     *   - **`QUIT_KEY`** — the way out (§8.11). It is taken before the trigger
+     *     rather than beside it, because a key that reached `fire` would be a
+     *     miss: ten points off and the streak gone for asking to leave.
      *   - **`HELD`** — shift, ctrl, alt and the cmd keys. It is the very set
      *     `useKeyEcho` never flares, imported rather than restated: a capital
      *     is a shift and a letter (§3.3), and a game that charged a child for
@@ -258,6 +322,12 @@ export function useStormClock(wave: Wave): {
       // mouse unable to focus a button, let alone press one.
       if (live.current.ending !== null) return;
       if (event.repeat || event.ctrlKey || event.metaKey) return;
+      // Before the trigger, and after the chord guard: the way out is not a
+      // shot (`QUIT_KEY`), but cmd+Escape is the operating system's.
+      if (event.code === QUIT_KEY) {
+        quitRef.current?.();
+        return;
+      }
       if (HELD.has(event.code)) return;
       if (!event.altKey && keyX(event.code) !== null) event.preventDefault();
 
@@ -309,11 +379,11 @@ export function useStormClock(wave: Wave): {
     // of anything that might stop propagation on the way up.
     window.addEventListener("keydown", onKeyDown, true);
 
-    // The only exit there is, and every way out runs it. Quitting is one of
-    // them today: this screen has no quit control, so leaving it is a
-    // navigation, and a navigation unmounts the route. A quit that instead
-    // kept the field on screen would be a pause, and a pause is a thing this
-    // effect has to be told about — an input, not an omission.
+    // Every way out of a run runs this, and there are three: the route being
+    // left, the run ending, and the pause above. Quitting is now the first of
+    // them by way of the third — the sheet pauses the storm, and confirming it
+    // navigates — which is why `paused` is an input to this effect rather than
+    // something it could have been left to infer.
     //
     // The listener goes with the frame, for a plainer reason than the loop's:
     // one left on the window outlives the screen. It would hold this run's
@@ -325,7 +395,7 @@ export function useStormClock(wave: Wave): {
       cancelAnimationFrame(frame);
       window.removeEventListener("keydown", onKeyDown, true);
     };
-  }, [wave]);
+  }, [wave, paused]);
 
   return { state, skyRef };
 }

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -2339,10 +2339,13 @@ label.segmented__btn {
 /* One wash of `--flare` per wrong key, and never a sequence: a single pass on
    an element `StormHud` mounts from a counter that only goes up, exactly as
    the shield's damage tint is (§8.10, decision 42). It rests at zero and
-   animates down to it, so `prefers-reduced-motion` — which clamps every
-   animation to one 0.001ms pass — leaves the score exactly as it found it, and
-   what a child who asked for less motion still gets is the number itself,
-   which has already fallen. */
+   animates down to it, so nothing is lost by taking it off entirely — which
+   is what the reduced-motion block below does, `animation: none` rather than
+   base.css's 0.001ms clamp (§8.10). Do not read that block as redundant with
+   the clamp: the clamp shortens this animation, the block stops it existing,
+   and the difference is one `animationstart` the smoke suite counts. What a
+   child who asked for less motion still gets is the number itself, which has
+   already fallen. */
 .storm__miss {
   position: absolute;
   inset: 0;
@@ -2498,9 +2501,11 @@ label.segmented__btn {
    a letter lands or a repair pays out, not sixty times a second, so the layout
    property is the honest one and costs nothing. The transition is what makes a
    repair visible as a repair — the block grows back where damage drops it —
-   and it ends where `--hp` says either way, so `prefers-reduced-motion`
-   clamping every transition to 0.001ms (base.css) loses the movement and none
-   of the reading. */
+   and it ends where `--hp` says either way, so it is switched off outright
+   under `prefers-reduced-motion` (`transition: none`, in the block below —
+   §8.10) and the movement goes while none of the reading does. The block is
+   what does that here, not base.css's 0.001ms clamp: the clamp would still
+   run this transition, only faster. */
 .storm__zone::before {
   content: "";
   position: absolute;
@@ -2536,14 +2541,19 @@ label.segmented__btn {
    `StormShield` from a counter that only goes up, so it exists exactly once
    per landing and once per repair. Two letters landing on one zone inside a
    single `tick` move that counter by two, which is still one element and
-   therefore still one tint (§8.10).
+   therefore still one tint (§8.10). What that rules out is the tint
+   restarting on a frame where nothing happened; how often a WAVE may land on
+   one zone is a separate question, and one the generator does not yet answer
+   — see §8.10 for what is measured and what STM10 still owes it.
 
    Both rest at `opacity: 0` and animate down to it, so the animation adds
-   nothing to the picture once it is over and `prefers-reduced-motion` — which
-   clamps every animation to one 0.001ms pass — leaves the segment exactly as
-   it would have found it. What a child who asked for less motion still gets
-   is the block's own height, which is the damage itself rather than a report
-   of it.                                                                  */
+   nothing to the picture once it is over — which is why the reduced-motion
+   block below can take both off outright with `animation: none` and leave the
+   segment exactly as it would have found it. That block, and not base.css's
+   0.001ms clamp, is what suppresses these two under the setting; the clamp
+   only shortens them, and a shortened animation still starts. What a child
+   who asked for less motion still gets is the block's own height, which is
+   the damage itself rather than a report of it.                           */
 .storm__hit,
 .storm__mend {
   position: absolute;
@@ -2593,9 +2603,12 @@ label.segmented__btn {
    one flat box rather than layers at different speeds, and the only thing on
    the screen resembling a particle is a hailstone, which is the game. The
    guarantee is kept by not having built them, and it is measured rather than
-   promised — `e2e/smoke.mjs` counts every `animationstart` over a whole run
-   and holds the total to one per letter that lands, so a shake or a burst
-   added later fails a check that is already looking.
+   promised — `e2e/smoke.mjs` runs the same twelve-landing wave twice and
+   counts `animationstart` over the whole of each: twelve under normal motion
+   (one per letter that lands), and zero under this setting. Both censuses
+   filter on `animationName` starting `storm-`, so what they can catch is a
+   new animation named into this family; one added under any other prefix is
+   invisible to them and needs its own check.
 
    What is left is the three tints, and they are switched off rather than
    left to the blanket clamp. Under the clamp they still start and still fire

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -2305,12 +2305,17 @@ label.segmented__btn {
   position: absolute;
   inset: 0;
 
-  /* Two columns and one row: the score at one end and the multiplier at the
-     other, and nothing else — what a run PAID is the ending screen's to say
-     (`StormOver`), where there is room to say it beside the finger that let
-     the storm through. */
+  /* Three columns and one row: the score at one end, the multiplier at the
+     other, and the way out between them — what a run PAID is the ending
+     screen's to say (`StormOver`), where there is room to say it beside the
+     finger that let the storm through.
+
+     Each child names its own column rather than being placed in order,
+     because the middle one is not always there: the quit goes when the gun
+     does (`StormHud`), and auto-placement would then slide the multiplier
+     into the middle of the sky on the frame a run ends. */
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr auto 1fr;
   align-items: start;
   padding: calc(var(--key) * 0.12) calc(var(--key) * 0.1);
 
@@ -2325,6 +2330,7 @@ label.segmented__btn {
    lights up. */
 .storm__score {
   position: relative;
+  grid-column: 1;
   justify-self: start;
   padding: calc(var(--key) * 0.08) calc(var(--key) * 0.16);
   border-radius: calc(var(--key) * 0.14);
@@ -2362,6 +2368,7 @@ label.segmented__btn {
    starts and when one breaks, which is twice a run and not once a hit, so
    there is nothing here that could become a flash sequence. */
 .storm__combo {
+  grid-column: 3;
   justify-self: end;
   scale: 1;
 
@@ -2375,6 +2382,46 @@ label.segmented__btn {
 .storm__combo[data-hot] {
   scale: 1.12;
   color: var(--lime);
+}
+
+/* The way out, mid-run (docs/typing.md §8.8, decision 54).
+
+   A storm is a whole viewport with no site chrome over it, so this is the only
+   exit a child has until the run ends — and on a tablet, where the game cannot
+   be played at all, it is the only thing on the screen that does anything.
+   `Escape` is the same door for a child at a keyboard (`QUIT_KEY`), which this
+   one cannot be: `Tab` is a key the gun swallows while it is live.
+
+   `pointer-events` are handed back here and nowhere else in the sky. The sky
+   refuses them so a drag cannot select a hailstorm and a tap cannot land on a
+   letter, and this is the single exception — the one thing in there a finger
+   is meant to hit.
+
+   Drawn like the race's quit and dimmer than the numbers beside it: it is the
+   least urgent thing in the sky, and the letters have to stay the loudest. */
+.storm__quit {
+  grid-column: 2;
+  pointer-events: auto;
+
+  font-family: var(--font-mono);
+  font-size: calc(var(--key) * 0.32);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--chalk-dim);
+  padding: 0.35em 0.9em;
+  /* In key units like everything else in this field, and NOT the race's pill:
+     a pixel radius here would be the one length in the storm that did not
+     move with `--key`. */
+  border-radius: calc(var(--key) * 0.18);
+  border: 1px solid var(--hairline);
+}
+
+/* Brighter, not redder. The race's quit goes to `--flare` on hover and this
+   one must not: `--flare` is a wrong, and on this screen it is already damage,
+   a hole and a wrong key. Leaving a storm is none of those. */
+.storm__quit:hover {
+  color: var(--chalk);
+  border-color: color-mix(in oklab, var(--accent) 45%, transparent);
 }
 
 /* ── Hailstorm: the shield ───────────────────────────────────────────────
@@ -2524,6 +2571,53 @@ label.segmented__btn {
 @keyframes storm-mend {
   from {
     opacity: 0.7;
+  }
+}
+
+/* ── Hailstorm under `prefers-reduced-motion` ────────────────────────────
+   What comes off, and the one thing that cannot (docs/typing.md §8.10, #155).
+
+   **The falling stays.** A falling-letter game cannot honour the setting by
+   removing the falling, and this is why the fall was never written as an
+   animation in the first place: `useStormClock` writes `--drop` onto each
+   stone from a `requestAnimationFrame` loop and the rule above multiplies it
+   by the height of the sky, so base.css's blanket clamp — every animation to
+   one 0.001ms pass, every transition likewise — has nothing of the storm's
+   motion to reach. That is the same reason `.fuse__fill` scales rather than
+   animating: a clock a player asked less motion of still has to run.
+
+   **What comes off is decoration, and there is less of it here than the
+   design feared.** §8.10 asks for no screen shake, no parallax and no
+   particles under this setting, and the honest answer is that Hailstorm has
+   never had any of the three: nothing translates but the stones, the sky is
+   one flat box rather than layers at different speeds, and the only thing on
+   the screen resembling a particle is a hailstone, which is the game. The
+   guarantee is kept by not having built them, and it is measured rather than
+   promised — `e2e/smoke.mjs` counts every `animationstart` over a whole run
+   and holds the total to one per letter that lands, so a shake or a burst
+   added later fails a check that is already looking.
+
+   What is left is the three tints, and they are switched off rather than
+   left to the blanket clamp. Under the clamp they still start and still fire
+   an `animationstart`, 0.001ms of a wash nobody sees; `animation: none` is
+   the same picture with the event and the work gone, and it is what makes
+   "zero storm animations ran" a thing the browser can be asked. Nothing is
+   lost by it: both damage tints rest at `opacity: 0` and animate DOWN to it,
+   so what a child who asked for less motion still gets is the block's own
+   height — the damage itself rather than a report of it — and a score that
+   has already fallen.                                                      */
+@media (prefers-reduced-motion: reduce) {
+  .storm__hit,
+  .storm__mend,
+  .storm__miss {
+    animation: none;
+  }
+
+  /* The armour's height and the multiplier's step still change; they just
+     arrive rather than travel. Both end where the state says either way. */
+  .storm__zone::before,
+  .storm__combo {
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## STM09 · Reduced motion, and the device with no keys

Closes #155

### Reduced motion

There was no storm-specific path before. `base.css`'s blanket clamp
(`animation-duration: 0.001ms !important`) was the whole of it, and the fall
survived only because **the fall was never an animation** — `useStormClock`
writes `--drop` from rAF, so the clamp had nothing to grab.

**Screen shake, parallax and particles did not exist, so nothing was removed.**
§8.10 says that rather than inventing decoration to take off.

The three tints now carry `animation: none` under the setting instead of being
left to the clamp. Measured: **12 `animationstart` at 1e-06s before, 0 after**;
peak tint opacity 0.85 → 0. The falling stays — 24 distinct positions in 24
readings over 600ms.

### Keyboard detection (decision 53): proof beats a proxy

**Proof** is any `keydown` carrying a `code` — the field the gun already reads —
latched by a one-shot capture listener that outlives the ladder, so keys typed
during a lesson still count. The **guess** is only
`(any-pointer: coarse) and (any-hover: none)`, so a desktop with a touchscreen
is not caught. No UA sniffing, nothing stored, and everything unanswerable is a
yes.

Measured on a touch-only context: all 20 storm tiles disabled naming the
keyboard, while every other rung is identical to desktop (11 open, 69 shut);
**the storm route still opens and plays**; and one keystroke flips all 20 live
with nothing reloaded, while the media query still reports a tablet.

The tile is `Button variant="bare"` from the kit — `aria-disabled="true"` with
the reason in its accessible name and the `disabled` property false, so tab
order is intact.

### Fall cap `MIN_FALL_MS = 800` (decision 52)

Raises **both ends of a range** rather than flooring samples, so every existing
spec × seed builds a byte-identical wave: 7 `SPECS` rows plus the live
`PREVIEW_SPEC` × 17 seeds — **136/136 identical to `develop`**. `configKey` and
saved-run replay are untouched.

### Quit and Escape (decisions 54, 55)

A Quit control in the HUD, the only element given `pointer-events` back.
`Escape` is taken inside the gun's listener **before** the trigger, so leaving
costs no points (score −40 → −40 across it). The sheet freezes the wave
(`--drop` pinned for 2000ms, 0 frames pending) and resumes at exactly 1× wall
clock. **Quitting mid-wave saves zero rows**, counted in IndexedDB.

### `preventDefault`

Swallowed: Space, Slash, Tab, Shift+Tab, Enter, Backspace and the rest that
would scroll. Not swallowed: arrows, Escape, F5/F11/F12, or anything with a
modifier. `scrollY 0`, focus never trapped — Tab moves nothing while live, and
after an ending the gun returns early so Tab reaches the buttons.

### Review pass

Seven findings, **all documentation or test-strength — no functional defect**:

- Three `game.css` comments still credited base.css's clamp for honouring
  reduced motion, which would have led a reader to delete the new block as
  redundant.
- A smoke comment claimed there was no quit control, when the same file clicks
  one 900 lines later.
- "the other eighty rungs are untouched" was asserted as `> 0` (which passes if
  79 of 80 were wrongly shut) and is now `=== 11`.
- The "nothing but the stones is moved" check read three named selectors; it now
  enumerates `main.storm` and every descendant, reading `getAttribute("class")`
  rather than `className` because that is an `SVGAnimatedString` on the icon
  nodes the check exists to catch. Proved by sabotaging a `transform` onto
  `.storm__hud`, which none of the old selectors named.

### The open safety question — deferred, not solved

Nothing floors `gap`, and same-zone tints 100ms apart produce full 0↔0.85
opacity swings.

The Fixer measured that a `MIN_GAP_MS` is **the wrong instrument**: `gap` does
not control the flashing rate, because `fall` is a range too and letters spawned
a second apart land together — the "capitals" spec at gap 600–1000ms already
lands two on one zone 14ms apart. Flooring lesson 93's gap at 350ms takes one
zone from 4 tint starts/second to 3; flooring it at 800ms — which would delete
"whiteout" — still leaves 3. The real hazard is a *band* of roughly 50–333ms,
not a floor, since the decay curve means decision 42's re-peak only holds under
~20ms.

**Nothing strobes today.** The only wave in the product peaks at 2 tint starts
per second on any one zone, with at most two of eight zones lit at once —
inside WCAG 2.3.1's three-per-second limit before the small-safe-area exemption
is even reached.

The durable fix is a **per-zone tint-rate rule read off the built schedule**,
carried into #156 along with the same open question for `.storm__miss`, whose
cadence is the child's own keypress rate.

### Validation

- `npm run type-check` — clean
- `npm run build` — static, 200 pages
- `npx eslint . --ignore-pattern '.claude/**'` — silent
- `npx vitest run --exclude '.claude/**'` — 101 files, 2120 passing
- `npm run test:smoke` — all checks passed, console errors: none
