### PR TITLE
STM10 · Twenty storm levels, woven into the ladder (#156)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -751,7 +751,8 @@ Four things about the shape of the table:
 The seed is the level's own number, or the first above it whose wave keeps the
 level's promises — no zone tinting more than twice a second (§8.10), six of the
 eight fingers used, and no finger taking more than a third of the letters
-(decision 58). Five of the twenty needed the bump.
+(decision 58). Six of the twenty needed the bump — lessons 4, 53, 65, 73, 89
+and 93 — and none of them by more than six.
 
 ---
 
@@ -1568,9 +1569,14 @@ guess was, with the way out drawn on it (§8.11). Measured in a browser
 the storm route still opens, and one keystroke flips every tile back with
 nothing reloaded and the pointer still reporting a tablet.
 
-And the skip rule itself, measured the same way: with lesson 44 passed and
-lesson 45's storm never opened, lesson 46 is the tile marked "Start here" — and
-after a run of 45 that the storm got through, it still is.
+The skip rule itself is held in the unit suite rather than in the browser, and
+in two halves that meet at the tile. `ladder.test.ts` has the rule — "opens
+lesson 46 when 44 is cleared, whatever happened at 45" takes both endings a
+storm can have, and "is stepped over at every one of the twenty rungs" says it
+is a property of the ladder rather than a fact about lesson 45.
+`LessonLadder.test.tsx` has what a child sees: "leaves a skipped storm open
+behind the pointer" is the storm still enterable with the pointer past it, and
+"says every tile's state out loud" is where `next` is spoken as "Start here".
 
 ### 8.9 · DOM, not canvas
 
@@ -1710,8 +1716,8 @@ falling. What it can and must do:
   bounded instead is how often it can happen: WCAG 2.3.1 counts _more than
   three flashes in any one second_, and every one of the twenty levels peaks at
   **two tint starts per second on any one zone**, with at most two of the eight
-  lit at once — measured on the wave each of them ships (§5.7) and on sixteen
-  other seeds apiece, where the worst any spec reaches is three.
+  lit at once — measured on the wave each of them ships (§5.7), which is the
+  wave a child meets and the only one there is (decision 58).
 
   The obvious fix is the wrong one and it is worth writing down before somebody
   reaches for it. **`gap` is not the lever, and there is no `MIN_GAP_MS` to
@@ -1730,27 +1736,44 @@ falling. What it can and must do:
   must be — and it is kept in **two** places, because the two things that light
   have two different clocks (decision 57):
 
-  - **A zone's tint is the schedule's, so the specs carry it.**
-    `storms.test.ts` builds every one of the twenty, at its own seed and at
-    sixteen others, and asserts that no zone starts more than **three** tints
-    inside any one second — WCAG 2.3.1's own line, which is _more than_ three
-    flashes in any one second. The twenty as they ship are held to **two**, so
-    what a child meets has a full flash a second of headroom over the line, and
-    at most two of the eight zones are ever lit inside one 150 ms tint. The
-    count is deliberately an over-count: landings within ~20 ms re-peak one lit
-    tint and are one visible episode, and counting them separately errs towards
-    the strobe. It is asserted over the pool of seeds and not only the shipped
-    one, so it is a property of the specs rather than of six lucky rolls.
+  - **A zone's tint is the schedule's, so the seed carries it.**
+    `storms.test.ts` builds every one of the twenty at the seed it ships with
+    and asserts that no zone starts more than **two** tints inside any one
+    second — a full flash a second of headroom under WCAG 2.3.1's own line,
+    which is _more than_ three flashes in any one second — with at most two of
+    the eight zones lit inside one 150 ms tint. The count is deliberately an
+    over-count: landings within ~20 ms re-peak one lit tint and are one visible
+    episode, and counting them separately errs towards the strobe.
+
+    **The guarantee is per shipped seed, and it is worth being exact about
+    that.** A `WaveSpec` is a range, so a spec is not safe or unsafe — a
+    _built wave_ is, and the shipped wave is the one whose seed was derived to
+    keep the rule (§5.7, decision 58). The test re-derives all twenty from that
+    rule rather than trusting the column, so a change to `buildWave` that moved
+    a wave over the line fails loudly instead of shipping. The same twenty
+    specs are also built at sixteen other seeds apiece and held under three,
+    which is a **sample and not a bound**: swept far more widely, four of them
+    (lessons 83, 89, 93 and 99) do reach four or five at seeds nobody is
+    served. Tightening those four rows so the bound held at any seed would be a
+    stronger thing to have, and it is not what ships today.
+
   - **The score's `--flare` wash is a hand's, so the reducer carries it.** No
     `WaveSpec` can shape how fast a child presses wrong keys; auto-repeat is
     already not a shot (decision 44), but eight or ten deliberate presses a
     second is a seven-year-old having a bad time. So `StormState` grew
     `missTintAt` — the wave time the wash last started, which is what the HUD
-    mounts the element from — and it only moves once `MIN_TINT_GAP_MS` (340 ms)
-    has passed. Every other cost of a miss is charged in full whether it lights
-    or not: the ten points, the streak, the mark against the run. Measured in
-    `e2e/smoke.mjs`: eight wrong keys 200 ms apart cost eighty points and draw
-    four flashes, the closest pair 408 ms apart.
+    mounts the element from — and it only moves once `MIN_TINT_GAP_MS` (500 ms)
+    has passed, which is **two starts inside any second**: the same headroom
+    the zone tints have, on the same screen, for the same five-year-old. 340 ms
+    would have permitted three — 0, 340 and 680 — which is the standard's
+    ceiling with nothing to spare, on the one screen where a child hammers keys
+    _because they are losing_. Every other cost of a miss is charged in full
+    whether it lights or not: the ten points, the streak, the mark against the
+    run. Measured over sixty wrong keys at each of fifteen cadences from 10 ms
+    to 750 ms (`storm.test.ts`): all sixty charged every time, and no second
+    with more than two starts in it. And in a browser (`e2e/smoke.mjs`): eight
+    wrong keys 200 ms apart cost eighty points and draw three flashes, the
+    closest pair over 600 ms apart.
 
 - **Fall speeds are capped** at the top of the ladder. "Whiteout" at lesson 89
   should be hard because there are many letters, not because one is a blur.
@@ -1987,11 +2010,13 @@ The four that carry this epic, in the order they are worth writing:
 
 Plus the two the twenty storms brought with them, both in `storms.test.ts`:
 
-5. **No zone can strobe.** Every one of the twenty specs, at its own seed and
-   at sixteen others, starts at most three tints on any one zone inside any one
-   second — WCAG 2.3.1's line — and the shipped twenty are held to two (§8.10).
-   Read off the built schedule, because `fall` is a range and the question is
-   about landings rather than about spawns.
+5. **No zone can strobe.** Every one of the twenty waves that ship starts at
+   most two tints on any one zone inside any one second — a flash under WCAG
+   2.3.1's line of more than three — and the seed that makes that true is
+   re-derived by the test rather than trusted (§8.10, decision 58). The same
+   specs at sixteen other seeds are held under three, as a sample rather than
+   as a property of the specs. Read off the built schedule, because `fall` is a
+   range and the question is about landings rather than about spawns.
 6. **The doc and the specs agree.** §5.7's table is read out of
    `docs/typing.md` and compared with the shipped rows column by column. A
    design doc that disagreed with the code would be a defect here, so it is one

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -527,12 +527,12 @@ minute; `acc` is the whole-lesson accuracy bar.
 |   1 | Two keys                  | `f j` | keys    | guide🔒 |    20 |   8 | 95% |
 |   2 | Four keys                 | `d k` | keys    | guide🔒 |    20 |   8 | 95% |
 |   3 | Six keys                  | `s l` | keys    | guide🔒 |    24 |   9 | 95% |
-|   4 | Hailstorm · First ice     | —     | storm   | guide🔒 |     — |   — |   — |
+|   4 | Hailstorm · First ice     | —     | storm   | guide🔒 |    12 |   — |   — |
 |   5 | Both pinkies              | `a ;` | keys    | guide🔒 |    24 |   9 | 95% |
 |   6 | The inside reach          | `g h` | keys    | guide🔒 |    24 |  10 | 95% |
 |   7 | Home-row words            | —     | words   | guide   |    25 |  11 | 95% |
 |   8 | Pairs that repeat         | —     | bigrams | guide   |    25 |  11 | 95% |
-|   9 | Hailstorm · Home row      | —     | storm   | guide   |     — |   — |   — |
+|   9 | Hailstorm · Home row      | —     | storm   | guide   |    16 |   — |   — |
 |  10 | **Checkpoint · Home row** | —     | words   | off🔒   |    30 |  12 | 97% |
 
 **Block 2 · Reaching up**
@@ -541,13 +541,13 @@ minute; `acc` is the whole-lesson accuracy bar.
 | --: | ------------------------- | ----- | ------- | ------- | ----: | --: | --: |
 |  11 | Up to e and i             | `e i` | keys    | guide🔒 |    24 |   9 | 95% |
 |  12 | Up to r and u             | `r u` | keys    | guide🔒 |    24 |   9 | 95% |
-|  13 | Hailstorm · Eight lanes   | —     | storm   | guide   |     — |   — |   — |
+|  13 | Hailstorm · Eight lanes   | —     | storm   | guide   |    18 |   — |   — |
 |  14 | The long reach            | `t y` | keys    | guide🔒 |    24 |  10 | 95% |
 |  15 | Up to w and o             | `w o` | keys    | guide🔒 |    26 |  10 | 95% |
 |  16 | Real words at last        | —     | words   | guide   |    30 |  12 | 95% |
 |  17 | The corners               | `q p` | keys    | guide🔒 |    26 |  10 | 95% |
 |  18 | th · he · er · re         | —     | bigrams | guide   |    30 |  13 | 95% |
-|  19 | Hailstorm · Two rows      | —     | storm   | keys    |     — |   — |   — |
+|  19 | Hailstorm · Two rows      | —     | storm   | keys    |    20 |   — |   — |
 |  20 | **Checkpoint · Two rows** | —     | words   | off🔒   |    35 |  15 | 97% |
 
 **Block 3 · Reaching down**
@@ -556,13 +556,13 @@ minute; `acc` is the whole-lesson accuracy bar.
 | --: | ----------------------------- | ----- | --------- | ------- | ----: | --: | --: |
 |  21 | Down to v and m               | `v m` | keys      | guide🔒 |    26 |  11 | 95% |
 |  22 | c, and the comma              | `c ,` | keys      | guide🔒 |    26 |  11 | 95% |
-|  23 | Hailstorm · Down low          | —     | storm     | guide   |     — |   — |   — |
+|  23 | Hailstorm · Down low          | —     | storm     | guide   |    22 |   — |   — |
 |  24 | x, and the full stop          | `x .` | keys      | guide🔒 |    26 |  12 | 95% |
 |  25 | The last corner               | `z /` | keys      | guide🔒 |    26 |  12 | 95% |
 |  26 | The last two                  | `b n` | keys      | guide🔒 |    28 |  12 | 95% |
 |  27 | Every letter                  | —     | words     | guide   |    35 |  14 | 95% |
 |  28 | an · in · on · nd · nt        | —     | bigrams   | keys    |    35 |  15 | 95% |
-|  29 | Hailstorm · Whole alphabet    | —     | storm     | keys    |     — |   — |   — |
+|  29 | Hailstorm · Whole alphabet    | —     | storm     | keys    |    24 |   — |   — |
 |  30 | **Checkpoint · Every letter** | —     | sentences | off🔒   |    40 |  18 | 97% |
 
 **Block 4 · Capitals**
@@ -572,12 +572,12 @@ minute; `acc` is the whole-lesson accuracy bar.
 |  31 | The right shift                 | `⇧`→left letters  | keys      | guide🔒 |    30 |  13 | 95% |
 |  32 | The left shift                  | `⇧`→right letters | keys      | guide🔒 |    30 |  13 | 95% |
 |  33 | Names, and the word I           | —                 | words     | guide   |    35 |  15 | 95% |
-|  34 | Hailstorm · Capitals            | —                 | storm     | keys    |     — |   — |   — |
+|  34 | Hailstorm · Capitals            | —                 | storm     | keys    |    26 |   — |   — |
 |  35 | The apostrophe                  | `'`               | keys      | guide🔒 |    30 |  14 | 95% |
 |  36 | First sentences                 | —                 | sentences | keys    |    35 |  16 | 95% |
 |  37 | Where the comma goes            | —                 | sentences | keys    |    40 |  17 | 95% |
 |  38 | Places and people               | —                 | sentences | keys    |    40 |  18 | 95% |
-|  39 | Hailstorm · Shift under fire    | —                 | storm     | off     |     — |   — |   — |
+|  39 | Hailstorm · Shift under fire    | —                 | storm     | off     |    28 |   — |   — |
 |  40 | **Checkpoint · Real sentences** | —                 | sentences | off🔒   |    45 |  20 | 97% |
 
 **Block 5 · Fluency**
@@ -588,11 +588,11 @@ minute; `acc` is the whole-lesson accuracy bar.
 |  42 | th · he · in · er       | —   | bigrams | keys  |    40 |  19 | 95% |
 |  43 | an · re · on · at · en  | —   | bigrams | keys  |    40 |  20 | 95% |
 |  44 | The hard pairs          | —   | bigrams | keys  |    40 |  19 | 95% |
-|  45 | Hailstorm · Pairs       | —   | storm   | keys  |     — |   — |   — |
+|  45 | Hailstorm · Pairs       | —   | storm   | keys  |    30 |   — |   — |
 |  46 | Hands that take turns   | —   | words   | off   |    45 |  22 | 95% |
 |  47 | One hand at a time      | —   | words   | keys  |    40 |  20 | 95% |
 |  48 | The hundred             | —   | words   | off   |    50 |  24 | 95% |
-|  49 | Hailstorm · Whole words | —   | storm   | off   |     — |   — |   — |
+|  49 | Hailstorm · Whole words | —   | storm   | off   |    32 |   — |   — |
 |  50 | **Checkpoint · Fluent** | —   | passage | off🔒 |    60 |  25 | 97% |
 
 **Block 6 · Numbers**
@@ -601,13 +601,13 @@ minute; `acc` is the whole-lesson accuracy bar.
 | --: | --------------------------- | ----- | ------- | ------- | ----: | --: | --: |
 |  51 | Four and five               | `4 5` | keys    | guide🔒 |    30 |  16 | 95% |
 |  52 | Three and six               | `3 6` | keys    | guide🔒 |    30 |  16 | 95% |
-|  53 | Hailstorm · Digits          | —     | storm   | guide   |     — |   — |   — |
+|  53 | Hailstorm · Digits          | —     | storm   | guide   |    30 |   — |   — |
 |  54 | Two and seven               | `2 7` | keys    | guide🔒 |    30 |  17 | 95% |
 |  55 | One and eight               | `1 8` | keys    | guide🔒 |    30 |  17 | 95% |
 |  56 | Nine and nought             | `9 0` | keys    | guide🔒 |    30 |  18 | 95% |
 |  57 | Ages, dates and scores      | —     | numbers | keys    |    40 |  19 | 95% |
 |  58 | Words and numbers together  | —     | mixed   | keys    |    45 |  20 | 95% |
-|  59 | Hailstorm · Numbers falling | —     | storm   | keys    |     — |   — |   — |
+|  59 | Hailstorm · Numbers falling | —     | storm   | keys    |    34 |   — |   — |
 |  60 | **Checkpoint · Numbers**    | —     | mixed   | off🔒   |    50 |  22 | 97% |
 
 **Block 7 · Punctuation**
@@ -618,11 +618,11 @@ minute; `acc` is the whole-lesson accuracy bar.
 |  62 | Speech marks                | `"`           | keys    | guide🔒 |    35 |  18 | 95% |
 |  63 | Hyphen and underscore       | `- _`         | keys    | guide🔒 |    35 |  19 | 95% |
 |  64 | Colon and semicolon         | `: ;`         | keys    | guide🔒 |    35 |  19 | 95% |
-|  65 | Hailstorm · Punctuation     | —             | storm   | keys    |     — |   — |   — |
+|  65 | Hailstorm · Punctuation     | —             | storm   | keys    |    34 |   — |   — |
 |  66 | Brackets                    | `( )`         | keys    | guide🔒 |    35 |  19 | 95% |
 |  67 | Above the numbers           | `@ # $ % & *` | keys    | guide🔒 |    35 |  18 | 95% |
 |  68 | Slash, plus, equals         | `/ \ + =`     | keys    | guide🔒 |    35 |  19 | 95% |
-|  69 | Hailstorm · Symbols         | —             | storm   | off     |     — |   — |   — |
+|  69 | Hailstorm · Symbols         | —             | storm   | off     |    36 |   — |   — |
 |  70 | **Checkpoint · Punctuated** | —             | passage | off🔒   |    55 |  24 | 97% |
 
 **Block 8 · Endurance**
@@ -631,13 +631,13 @@ minute; `acc` is the whole-lesson accuracy bar.
 | --: | -------------------------------- | --- | ------- | ----- | ----: | --: | --: |
 |  71 | Sixty words                      | —   | passage | off   |    60 |  22 | 96% |
 |  72 | A whole paragraph                | —   | passage | off   |    70 |  23 | 96% |
-|  73 | Hailstorm · The long wave        | —   | storm   | off   |     — |   — |   — |
+|  73 | Hailstorm · The long wave        | —   | storm   | off   |    50 |   — |   — |
 |  74 | The sight words, again           | —   | words   | off   |    60 |  24 | 96% |
 |  75 | Verses                           | —   | passage | off   |    70 |  24 | 96% |
 |  76 | Someone speaking                 | —   | passage | off   |    70 |  25 | 96% |
 |  77 | Eighty words                     | —   | passage | off   |    80 |  26 | 96% |
 |  78 | Numbers in prose                 | —   | passage | off   |    80 |  26 | 96% |
-|  79 | Hailstorm · No repairs           | —   | storm   | off   |     — |   — |   — |
+|  79 | Hailstorm · No repairs           | —   | storm   | off   |    36 |   — |   — |
 |  80 | **Checkpoint · A hundred words** | —   | passage | off🔒 |   100 |  28 | 97% |
 
 **Block 9 · Speed**
@@ -646,13 +646,13 @@ minute; `acc` is the whole-lesson accuracy bar.
 | --: | ---------------------------- | --- | ------- | ----- | ----: | --: | --: |
 |  81 | Sprint · Common words        | —   | sprint  | off   |    30 |  28 | 95% |
 |  82 | Sprint · Alternating hands   | —   | sprint  | off   |    30 |  30 | 95% |
-|  83 | Hailstorm · Hard rain        | —   | storm   | off   |     — |   — |   — |
+|  83 | Hailstorm · Hard rain        | —   | storm   | off   |    40 |   — |   — |
 |  84 | Sprint · The hard pairs      | —   | sprint  | off   |    30 |  28 | 95% |
 |  85 | Sprint · Capitals            | —   | sprint  | off   |    30 |  29 | 95% |
 |  86 | Sprint · Numbers             | —   | sprint  | off   |    30 |  26 | 95% |
 |  87 | Sprint · Punctuation         | —   | sprint  | off   |    30 |  28 | 95% |
 |  88 | A solid minute               | —   | passage | off   |    90 |  32 | 95% |
-|  89 | Hailstorm · Whiteout         | —   | storm   | off   |     — |   — |   — |
+|  89 | Hailstorm · Whiteout         | —   | storm   | off   |    44 |   — |   — |
 |  90 | **Checkpoint · Thirty-five** | —   | passage | off🔒 |    80 |  35 | 96% |
 
 **Block 10 · Everything**
@@ -661,13 +661,13 @@ minute; `acc` is the whole-lesson accuracy bar.
 | --: | ---------------------------- | --- | ------- | ----- | ----: | --: | ------: |
 |  91 | Mixed prose                  | —   | passage | off   |    90 |  30 |     96% |
 |  92 | Prose with numbers           | —   | mixed   | off   |    90 |  30 |     96% |
-|  93 | Hailstorm · Everything falls | —   | storm   | off   |     — |   — |       — |
+|  93 | Hailstorm · Everything falls | —   | storm   | off   |    46 |   — |       — |
 |  94 | A long verse                 | —   | passage | off   |   100 |  31 |     96% |
 |  95 | An address, a price, a date  | —   | mixed   | off   |    80 |  30 |     96% |
 |  96 | A hundred and twenty         | —   | passage | off   |   120 |  32 |     96% |
 |  97 | The accuracy run             | —   | passage | off   |    80 |  28 | **99%** |
 |  98 | Sprint · Everything          | —   | sprint  | off   |    40 |  36 |     95% |
-|  99 | Hailstorm · The last storm   | —   | storm   | off   |     — |   — |       — |
+|  99 | Hailstorm · The last storm   | —   | storm   | off   |    50 |   — |       — |
 | 100 | **The Ice Exam**             | —   | passage | off🔒 |   150 |  38 |     97% |
 
 Twenty Hailstorm levels, ten checkpoints, thirty that introduce keys.
@@ -678,6 +678,80 @@ Lesson 50 asks for 25 wpm and lesson 51 asks for 16. That is not a bug in the
 table. It is the truth about learning a new key, written into the pass mark so
 that a child who has just met the number row is not measured against the person
 they were yesterday. See §6.3.
+
+A storm's Words column is its **wave's `count`** — letters, not words — which
+is what its `wordCount` is (§8.3, §8.7). Its wpm and its accuracy stay — for
+the reason §6.1 gives: it is marked on surviving a wave, and the accuracy bar
+it does carry is the new-key gate's 90% rather than a passage's.
+
+### 5.7 · The twenty storms
+
+The rest of each Hailstorm row, which is the level itself (§8.3). `gap` is the
+ms between spawns and `fall` is the ms to cross the sky, both sampled per
+letter from the range shown; `shield` is hit points per finger; `mends` is the
+combo that repairs the weakest zone, and `—` is none.
+
+|   # | Title            | Len |       gap |      fall | shield | mends | Rains    | seed |
+| --: | ---------------- | --: | --------: | --------: | -----: | ----: | -------- | ---: |
+|   4 | First ice        |  12 | 1500–1900 |  900–1200 |      4 |     4 | —        |    6 |
+|   9 | Home row         |  16 | 1300–1600 |  900–1250 |      3 |     4 | —        |    9 |
+|  13 | Eight lanes      |  18 | 1200–1500 |  900–1150 |      3 |     4 | —        |   13 |
+|  19 | Two rows         |  20 | 1000–1300 | 1000–1500 |      3 |     4 | —        |   19 |
+|  23 | Down low         |  22 |  900–1200 | 1100–1600 |      3 |     5 | —        |   23 |
+|  29 | Whole alphabet   |  24 |  800–1100 | 1200–1700 |      3 |     5 | —        |   29 |
+|  34 | Capitals         |  26 |  750–1050 | 1200–1800 |      3 |     5 | capitals |   34 |
+|  39 | Shift under fire |  28 |  700–1000 | 1300–1900 |      3 |     5 | capitals |   39 |
+|  45 | Pairs            |  30 |   650–950 | 1300–2000 |      3 |     6 | —        |   45 |
+|  49 | Whole words      |  32 |   600–900 | 1400–2000 |      3 |     6 | —        |   49 |
+|  53 | Digits           |  30 |  700–1000 | 1300–1800 |      3 |     6 | digits   |   55 |
+|  59 | Numbers falling  |  34 |   600–850 | 1400–2000 |      3 |     6 | digits   |   59 |
+|  65 | Punctuation      |  34 |   600–850 | 1400–2100 |      3 |     6 | marks    |   66 |
+|  69 | Symbols          |  36 |   550–800 | 1500–2100 |      3 |     6 | marks    |   69 |
+|  73 | The long wave    |  50 |   550–800 | 1500–2200 |      3 |     8 | —        |   74 |
+|  79 | No repairs       |  36 |   500–750 | 1400–2000 |      3 |     — | —        |   79 |
+|  83 | Hard rain        |  40 |   450–650 | 1300–1900 |      3 |     — | —        |   83 |
+|  89 | Whiteout         |  44 |   300–450 | 1900–2600 |      3 |     — | —        |   95 |
+|  93 | Everything falls |  46 |   350–550 | 1300–1900 |      2 |     — | —        |   95 |
+|  99 | The last storm   |  50 |   300–500 | 1200–1800 |      2 |     — | —        |   99 |
+
+**There is no `keys` column, and there cannot be one.** A level's pool is
+`unlockedAt(n)` — the same computed alphabet its neighbours' words come from
+(§5.2) — so a storm can never ask for a key the ladder has not taught, and
+moving a storm up the ladder moves what falls in it. "Rains" is a weighting on
+top of that pool, not a replacement for it: the named class is repeated until
+it is about half of what can fall, which is what makes lesson 53 a level about
+the number row when only `3 4 5 6` have arrived (`storms.ts`). `marks` is that
+module's name for everything which is neither a letter nor a digit nor the
+space — the punctuation and the symbols, stated as the complement so that a
+key added to the layout is in it without an edit.
+
+The table above is not prose: `storms.test.ts` reads it out of this file and
+checks it against the twenty rows that ship, column by column. A design doc
+that disagreed with the code would be a defect here, so it is one the suite can
+see.
+
+Four things about the shape of the table:
+
+- **`gap` clears `fall` at lessons 4, 9 and 13** — one letter on screen at a
+  time, pure reaction (§8.3) — and overlaps from 19 on, which is reading ahead.
+  Measured in a browser at 1280×1000: lesson 4 peaks at one letter in the sky,
+  lesson 45 at three, lesson 89 at seven.
+- **It does not climb smoothly, and must not be smoothed.** Lesson 53's storm
+  eases where the number row has just arrived, exactly as the wpm column does
+  (§6.3, decision 11); lesson 73 is long where 79 is dense. What climbs is each
+  quarter of the twenty, in both length and letters a second, and that is what
+  `storms.test.ts` holds it to.
+- **The repairs stop at 79 and never come back**, which is that level's name
+  and the block's turn: below it the weakest zone mends every `mends` clean
+  hits, above it what breaks stays broken.
+- **No row asks for a fall under `MIN_FALL_MS`** (800ms, §8.10, decision 52).
+  The floor is a backstop, not a knob; a row that went under it would come out
+  of `fallRange` as a metronome and quietly not be what it says.
+
+The seed is the level's own number, or the first above it whose wave keeps the
+level's promises — no zone tinting more than twice a second (§8.10), six of the
+eight fingers used, and no finger taking more than a third of the letters
+(decision 58). Five of the twenty needed the bump.
 
 ---
 
@@ -887,12 +961,13 @@ flipped. A `keyboard` absent from the config is a different matter — free play
 or a run started without a brief in front of it — and absent is not evidence of
 a hidden board, so `=== "off"` refuses it rather than guessing.
 
-**`unbroken` is waiting for the waves, and the guard says so.** A storm level's
-`wordCount` is its wave's `count` (§8.3) and every one of the twenty is `0`
-until STM10 writes them — so `survived` is vacuously true and "cleared a wave"
-is a claim about a wave that does not exist. The badge requires the wave to have
-a length, which is a guard that retires itself the day the waves land rather
-than a line someone has to remember to delete (decision 29). "Shield untouched"
+**`unbroken` requires the wave to have a length, and now every one of them
+does.** A storm level's `wordCount` is its wave's `count` (§5.7, §8.3), so the
+guard that kept the badge unearnable while the twenty rows were `0` has retired
+itself exactly as it was written to (decision 29) — a guard rather than a line
+someone had to remember to delete. It stays because it is still the sentence
+the badge makes: with no wave, `survived` is vacuously true and "cleared a
+wave" is a claim about a wave that does not exist. "Shield untouched"
 is read as **no letter reached the bottom**, which is what takes a point off a
 segment (§8.5): a storm's cards are its falling letters (§8.7), so a run with
 nothing marked wrong is a run where nothing got through. That errs strict, and
@@ -1033,6 +1108,14 @@ is generated up front from `mulberry32(seed)`, exactly as every deck on this
 site is. That makes a run **replayable**, which matters more than it sounds: it
 is what lets a child retry the level that beat them and meet the same storm,
 and it is what makes the rules unit-testable without a browser.
+
+**And the seed is the level's, not the visit's** (decision 58). Each of the
+twenty carries one (§5.7), so opening lesson 45 twice is opening the same level
+twice — "I beat Whiteout" is a sentence about a thing rather than about a roll,
+and the twenty waves the no-strobe rule is measured on (§8.10) are the twenty a
+child actually meets rather than a sample of what a generator might produce.
+"Try this wave again" already meant the same letters in the same lanes; this is
+the same promise across two visits instead of two attempts.
 
 `gap` and `fall` as ranges rather than numbers is what "sometimes even random
 within the level" means. Early levels set `gap` wider than `fall`, so there is
@@ -1258,7 +1341,10 @@ it. So the `×1.6` a child watches climb in the HUD is the figure their XP is
 being paid at, and the score and the payout cannot tell them two different
 stories about one run. The storm may not import `progress.ts` to get it: that
 module reaches `decks/index.ts`, the front door every island downloads, and
-STM10 puts a `WaveSpec` on each storm lesson (§5.3, decision 7).
+`lessons.ts` — which the deck layer imports — names a `WaveSpec` on each storm
+lesson (§5.3, decision 7). It names it as a **type**, which is erased: the
+keyboard layout `storm.ts` reads never reaches that chunk, and the shipped
+build is checked for it (no `ShiftRight` in the shared bundle).
 
 **A wrong key costs `MISS_POINTS` (ten) and the streak.** Equal to a plain hit
 on purpose — one wrong key undoes one clean one, which is a sentence a
@@ -1355,11 +1441,12 @@ hands `useRaceFinish` a `previousBest` of `null`, which is what makes
 `summariseRun.personalRecord` false and the 150 XP unpayable — but it decides
 this run's own panel and nothing else. Every _other_ "best" on the site is
 `bestRun`, which groups a player's runs by `configKey` and picks on
-`compareRuns`, and a storm's key is a lesson's key: without a second signal the
-record book's "your best" column, the house best beside it, and — the moment
-STM10 gives lesson 39 a `WaveSpec` and `lessonKey` starts returning
-`typing|L39|12` — the lesson brief's best and its rival list would all rank
-storms against each other on time, and hand the record to the shortest life.
+`compareRuns`, and a storm's key IS a lesson's key: `lessonKey(lesson)` returns
+`typing|L39|28` and so does `configKey(stormConfig(...))`, because a storm
+level's `wordCount` is its wave's `count` (§5.7). Without a second signal the
+record book's "your best" column, the house best beside it, the lesson brief's
+best and every rival list would rank storms against each other on time, and
+hand the record to the shortest life.
 
 So the run says what it is. `stormConfig` writes **`storm: true`** into its
 `TypingConfig`, `isRanked` in `decks/index.ts` reads it, and `bestRun` drops
@@ -1370,7 +1457,9 @@ a saved run outlives the ladder it was played on (§5.4): re-tune lesson 39 out
 of a Hailstorm and a derived rule would quietly start ranking every storm
 already in the record book. It is optional, never `false`, and inert in
 `configKey` — a storm and its lesson still key identically, which they must, or
-STM10 would orphan every storm already saved.
+the twenty waves landing would have orphaned every storm already saved.
+`stormSession.test.ts` asserts both halves over all twenty: the keys match, and
+`bestRun` and `ghostsFor` still hand back nothing at them.
 
 A run that holds no record is still a run in every other way: the record book
 _lists_ it, it pays its XP, it earns badges, and its letters feed the drill
@@ -1384,9 +1473,13 @@ The XP on the ending panel is the run's own `stormXp` — what its letters paid
 not restated on the panel: the four figures there are about the weather, and a
 bonus line is a results screen's business.
 
-`configKey` is `typing|L39|12` — the lesson, and the **wave's** length, never
+`configKey` is `typing|L39|28` — the lesson, and the **wave's** length, never
 the letters that were survived. Retries of a level therefore compare with each
-other, which is the whole point of the key (§5.4).
+other, which is the whole point of the key (§5.4). It is the same string
+`lessonKey(lesson)` returns, because a storm level's `wordCount` IS its wave's
+`count` (§5.7): sharing a bucket is what makes a retry comparable, and it is
+exactly what makes `storm: true` necessary, because the bucket is what
+`bestRun` ranks.
 
 **Saved exactly once, and a retry is a new run** (decision 51). The run is
 written on the frame `ending` appears, which the reducer sets once and never
@@ -1411,9 +1504,25 @@ Two reasons, and either alone is sufficient:
   the ones that need a reason to keep going; a game level that a child cannot
   beat would be the exact opposite of what it was put there for.
 
-The ladder marks them clearly — a different tile, "worth playing, not
-required" — and the tile is disabled with a reason on a device with no
-keyboard, rather than failing mysteriously.
+The ladder marks them clearly — a diamond rather than a square, and "Hailstorm
+— worth playing, never required" first in every one of the twenty tiles' spoken
+names — and the tile is disabled with a reason on a device with no keyboard,
+rather than failing mysteriously. `tileState` draws it like any other rung
+otherwise: filled behind the child, outlined ahead of them, and locked with
+what would open it on a rung they have not climbed to (`lockNote`, which walks
+down past any storm in the way, so it never asks a child to pass a wave).
+
+**A storm's door is its own screen** (`StormBrief`). The other eighty rungs
+open `LessonBrief`, which is three bars, a best and a keyboard control — and a
+storm has none of the three: it is marked on surviving a wave (§6.1), it holds
+no record at all (decision 50), and its keyboard is not a hint under a passage
+but the gun itself (§8.2). What it says instead is how a storm is played (only
+the lowest letter can be shot, which is not guessable from watching), what
+_this_ storm is — its length, its shield, whether it repairs and what it mostly
+rains, which is what makes "First ice" and "Whiteout" different screens rather
+than one screen with different numbers behind it — and that nothing waits on
+it: **"Lesson 46 opens whether you play this or not"**, in as many words, on
+the one screen with room for the sentence.
 
 **How the tile knows** (`useKeyboardPresence`, decision 53). There is no
 browser API for "a keyboard is attached", so the answer is built out of two
@@ -1452,12 +1561,16 @@ honest answer out; re-proving it costs one keystroke and a child at a keyboard
 makes hundreds.
 
 **And the route is not gated by any of it.** A wrong guess costs a child a
-tile, never the game — `#/p/:id/storm` opens and plays whatever the guess was,
-with the way out drawn on it (§8.11). Measured in a browser (`e2e/smoke.mjs`
-§13): on a touch-only context all twenty storm tiles are `aria-disabled` and
-name the keyboard, the other eighty rungs are untouched, the storm route still
-opens, and one keystroke flips every tile back with nothing reloaded and the
-pointer still reporting a tablet.
+tile, never the game — `#/p/:id/storm/:lessonId` opens and plays whatever the
+guess was, with the way out drawn on it (§8.11). Measured in a browser
+(`e2e/smoke.mjs` §13): on a touch-only context all twenty storm tiles are
+`aria-disabled` and name the keyboard, the other eighty rungs are untouched,
+the storm route still opens, and one keystroke flips every tile back with
+nothing reloaded and the pointer still reporting a tablet.
+
+And the skip rule itself, measured the same way: with lesson 44 passed and
+lesson 45's storm never opened, lesson 46 is the tile marked "Start here" — and
+after a run of 45 that the storm got through, it still is.
 
 ### 8.9 · DOM, not canvas
 
@@ -1593,11 +1706,12 @@ falling. What it can and must do:
   each other re-peak, as the 15 ms measurement above found; landings 100 ms
   apart do not — the zone has gone dark and comes back, which is a blink.
   Between roughly 50 ms and 333 ms is therefore a band where a zone genuinely
-  flashes, and **nothing in the generator keeps a wave out of it**. What bounds
-  the risk today is only how often it can happen: WCAG 2.3.1 counts _more than
-  three flashes in any one second_, and the stand-in wave at its fixed seed
-  peaks at **two tint starts per second on any one zone**, with at most two of
-  the eight lit at once.
+  flashes, and **nothing in the generator keeps a wave out of it**. So what is
+  bounded instead is how often it can happen: WCAG 2.3.1 counts _more than
+  three flashes in any one second_, and every one of the twenty levels peaks at
+  **two tint starts per second on any one zone**, with at most two of the eight
+  lit at once — measured on the wave each of them ships (§5.7) and on sixteen
+  other seeds apiece, where the worst any spec reaches is three.
 
   The obvious fix is the wrong one and it is worth writing down before somebody
   reaches for it. **`gap` is not the lever, and there is no `MIN_GAP_MS` to
@@ -1605,21 +1719,38 @@ falling. What it can and must do:
   _land_ on one finger, and because `fall` is a range as well, two letters
   spawned far apart land together: `storm.test.ts`'s "capitals", at `gap`
   600–1000 ms, already lands two letters on one zone 14 ms apart. Measured on
-  "everything falls", the lesson-93 shape: flooring its `gap` at 350 ms takes
-  one zone from four tint starts a second to three, and flooring it at 800 ms —
-  which would make the top of the ladder one letter at a time and delete
-  "whiteout" — still leaves three. A floor on `gap` buys a difficulty ceiling
-  and almost no safety.
+  its "everything falls", the lesson-93 shape: flooring its `gap` at 350 ms
+  takes one zone from four tint starts a second to three, and flooring it at
+  800 ms — which would make the top of the ladder one letter at a time and
+  delete "whiteout" — still leaves three. A floor on `gap` buys a difficulty
+  ceiling and almost no safety.
 
-  So the rule the twenty specs have to keep is **a count of tint starts per
-  zone per second**, read off the built schedule the way `fallRange` says such
-  questions must be. Which of the two ways to keep it — shaping the specs so no
-  zone lands twice inside the band, or making the tint itself rate-insensitive
-  so no spec can — is STM10's to decide, because it is the story that writes
-  the twenty rows and the one that retires the stand-in the numbers above are
-  measured on. The same question is open for `.storm__miss`, whose cadence is
-  not a wave's at all but the rate a child can press wrong keys at, and which
-  `StormState` currently records as a bare count with no times on it.
+  So the rule the twenty specs keep is **a count of tint starts per zone per
+  second**, read off the built schedule the way `fallRange` says such questions
+  must be — and it is kept in **two** places, because the two things that light
+  have two different clocks (decision 57):
+
+  - **A zone's tint is the schedule's, so the specs carry it.**
+    `storms.test.ts` builds every one of the twenty, at its own seed and at
+    sixteen others, and asserts that no zone starts more than **three** tints
+    inside any one second — WCAG 2.3.1's own line, which is _more than_ three
+    flashes in any one second. The twenty as they ship are held to **two**, so
+    what a child meets has a full flash a second of headroom over the line, and
+    at most two of the eight zones are ever lit inside one 150 ms tint. The
+    count is deliberately an over-count: landings within ~20 ms re-peak one lit
+    tint and are one visible episode, and counting them separately errs towards
+    the strobe. It is asserted over the pool of seeds and not only the shipped
+    one, so it is a property of the specs rather than of six lucky rolls.
+  - **The score's `--flare` wash is a hand's, so the reducer carries it.** No
+    `WaveSpec` can shape how fast a child presses wrong keys; auto-repeat is
+    already not a shot (decision 44), but eight or ten deliberate presses a
+    second is a seven-year-old having a bad time. So `StormState` grew
+    `missTintAt` — the wave time the wash last started, which is what the HUD
+    mounts the element from — and it only moves once `MIN_TINT_GAP_MS` (340 ms)
+    has passed. Every other cost of a miss is charged in full whether it lights
+    or not: the ten points, the streak, the mark against the run. Measured in
+    `e2e/smoke.mjs`: eight wrong keys 200 ms apart cost eighty points and draw
+    four flashes, the closest pair 408 ms apart.
 
 - **Fall speeds are capped** at the top of the ladder. "Whiteout" at lesson 89
   should be hard because there are many letters, not because one is a blur.
@@ -1627,11 +1758,13 @@ falling. What it can and must do:
   The cap is `MIN_FALL_MS` in `buildWave`, and it is there rather than in the
   levels because the twenty `WaveSpec`s are a table and a table gets tightened
   one row at a time until a level nobody can read ships (decision 52). 800ms is
-  a judgement rather than a measured reaction time, and it is anchored to this
-  epic's own level shapes: the fastest fall any of them declares is 800ms, so
-  the floor is the fastest the ladder ever _means_ to be. At the 1280×1000
-  viewport the smoke suite runs at, a fall crosses 615px of sky — 154px/s at
-  the stand-in wave's four seconds, and 769px/s at the floor.
+  a judgement rather than a measured reaction time, and it is anchored to the
+  ladder's own shapes: the fastest fall any of the twenty declares is 900ms
+  (lessons 4, 9 and 13, §5.7), so the floor sits just under the fastest the
+  ladder ever _means_ to be and no row is touched by it. At the 1280×1000
+  viewport the smoke suite runs at, a fall crosses 615px of sky — 236px/s at
+  lesson 89's 2.6 seconds, 683px/s at lesson 13's 900ms, and 769px/s at the
+  floor.
 
   It is a backstop and not a difficulty knob: `fallRange(spec)` is the spec's
   own range with both ends raised to the floor, so a wave written entirely
@@ -1701,13 +1834,13 @@ exactly the child least able to get out of it.
 
 `/typing` keeps its hash router; the island grows three screens.
 
-| Route             | Screen                                                     |
-| ----------------- | ---------------------------------------------------------- |
-| `#/`              | Player select (unchanged)                                  |
-| `#/p/:id`         | **The ladder** — a hundred tiles, plus a Free play section |
-| `#/p/:id/go`      | A lesson run, or a free-play run. Driven by `pending`.     |
-| `#/p/:id/storm`   | A Hailstorm run                                            |
-| `#/p/:id/results` | Results — lesson bars, or the free-play scoreline          |
+| Route                     | Screen                                                     |
+| ------------------------- | ---------------------------------------------------------- |
+| `#/`                      | Player select (unchanged)                                  |
+| `#/p/:id`                 | **The ladder** — a hundred tiles, plus a Free play section |
+| `#/p/:id/go`              | A lesson run, or a free-play run. Driven by `pending`.     |
+| `#/p/:id/storm/:lessonId` | A Hailstorm run — the level is the rung (§5.7)             |
+| `#/p/:id/results`         | Results — lesson bars, or the free-play scoreline          |
 
 The run routes are driven by `RaceContext.pending` exactly as today, so the
 guards that stop a mid-navigation flicker (the ones documented at the top of
@@ -1719,15 +1852,16 @@ around them is how they come back.
 blocks named down the side, cleared tiles filled, the next one lit with `--go`,
 later ones dim, checkpoints marked, Hailstorm tiles a different shape. Choosing
 a tile opens a brief: what it teaches, the three bars it wants, your best if
-you have one, and Start.
+you have one, and Start — or, on a storm, what the wave is and that nothing
+waits on it (`StormBrief`, §8.8).
 
 It is the screen that makes a hundred lessons feel like a map rather than a
 syllabus, and it is the one piece of UI in this epic worth spending real design
 time on.
 
-Component budget: `LessonLadder`, `LessonTile`, `LessonBrief`, `PassBars`,
-`Keyboard`, `StormRun`, `StormField`, `StormShield`, `StormOver`. All under the
-300-line cap;
+Component budget: `LessonLadder`, `LessonTile`, `LessonBrief`, `StormBrief`,
+`PassBars`, `Keyboard`, `StormRun`, `StormField`, `StormShield`, `StormOver`.
+All under the 300-line cap;
 the ladder is the only one that will come close, and the brief splitting out is
 why it won't. `StormRun` is the route and `StormField` is the screen it draws:
 the field is a pure function of one `StormState`, so the wave, the clock and
@@ -1772,63 +1906,68 @@ which is what every run saved before this is.
 
 ## 11 · Decisions, recorded
 
-|     | Decision                                                 | Because                                                                                                      |
-| --- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| 1   | The keyboard layout is engine, not view                  | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture        |
-| 2   | `code`, not `key`                                        | Shift+`4` produces `$` and there is no `$` key to light up                                                   |
-| 3   | Keys release on a timer, not `keyup`                     | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                              |
-| 4   | The board is `aria-hidden`                               | Sixty announcing spans is not accessibility; the passage already carries the state                           |
-| 5   | The visual keyboard is never tappable                    | A tappable board is a hunt-and-peck trainer, which is the thing this is against                              |
-| 6   | Lesson text is generated, not written                    | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                          |
-| 7   | The lexicon must not be reachable from `decks/index.ts`  | The same import took the shared chunk 46 KB → 222 KB once already                                            |
-| 8   | Ghost identity is the lesson, not the passage            | Every run generates different words; keying on them buckets every run alone                                  |
-| 9   | Three pass bars, not one score                           | A single number says you failed; three say what to fix                                                       |
-| 10  | Accuracy is flat and high; speed scales                  | An accuracy bar you can hammer past teaches hammering                                                        |
-| 11  | The speed bar dips when a key arrives                    | You have just got slower and you should have                                                                 |
-| 12  | The new-key gate                                         | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                           |
-| 13  | Per-key stats come from cards, not keystrokes            | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven          |
-| 14  | Progress is derived, never stored                        | No migration, self-heals when criteria change, cannot disagree with the record book                          |
-| 15  | Unlock is `max(cleared) + 1`                             | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                              |
-| 16  | Any checkpoint, any time                                 | It is a placement test, a skip-ahead and an ordering rule in one sentence                                    |
-| 17  | A lesson has no ghost and no time penalty                | A penalty double-counts accuracy and makes the wpm number a lie                                              |
-| 18  | Hailstorm is a route in the typing island                | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard     |
-| 19  | Letters fall down their key's column                     | The lane is a spatial hint — the game teaches the layout the whole time it is played                         |
-| 20  | Only the lowest letter can be shot                       | Otherwise spraying the keyboard is a winning strategy                                                        |
-| 21  | The shield is eight finger zones                         | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise            |
-| 22  | Score can fall, XP cannot                                | XP is cumulative across years and four games; a bad five minutes must not lower a level                      |
-| 23  | A Hailstorm run is a `Session`                           | Record book, XP, badges and the drill builder all work with no new code                                      |
-| 24  | Hailstorm never gates the ladder                         | A tablet has no keys, and a reward that blocks you is not a reward                                           |
-| 25  | DOM, not canvas                                          | Eleven custom properties change the whole app's biome; a canvas is a hole in that                            |
-| 26  | US ANSI only, and say so                                 | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                                |
-| 27  | A lesson's keyboard seeds; it does not overrule          | All hundred name a mode, so an override beats the player's own setting on every rung                         |
-| 28  | `eyes-up` reads the board the run was typed under        | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory           |
-| 29  | `unbroken` is gated on the wave having a length          | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete      |
-| 30  | A falling letter is on the field on `[spawn, land)`      | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two          |
-| 31  | A letter carries its key, finger and lane                | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift           |
-| 32  | The target is the greatest fall progress, not `landMs`   | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen               |
-| 33  | An exact tie goes to the earlier spawn                   | The index is the letter's identity, so a replay resolves the same dead heat the same way                     |
-| 34  | A repair never lifts a zone above `spec.shield`          | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                     |
-| 35  | A tick resolves every landing inside it                  | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's                |
-| 36  | The field's lanes step back half a `--key-gap`           | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference   |
-| 37  | `--key` is declared once, at the root                    | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key       |
-| 38  | A frame is clamped to 100ms of wave time                 | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield       |
-| 39  | The loop writes `--drop`; the stylesheet owns the fall   | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either    |
-| 40  | The field re-renders on the picture, not on the frame    | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal         |
-| 41  | A shield segment is its finger's home-row span           | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on  |
-| 42  | A tint is an element keyed by a counter, not a class     | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe    |
-| 43  | A stroke at an empty sky flares the whole board          | It costs ten points and the streak, and a key that costs a child points must not light `--lime`              |
-| 44  | Key auto-repeat is not a shot                            | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                    |
-| 45  | The HUD is drawn inside the sky, not as a row of its own | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give               |
-| 46  | A wrong key costs score; a letter through costs shield   | One failure, one cost — the landing has already taken the thing that ends runs                               |
-| 47  | The ending stands where the board did                    | The gun is dead, and the sky it leaves whole is the shield with the hole in it that the sentence is about    |
-| 48  | A storm's cards are its letters, not its keystrokes      | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both    |
-| 49  | A letter that got through is a `timedOut` card           | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped     |
-| 50  | A storm has no ghost and holds no record                 | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it           |
-| 51  | A retry is a new run, so it is a remount                 | The finish guard, the history snapshot and the clock all have to start again; one instance is one run        |
-| 52  | Fall time has a floor, in the generator                  | The twenty specs are a table, and a table gets tightened a row at a time until a level nobody can read ships |
-| 53  | A keystroke proves a keyboard; the pointer only guesses  | Every proxy is wrong about somebody, and wrongly shut is a child locked out where wrongly open is a dud tile |
-| 54  | The quit sheet is the storm's pause                      | A wave falling behind it would break a shield while a child read "it won't be saved"                         |
-| 55  | `Escape` leaves, and is taken before the trigger         | Every other key while a run is live is a shot, so a way out on a second listener would cost ten points       |
+|     | Decision                                                      | Because                                                                                                         |
+| --- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| 1   | The keyboard layout is engine, not view                       | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture           |
+| 2   | `code`, not `key`                                             | Shift+`4` produces `$` and there is no `$` key to light up                                                      |
+| 3   | Keys release on a timer, not `keyup`                          | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                                 |
+| 4   | The board is `aria-hidden`                                    | Sixty announcing spans is not accessibility; the passage already carries the state                              |
+| 5   | The visual keyboard is never tappable                         | A tappable board is a hunt-and-peck trainer, which is the thing this is against                                 |
+| 6   | Lesson text is generated, not written                         | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                             |
+| 7   | The lexicon must not be reachable from `decks/index.ts`       | The same import took the shared chunk 46 KB → 222 KB once already                                               |
+| 8   | Ghost identity is the lesson, not the passage                 | Every run generates different words; keying on them buckets every run alone                                     |
+| 9   | Three pass bars, not one score                                | A single number says you failed; three say what to fix                                                          |
+| 10  | Accuracy is flat and high; speed scales                       | An accuracy bar you can hammer past teaches hammering                                                           |
+| 11  | The speed bar dips when a key arrives                         | You have just got slower and you should have                                                                    |
+| 12  | The new-key gate                                              | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                              |
+| 13  | Per-key stats come from cards, not keystrokes                 | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven             |
+| 14  | Progress is derived, never stored                             | No migration, self-heals when criteria change, cannot disagree with the record book                             |
+| 15  | Unlock is `max(cleared) + 1`                                  | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                                 |
+| 16  | Any checkpoint, any time                                      | It is a placement test, a skip-ahead and an ordering rule in one sentence                                       |
+| 17  | A lesson has no ghost and no time penalty                     | A penalty double-counts accuracy and makes the wpm number a lie                                                 |
+| 18  | Hailstorm is a route in the typing island                     | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard        |
+| 19  | Letters fall down their key's column                          | The lane is a spatial hint — the game teaches the layout the whole time it is played                            |
+| 20  | Only the lowest letter can be shot                            | Otherwise spraying the keyboard is a winning strategy                                                           |
+| 21  | The shield is eight finger zones                              | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise               |
+| 22  | Score can fall, XP cannot                                     | XP is cumulative across years and four games; a bad five minutes must not lower a level                         |
+| 23  | A Hailstorm run is a `Session`                                | Record book, XP, badges and the drill builder all work with no new code                                         |
+| 24  | Hailstorm never gates the ladder                              | A tablet has no keys, and a reward that blocks you is not a reward                                              |
+| 25  | DOM, not canvas                                               | Eleven custom properties change the whole app's biome; a canvas is a hole in that                               |
+| 26  | US ANSI only, and say so                                      | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                                   |
+| 27  | A lesson's keyboard seeds; it does not overrule               | All hundred name a mode, so an override beats the player's own setting on every rung                            |
+| 28  | `eyes-up` reads the board the run was typed under             | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory              |
+| 29  | `unbroken` is gated on the wave having a length               | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete         |
+| 30  | A falling letter is on the field on `[spawn, land)`           | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two             |
+| 31  | A letter carries its key, finger and lane                     | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift              |
+| 32  | The target is the greatest fall progress, not `landMs`        | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen                  |
+| 33  | An exact tie goes to the earlier spawn                        | The index is the letter's identity, so a replay resolves the same dead heat the same way                        |
+| 34  | A repair never lifts a zone above `spec.shield`               | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                        |
+| 35  | A tick resolves every landing inside it                       | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's                   |
+| 36  | The field's lanes step back half a `--key-gap`                | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference      |
+| 37  | `--key` is declared once, at the root                         | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key          |
+| 38  | A frame is clamped to 100ms of wave time                      | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield          |
+| 39  | The loop writes `--drop`; the stylesheet owns the fall        | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either       |
+| 40  | The field re-renders on the picture, not on the frame         | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal            |
+| 41  | A shield segment is its finger's home-row span                | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on     |
+| 42  | A tint is an element keyed by a counter, not a class          | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe       |
+| 43  | A stroke at an empty sky flares the whole board               | It costs ten points and the streak, and a key that costs a child points must not light `--lime`                 |
+| 44  | Key auto-repeat is not a shot                                 | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                       |
+| 45  | The HUD is drawn inside the sky, not as a row of its own      | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give                  |
+| 46  | A wrong key costs score; a letter through costs shield        | One failure, one cost — the landing has already taken the thing that ends runs                                  |
+| 47  | The ending stands where the board did                         | The gun is dead, and the sky it leaves whole is the shield with the hole in it that the sentence is about       |
+| 48  | A storm's cards are its letters, not its keystrokes           | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both       |
+| 49  | A letter that got through is a `timedOut` card                | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped        |
+| 50  | A storm has no ghost and holds no record                      | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it              |
+| 51  | A retry is a new run, so it is a remount                      | The finish guard, the history snapshot and the clock all have to start again; one instance is one run           |
+| 52  | Fall time has a floor, in the generator                       | The twenty specs are a table, and a table gets tightened a row at a time until a level nobody can read ships    |
+| 53  | A keystroke proves a keyboard; the pointer only guesses       | Every proxy is wrong about somebody, and wrongly shut is a child locked out where wrongly open is a dud tile    |
+| 54  | The quit sheet is the storm's pause                           | A wave falling behind it would break a shield while a child read "it won't be saved"                            |
+| 55  | `Escape` leaves, and is taken before the trigger              | Every other key while a run is live is a shot, so a way out on a second listener would cost ten points          |
+| 56  | A storm level cannot name its own keys                        | The row holds a `WaveSpec` minus `keys`, so the pool can only be `unlockedAt(n)` and reachability is structural |
+| 57  | The miss flash has a floor, in the reducer                    | A zone's tint rate is the schedule's and the specs keep it; a wrong key's is a hand's, and no spec can          |
+| 58  | A storm's seed is the level's, not the visit's                | A level is the same weather twice, and the twenty waves measured for strobe are the twenty a child meets        |
+| 59  | A lesson is cleared only by a run that says it is that lesson | A drill files under the lesson's mode, so mode alone would let practising a lesson clear it                     |
+| 60  | A storm's brief is its own screen                             | Three bars, a best and a keyboard control are three things a storm does not have, and it has three of its own   |
 
 ---
 
@@ -1845,6 +1984,18 @@ The four that carry this epic, in the order they are worth writing:
    produces byte-identical keys. Runs from before must still find their ghosts.
 4. **The storm reducer.** Spawn schedule, lowest-target resolution, shield
    depletion, repair, scoring, death — all pure, all without a DOM.
+
+Plus the two the twenty storms brought with them, both in `storms.test.ts`:
+
+5. **No zone can strobe.** Every one of the twenty specs, at its own seed and
+   at sixteen others, starts at most three tints on any one zone inside any one
+   second — WCAG 2.3.1's line — and the shipped twenty are held to two (§8.10).
+   Read off the built schedule, because `fall` is a range and the question is
+   about landings rather than about spawns.
+6. **The doc and the specs agree.** §5.7's table is read out of
+   `docs/typing.md` and compared with the shipped rows column by column. A
+   design doc that disagreed with the code would be a defect here, so it is one
+   the suite can see.
 
 Plus the ones that are cheap and catch the embarrassing failures: `strokeFor`
 round-trips every character in every lesson; the hundred lessons have unique

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -464,8 +464,20 @@ try {
   await page.getByText("Smoke", { exact: false }).first().click();
   await page.waitForTimeout(700);
   const player = (await page.evaluate(() => location.hash)).replace("#/p/", "");
-  // Nothing links to the storm until the ladder grows its tiles, so the URL is
-  // the only way in — which is what the route is for at this stage.
+  /**
+   * Open lesson 4's storm — "First ice", the first of the twenty (§5.6).
+   *
+   * By URL rather than by pressing its tile, which section 13 does: what these
+   * sections are about is the game, and a tile press would put the ladder's
+   * unlock rule in front of every one of them. The rung is in the path because
+   * a storm is a level (`#/p/:id/storm/:lessonId`).
+   *
+   * Lesson 4 is the one the numbers below are of: twelve letters, one at a
+   * time — `gap` clears `fall`, so this level never puts two on screen — over
+   * about twenty seconds, from the seed the table gives it. Being able to sit
+   * through a whole wave is why the FIRST storm is the one measured.
+   */
+  const STORM_LESSON = "L04";
   const storm = async () => {
     // Out to the ladder first, so this is a fresh mount every time it is
     // called: a hash set to the one it already holds fires no navigation, and
@@ -474,30 +486,33 @@ try {
     // has — the HUD's Quit button and `Escape` both open the sheet (§8.11),
     // and section 12 leaves that way on purpose.
     await page.evaluate((id) => (location.hash = `#/p/${id}`), player);
-    await page.evaluate((id) => (location.hash = `#/p/${id}/storm`), player);
+    await page.evaluate(
+      ([id, lesson]) => (location.hash = `#/p/${id}/storm/${lesson}`),
+      [player, STORM_LESSON],
+    );
     await page.waitForSelector(".storm__letter", { timeout: 8000 });
   };
 
   await storm();
   /*
-   * Thirty-six readings across 900ms, rather than two readings 300ms apart —
-   * and the difference is the entire value of the check.
+   * Twenty-eight readings across 700ms, rather than two readings apart — and
+   * the difference is the entire value of the check.
    *
-   * The stand-in wave spawns a letter every 300ms and every spawn is a redraw,
-   * so React rewrites each stone's inline `--drop` from `state.timeMs` at
-   * least once inside any 300ms window. Two readings that far apart therefore
-   * move whether or not the rAF loop writes anything at all: delete the loop's
-   * only side effect and the pair still differs, because the re-render alone
-   * carried the stone. What the re-render cannot fake is the SHAPE of the
-   * motion — without the loop the stone climbs a 300ms staircase, three or
-   * four distinct positions across this window, where the loop gives one per
-   * frame. So the assertion is on the count of distinct positions, which is
-   * the one number a staircase and a fall cannot both satisfy.
+   * Every spawn is a redraw, so React rewrites each stone's inline `--drop`
+   * from `state.timeMs` whenever the picture changes. Two readings far enough
+   * apart therefore move whether or not the rAF loop writes anything at all:
+   * delete the loop's only side effect and the pair still differs, because the
+   * re-render alone carried the stone. What the re-render cannot fake is the
+   * SHAPE of the motion — without the loop this level's stone would sit still
+   * until the next spawn a second and a half later, one position across this
+   * whole window, where the loop gives one per frame. So the assertion is on
+   * the count of distinct positions, which is the one number a staircase and a
+   * fall cannot both satisfy.
    *
    * The element is held rather than re-queried between readings: React keys
    * the sky by wave index, so this node survives every re-render for as long
-   * as its letter is airborne — and the wave's first letter falls for four
-   * seconds, comfortably longer than this samples for.
+   * as its letter is airborne — and this level's first letter falls for 900ms,
+   * which is why the window below is 700 and not a second.
    */
   const fall = await page.evaluate(async () => {
     // The first stone in DOM order, which is wave-index (spawn) order because
@@ -506,14 +521,14 @@ try {
     // reorders, so it is the same element on every reading below.
     const stone = document.querySelector(".storm__letter");
     const tops = [];
-    for (let i = 0; i < 36; i++) {
+    for (let i = 0; i < 28; i++) {
       tops.push(stone.getBoundingClientRect().top);
       await new Promise((done) => window.setTimeout(done, 25));
     }
     return {
       // Rounded to whole pixels so sub-pixel noise cannot be counted as
       // movement. A frame of this wave is several pixels, so nothing real is
-      // rounded away, and a 300ms step is roughly fifty.
+      // rounded away, and a whole spawn gap is the height of the sky.
       distinct: new Set(tops.map((top) => Math.round(top))).size,
       samples: tops.length,
       // The loop and the render must never disagree about `--drop`, so the
@@ -529,8 +544,8 @@ try {
   check(
     "a stone moves on every frame, not once per spawn",
     fall.distinct >= 12 && fall.forwards && fall.attached,
-    `${fall.distinct} distinct positions in ${fall.samples} readings over 900ms, ` +
-      `${fall.travelled}px travelled (a per-spawn staircase gives 3)`,
+    `${fall.distinct} distinct positions in ${fall.samples} readings over 700ms, ` +
+      `${fall.travelled}px travelled (a per-spawn staircase gives 1)`,
   );
   check(
     "the loop has exactly one frame in flight while it runs",
@@ -646,13 +661,13 @@ try {
     );
   });
 
-  // And a run that reaches its end stops itself. The stand-in wave is twelve
-  // letters over 7.3s, and nothing is pressed at it, so this waits out a whole
-  // storm and every letter of it lands.
+  // And a run that reaches its end stops itself. Lesson 4's wave is twelve
+  // letters over twenty seconds, and nothing is pressed at it, so this waits
+  // out a whole storm and every letter of it lands.
   await storm();
   await page
     .waitForFunction(() => window.__pendingFrames() === 0, null, {
-      timeout: 15000,
+      timeout: 30000,
     })
     .catch(() => {});
   const ended = await page.evaluate(() => ({
@@ -718,16 +733,21 @@ try {
     damage.tints.filter((tint) => tint.name !== "storm-hit").length === 0,
     [...new Set(damage.tints.map((tint) => tint.name))].join() || "none",
   );
-  // Three zones took three letters each in this wave, and a zone at zero is a
-  // hole — drawn as one, off the same number the reducer holds. Twelve
-  // landings is what the numbers below are of: shoot one of those letters and
-  // its zone keeps the point, which the run after this one does.
+  // Lesson 4's wave drops four of its twelve letters on the right index and
+  // three on the right ring, against a shield of four (§5.6) — so exactly one
+  // zone is emptied and drawn as a hole, off the same number the reducer
+  // holds, and no fifth letter ever lands on it. That is the level's own
+  // promise: the first storm a child meets cannot end before its letters do
+  // (`storms.test.ts`), so twelve landings is what the census above is of.
   const holes = damage.zones.filter((zone) => zone.hole);
   check(
     "a zone the storm emptied is drawn as a hole",
-    holes.length === 3 &&
+    holes.length === 1 &&
       holes.every((zone) => zone.hp === 0) &&
-      holes.map((zone) => zone.finger).join() === "l-index,r-index,r-middle",
+      holes.map((zone) => zone.finger).join() === "r-index" &&
+      // And the zone that took three of four is drawn short but whole, which
+      // is what makes the hole above a hole rather than a colour.
+      damage.zones.some((zone) => !zone.hole && zone.hp === 0.25),
     damage.zones.map((z) => `${z.finger}:${z.hp.toFixed(2)}`).join(" "),
   );
 
@@ -736,13 +756,13 @@ try {
    *
    * A browser is the only place two halves of it can be checked at once. The
    * panel stands in the BOARD's grid track rather than over the sky, which is
-   * what leaves the shield — with its three holes still in it — on screen
-   * beside the sentence about it; the unit suite renders the panel alone and
-   * cannot see either the board it replaced or the eight segments it left
-   * behind. This run is the cleared ending, because nothing was pressed at it
-   * and every letter therefore resolved; the breach ending has no reachable
-   * wave in the stand-in (three zones take three letters each and the shield
-   * is three deep), and its wording is `StormOver.test.tsx`'s.
+   * what leaves the shield — with the hole still in it — on screen beside the
+   * sentence about it; the unit suite renders the panel alone and cannot see
+   * either the board it replaced or the eight segments it left behind. This
+   * run is the cleared ending, because nothing was pressed at it and every
+   * letter therefore resolved; the breach ending is not reachable on this
+   * level at all (§5.6: no zone takes more letters than its four-deep shield
+   * can hold), and its wording is `StormOver.test.tsx`'s.
    */
   const over = await page.evaluate(() => {
     const panel = document.querySelector(".storm__over");
@@ -765,8 +785,8 @@ try {
     "a run that ends says what the storm did, where the board was",
     over.text?.includes("Wave cleared") &&
       over.text.includes("Shield left") &&
-      // Twelve landed and the shield is eight zones of three deep.
-      over.text.includes("12/24") &&
+      // Twelve landed, and lesson 4's shield is eight zones of four deep.
+      over.text.includes("20/32") &&
       over.buttons.join("|") === "Try this wave again|Back to the ladder" &&
       over.keys === 0 &&
       over.zones === 8 &&
@@ -788,9 +808,12 @@ try {
    * unit suite. What is measured here is the join: press a key, read the HUD.
    *
    * Every press is deterministic without knowing the wave, because the target
-   * is the lowest letter and this stand-in falls every letter at one speed —
-   * so the lowest is the earliest still on the field, and its own character
-   * shoots it.
+   * is a thing the field says out loud: the lowest letter is the greatest
+   * `--drop` (§8.4, decision 32), which the loop writes onto every stone, and
+   * its own character shoots it. Read that way rather than as "the earliest
+   * still on the field", which is a different ordering the moment two letters
+   * fall at different speeds — and every one of the twenty levels draws its
+   * falls from a range (§8.3).
    *
    * ── Nothing here may read the field and then act on the reading ───────────
    * The reducer marks a key against the target it holds **when the key
@@ -846,22 +869,24 @@ try {
   const read = () =>
     page.evaluate(() => {
       const stones = [...document.querySelectorAll(".storm__letter")];
-      // Lowest is the earliest spawn here, and `data-stone` is the letter's
-      // index in the wave, which is spawn order (§8.3).
+      // Lowest is the greatest `--drop`, with the earlier spawn taking an
+      // exact tie — `targetIndex`, read off the field (§8.4, decision 33).
+      const dropOf = (stone) =>
+        Number(window.getComputedStyle(stone).getPropertyValue("--drop"));
       let low = null;
       for (const stone of stones)
         if (
           low === null ||
-          Number(stone.dataset.stone) < Number(low.dataset.stone)
+          dropOf(stone) > dropOf(low) ||
+          (dropOf(stone) === dropOf(low) &&
+            Number(stone.dataset.stone) < Number(low.dataset.stone))
         )
           low = stone;
       return {
         chars: stones.map((stone) => stone.textContent.toLowerCase()),
         index: low && Number(low.dataset.stone),
         ch: low && low.textContent,
-        drop:
-          low &&
-          Number(window.getComputedStyle(low).getPropertyValue("--drop")),
+        drop: low && dropOf(low),
       };
     });
 
@@ -875,36 +900,40 @@ try {
    * reading is at best one round trip stale. This pays one, and the answer is
    * a frame old.
    *
-   * `0.7` is the last drop it will aim at. `--drop` is the 0→1 the renderer
-   * writes on each stone (STM03), the stand-in's fall is four seconds of wave
+   * `0.35` is the last drop it will aim at. `--drop` is the 0→1 the renderer
+   * writes on each stone (STM03), lesson 4's falls are 900–1200ms of wave
    * time, and wave time only ever runs slower than the clock — so leaving the
-   * last three tenths of a fall unshot leaves at least 1.2s of real time for
+   * last two thirds of a fall unshot leaves at least 580ms of real time for
    * the press to arrive in. Waiting is the ordinary case and not a slow
-   * machine: a letter spawns every 300ms, this shoots faster than that, and
-   * the sky between a shot and the next spawn is genuinely empty.
+   * machine: this level puts one letter on screen at a time and spawns the
+   * next 1.5–1.9s later, so the sky between a shot and the next spawn is
+   * genuinely empty.
    *
-   * **The budget is short on purpose.** There are only two reasons to wait —
-   * the next spawn (300ms) and, at the very start, a first letter that was
-   * already too low when the driver arrived. Neither takes 2.5s, and past that
-   * the wave has simply outrun the hand: from the first landing onwards the
-   * lowest letter is always in the last tenth of its fall, so there is no
-   * letter left that a press can be promised to reach and no amount of further
-   * waiting will produce one. A fresh wave is the only way back, which is what
-   * `cleanRun` does with this `null`.
+   * **The budget is generous enough for one spawn gap and no more.** There are
+   * only two reasons to wait — the next spawn, and at the very start a first
+   * letter that was already too low when the driver arrived. Past that the
+   * wave has outrun the hand: the lowest letter is always deep in its fall, so
+   * there is no letter left that a press can be promised to reach and no
+   * amount of further waiting will produce one. A fresh wave is the only way
+   * back, which is what `cleanRun` does with this `null`.
    */
-  const armed = async (budgetMs = 2500) => {
+  const armed = async (budgetMs = 3000) => {
     const handle = await page
       .waitForFunction(
         (room) => {
           const stones = [...document.querySelectorAll(".storm__letter")];
           if (stones.length === 0) return null;
+          const dropOf = (stone) =>
+            Number(window.getComputedStyle(stone).getPropertyValue("--drop"));
           let low = stones[0];
           for (const stone of stones)
-            if (Number(stone.dataset.stone) < Number(low.dataset.stone))
+            if (
+              dropOf(stone) > dropOf(low) ||
+              (dropOf(stone) === dropOf(low) &&
+                Number(stone.dataset.stone) < Number(low.dataset.stone))
+            )
               low = stone;
-          const drop = Number(
-            window.getComputedStyle(low).getPropertyValue("--drop"),
-          );
+          const drop = dropOf(low);
           if (!(drop <= room)) return null;
           return {
             chars: stones.map((stone) => stone.textContent.toLowerCase()),
@@ -913,7 +942,7 @@ try {
             drop,
           };
         },
-        0.7,
+        0.35,
         { timeout: budgetMs },
       )
       .catch(() => null);
@@ -1101,16 +1130,11 @@ try {
   // is the score going under: it is the run's own number and it is allowed to.
   //
   // The 200ms is spacing, not patience, and it is what the flash count at the
-  // bottom of this section depends on: the HUD's `--flare` is an element keyed
-  // by the miss counter, so misses landing inside one frame replace the element
-  // before its animation has started, and the listener on `document` sees ONE
-  // `animationstart` for all of them — the same under-count the shield's tint
-  // has for two landings in one tick (§8.10, and the note above the damage run
-  // in this file), and the same safe direction. It is not a one-in-eight
-  // rounding error. Measured on this build: eight wrong keys pressed back to
-  // back land inside 10ms, mount eight elements and draw ONE flash; thirty
-  // inside 21ms also draw one. The 200ms is what buys each flash a frame of
-  // its own, and at that cadence all eight are counted.
+  // bottom of this section is about. Eight wrong keys 200ms apart is five a
+  // second, which is faster than the `--flare` wash is allowed to light
+  // (`MIN_TINT_GAP_MS`, decision 57) — so this is the strobe case, played at a
+  // rate a seven-year-old really can hammer at, and the check below is that
+  // every one of the eight is CHARGED while fewer than eight light.
   const MISSES = 8;
   // Presses the HUD never answered. Each one would be a miss the flash count
   // at the bottom is short by, and the reason is worth carrying to the check
@@ -1144,7 +1168,7 @@ try {
   // untouched one did.
   await page
     .waitForFunction(() => window.__pendingFrames() === 0, null, {
-      timeout: 15000,
+      timeout: 30000,
     })
     .catch(() => {});
   await page.waitForTimeout(300);
@@ -1213,17 +1237,27 @@ try {
       `after ${shot.length} shot`,
   );
   check(
-    "one flash of red per wrong key, and never two inside one flash",
-    // The HUD's flare is mounted from the miss counter exactly as the shield's
-    // tint is from the landing counter (§8.10, decision 42), so the same
-    // measurement holds it: one element per event, and no element restarted.
-    // 220ms is the flash; the presses above are 200ms apart on purpose, so a
-    // pair closer than that would be the animation restarting rather than the
-    // hand moving.
-    flashes.length === MISSES &&
+    "a hand cannot strobe the score, however fast it hammers",
+    // **The half of §8.10 no `WaveSpec` can keep** (decision 57). A zone's
+    // tint rate is a property of the schedule and the twenty levels are held
+    // under it by `storms.test.ts`; a miss is a child pressing a wrong key,
+    // and the only place that can be bounded is the reducer. So the wash is
+    // mounted from `missTintAt`, a wave-time stamp that moves at most once
+    // every 340ms — under WCAG 2.3.1's three flashes a second with room to
+    // spare — and eight presses at five a second must therefore light FEWER
+    // than eight times while costing all eight.
+    //
+    // The floor is the measurement that says it did not merely mount fewer
+    // elements: 150ms is the tint's own life, so a pair closer than that would
+    // be an animation restarting rather than a hand moving, and 340 is the
+    // rule itself. Both are asserted; the second implies the first, and the
+    // first is the one that has been true since the shield's tint was built.
+    flashes.length > 0 &&
+      flashes.length < MISSES &&
       flashes.every((tint) => tint.finger === undefined) &&
-      rhythm(flashes, () => "hud") >= 150,
-    `${flashes.length} flashes for ${MISSES} wrong keys, ` +
+      rhythm(flashes, () => "hud") >= 150 &&
+      rhythm(flashes, () => "hud") >= 340,
+    `${flashes.length} flashes for ${MISSES} wrong keys 200ms apart, ` +
       `closest pair ${rhythm(flashes, () => "hud")}ms apart`,
   );
 
@@ -1248,17 +1282,19 @@ try {
    */
   log("\n10. A storm is a session, and a retry is a second one");
   const stormRuns = async () =>
-    (await readStore("sessions")).filter((s) => s.mode === "typing:L39");
+    (await readStore("sessions")).filter(
+      (s) => s.mode === `typing:${STORM_LESSON}`,
+    );
 
   /**
    * Waits — in the page, against the same database the app writes to — until
    * exactly `want` storm runs are stored. `false` if it never got there, which
    * says "too few, or the count went past it and stayed".
    */
-  const storedRuns = (want) =>
+  const storedRuns = (target) =>
     page
       .waitForFunction(
-        (target) =>
+        ([lesson, want]) =>
           new Promise((res) => {
             const open = indexedDB.open("schoolskills");
             open.onerror = () => res(false);
@@ -1269,12 +1305,12 @@ try {
                 .getAll();
               all.onsuccess = () =>
                 res(
-                  all.result.filter((s) => s.mode === "typing:L39").length ===
-                    target,
+                  all.result.filter((s) => s.mode === `typing:${lesson}`)
+                    .length === want,
                 );
             };
           }),
-        want,
+        [STORM_LESSON, target],
         { timeout: 8000 },
       )
       .then(() => true)
@@ -1290,9 +1326,13 @@ try {
       saved.length === 2 &&
       saved.every(
         (s) =>
-          s.configKey === "typing|L39|12" &&
-          s.config.lessonId === "L39" &&
-          s.seed === 353 &&
+          s.configKey === `typing|${STORM_LESSON}|12` &&
+          s.config.lessonId === STORM_LESSON &&
+          s.config.storm === true &&
+          // The level's own seed, off `STORM_WAVES` — a storm is the same
+          // weather every time it is opened (decision 58), so two runs a
+          // minute apart are two runs of one storm and not two storms.
+          s.seed === 6 &&
           s.cards.length === 12,
       ),
     `${saved.length} run(s): ${saved.map((s) => `${s.mode} ${s.configKey} ${s.correct}/${s.cards.length}`).join(", ")}`,
@@ -1301,9 +1341,14 @@ try {
     "a wave nobody pressed at saves twelve letters that all got through",
     untouched?.correct === 0 &&
       untouched?.incorrect === 12 &&
-      // Twelve four-second falls. `ms` is the letter's own time in the air,
-      // so the total is the wave's letters and not the wall clock.
-      untouched?.durationMs === 48000 &&
+      // `ms` is the letter's own time in the air and the total is the sum of
+      // them, not a wall clock — which is the whole of §8.7's `durationMs` for
+      // a wave whose letters can overlap. Derived rather than a number written
+      // here, because every level draws its falls from a range (§8.3): what is
+      // asserted is that each is one of lesson 4's, and that the total is
+      // exactly what they add up to.
+      untouched?.durationMs ===
+        untouched?.cards.reduce((sum, c) => sum + c.ms, 0) &&
       untouched?.cards.every(
         (c) =>
           c.prompt === c.answer &&
@@ -1311,7 +1356,8 @@ try {
           c.given === null &&
           c.ok === false &&
           c.timedOut === true &&
-          c.ms === 4000,
+          c.ms >= 900 &&
+          c.ms <= 1200,
       ),
     `${untouched?.correct}/${untouched?.incorrect} in ${untouched?.durationMs}ms`,
   );
@@ -1323,8 +1369,9 @@ try {
       handsOn?.bestStreak === shot.length &&
       handsOn?.cards.filter((c) => c.ok).every((c) => c.given === c.answer) &&
       // A shot letter was caught before it landed, so its time in the air is
-      // less than the fall — which is what makes it worth XP (§8.6).
-      handsOn?.cards.filter((c) => c.ok).every((c) => c.ms < 4000),
+      // less than the fastest fall this level can draw — which is what makes
+      // it worth XP (§8.6).
+      handsOn?.cards.filter((c) => c.ok).every((c) => c.ms < 900),
     `${handsOn?.correct} shot, ${handsOn?.incorrect} through, ` +
       `${handsOn?.xpEarned} XP, best combo ${handsOn?.bestStreak}`,
   );
@@ -1337,7 +1384,7 @@ try {
   await page.waitForSelector(".storm__letter", { timeout: 8000 });
   await page
     .waitForFunction(() => document.querySelector(".storm__over") !== null, {
-      timeout: 20000,
+      timeout: 30000,
     })
     .catch(() => {});
   const threeRuns = await storedRuns(3);
@@ -1376,10 +1423,11 @@ try {
   const calm = await page.evaluate(async () => {
     // The same measurement as the fall at the top of section 9, on a page that
     // has asked for less motion: distinct positions are what a re-render alone
-    // cannot fake, because without the loop a stone climbs a 300ms staircase.
+    // cannot fake, because without the loop a stone would not move at all
+    // between two spawns a second and a half apart.
     const stone = document.querySelector(".storm__letter");
     const tops = [];
-    for (let i = 0; i < 24; i++) {
+    for (let i = 0; i < 20; i++) {
       tops.push(stone.getBoundingClientRect().top);
       await new Promise((done) => window.setTimeout(done, 25));
     }
@@ -1412,7 +1460,7 @@ try {
   check(
     "a stone still falls, frame by frame, for a child who asked for less motion",
     calm.distinct >= 12 && calm.forwards && calm.travelled > 0,
-    `${calm.distinct} distinct positions in 24 readings over 600ms, ` +
+    `${calm.distinct} distinct positions in 20 readings over 500ms, ` +
       `${calm.travelled}px travelled`,
   );
   check(
@@ -1429,7 +1477,7 @@ try {
   // so the number below is over twelve landings and not over a quiet moment.
   await page
     .waitForFunction(() => window.__pendingFrames() === 0, null, {
-      timeout: 15000,
+      timeout: 30000,
     })
     .catch(() => {});
   await page.waitForTimeout(300);
@@ -1439,9 +1487,9 @@ try {
   }));
   check(
     "twelve letters land and not one animation runs",
-    quiet.tints.length === 0 && quiet.zones === 3,
+    quiet.tints.length === 0 && quiet.zones === 1,
     `${quiet.tints.length} storm animations over a whole wave, ` +
-      `${quiet.zones} zones emptied (the damage still happened)`,
+      `${quiet.zones} zone emptied (the damage still happened)`,
   );
   await page.emulateMedia({ reducedMotion: null });
 
@@ -1499,6 +1547,14 @@ try {
   // And the way out. `Escape` is not a key the board carries, so it is neither
   // swallowed nor fired at the lowest letter — a way out that cost ten points
   // and a streak would be a trap.
+  //
+  // A letter has to be in the sky for the freeze below to be measurable, and
+  // on this level the sky is empty between letters — one at a time is what
+  // makes lesson 4 a reaction level (§5.6). So the same `armed()` the shots
+  // used waits for a stone with most of its fall left, and `Escape` follows it
+  // immediately: what is then frozen has hundreds of milliseconds of wave time
+  // still to run, and standing still for 900 of them is the pause.
+  const paused = await armed(3000);
   const scoreAtQuit = await page.evaluate(() =>
     Number(document.querySelector(".storm__score").textContent),
   );
@@ -1507,15 +1563,15 @@ try {
     timeout: 4000,
   });
   const asked = await page.evaluate(async () => {
+    // The stone the sheet froze, whichever it is: with the run paused nothing
+    // spawns and nothing lands, so the deepest `--drop` in the sky is the same
+    // element at both readings.
     const lowest = () => {
-      const stones = [...document.querySelectorAll(".storm__letter")];
-      let low = stones[0];
-      for (const stone of stones)
-        if (Number(stone.dataset.stone) < Number(low.dataset.stone))
-          low = stone;
-      return low
-        ? Number(window.getComputedStyle(low).getPropertyValue("--drop"))
-        : null;
+      const drops = [...document.querySelectorAll(".storm__letter")].map(
+        (stone) =>
+          Number(window.getComputedStyle(stone).getPropertyValue("--drop")),
+      );
+      return drops.length ? Math.max(...drops) : null;
     };
     const before = lowest();
     await new Promise((done) => window.setTimeout(done, 900));
@@ -1531,7 +1587,8 @@ try {
   });
   check(
     "Escape asks rather than fires, and the storm stops where it stood",
-    asked.escaped.code === "Escape" &&
+    paused !== null &&
+      asked.escaped.code === "Escape" &&
       asked.escaped.prevented === false &&
       asked.score === scoreAtQuit &&
       asked.before !== null &&
@@ -1647,7 +1704,10 @@ try {
   // And the route itself is not gated by any of it. A wrong guess must cost a
   // child a tile, never the game — so a URL still opens a playable storm, with
   // the way out drawn on it.
-  await tablet.evaluate(() => (location.hash = `${location.hash}/storm`));
+  await tablet.evaluate(
+    (lesson) => (location.hash = `${location.hash}/storm/${lesson}`),
+    STORM_LESSON,
+  );
   await tablet.waitForSelector(".storm__letter", { timeout: 8000 });
   const reachable = await tablet.evaluate(() => ({
     stones: document.querySelectorAll(".storm__letter").length,
@@ -1667,7 +1727,9 @@ try {
       reachable.quit === 1 &&
       proved.touchOnly === true &&
       proved.said === 0 &&
-      proved.legend.includes("Coming soon"),
+      // What the legend says on a device that can play them, which is the one
+      // fact a child needs before pressing a diamond (§8.8).
+      proved.legend.includes("Nothing on the ladder waits on one"),
     `the route opened ${reachable.stones} stone(s) either way; ` +
       `after one key ${proved.said}/${proved.storms} still name a keyboard`,
   );

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -1131,10 +1131,11 @@ try {
   //
   // The 200ms is spacing, not patience, and it is what the flash count at the
   // bottom of this section is about. Eight wrong keys 200ms apart is five a
-  // second, which is faster than the `--flare` wash is allowed to light
-  // (`MIN_TINT_GAP_MS`, decision 57) — so this is the strobe case, played at a
-  // rate a seven-year-old really can hammer at, and the check below is that
-  // every one of the eight is CHARGED while fewer than eight light.
+  // second, which is two and a half times faster than the `--flare` wash is
+  // allowed to light (`MIN_TINT_GAP_MS`, decision 57) — so this is the strobe
+  // case, played at a rate a seven-year-old really can hammer at, and the
+  // check below is that every one of the eight is CHARGED while fewer than
+  // eight light.
   const MISSES = 8;
   // Presses the HUD never answered. Each one would be a miss the flash count
   // at the bottom is short by, and the reason is worth carrying to the check
@@ -1239,24 +1240,27 @@ try {
   check(
     "a hand cannot strobe the score, however fast it hammers",
     // **The half of §8.10 no `WaveSpec` can keep** (decision 57). A zone's
-    // tint rate is a property of the schedule and the twenty levels are held
-    // under it by `storms.test.ts`; a miss is a child pressing a wrong key,
-    // and the only place that can be bounded is the reducer. So the wash is
-    // mounted from `missTintAt`, a wave-time stamp that moves at most once
-    // every 340ms — under WCAG 2.3.1's three flashes a second with room to
-    // spare — and eight presses at five a second must therefore light FEWER
-    // than eight times while costing all eight.
+    // tint rate is a property of the schedule and each of the twenty levels
+    // ships at two starts a second (`storms.test.ts`); a miss is a child
+    // pressing a wrong key, and the only place that can be bounded is the
+    // reducer. So the wash is mounted from `missTintAt`, a wave-time stamp
+    // that moves at most once every 500ms — two flashes a second, the same
+    // headroom the zone tints have under WCAG 2.3.1's line of more than three
+    // — and eight presses at five a second must therefore light FEWER than
+    // eight times while costing all eight.
     //
     // The floor is the measurement that says it did not merely mount fewer
     // elements: 150ms is the tint's own life, so a pair closer than that would
-    // be an animation restarting rather than a hand moving, and 340 is the
+    // be an animation restarting rather than a hand moving, and 500 is the
     // rule itself. Both are asserted; the second implies the first, and the
     // first is the one that has been true since the shield's tint was built.
+    // Wall-clock against a wave-time rule is the safe direction: wave time is
+    // clamped per frame and can only run behind the wall, never ahead of it.
     flashes.length > 0 &&
       flashes.length < MISSES &&
       flashes.every((tint) => tint.finger === undefined) &&
       rhythm(flashes, () => "hud") >= 150 &&
-      rhythm(flashes, () => "hud") >= 340,
+      rhythm(flashes, () => "hud") >= 500,
     `${flashes.length} flashes for ${MISSES} wrong keys 200ms apart, ` +
       `closest pair ${rhythm(flashes, () => "hud")}ms apart`,
   );

--- a/src/engine/combo.ts
+++ b/src/engine/combo.ts
@@ -8,8 +8,8 @@
  * may not import `progress.ts`. That file is reachable from
  * `engine/decks/index.ts`, the front door every island on the site downloads,
  * and `progress.ts` pulls the deck registry, the hundred lessons and the
- * ladder in behind it (§5.3, decision 7); STM10 also puts a `WaveSpec` on each
- * storm lesson, which would close the import into a cycle.
+ * ladder in behind it (§5.3, decision 7); the hundred lessons name a
+ * `WaveSpec` on each storm row, which would close the import into a cycle.
  *
  * The alternative was a second `1 + min(streak, 10) / 10` written in the storm,
  * and a second copy of a curve is how a race and a shooter end up paying out

--- a/src/engine/decks/index.ts
+++ b/src/engine/decks/index.ts
@@ -101,10 +101,10 @@ export function buildDeck(config: RaceConfig, seed: number): Card[] {
  * "house best" columns, the `previousBest` a results screen pays the
  * personal-best bonus on, and `ghostsFor`, which is where every rival a setup
  * screen offers comes from. That matters most for the consumers that do not
- * exist yet. STM10 gives lesson 39 a `WaveSpec`, at which point
- * `lessonKey(lesson)` is `typing|L39|12` — the same string `stormConfig`
- * already writes — and `TypingSetup`'s brief and rival list would start
- * reading storms as lesson runs without a line of them changing.
+ * exist yet, and it is not hypothetical for the ones that do: lesson 39 has a
+ * `WaveSpec`, so `lessonKey(lesson)` is `typing|L39|28` — the same string
+ * `stormConfig` writes — and every "best" that groups by key reads a storm and
+ * a run of that lesson as one group.
  *
  * An unranked run is still a run in every other way: the record book lists it,
  * it pays its XP, it earns badges and its cards feed the drill builder. It

--- a/src/engine/progress.test.ts
+++ b/src/engine/progress.test.ts
@@ -414,12 +414,14 @@ describe("Eyes Up", () => {
 /* ── Unbroken ────────────────────────────────────────────────────────────── */
 
 /**
- * Give a storm level the wave it will get from STM10, for the length of one
- * test, and take it back.
+ * Run one test against a storm level whose wave is a given length.
  *
- * `wordCount` is a storm's wave length (§8.3), and every one of the twenty is
- * `0` until STM10 writes the `WaveSpec`s. Mutating it here is standing in for
- * the deploy that writes them — nothing else about the world changes.
+ * The twenty waves are real now (#156), so this is no longer standing in for a
+ * deploy — it is how a test about the badge's *guard* asks its question
+ * without being a test about lesson 4's `count`. Three of the cases below turn
+ * on the relationship between a run's cards and the wave's length, and pinning
+ * them to whatever the table says today would make a difficulty pass look like
+ * a badge regression.
  */
 function withWave(n: number, count: number, body: () => void) {
   const of = lesson(n);
@@ -434,22 +436,33 @@ function withWave(n: number, count: number, body: () => void) {
 
 describe("Unbroken", () => {
   /**
-   * The premise of the guard, pinned so that it cannot quietly stop being
-   * true: no storm level has a wave yet, so no run can have cleared one.
+   * The premise of the guard, the other way up from how it started life.
+   *
+   * It used to read "no storm level has a wave yet", which is what made the
+   * badge unearnable before the waves landed (decision 29). Now every one of
+   * the twenty has a length, so what has to stay true is that they all do: a
+   * storm whose `count` slipped back to zero would be a rung that quietly
+   * cannot earn a badge it advertises, and `survived` would pass every run of
+   * it — including one that died at letter one.
    */
-  it("has nothing to fire on — no Hailstorm level has a wave yet", () => {
+  it("has a wave on every Hailstorm level to fire on", () => {
     const storms = LESSONS.filter((l) => l.pass.kind === "storm");
-    expect(storms.length).toBeGreaterThan(0);
-    for (const of of storms) expect(of.wordCount).toBe(0);
+    expect(storms.length).toBe(20);
+    for (const of of storms) expect(of.wordCount).toBeGreaterThan(0);
   });
 
-  it("is not awarded for a flawless run of a storm level with no wave", () => {
-    const of = lesson(4);
-    const flawless = lessonRun(
-      of,
-      ["a", "s", "d"].map((letter) => card(letter, letter)),
-    );
-    expect(badgesFor(flawless)).not.toContain("unbroken");
+  it("is not awarded for a storm level with no wave", () => {
+    // The guard itself, with the wave taken away for one test: a run that met
+    // three letters of a level that has none is a claim about a wave that does
+    // not exist. It cannot happen off today's table and is what the line in
+    // `progress.ts` is there for, so it is asked directly.
+    withWave(4, 0, () => {
+      const flawless = lessonRun(
+        lesson(4),
+        ["a", "s", "d"].map((letter) => card(letter, letter)),
+      );
+      expect(badgesFor(flawless)).not.toContain("unbroken");
+    });
   });
 
   it("does not throw on a storm-shaped run", () => {

--- a/src/engine/progress.ts
+++ b/src/engine/progress.ts
@@ -414,14 +414,15 @@ function courseBadges(
   )
     earned.push("eyes-up");
 
-  /* ── `unbroken`, which is waiting for the waves (STM10) ─────────────────────
+  /* ── `unbroken`, and the guard that retired itself ─────────────────────────
      Guarded on the wave rather than on the absence of a screen that could
-     start one. A storm level's `wordCount` is its wave's `count` (§8.3) and
-     every one of the twenty is `0` until STM10 writes the `WaveSpec`s — so
-     `survived` is vacuously true, "cleared a wave" is a claim about a wave
-     that does not exist, and this badge must not be given for it. Stating the
-     guard as "the wave has a length" means it retires itself the day the waves
-     land, rather than being a line someone has to remember to delete.
+     start one. A storm level's `wordCount` is its wave's `count` (§5.7, §8.3),
+     and every one of the twenty was `0` until the waves landed — so `survived`
+     was vacuously true, "cleared a wave" was a claim about a wave that did not
+     exist, and the badge had to be refused for it. Stating the guard as "the
+     wave has a length" is what let it retire itself the day the twenty rows
+     were written, rather than being a line someone had to remember to delete
+     (decision 29). It stays because it is still the badge's own sentence.
 
      "Shield untouched" is read as **no letter reached the bottom**, which is
      what takes a point off a segment (§8.5). A storm's cards are its falling

--- a/src/engine/typing/generate.test.ts
+++ b/src/engine/typing/generate.test.ts
@@ -62,8 +62,15 @@ const SEEDS = [
   16777216, 31337, 8675309,
 ];
 
-/** Every lesson that has text — the storms have a wave instead (§8.3). */
-const WITH_TEXT = LESSONS.filter((lesson) => lesson.wordCount > 0);
+/**
+ * Every lesson that has text — the storms have a wave instead (§8.3).
+ *
+ * Read off the *kind* and not off `wordCount`, which stopped being able to
+ * answer this the day the twenty waves landed: a storm level's `wordCount` is
+ * its wave's `count` (§5.6), so "has a length" is now true of all hundred and
+ * "has words" is true of eighty.
+ */
+const WITH_TEXT = LESSONS.filter((lesson) => lesson.kind.type !== "storm");
 
 /** The lessons the new-key invariants are about. */
 const INTRODUCING = WITH_TEXT.filter((lesson) => lesson.introduces.length > 0);
@@ -110,12 +117,14 @@ describe("the reachability invariant", () => {
    *
    * A lesson asks for `wordCount` words because that is what its wpm bar is
    * computed against (§6.3): a lesson that quietly ran nine words short would
-   * report a speed nobody typed. Storm levels are the exception the type
-   * already carries — `wordCount` is 0 and the wave decides the length.
+   * report a speed nobody typed. Storm levels are the exception, and their
+   * `wordCount` means something else entirely — the letters in the wave — so
+   * they are asked the question they do have an answer to instead, three tests
+   * down: a storm generates no text at all.
    */
   it("produces exactly the number of words the lesson asks for", () => {
     const offenders: string[] = [];
-    for (const lesson of LESSONS)
+    for (const lesson of WITH_TEXT)
       for (const seed of SEEDS) {
         const words = generate(lesson, seed);
         if (words.length !== lesson.wordCount)

--- a/src/engine/typing/ladder.test.ts
+++ b/src/engine/typing/ladder.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CardResult, Session } from "@/engine/types";
 
+import { buildDrill } from "@/engine/decks";
 import { typingMode } from "@/engine/decks/typing";
 import { ladderProgress } from "./ladder";
 import { LESSONS } from "./lessons";
@@ -155,6 +156,33 @@ describe("a child who has done nothing", () => {
     expect(progress.next).toBe(1);
   });
 
+  /**
+   * A drill is filed under the mode it came from, and is not that lesson.
+   *
+   * `buildDrill(keys, "typing:L41")` builds ten to forty words of trouble
+   * keys with a `wordCount` of its own and **no `lessonId`** — the practice
+   * deck a child takes from lesson 41's results, or from the finger a storm
+   * broke (§8.5). Filed by mode alone it would clear the lesson it was offered
+   * from without the lesson ever being run: the ladder would fill in behind a
+   * child who only ever practised. `progress.ts` already reads its badges off
+   * `config.lessonId` for the same reason; this is that rule, one module over.
+   */
+  it("is not advanced by a drill filed under a lesson's mode", () => {
+    const drill = {
+      ...passing(lesson(41)),
+      config: buildDrill(["all", "glad"], typingMode("L41"), {
+        inputMode: "type" as const,
+        timeLimitMs: null,
+      }),
+    };
+    expect(drill.mode).toBe("typing:L41");
+    expect(drill.config).not.toHaveProperty("lessonId");
+    expect(ladderProgress([drill]).cleared.has(41)).toBe(false);
+    // And the lesson itself still clears it, so this is a discriminator and
+    // not a wall.
+    expect(ladderProgress([passing(lesson(41))]).cleared.has(41)).toBe(true);
+  });
+
   /** Fast enough, and half of it wrong. Lesson 41 asks 95%. */
   it("is not advanced by a run that missed a bar", () => {
     const sloppy = run(lesson(41), [card("all", "all"), card("glad", "glaf")], {
@@ -250,6 +278,28 @@ describe("Hailstorm never gates the ladder", () => {
     // And the same for a child who never opened the storm at all. Stepped
     // over, not skipped: 45 is below `next`, so the storm stays open.
     expect(ladderProgress([passing(lesson(44))]).next).toBe(46);
+  });
+
+  /**
+   * All twenty, and not only the one §8.8 uses as its example.
+   *
+   * The rule is a property of the ladder rather than of lesson 45: every storm
+   * sits between two lessons, and clearing the one below it has to open the
+   * one above it — at rung 4, where a child has met four keys, and at rung 99,
+   * where the only thing above is the Ice Exam. A table re-cut so that two
+   * storms sat side by side would break this and nothing else.
+   */
+  it("is stepped over at every one of the twenty rungs", () => {
+    const storms = LESSONS.filter((l) => l.kind.type === "storm");
+    expect(storms).toHaveLength(20);
+
+    for (const storm of storms) {
+      const below = lesson(storm.n - 1);
+      expect(below.kind.type, `lesson ${below.n}`).not.toBe("storm");
+      const progress = ladderProgress([passing(below)]);
+      expect(progress.best, `after lesson ${below.n}`).toBe(below.n);
+      expect(progress.next, `past storm ${storm.n}`).toBe(storm.n + 1);
+    }
   });
 
   /**

--- a/src/engine/typing/ladder.ts
+++ b/src/engine/typing/ladder.ts
@@ -122,6 +122,19 @@ function derive(sessions: readonly LadderRun[]): LadderProgress {
     // replays a lesson they have beaten. Runs of a lesson *not* yet cleared
     // each still pay a verdict, retries included, until one of them clears it.
     if (!lesson || cleared.has(lesson.n)) continue;
+    // ── A lesson is cleared by a run that says it IS that lesson ───────────
+    // The mode is not enough on its own. `buildDrill` files a practice deck
+    // under the mode it came from, so the drill a child takes from lesson 41's
+    // results — or from the finger a storm broke (§8.5) — is also
+    // `typing:L41`: ten to forty words of trouble keys, with its own
+    // `wordCount`, that would otherwise clear the lesson it was offered from
+    // without the lesson ever being run. `lessonId` is the discriminator §5.4
+    // put on the config for exactly this, and `progress.ts` already reads the
+    // badges off it rather than off the mode; this is the same rule, one
+    // module over. A run from before the ladder existed carries no `lessonId`
+    // and no lesson mode either, so nothing already saved changes.
+    if (session.config?.kind !== "typing") continue;
+    if (session.config.lessonId !== lesson.id) continue;
     // A `Session` is a `Run`: what passes a lesson is what the child did, not
     // which profile did it or when.
     if (verdictFor(session, lesson).passed) cleared.add(lesson.n);

--- a/src/engine/typing/lessons.ts
+++ b/src/engine/typing/lessons.ts
@@ -1,4 +1,5 @@
 import type { KeyboardMode } from "@/engine/types";
+import type { WaveSpec } from "./storm";
 
 /**
  * The hundred lessons of Frost Keys, as data (docs/typing.md §5).
@@ -58,16 +59,57 @@ export type LessonKind =
   /** Short and fast — the speed bar moved up and the length cut down. */
   | { type: "sprint" }
   /**
-   * A Hailstorm level (§8).
+   * A Hailstorm level, and the storm it is (§8, §5.6's storm table).
    *
-   * §5.1 gives this variant a `wave: WaveSpec` and it will get one. The twenty
-   * waves are keyed off each lesson's *unlocked set*, so they can only be
-   * written once `keys.ts` exists — which is why §13 builds them last (WEAVE,
-   * step 24) rather than here. Adding the field later is additive; until then
-   * a storm level is identified by its type alone, which is all the ladder,
-   * the record book and the skip rule (§8.8) need from it.
+   * The wave is a `WaveSpec` **minus its keys** (`StormShape` below, decision
+   * 56), which is the whole of how "a storm can never ask for a key the ladder
+   * has not taught" is kept: there is nowhere in the table to write one down.
+   * `storms.ts` composes the real spec by drawing the pool from
+   * `unlockedAt(n)` — the same computed alphabet every lesson's words come
+   * from (§5.2) — so moving a storm up the ladder moves what falls in it, and
+   * a level cannot be given a key by hand.
    */
-  | { type: "storm" };
+  | { type: "storm"; wave: StormShape };
+
+/**
+ * Which class of character a storm level is *about*, or absent for one that is
+ * about everything.
+ *
+ * §8.3 leaves repeats in `spec.keys` meaning "this falls more often", and this
+ * is the curriculum's half of that: "Hailstorm · Digits" has to rain digits
+ * and not one digit in six. The classes are named rather than written out as
+ * characters for the same reason `introduces` is per lesson — the pool is
+ * always a filter over what the ladder has taught by then, so a focus can only
+ * ever weight keys a child already has. `storms.ts` decides what each name
+ * matches.
+ */
+export type StormFocus = "capitals" | "digits" | "marks";
+
+/**
+ * The storm a level is, as the table writes it: everything a `WaveSpec` has
+ * except the keys, plus the two things only a level knows.
+ *
+ * `Omit<WaveSpec, "keys">` rather than a restatement of `count`, `gap`,
+ * `fall`, `shield` and `repairAt`, so a field added to the engine's spec is a
+ * field the table is asked for rather than one it silently stops carrying.
+ * The import is a type and is erased, which is what keeps `storm.ts` — and the
+ * keyboard layout behind it — out of the chunk `decks/index.ts` ships to every
+ * island (§5.3, decision 7).
+ */
+export type StormShape = Omit<WaveSpec, "keys"> & {
+  /**
+   * The seed this level's weather comes from (decision 58).
+   *
+   * A Hailstorm level is a *level*, so it is the same storm every time it is
+   * opened — the twenty waves that ship are the twenty a child meets, and the
+   * twenty the no-strobe rule is measured on (§8.10). "Try this wave again"
+   * already meant the same letters in the same lanes; this is the same promise
+   * across two visits instead of two attempts.
+   */
+  seed: number;
+  /** The characters this level rains, over the ones it merely includes. */
+  focus?: StormFocus;
+};
 
 /**
  * What passing looks like, in three bars rather than one score (§6.1).
@@ -236,7 +278,16 @@ type LessonRow = readonly [
   accuracy: number,
 ];
 
-/** A Hailstorm row. §5.6 prints — for its words, its wpm and its accuracy. */
+/**
+ * A Hailstorm row. §5.6 prints — for its wpm and its accuracy, and its Words
+ * column is the wave's `count`, which `toLesson` reads out of `STORM_WAVES`.
+ *
+ * The wave is a table of its own rather than six more columns here, exactly as
+ * §5.6 prints it: a storm's numbers are read against *each other* — a `gap`
+ * means nothing except beside the `fall` it does or does not clear — where a
+ * lesson's columns are read down the page against the same column on the rows
+ * above. Two tables, each shaped like the thing it is.
+ */
 type StormRow = readonly [
   n: number,
   title: string,
@@ -428,6 +479,101 @@ const ROWS: readonly Row[] = [
   [100, "The Ice Exam", "", "passage", "off!", 150, 38, 97],
 ];
 
+/**
+ * One storm, as §5.6's storm table writes it: the six numbers that make a
+ * level, its seed, and the class of character it is about.
+ *
+ * Positional for the same reason `LessonRow` is — this is read as a table, and
+ * a column out of line is invisible in twenty objects of seven fields. The
+ * ranges are flat pairs because that is how they are read: `gap` against
+ * `fall` is the whole difficulty shape (§8.3), and the eye compares two
+ * columns down the page rather than two brackets across a row.
+ */
+type StormWaveRow = readonly [
+  n: number,
+  count: number,
+  gapFrom: number,
+  gapTo: number,
+  fallFrom: number,
+  fallTo: number,
+  shield: number,
+  repairAt: number,
+  seed: number,
+  focus?: StormFocus,
+];
+
+/**
+ * The twenty storms (docs/typing.md §5.6's storm table, §8.3).
+ *
+ * Four things about the shape of it, and none of them is arbitrary:
+ *
+ *   - **`gap` clears `fall` at the top of the ladder and overlaps below it.**
+ *     Lessons 4, 9 and 13 never put two letters on screen — pure reaction —
+ *     and from 19 on they stack, which is reading ahead. Both halves are
+ *     asserted off the *built* schedule in `storms.test.ts`, because
+ *     `MIN_FALL_MS` can raise a fall and turn a spacing promise into an
+ *     overlap (§8.10, decision 52).
+ *   - **It does not climb smoothly, and must not be smoothed.** Lesson 53's
+ *     storm eases where the number row has just arrived, exactly as the wpm
+ *     column does (§6.3, decision 11); lesson 73 is long where 79 is dense.
+ *     What climbs is each *quarter* of the twenty, which is what the test
+ *     holds it to.
+ *   - **The repairs stop at 79 and never come back.** "No repairs" is that
+ *     level's name and the block's turn: below it the weakest zone mends every
+ *     `repairAt` clean hits, above it what breaks stays broken.
+ *   - **No row asks for a fall under `MIN_FALL_MS`.** The floor is a backstop
+ *     and not a knob (decision 52); a row that went under it would come out of
+ *     `fallRange` as a metronome at 800ms and quietly not be what it says.
+ *
+ * The seed is the level's own number, or the first above it whose wave keeps
+ * the level's promises — no zone tinting more than twice a second (§8.10), six
+ * of the eight fingers used, and no finger taking more than a third of the
+ * letters. Five of the twenty needed the bump; `storms.test.ts` re-derives all
+ * twenty rather than trusting the column (decision 58).
+ */
+const STORM_WAVES: readonly StormWaveRow[] = [
+  //  n  len       gap        fall  shield repair seed  focus
+  [4, 12, 1500, 1900, 900, 1200, 4, 4, 6],
+  [9, 16, 1300, 1600, 900, 1250, 3, 4, 9],
+  [13, 18, 1200, 1500, 900, 1150, 3, 4, 13],
+  [19, 20, 1000, 1300, 1000, 1500, 3, 4, 19],
+  [23, 22, 900, 1200, 1100, 1600, 3, 5, 23],
+  [29, 24, 800, 1100, 1200, 1700, 3, 5, 29],
+  [34, 26, 750, 1050, 1200, 1800, 3, 5, 34, "capitals"],
+  [39, 28, 700, 1000, 1300, 1900, 3, 5, 39, "capitals"],
+  [45, 30, 650, 950, 1300, 2000, 3, 6, 45],
+  [49, 32, 600, 900, 1400, 2000, 3, 6, 49],
+  [53, 30, 700, 1000, 1300, 1800, 3, 6, 55, "digits"],
+  [59, 34, 600, 850, 1400, 2000, 3, 6, 59, "digits"],
+  [65, 34, 600, 850, 1400, 2100, 3, 6, 66, "marks"],
+  [69, 36, 550, 800, 1500, 2100, 3, 6, 69, "marks"],
+  [73, 50, 550, 800, 1500, 2200, 3, 8, 74],
+  [79, 36, 500, 750, 1400, 2000, 3, 0, 79],
+  [83, 40, 450, 650, 1300, 1900, 3, 0, 83],
+  [89, 44, 300, 450, 1900, 2600, 3, 0, 95],
+  [93, 46, 350, 550, 1300, 1900, 2, 0, 95],
+  [99, 50, 300, 500, 1200, 1800, 2, 0, 99],
+];
+
+/** The twenty, by the rung that hosts them. */
+const WAVE_BY_N = new Map<number, StormShape>(
+  STORM_WAVES.map(([n, count, gapFrom, gapTo, fallFrom, fallTo, ...rest]) => {
+    const [shield, repairAt, seed, focus] = rest;
+    return [
+      n,
+      {
+        count,
+        gap: [gapFrom, gapTo],
+        fall: [fallFrom, fallTo],
+        shield,
+        repairAt,
+        seed,
+        ...(focus ? { focus } : {}),
+      },
+    ];
+  }),
+);
+
 // ── Table → lessons ──────────────────────────────────────────────────────────
 
 /**
@@ -451,11 +597,19 @@ const MODE_OF: Record<Keyboard, KeyboardMode> = {
   "guide!": "guide",
 };
 
-const kindFor = (n: number, kind: RowKind): LessonKind =>
+/**
+ * The `Kind` cell as a `LessonKind`, for every kind that is only its own name.
+ *
+ * A storm row is the exception and is built in `toLesson` instead: its variant
+ * carries a wave, which lives in `STORM_WAVES` and is looked up by rung.
+ * `Exclude<RowKind, "storm">` on the parameter is what makes reaching for it
+ * here a type error rather than a `{ type: "storm" }` missing its wave.
+ */
+const kindFor = (n: number, kind: Exclude<RowKind, "storm">): LessonKind =>
   kind === "bigrams" ? { type: "bigrams", focus: BIGRAMS[n] } : { type: kind };
 
 function toLesson(row: Row): Lesson {
-  const [n, title, introduced, kind, keyboard] = row;
+  const [n, title, introduced, , keyboard] = row;
   const locked = keyboard.endsWith("!");
   const introduces = [...introduced];
   const base = {
@@ -464,7 +618,6 @@ function toLesson(row: Row): Lesson {
     block: Math.ceil(n / 10),
     title,
     introduces,
-    kind: kindFor(n, kind),
     keyboard: MODE_OF[keyboard],
     // A storm level is `keyboard: "guide"` without the lock as often as not,
     // so this stays undefined rather than false: `keyboardLocked?: true` is
@@ -477,20 +630,37 @@ function toLesson(row: Row): Lesson {
     ...(n % 10 === 0 ? { checkpoint: true as const } : {}),
   };
 
-  if (row[3] === "storm")
+  if (row[3] === "storm") {
+    const wave = WAVE_BY_N.get(n);
+    // A storm row with no wave is a table that has stopped describing itself,
+    // and it can only be reached by editing one of the two above without the
+    // other — never by anything a child does and never by anything already
+    // saved. So it is loud at module load, where `storms.test.ts` meets it on
+    // its first assertion, rather than a stand-in storm nobody chose or an
+    // `undefined` that reaches the field as a crash mid-run.
+    if (!wave) throw new Error(`lesson ${n} is a storm with no wave`);
     return {
       ...base,
-      // A storm level's length is its wave's `count` (§8.3), which arrives
-      // with the waves themselves. Zero says "not a passage" rather than
-      // "empty passage", and nothing reads it until then.
-      wordCount: 0,
+      kind: { type: "storm", wave },
+      // **A storm level's length is its wave's `count`** (§8.3), and this is
+      // the one place the two are joined. Three things read it back and all
+      // three would be wrong against any other number: `survived` in
+      // `verdict.ts` is `cards.length >= wordCount`, the `unbroken` badge is
+      // guarded on the wave having a length (decision 29), and `lessonKey` —
+      // the string a run is filed under — is `typing|L39|28`, which is what
+      // makes a storm and its lesson share one bucket (§5.4, §8.7).
+      wordCount: wave.count,
       pass: { kind: "storm", survive: true, accuracy: STORM_ACCURACY },
     };
+  }
 
-  // The last three columns, which only a lesson row carries.
-  const [, , , , , wordCount, wpm, accuracy] = row;
+  // The last three columns, which only a lesson row carries — and the `Kind`
+  // cell again, which is only now narrowed to the eight a `kindFor` can take:
+  // the return above is what tells the checker this row is not a storm.
+  const [, , , kind, , wordCount, wpm, accuracy] = row;
   return {
     ...base,
+    kind: kindFor(n, kind),
     wordCount,
     pass: {
       kind: "lesson",

--- a/src/engine/typing/lessons.ts
+++ b/src/engine/typing/lessons.ts
@@ -528,7 +528,7 @@ type StormWaveRow = readonly [
  * The seed is the level's own number, or the first above it whose wave keeps
  * the level's promises — no zone tinting more than twice a second (§8.10), six
  * of the eight fingers used, and no finger taking more than a third of the
- * letters. Five of the twenty needed the bump; `storms.test.ts` re-derives all
+ * letters. Six of the twenty needed the bump; `storms.test.ts` re-derives all
  * twenty rather than trusting the column (decision 58).
  */
 const STORM_WAVES: readonly StormWaveRow[] = [
@@ -555,7 +555,17 @@ const STORM_WAVES: readonly StormWaveRow[] = [
   [99, 50, 300, 500, 1200, 1800, 2, 0, 99],
 ];
 
-/** The twenty, by the rung that hosts them. */
+/**
+ * The twenty, by the rung that hosts them.
+ *
+ * `satisfies StormShape` and not only the `Map`'s type argument, because the
+ * two are not the same check: excess properties do not survive a `.map` into a
+ * `new Map<number, StormShape>`, so a `keys` written here would have
+ * type-checked clean and then been discarded in silence by `waveSpecFor`'s
+ * spread. `satisfies` fires excess-property checking on the literal itself,
+ * which is what makes "a storm cannot name its own keys" (decision 56) a thing
+ * the compiler refuses rather than a thing the spread order rescues.
+ */
 const WAVE_BY_N = new Map<number, StormShape>(
   STORM_WAVES.map(([n, count, gapFrom, gapTo, fallFrom, fallTo, ...rest]) => {
     const [shield, repairAt, seed, focus] = rest;
@@ -569,7 +579,7 @@ const WAVE_BY_N = new Map<number, StormShape>(
         repairAt,
         seed,
         ...(focus ? { focus } : {}),
-      },
+      } satisfies StormShape,
     ];
   }),
 );

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -7,6 +7,7 @@ import { cardXp, stormXp } from "@/engine/progress";
 import { unlockedAt } from "./keys";
 import {
   MIN_FALL_MS,
+  MIN_TINT_GAP_MS,
   SHIELD_FINGERS,
   buildWave,
   fallRange,
@@ -126,11 +127,20 @@ const SPECS: [name: string, spec: WaveSpec][] = [
   ["the long wave", spec({ keys: [...unlockedAt(100)], count: 60 })],
 ];
 
-/** The specs whose `gap` clears their `fall` — the levels that are pure reaction. */
-const REACTION = SPECS.filter(([, s]) => s.gap[0] >= s.fall[1]);
-
-/** The specs whose ranges overlap — the levels that stack letters up. */
-const STACKING = SPECS.filter(([, s]) => s.gap[1] < s.fall[0]);
+/**
+ * The specs whose `gap` clears their `fall` — the levels that are pure
+ * reaction — and the ones whose ranges overlap.
+ *
+ * Both read `fallRange(spec)` and never `spec.fall`, which is what
+ * `fallRange`'s own docstring asks for: `MIN_FALL_MS` can only ever RAISE a
+ * fall, so a spec that declared "one letter at a time" with falls under the
+ * floor gets letters that overlap — and a classifier reading the declaration
+ * would put it in the group whose assertion is that they never do. Today's
+ * fixtures are all above the floor, so the two readings agree; the pair at the
+ * bottom of this file is what keeps that a fact rather than an assumption.
+ */
+const REACTION = SPECS.filter(([, s]) => s.gap[0] >= fallRange(s)[1]);
+const STACKING = SPECS.filter(([, s]) => s.gap[1] < fallRange(s)[0]);
 
 /**
  * The most letters on the field at any one moment.
@@ -499,7 +509,7 @@ describe("when gap clears fall, one letter falls at a time", () => {
 
     for (const [name, s] of REACTION) {
       expect(s.gap[0], `${name} is a reaction level`).toBeGreaterThanOrEqual(
-        s.fall[1],
+        fallRange(s)[1],
       );
       for (const seed of SEEDS)
         expect(maxOnScreen(buildWave(s, seed)), `${name} @ ${seed}`).toBe(1);
@@ -512,6 +522,26 @@ describe("when gap clears fall, one letter falls at a time", () => {
     const s = spec({ count: 30, gap: [900, 900], fall: [900, 900] });
     for (const seed of SEEDS)
       expect(maxOnScreen(buildWave(s, seed)), `@ ${seed}`).toBe(1);
+  });
+
+  it("is not a reaction level just because the row says so", () => {
+    // The floor raises a fall and can therefore turn a spacing promise into an
+    // overlap (§8.10, `fallRange`): this spec's own numbers read as one letter
+    // at a time — 700ms between spawns against a 500ms fall — and the wave it
+    // builds puts two on screen, because every letter falls for 800ms. Which
+    // is the right way for it to go; the alternative is a level keeping its
+    // promise by dropping letters nobody could read.
+    //
+    // It is here because the classification above is otherwise only ever asked
+    // of specs written above the floor, where the two readings agree and a
+    // classifier reading `spec.fall` would look correct forever.
+    const s = spec({ count: 20, gap: [700, 700], fall: [300, 500] });
+    expect(s.gap[0], "reads as a reaction level").toBeGreaterThanOrEqual(
+      s.fall[1],
+    );
+    expect(s.gap[0], "and is not one").toBeLessThan(fallRange(s)[1]);
+    for (const seed of SEEDS)
+      expect(maxOnScreen(buildWave(s, seed)), `@ ${seed}`).toBe(2);
   });
 
   it("stops holding one millisecond the other side of it", () => {
@@ -858,6 +888,83 @@ describe("a wrong key costs", () => {
     expect(through.score, "and cost the score nothing").toBe(hit.score);
     expect(through.misses, "it is not a wrong key").toBe(0);
     expect(through.combo, "it does break the streak").toBe(0);
+  });
+});
+
+/* ── The miss flash, and the one cadence a wave cannot shape (decision 57) ──
+ *
+ * §8.10's "no strobe, ever, in any mode" is kept two different ways, because
+ * the two things that light have two different clocks. A shield zone tints
+ * when a letter LANDS, so its rate is a property of the schedule and is held
+ * under three a second by the twenty levels themselves (`storms.test.ts`). The
+ * score's `--flare` wash fires when a child presses a WRONG KEY, and no spec
+ * can shape a hand: auto-repeat is already not a shot (decision 44), but eight
+ * or ten deliberate presses a second is a seven-year-old having a bad time and
+ * not a bug to defend against.
+ *
+ * So the wash carries its own floor, here in the reducer where the clock is.
+ * What a miss costs is unchanged and unconditional; what is rate-limited is
+ * only the moment the HUD mounts a fresh element from (`StormHud`).
+ */
+describe("the miss flash cannot be strobed by a fast hand", () => {
+  /** A run with a letter in the air, so a wrong key is a miss and not a stroke
+   * at an empty sky — the two cost the same, and this keeps the cause plain. */
+  const live = () => to(runOf([at("f", 0, 20_000)]), 0);
+
+  it("is unlit until the first miss", () => {
+    expect(live().missTintAt).toBeNull();
+    expect(startStorm(buildWave(spec({}), 3)).missTintAt).toBeNull();
+  });
+
+  it("lights at the moment of the miss, in wave time", () => {
+    const missed = fire(to(live(), 1234), "KeyZ");
+    expect(missed.missTintAt).toBe(1234);
+    expect(missed.misses).toBe(1);
+  });
+
+  it("does not relight while the last flash is still recent", () => {
+    let state = fire(to(live(), 1000), "KeyZ");
+    const lit = state.missTintAt;
+
+    // Six more wrong keys over the next 300ms — a hand going about as fast as
+    // a hand goes. Every one of them costs ten points and the streak; none of
+    // them mounts a second element.
+    for (let ms = 1050; ms <= 1300; ms += 50)
+      state = fire(to(state, ms), "KeyZ");
+
+    expect(state.misses, "every miss counted").toBe(7);
+    expect(state.score, "and every miss charged").toBe(-70);
+    expect(state.missTintAt, "one flash, not seven").toBe(lit);
+  });
+
+  it("lights again once the gap has passed", () => {
+    const first = fire(to(live(), 0), "KeyZ");
+    const inside = fire(to(first, MIN_TINT_GAP_MS - 1), "KeyZ");
+    const after = fire(to(inside, MIN_TINT_GAP_MS), "KeyZ");
+
+    expect(inside.missTintAt).toBe(0);
+    expect(after.missTintAt).toBe(MIN_TINT_GAP_MS);
+  });
+
+  it("stays under three flashes in any one second, whatever the hand does", () => {
+    // WCAG 2.3.1's line, measured the way `storms.test.ts` measures a zone's:
+    // the count of starts inside a sliding second. The hand here presses a
+    // wrong key every 40ms for ten seconds, which is faster than a child can
+    // type and far faster than one can aim.
+    let state = live();
+    const lit: number[] = [];
+    for (let ms = 0; ms <= 10_000; ms += 40) {
+      state = fire(to(state, ms), "KeyZ");
+      if (state.missTintAt !== null && state.missTintAt !== lit.at(-1))
+        lit.push(state.missTintAt);
+    }
+
+    expect(state.misses, "the premise: a lot of wrong keys").toBe(251);
+    for (const at of lit)
+      expect(
+        lit.filter((other) => other >= at && other - at < 1000).length,
+        `from ${at}ms`,
+      ).toBeLessThanOrEqual(3);
   });
 });
 

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -8,6 +8,7 @@ import { unlockedAt } from "./keys";
 import {
   MIN_FALL_MS,
   MIN_TINT_GAP_MS,
+  MISS_POINTS,
   SHIELD_FINGERS,
   buildWave,
   fallRange,
@@ -895,12 +896,12 @@ describe("a wrong key costs", () => {
  *
  * §8.10's "no strobe, ever, in any mode" is kept two different ways, because
  * the two things that light have two different clocks. A shield zone tints
- * when a letter LANDS, so its rate is a property of the schedule and is held
- * under three a second by the twenty levels themselves (`storms.test.ts`). The
- * score's `--flare` wash fires when a child presses a WRONG KEY, and no spec
- * can shape a hand: auto-repeat is already not a shot (decision 44), but eight
- * or ten deliberate presses a second is a seven-year-old having a bad time and
- * not a bug to defend against.
+ * when a letter LANDS, so its rate is a property of the schedule and each of
+ * the twenty levels is held to two a second at its own seed (`storms.test.ts`).
+ * The score's `--flare` wash fires when a child presses a WRONG KEY, and no
+ * spec can shape a hand: auto-repeat is already not a shot (decision 44), but
+ * eight or ten deliberate presses a second is a seven-year-old having a bad
+ * time and not a bug to defend against.
  *
  * So the wash carries its own floor, here in the reducer where the clock is.
  * What a miss costs is unchanged and unconditional; what is rate-limited is
@@ -946,25 +947,55 @@ describe("the miss flash cannot be strobed by a fast hand", () => {
     expect(after.missTintAt).toBe(MIN_TINT_GAP_MS);
   });
 
-  it("stays under three flashes in any one second, whatever the hand does", () => {
-    // WCAG 2.3.1's line, measured the way `storms.test.ts` measures a zone's:
-    // the count of starts inside a sliding second. The hand here presses a
-    // wrong key every 40ms for ten seconds, which is faster than a child can
-    // type and far faster than one can aim.
-    let state = live();
-    const lit: number[] = [];
-    for (let ms = 0; ms <= 10_000; ms += 40) {
-      state = fire(to(state, ms), "KeyZ");
-      if (state.missTintAt !== null && state.missTintAt !== lit.at(-1))
-        lit.push(state.missTintAt);
-    }
+  it("stays at two flashes in any one second, whatever the hand does", () => {
+    // **Two, not three.** WCAG 2.3.1's line is *more than three* flashes in
+    // any one second, and a gap of `g` permits `ceil(1000 / g)` starts inside
+    // one — so 340ms would have sat exactly on the line with nothing to spare,
+    // and 500 buys the second flash back. That is the same headroom the twenty
+    // waves' zone tints ship with (§8.10), on the same screen, for the same
+    // five-year-old. Counted the way `storms.test.ts` counts a zone's: starts
+    // inside a sliding second, anchored at each start, which is where every
+    // window's maximum sits.
+    //
+    // Swept rather than hammered at one rate, because the worst case is not
+    // the fastest hand. A hand landing just inside the gap is the one that
+    // reached three, and no amount of pressing faster finds it — so the sweep
+    // walks the cadences either side of the constant as well as the ones a
+    // child can actually produce.
+    const PRESSES = 60;
+    // A letter that outlasts the whole sweep, so every press is a miss inside
+    // a live run rather than a key at a run that has already ended.
+    const held = () => to(runOf([at("f", 0, 120_000)]), 0);
 
-    expect(state.misses, "the premise: a lot of wrong keys").toBe(251);
-    for (const at of lit)
+    for (const cadence of [
+      10, 20, 40, 60, 100, 150, 200, 250, 333, 400, 450, 499, 500, 501, 750,
+    ]) {
+      let state = held();
+      const lit: number[] = [];
+      for (let press = 0; press < PRESSES; press++) {
+        state = fire(to(state, press * cadence), "KeyZ");
+        if (state.missTintAt !== null && state.missTintAt !== lit.at(-1))
+          lit.push(state.missTintAt);
+      }
+
+      // Every cost of a miss is charged in full at every cadence. Only the
+      // tint is throttled, and that is the whole of decision 57.
+      expect(state.misses, `${cadence}ms: every miss counted`).toBe(PRESSES);
+      expect(state.score, `${cadence}ms: every miss charged`).toBe(
+        -MISS_POINTS * PRESSES,
+      );
+      expect(state.combo, `${cadence}ms: every miss broke the streak`).toBe(0);
       expect(
-        lit.filter((other) => other >= at && other - at < 1000).length,
-        `from ${at}ms`,
-      ).toBeLessThanOrEqual(3);
+        lit.length,
+        `${cadence}ms: the premise, a wash that does light`,
+      ).toBeGreaterThan(0);
+
+      for (const start of lit)
+        expect(
+          lit.filter((other) => other >= start && other - start < 1000).length,
+          `${cadence}ms, from ${start}ms`,
+        ).toBeLessThanOrEqual(2);
+    }
   });
 });
 

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -255,10 +255,10 @@ function fallable(ch: string): Fallable | null {
  * a time — still leaves three. The floor would cost the density knob the top
  * of the ladder is built out of and buy almost no safety, so the rule the
  * twenty levels keep is a count per zone per second and not a floor here:
- * `storms.test.ts` builds each of them and asserts no zone starts more than
- * three tints inside any one second, which is WCAG 2.3.1's line (§8.10). The
- * other half of that rule is `MIN_TINT_GAP_MS` below, for the flash no wave
- * can shape (decision 57).
+ * `storms.test.ts` builds each of the twenty at the seed it ships with and
+ * asserts no zone starts more than **two** tints inside any one second, under
+ * WCAG 2.3.1's line of more than three (§8.10). The other half of that rule is
+ * `MIN_TINT_GAP_MS` below, for the flash no wave can shape (decision 57).
  */
 export const MIN_FALL_MS = 800;
 
@@ -561,10 +561,10 @@ export type StormState = {
    *
    * The count above cannot do that job, and this is the one cadence on this
    * screen no `WaveSpec` can shape (decision 57). A wave's tint rate is read
-   * off its own schedule and held under three a second by the twenty levels
-   * themselves (`storms.ts`); a miss happens when a child presses a wrong key,
-   * so its rate is the rate a hand can move at. Auto-repeat is already not a
-   * shot (decision 44), which takes 30Hz off the table, but a child mashing at
+   * off its own schedule and held to two a second by each of the twenty levels
+   * (`storms.ts`); a miss happens when a child presses a wrong key, so its rate
+   * is the rate a hand can move at. Auto-repeat is already not a shot
+   * (decision 44), which takes 30Hz off the table, but a child mashing at
    * eight or ten a second is not a bug and must not produce eight or ten
    * flashes — "no strobe, ever, in any mode" (§8.10) is a promise about the
    * screen and not about the wave.
@@ -602,18 +602,29 @@ export const MISS_POINTS = 10;
  * The least time between two starts of the score's miss wash, in wave ms
  * (§8.10, decision 57).
  *
- * **WCAG 2.3.1's line is more than three flashes in any one second**, so 340ms
- * holds the wash to at most two full flashes and a fraction inside any second
- * — under the line with room to spare, and this site's youngest player is
- * five. It is deliberately longer than the 150ms the tint is drawn for, so
- * what a fast hand gets is a wash that lights, fades and then is allowed to
- * light again, never a wash that blinks off and on inside its own animation.
+ * **WCAG 2.3.1's line is more than three flashes in any one second**, and 500ms
+ * holds the wash to **two starts inside any second** — the same number the
+ * twenty waves' zone tints ship at (§8.10), so the two things that light on
+ * this screen have the same full flash a second of headroom under the line.
+ *
+ * The arithmetic is worth writing down, because the obvious value is wrong.
+ * A gap of `g` permits `ceil(1000 / g)` starts inside a second: 340ms permits
+ * **three** — 0, 340 and 680 — which is exactly the standard's ceiling with
+ * nothing to spare, and this is the one screen on the site where the youngest
+ * player is hammering keys *because they are losing*. 500 is the largest round
+ * number that buys the second flash back. Measured by driving `fire` 60 times
+ * at cadences from 10ms to 750ms: every one of the 60 charged, and no second
+ * ever contains more than two starts.
+ *
+ * It is also deliberately longer than the 150ms the tint is drawn for, so what
+ * a fast hand gets is a wash that lights, fades and then is allowed to light
+ * again, never a wash that blinks off and on inside its own animation.
  *
  * Wave time and not wall-clock time, so the quit sheet's pause (§8.11) cannot
  * spend it: a run resumed after a minute behind the sheet is exactly where it
  * was, which is what "the sheet costs the run zero" means everywhere else.
  */
-export const MIN_TINT_GAP_MS = 340;
+export const MIN_TINT_GAP_MS = 500;
 
 /**
  * Stamp `cleared` on a state whose last letter has just been accounted for.

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -29,12 +29,15 @@
  * decide was decided here, before the first frame.
  *
  * ── And it has to stay small ─────────────────────────────────────────────────
- * `lessons.ts` is importable from the deck layer, and STM10 puts a `WaveSpec`
- * on each of the twenty storm lessons — which will make this module reachable
- * from `decks/index.ts`, the front door every island on the site downloads
- * (§5.3, decision 7). So it must never grow a table. There is nothing here but
- * the spec, the RNG, the keyboard and the rules: the characters a wave draws
- * from arrive as `spec.keys`, from a caller that already knows them.
+ * `lessons.ts` is importable from the deck layer, and each of the twenty storm
+ * lessons names a `WaveSpec` — as a **type**, which is erased, so this module
+ * and the keyboard layout behind it stay out of the chunk `decks/index.ts`
+ * ships to every island on the site (§5.3, decision 7). That is a build away
+ * from being untrue: one value import from `lessons.ts` and the layout is in
+ * every island's bundle. So it must never grow a table either. There is
+ * nothing here but the spec, the RNG, the keyboard and the rules: the
+ * characters a wave draws from arrive as `spec.keys`, from a caller that
+ * already knows them (`storms.ts`, decision 56).
  */
 import { comboMultiplier } from "@/engine/combo";
 import { keyX, strokeFor } from "@/engine/keyboard";
@@ -70,13 +73,19 @@ export type ShieldFinger = Exclude<Finger, "thumb">;
  */
 export type WaveSpec = {
   /**
-   * Which characters can fall. Usually "everything unlocked by lesson n".
+   * Which characters can fall — for the twenty levels, everything unlocked by
+   * that lesson, with the level's focus weighted up inside it (§5.7).
    *
    * Order and repeats are the caller's to use: a character listed twice falls
    * about twice as often, which is how a level built around six new symbols
    * weights them above the forty a child already has. Anything this board
    * cannot produce, and anything typed with a thumb, is dropped rather than
    * refused — see `buildWave`.
+   *
+   * A level cannot write this field down: the shape the ladder holds is a
+   * `WaveSpec` minus this one key, and `storms.ts` is the only place the two
+   * are joined (decision 56). That is what makes "a storm can never ask for a
+   * key the ladder has not taught" structural rather than a promise.
    */
   keys: string[];
   /** How many letters in the wave. */
@@ -223,10 +232,10 @@ function fallable(ch: string): Fallable | null {
  * forgotten by a row.
  *
  * 800ms is a judgement and worth being honest about that — it is not a
- * measured reaction time. What it is anchored to is the epic's own level
- * shapes: the fastest fall any of them declares is 800ms (`storm.test.ts`'s
- * "home row", lesson 9), so the floor is the fastest the ladder ever *means*
- * to be. Under it a letter stops being a thing to read, find and press and
+ * measured reaction time. What it is anchored to is the ladder's own shapes:
+ * the fastest fall any of the twenty declares is 900ms (lessons 4, 9 and 13,
+ * §5.7), so the floor sits just under the fastest the ladder ever *means* to
+ * be and no row is touched by it. Under it a letter stops being a thing to read, find and press and
  * becomes a streak going past — which is the failure §8.10 names, and the one
  * a five-year-old cannot tell from the game being broken.
  *
@@ -244,8 +253,12 @@ function fallable(ch: string): Fallable | null {
  * `gap` at 350ms takes one zone from four tint starts a second to three, and
  * flooring it at 800ms — which would make the top of the ladder one letter at
  * a time — still leaves three. The floor would cost the density knob the top
- * of the ladder is built out of and buy almost no safety, so the rule STM10
- * has to keep is a count per zone per second and not a floor here (§8.10).
+ * of the ladder is built out of and buy almost no safety, so the rule the
+ * twenty levels keep is a count per zone per second and not a floor here:
+ * `storms.test.ts` builds each of them and asserts no zone starts more than
+ * three tints inside any one second, which is WCAG 2.3.1's line (§8.10). The
+ * other half of that rule is `MIN_TINT_GAP_MS` below, for the flash no wave
+ * can shape (decision 57).
  */
 export const MIN_FALL_MS = 800;
 
@@ -536,8 +549,33 @@ export type StormState = {
    * `cards.length >= wordCount`, and the `unbroken` badge (§8.7, decision 48).
    * What a miss cost is still saved, in the streak it broke: `bestStreak` is
    * `bestCombo`, and the combo a wrong key ended is one the maximum never saw.
+   *
+   * It is the count and **not** what the HUD's flash is mounted from — see
+   * `missTintAt` below, which is the half of this that a hand can strobe.
    */
   readonly misses: number;
+  /**
+   * When the score's `--flare` wash last started, in wave time — `null` before
+   * the first one. **A new value is a new flash, and an unchanged one is the
+   * same element left alone** (§8.10, decision 42).
+   *
+   * The count above cannot do that job, and this is the one cadence on this
+   * screen no `WaveSpec` can shape (decision 57). A wave's tint rate is read
+   * off its own schedule and held under three a second by the twenty levels
+   * themselves (`storms.ts`); a miss happens when a child presses a wrong key,
+   * so its rate is the rate a hand can move at. Auto-repeat is already not a
+   * shot (decision 44), which takes 30Hz off the table, but a child mashing at
+   * eight or ten a second is not a bug and must not produce eight or ten
+   * flashes — "no strobe, ever, in any mode" (§8.10) is a promise about the
+   * screen and not about the wave.
+   *
+   * So the flash is rate-limited where the rule lives rather than in the view:
+   * a miss inside `MIN_TINT_GAP_MS` of the last flash still costs the points
+   * and still breaks the streak, and simply does not re-light a wash that is
+   * already lit. The reducer is the only thing here holding a clock, which is
+   * why this is a field and not a `useRef` in the HUD.
+   */
+  readonly missTintAt: number | null;
   /** How the run finished, or `null` while it is live. */
   readonly ending: StormEnding | null;
 };
@@ -559,6 +597,23 @@ export type StormState = {
  */
 export const HIT_POINTS = 10;
 export const MISS_POINTS = 10;
+
+/**
+ * The least time between two starts of the score's miss wash, in wave ms
+ * (§8.10, decision 57).
+ *
+ * **WCAG 2.3.1's line is more than three flashes in any one second**, so 340ms
+ * holds the wash to at most two full flashes and a fraction inside any second
+ * — under the line with room to spare, and this site's youngest player is
+ * five. It is deliberately longer than the 150ms the tint is drawn for, so
+ * what a fast hand gets is a wash that lights, fades and then is allowed to
+ * light again, never a wash that blinks off and on inside its own animation.
+ *
+ * Wave time and not wall-clock time, so the quit sheet's pause (§8.11) cannot
+ * spend it: a run resumed after a minute behind the sheet is exactly where it
+ * was, which is what "the sheet costs the run zero" means everywhere else.
+ */
+export const MIN_TINT_GAP_MS = 340;
 
 /**
  * Stamp `cleared` on a state whose last letter has just been accounted for.
@@ -600,6 +655,7 @@ export function startStorm(wave: Wave): StormState {
     combo: 0,
     score: 0,
     misses: 0,
+    missTintAt: null,
     ending: null,
   });
 }
@@ -814,11 +870,21 @@ export function fire(state: StormState, code: string): StormState {
     // A miss: the streak, the score and a mark against the run. Nothing on the
     // field moves — the letter the child should have shot is still falling,
     // which is the other half of the cost.
+    //
+    // The flash is the one part of that a fast hand could turn into a strobe,
+    // so it is the one part with a clock on it: the wash starts again only
+    // once `MIN_TINT_GAP_MS` of wave time has passed, and every other cost of
+    // a miss is charged in full whether it lights or not (decision 57).
     return {
       ...state,
       combo: 0,
       score: state.score - MISS_POINTS,
       misses: state.misses + 1,
+      missTintAt:
+        state.missTintAt === null ||
+        state.timeMs - state.missTintAt >= MIN_TINT_GAP_MS
+          ? state.timeMs
+          : state.missTintAt,
     };
 
   const resolved = state.resolved.slice();
@@ -847,8 +913,7 @@ export function fire(state: StormState, code: string): StormState {
  * much armour is left and how long the best streak ran are all `state` — so
  * they are decided here, and the screen puts them on a page. What is NOT here
  * is XP: `stormXp` lives in `progress.ts`, which reaches `decks/index.ts`, and
- * this module is one hop from the deck layer from STM10 onwards (see the file
- * header).
+ * this module is one type-only hop from the deck layer (see the file header).
  */
 
 /** What one zone has been through: the two things worth drawing an event for. */

--- a/src/engine/typing/storms.test.ts
+++ b/src/engine/typing/storms.test.ts
@@ -46,13 +46,23 @@ import {
  */
 
 /**
- * Enough seeds that a rare draw is not a lucky pass.
+ * A sample of the space a spec can draw from, and honestly no more than that.
  *
- * The same spread `storm.test.ts` and `generate.test.ts` use, and it matters
- * more here than in either: the twenty ship with a seed each (decision 58), so
- * a rule proved only at those twenty would be a fact about six lucky rolls
- * rather than about the specs. Everything below that can be asked of a
- * *distribution* is asked of these as well as of the shipped wave.
+ * The same spread `storm.test.ts` and `generate.test.ts` use. What it is for
+ * differs by claim, and the difference is worth stating once here rather than
+ * being inferred at each assertion below:
+ *
+ *   - **Reachability** really is universal over seeds — a wave can only ever
+ *     draw from `stormPool`, whatever the roll — so asking it at sixteen is
+ *     asking it of the generator, and a seventeenth would only be slower.
+ *   - **The tint rate is not.** A `WaveSpec` is a pair of *ranges*, so it is a
+ *     built wave and not a spec that is safe or unsafe, and sixteen seeds are
+ *     sixteen measurements rather than a bound. Swept far more widely, four of
+ *     the twenty specs (83, 89, 93, 99) do reach four or five starts a second
+ *     at seeds nobody is ever served. What makes the shipped twenty safe is
+ *     that a level's seed is derived to keep the rule and frozen (decision 58,
+ *     re-derived in "each level's seed" below), not that the specs cannot roll
+ *     a bad wave.
  */
 const SEEDS = [
   0, 1, 2, 7, 42, 99, 128, 1000, 4242, 65535, 123456, 999983, 2147483647,
@@ -340,22 +350,25 @@ describe("no zone can strobe", () => {
    * patches lighting in turn rather than a flash. A zone taking four is the
    * failure.
    *
-   * Three is the hard bound and it is the standard's, not a preference. What
-   * ships is held to two by `SHIPPED` below — the same peak §8.10 measured on
-   * the stand-in wave — so the twenty a child meets have a full flash a second
-   * of headroom over the line, and the rule still says where the line is.
+   * Three is the standard's line and not a preference — but it is asserted
+   * here over a *sample* of sixteen seeds per spec, which is a measurement and
+   * not a property of the specs (see `SEEDS`). The claim that carries a child
+   * is the next one down: `SHIPPED` is held to two, at the seed each level
+   * freezes, and "each level's seed" re-derives that seed from the rule rather
+   * than reading it off the table.
    */
   const MAX_TINTS_PER_ZONE_PER_SECOND = 3;
 
   /**
    * And what the shipped twenty are actually at.
    *
-   * The seed on each row is chosen to keep it (decision 58, pinned below), so
-   * this is not a hope about a draw: it is the wave that is served.
+   * The seed on each row is derived to keep it (decision 58, re-derived
+   * below), so this is not a hope about a draw: it is the wave that is served,
+   * and the one claim here that is a guarantee rather than a sample.
    */
   const SHIPPED_MAX = 2;
 
-  it("holds every spec under the line, at every seed", () => {
+  it("holds every spec under the line, at the sixteen seeds sampled", () => {
     for (const [name, , wave] of SAMPLED)
       expect(peakTintRate(wave), name).toBeLessThanOrEqual(
         MAX_TINTS_PER_ZONE_PER_SECOND,
@@ -503,8 +516,8 @@ describe("each level's seed", () => {
    * in the table — and twenty unexplained numbers would be twenty things
    * nobody could ever safely edit. So the rule is written here and the table
    * is checked against it: **the level's own number, or the first seed above
-   * it whose wave keeps the level's promises.** Fifteen of the twenty are the
-   * lesson number itself; the other five are within six of it.
+   * it whose wave keeps the level's promises.** Fourteen of the twenty are the
+   * lesson number itself; the other six are within six of it.
    *
    * The promises are the three things this file has already asserted about
    * every shipped wave, which is what makes this a derivation rather than a

--- a/src/engine/typing/storms.test.ts
+++ b/src/engine/typing/storms.test.ts
@@ -1,0 +1,549 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { strokeFor } from "@/engine/keyboard";
+import { unlockedAt } from "./keys";
+import { LESSONS } from "./lessons";
+import {
+  MIN_FALL_MS,
+  buildWave,
+  fallRange,
+  isAirborne,
+  startStorm,
+  type ShieldFinger,
+  type Wave,
+  type WaveSpec,
+} from "./storm";
+import {
+  STORM_LESSONS,
+  isStormLesson,
+  stormPool,
+  stormWave,
+  waveSpecFor,
+  type StormLesson,
+} from "./storms";
+
+/**
+ * The twenty Hailstorm levels (docs/typing.md §5.6, §8.1, §8.3, §8.10).
+ *
+ * Three kinds of claim live here and they are worth separating before reading
+ * any of them:
+ *
+ *   - **Reachability**, which is the one a child would meet. A storm may only
+ *     rain keys the ladder has taught by its own rung — the same invariant
+ *     §5.2 holds the generated passages to, asked of the waves.
+ *   - **Safety**, which nobody would ever meet as a bug report. §8.10's "no
+ *     strobe, ever, in any mode" is a promise about how often one shield zone
+ *     can light up, and #155 established by measurement that no floor on `gap`
+ *     buys it — two letters spawned a second apart can land together, because
+ *     `fall` is a range too. So the rule is a **count of tint starts per zone
+ *     per second, read off the built schedule**, and this is where the twenty
+ *     specs meet it.
+ *   - **Shape**, which is what makes twenty levels a ladder rather than twenty
+ *     copies: one letter at a time at the bottom, five or more in the air at
+ *     the top, repairs that stop, and a shield that thins.
+ */
+
+/**
+ * Enough seeds that a rare draw is not a lucky pass.
+ *
+ * The same spread `storm.test.ts` and `generate.test.ts` use, and it matters
+ * more here than in either: the twenty ship with a seed each (decision 58), so
+ * a rule proved only at those twenty would be a fact about six lucky rolls
+ * rather than about the specs. Everything below that can be asked of a
+ * *distribution* is asked of these as well as of the shipped wave.
+ */
+const SEEDS = [
+  0, 1, 2, 7, 42, 99, 128, 1000, 4242, 65535, 123456, 999983, 2147483647,
+  16777216, 31337, 8675309,
+];
+
+/** The rungs §5.6 gives a storm, transcribed from the doc rather than derived. */
+const RUNGS = [
+  4, 9, 13, 19, 23, 29, 34, 39, 45, 49, 53, 59, 65, 69, 73, 79, 83, 89, 93, 99,
+];
+
+/** Every wave the twenty ship with — the storms a child actually meets. */
+const SHIPPED: [name: string, lesson: StormLesson, wave: Wave][] =
+  STORM_LESSONS.map((lesson) => [lesson.title, lesson, stormWave(lesson)]);
+
+/** Every spec, crossed with the sweep of seeds. */
+const SAMPLED: [name: string, spec: WaveSpec, wave: Wave][] =
+  STORM_LESSONS.flatMap((lesson) => {
+    const spec = waveSpecFor(lesson);
+    return SEEDS.map((seed): [string, WaveSpec, Wave] => [
+      `${lesson.id} @ ${seed}`,
+      spec,
+      buildWave(spec, seed),
+    ]);
+  });
+
+/**
+ * When each zone lights up, in ms: one entry per letter that lands on it.
+ *
+ * Read off the **built schedule** and not off the spec, which is the whole
+ * point (§8.10, `fallRange`). A zone tints when a letter *lands* on the finger
+ * above it, and a landing is `spawnMs + fallMs` — two draws, not one — so a
+ * question about how often a zone lights can only be answered after the wave
+ * exists.
+ *
+ * Every letter counts, because a run in which nothing is shot is the worst
+ * case and the one a child who cannot keep up is actually having. A letter
+ * that IS shot never lands and never tints.
+ */
+function tintsByZone(wave: Wave): Map<ShieldFinger, number[]> {
+  const zones = new Map<ShieldFinger, number[]>();
+  for (const letter of wave.letters) {
+    const at = zones.get(letter.finger) ?? [];
+    at.push(letter.landMs);
+    zones.set(letter.finger, at);
+  }
+  for (const at of zones.values()) at.sort((a, b) => a - b);
+  return zones;
+}
+
+/**
+ * The most tints one zone starts inside any one-second window.
+ *
+ * A sliding window anchored at each landing, which is where every window's
+ * maximum sits: moving the window's start off a landing can only drop letters
+ * from the front.
+ *
+ * Deliberately an over-count. §8.10 measured the tint's own curve — 40% of
+ * peak gone by 20ms, 90% by 50ms — so two landings within ~20ms of each other
+ * re-peak one lit tint and are one visible episode rather than two flashes.
+ * Counting them separately errs towards the strobe, which is the direction to
+ * be wrong in.
+ */
+function peakTintRate(wave: Wave, windowMs = 1000): number {
+  let peak = 0;
+  for (const at of tintsByZone(wave).values())
+    for (let i = 0; i < at.length; i++) {
+      let inside = 0;
+      for (let j = i; j < at.length && at[j] - at[i] < windowMs; j++) inside++;
+      peak = Math.max(peak, inside);
+    }
+  return peak;
+}
+
+/** The most zones that light within one tint's life of each other. */
+function peakZonesLit(wave: Wave, windowMs = 150): number {
+  const landings = wave.letters
+    .map((letter) => ({ at: letter.landMs, finger: letter.finger }))
+    .sort((a, b) => a.at - b.at);
+
+  let peak = 0;
+  for (let i = 0; i < landings.length; i++) {
+    const lit = new Set<ShieldFinger>();
+    for (
+      let j = i;
+      j < landings.length && landings[j].at - landings[i].at < windowMs;
+      j++
+    )
+      lit.add(landings[j].finger);
+    peak = Math.max(peak, lit.size);
+  }
+  return peak;
+}
+
+/**
+ * The most letters on the field at once.
+ *
+ * The count only ever rises at a spawn, so asking `isAirborne` at every spawn
+ * instant finds the maximum without sweeping the clock — and it asks the
+ * engine's own half-open interval rather than restating it (§8.3).
+ */
+const maxOnScreen = (wave: Wave): number =>
+  Math.max(
+    0,
+    ...wave.letters.map(
+      (letter) =>
+        wave.letters.filter((other) => isAirborne(other, letter.spawnMs))
+          .length,
+    ),
+  );
+
+/** How many letters land on the busiest zone. */
+const busiestZone = (wave: Wave): number =>
+  Math.max(0, ...[...tintsByZone(wave).values()].map((at) => at.length));
+
+/** The four groups of five the ladder walks through, in order. */
+const QUARTERS = [0, 5, 10, 15].map((from) => SHIPPED.slice(from, from + 5));
+
+/** Letters a second, which is what a `gap` range means for the run as a whole. */
+const density = (spec: WaveSpec) => 2000 / (spec.gap[0] + spec.gap[1]);
+
+const mean = (values: number[]) =>
+  values.reduce((sum, value) => sum + value, 0) / values.length;
+
+describe("the twenty levels", () => {
+  /**
+   * **§5.7 is checked, not trusted.**
+   *
+   * "The design doc and the shipped specs agree" is an acceptance criterion of
+   * this story and it is the kind that rots in a week — twenty rows of numbers
+   * in prose, beside twenty rows of numbers in code, with nothing between them
+   * but somebody's diligence. So the doc's own table is read off disk and
+   * compared column by column, exactly as `StormField.test.tsx` reads
+   * `game.css` rather than restating its arithmetic.
+   *
+   * The doc is the source being checked and not the other way round: if these
+   * ever part company, one of them is wrong and this says which two cells to
+   * look at.
+   */
+  it("matches §5.7's table in docs/typing.md, column by column", () => {
+    const doc = readFileSync("docs/typing.md", "utf8");
+    // §5.7 alone: from its heading to the next one, so the twenty rows read
+    // here cannot quietly become §6's tables the day a section is added.
+    const table = doc.split("### 5.7 · The twenty storms")[1].split("\n## ")[0];
+    const rows = [...table.matchAll(/^\|\s*(\d+)\s*\|(.+)\|\s*$/gm)].map(
+      (match) => [
+        Number(match[1]),
+        ...match[2].split("|").map((cell) => cell.trim()),
+      ],
+    );
+    expect(rows).toHaveLength(20);
+
+    const printed = ([n, title, len, gap, fall, shield, mends, rains, seed]: (
+      string | number
+    )[]) => ({
+      n,
+      title,
+      len: Number(len),
+      gap: String(gap).split("–").map(Number),
+      fall: String(fall).split("–").map(Number),
+      shield: Number(shield),
+      repairAt: mends === "—" ? 0 : Number(mends),
+      focus: rains === "—" ? undefined : rains,
+      seed: Number(seed),
+    });
+
+    expect(rows.map(printed)).toEqual(
+      STORM_LESSONS.map((lesson) => ({
+        n: lesson.n,
+        // The doc's table drops the "Hailstorm · " every one of the twenty
+        // carries in §5.6, because the table it is in is only storms.
+        title: lesson.title.replace("Hailstorm · ", ""),
+        len: lesson.kind.wave.count,
+        gap: lesson.kind.wave.gap,
+        fall: lesson.kind.wave.fall,
+        shield: lesson.kind.wave.shield,
+        repairAt: lesson.kind.wave.repairAt,
+        focus: lesson.kind.wave.focus,
+        seed: lesson.kind.wave.seed,
+      })),
+    );
+  });
+
+  it("sits on the rungs §5.6 names, and on no others", () => {
+    expect(STORM_LESSONS.map((lesson) => lesson.n)).toEqual(RUNGS);
+    expect(LESSONS.filter(isStormLesson)).toHaveLength(20);
+  });
+
+  it("gives every one of them a wave with letters in it", () => {
+    // A `count` of 0 is not an empty level, it is a screen that ends on the
+    // frame it opens: `startStorm` stamps `cleared` on a wave with nothing in
+    // it (§8.3), and the route would write a 0-card session and show the
+    // ending panel before a child had touched a key.
+    for (const [name, lesson, wave] of SHIPPED) {
+      expect(lesson.kind.wave.count, name).toBeGreaterThan(0);
+      expect(wave.letters.length, name).toBe(lesson.kind.wave.count);
+      expect(startStorm(wave).ending, name).toBeNull();
+    }
+  });
+
+  it("makes the rung's `wordCount` its wave's length", () => {
+    // The join §8.7 rests on three times over: `survived` is
+    // `cards.length >= wordCount`, the `unbroken` badge is guarded on the wave
+    // having a length (decision 29), and `lessonKey` is `typing|L39|28`, which
+    // is what puts a storm and its rung in one bucket.
+    for (const [name, lesson] of SHIPPED)
+      expect(lesson.wordCount, name).toBe(lesson.kind.wave.count);
+  });
+});
+
+describe("a storm can only rain what the ladder has taught", () => {
+  /**
+   * **The acceptance criterion, and the same guarantee §5.2 gives the
+   * passages.** A child at lesson 13 has met fifteen characters, and a wave
+   * that dropped a `9` on them would be asking for a key nobody has shown them
+   * — unshootable, and unfair in the one mode where a letter you cannot find
+   * costs you a shield point.
+   *
+   * It is checked over the pool rather than over a built wave because the pool
+   * is the stronger statement: a wave is a sample of it, and a seed that
+   * happened not to draw the bad key would hide the fault until a re-tune.
+   */
+  it("draws every key from `unlockedAt(n)`", () => {
+    for (const lesson of STORM_LESSONS) {
+      const unlocked = unlockedAt(lesson.n);
+      for (const key of stormPool(lesson))
+        expect(unlocked.has(key), `${lesson.id}: ${JSON.stringify(key)}`).toBe(
+          true,
+        );
+    }
+  });
+
+  it("and every letter that actually falls is one of them", () => {
+    // The same claim one layer down, over every seed: `buildWave` filters the
+    // pool (a thumb's key, a character this board cannot produce) and must
+    // never add to it.
+    for (const [name, , wave] of SAMPLED) {
+      const lesson = STORM_LESSONS.find(
+        (l) => l.id === name.slice(0, name.indexOf(" ")),
+      )!;
+      const unlocked = unlockedAt(lesson.n);
+      for (const letter of wave.letters) {
+        expect(unlocked.has(letter.ch), `${name}: ${letter.ch}`).toBe(true);
+        expect(strokeFor(letter.ch), `${name}: ${letter.ch}`).not.toBeNull();
+        expect(letter.finger, `${name}: ${letter.ch}`).not.toBe("thumb");
+      }
+    }
+  });
+
+  it("rains what its title says, without ever replacing the rest", () => {
+    // A focused level is about half its own focus (`storms.ts`), which is what
+    // makes "Hailstorm · Digits" a level about the number row at lesson 53 —
+    // where only `3 4 5 6` have arrived, so a fixed multiplier would have put
+    // one digit in six on screen and called it a title.
+    const focused = STORM_LESSONS.filter((lesson) => lesson.kind.wave.focus);
+    expect(focused.map((lesson) => lesson.n)).toEqual([34, 39, 53, 59, 65, 69]);
+
+    for (const lesson of focused) {
+      const alphabet = [...unlockedAt(lesson.n)];
+      const pool = stormPool(lesson);
+      const extra = pool.length - alphabet.length;
+      expect(extra, `${lesson.id} weights nothing`).toBeGreaterThan(0);
+      // Between a third and two thirds of what can fall: enough to be the
+      // level's subject, never so much that the rest of the alphabet stops.
+      const share = extra / pool.length;
+      expect(share, `${lesson.id} share`).toBeGreaterThan(0.3);
+      expect(share, `${lesson.id} share`).toBeLessThan(0.7);
+    }
+
+    // And a level with no focus is exactly its rung's alphabet, in one copy.
+    for (const lesson of STORM_LESSONS.filter((l) => !l.kind.wave.focus))
+      expect(stormPool(lesson).length, lesson.id).toBe(
+        unlockedAt(lesson.n).size,
+      );
+  });
+});
+
+describe("no zone can strobe", () => {
+  /**
+   * **WCAG 2.3.1's own line: more than three flashes in any one second.**
+   *
+   * The unit is one shield zone, because that is the thing that lights: a
+   * `.storm__hit` tint is mounted per landing on one segment (§8.10, decision
+   * 42), and eight segments taking one letter each in a second is eight small
+   * patches lighting in turn rather than a flash. A zone taking four is the
+   * failure.
+   *
+   * Three is the hard bound and it is the standard's, not a preference. What
+   * ships is held to two by `SHIPPED` below — the same peak §8.10 measured on
+   * the stand-in wave — so the twenty a child meets have a full flash a second
+   * of headroom over the line, and the rule still says where the line is.
+   */
+  const MAX_TINTS_PER_ZONE_PER_SECOND = 3;
+
+  /**
+   * And what the shipped twenty are actually at.
+   *
+   * The seed on each row is chosen to keep it (decision 58, pinned below), so
+   * this is not a hope about a draw: it is the wave that is served.
+   */
+  const SHIPPED_MAX = 2;
+
+  it("holds every spec under the line, at every seed", () => {
+    for (const [name, , wave] of SAMPLED)
+      expect(peakTintRate(wave), name).toBeLessThanOrEqual(
+        MAX_TINTS_PER_ZONE_PER_SECOND,
+      );
+  });
+
+  it("holds the twenty that ship under two", () => {
+    for (const [name, , wave] of SHIPPED)
+      expect(peakTintRate(wave), name).toBeLessThanOrEqual(SHIPPED_MAX);
+  });
+
+  it("never lights more than half the shield at once", () => {
+    // The other half of a flash, which is area: eight zones lighting together
+    // is a band across the screen, where two is two small patches. §8.10
+    // measured the stand-in wave at two of eight; the twenty are held to four,
+    // and every seed to five.
+    for (const [name, , wave] of SHIPPED)
+      expect(peakZonesLit(wave), name).toBeLessThanOrEqual(4);
+    for (const [name, , wave] of SAMPLED)
+      expect(peakZonesLit(wave), name).toBeLessThanOrEqual(5);
+  });
+
+  it("would catch a spec that packed one zone", () => {
+    // The measurement, proved on a wave built to fail it: eight letters on one
+    // key, 150ms apart, is a zone lighting eight times in just over a second.
+    // Without this, "no spec exceeds the bound" could be passing because the
+    // function cannot count.
+    const packed = buildWave(
+      {
+        keys: ["f"],
+        count: 8,
+        gap: [150, 150],
+        fall: [MIN_FALL_MS, MIN_FALL_MS],
+        shield: 3,
+        repairAt: 0,
+      },
+      1,
+    );
+    expect(peakTintRate(packed)).toBe(7);
+    expect(peakZonesLit(packed)).toBe(1);
+  });
+});
+
+describe("the ladder's difficulty climbs", () => {
+  it("drops one letter at a time until lesson 19", () => {
+    // Pure reaction (§8.3): `gap` clears `fall`, so a letter lands before the
+    // next one spawns and there is never a second on screen. Read off the
+    // built schedule at every seed rather than off the declared range, because
+    // `MIN_FALL_MS` can raise a fall and turn a promise into an overlap.
+    for (const [name, lesson, wave] of SHIPPED) {
+      if (lesson.n >= 19) continue;
+      expect(maxOnScreen(wave), name).toBe(1);
+      for (const seed of SEEDS)
+        expect(
+          maxOnScreen(buildWave(waveSpecFor(lesson), seed)),
+          `${name} @ ${seed}`,
+        ).toBe(1);
+    }
+  });
+
+  it("stacks them from lesson 19 on, and four deep at the top", () => {
+    for (const [name, lesson, wave] of SHIPPED) {
+      if (lesson.n < 19) continue;
+      expect(maxOnScreen(wave), name).toBeGreaterThan(1);
+      if (lesson.n >= 83) expect(maxOnScreen(wave), name).toBeGreaterThan(3);
+    }
+  });
+
+  it("asks for more letters, faster, as it climbs", () => {
+    // Quarter by quarter rather than row by row, because the row-to-row curve
+    // dips on purpose: lesson 53's storm eases where the number row has just
+    // arrived, exactly as the wpm column does (§6.3, decision 11), and lesson
+    // 73 is long where 79 is dense. What may never happen is a *stretch* of
+    // the ladder that does not climb.
+    const counts = QUARTERS.map((quarter) =>
+      mean(quarter.map(([, lesson]) => lesson.kind.wave.count)),
+    );
+    const rates = QUARTERS.map((quarter) =>
+      mean(quarter.map(([, lesson]) => density(waveSpecFor(lesson)))),
+    );
+
+    for (let i = 1; i < QUARTERS.length; i++) {
+      expect(counts[i], `quarter ${i + 1} letters`).toBeGreaterThan(
+        counts[i - 1],
+      );
+      expect(rates[i], `quarter ${i + 1} rate`).toBeGreaterThan(rates[i - 1]);
+    }
+
+    // And end to end, which is the sentence a child would say: the last storm
+    // is more than three times the first.
+    const [, first] = SHIPPED[0];
+    const [, last] = SHIPPED[SHIPPED.length - 1];
+    expect(last.kind.wave.count).toBeGreaterThan(first.kind.wave.count * 3 - 1);
+  });
+
+  it("takes the repairs away at lesson 79 and never gives them back", () => {
+    // "No repairs" is the level's name and the block's turn (§5.6). Every
+    // storm below it mends the weakest zone every `repairAt` clean hits; from
+    // 79 up, what breaks stays broken.
+    for (const [name, lesson] of SHIPPED) {
+      const { repairAt } = lesson.kind.wave;
+      if (lesson.n < 79) expect(repairAt, name).toBeGreaterThan(0);
+      else expect(repairAt, name).toBe(0);
+    }
+  });
+
+  it("never deepens the shield as it climbs", () => {
+    const depths = SHIPPED.map(([, lesson]) => lesson.kind.wave.shield);
+    for (let i = 1; i < depths.length; i++)
+      expect(depths[i]).toBeLessThanOrEqual(depths[i - 1]);
+    expect(depths[0]).toBeGreaterThan(depths[depths.length - 1]);
+  });
+
+  it("cannot end before its letters do, on the very first storm", () => {
+    // "First ice" is the first thing on this ladder that is a game, met at
+    // lesson 4 by a child who has four keys and has never seen one. It is the
+    // one level whose wave cannot breach: no zone takes more letters than the
+    // shield can hold, so a child who presses nothing still sees all twelve
+    // and meets a hole rather than an ending.
+    const [name, lesson, wave] = SHIPPED[0];
+    expect(lesson.n).toBe(4);
+    expect(busiestZone(wave), name).toBeLessThanOrEqual(
+      lesson.kind.wave.shield,
+    );
+  });
+
+  it("writes every fall at or above the floor", () => {
+    // `MIN_FALL_MS` is a backstop and not a difficulty knob (decision 52): a
+    // spec that asked for something faster would come out of `fallRange` as a
+    // metronome at the floor, and the level would be quietly not what the row
+    // says. So no row asks.
+    for (const [name, lesson] of SHIPPED) {
+      const spec = waveSpecFor(lesson);
+      expect(spec.fall[0], name).toBeGreaterThanOrEqual(MIN_FALL_MS);
+      expect(fallRange(spec), name).toEqual(spec.fall);
+    }
+  });
+});
+
+describe("each level's seed", () => {
+  /**
+   * **The twenty seeds are derived, not chosen** (decision 58).
+   *
+   * A level is the same weather every time it is opened, so twenty numbers sit
+   * in the table — and twenty unexplained numbers would be twenty things
+   * nobody could ever safely edit. So the rule is written here and the table
+   * is checked against it: **the level's own number, or the first seed above
+   * it whose wave keeps the level's promises.** Fifteen of the twenty are the
+   * lesson number itself; the other five are within six of it.
+   *
+   * The promises are the three things this file has already asserted about
+   * every shipped wave, which is what makes this a derivation rather than a
+   * second opinion: the tint rate under two, at least six of the eight fingers
+   * used, and no zone taking more than a third of the letters.
+   */
+  const keeps = (wave: Wave, spec: WaveSpec) =>
+    peakTintRate(wave) <= 2 &&
+    tintsByZone(wave).size >= 6 &&
+    busiestZone(wave) * 3 <= spec.count;
+
+  it("is the first at or above its own rung that keeps them", () => {
+    for (const [name, lesson] of SHIPPED) {
+      const spec = waveSpecFor(lesson);
+      let first = lesson.n;
+      while (!keeps(buildWave(spec, first), spec)) first++;
+      expect(lesson.kind.wave.seed, name).toBe(first);
+    }
+  });
+
+  it("spreads a wave across the hand rather than stuttering on three keys", () => {
+    // The property the rule above is made of, stated for itself: a wave that
+    // dropped half its letters on one finger would be a level about that
+    // finger, and the shield's whole story — which finger let it through — is
+    // only worth telling when every finger had a turn.
+    for (const [name, , wave] of SHIPPED) {
+      expect(tintsByZone(wave).size, name).toBeGreaterThanOrEqual(6);
+      expect(busiestZone(wave) * 3, name).toBeLessThanOrEqual(
+        wave.letters.length,
+      );
+    }
+  });
+
+  it("is the same storm on every machine and in every session", () => {
+    // Decision 58, said as the thing a child would notice: opening lesson 45
+    // twice is opening the same level twice. `buildWave` is deterministic in
+    // `(spec, seed)` and both halves come off the rung, so this is what makes
+    // "I beat Whiteout" a sentence about a thing rather than about a roll.
+    for (const [name, lesson, wave] of SHIPPED)
+      expect(stormWave(lesson), name).toEqual(wave);
+  });
+});

--- a/src/engine/typing/storms.ts
+++ b/src/engine/typing/storms.ts
@@ -1,0 +1,160 @@
+import { unlockedAt } from "./keys";
+import { LESSONS, type Lesson, type StormFocus } from "./lessons";
+import { buildWave, type Wave, type WaveSpec } from "./storm";
+
+/**
+ * The twenty Hailstorm levels, as waves (docs/typing.md §5.6, §8.1, §8.3).
+ *
+ * `lessons.ts` writes down what each storm *is* — how many letters, how far
+ * apart, how fast, how deep the shield, whether it repairs — and this module
+ * is where that becomes a `WaveSpec` the engine can build. The split is not
+ * bookkeeping. It is the whole of the acceptance criterion that **a storm can
+ * never ask for a key the ladder has not taught** (decision 56): a
+ * `StormShape` has no `keys` field, so there is nowhere on the table to write a character, and the
+ * pool can only ever come from `unlockedAt(n)` — the same computed alphabet
+ * every lesson's words are drawn from (§5.2). Move lesson 39's storm to rung
+ * 12 and it rains what a child at lesson 12 has met, with nothing to edit.
+ *
+ * ── Why it is not in `lessons.ts` ────────────────────────────────────────────
+ * That module is the one file in `engine/typing/` the deck layer may import
+ * (§5.3, decision 7), and `unlockedAt` lives in `keys.ts`, which imports the
+ * ladder to build the alphabets from it. A pool computed in `lessons.ts` would
+ * therefore be a cycle at module load — the alphabets being built out of a
+ * table that is still being built. Here, the direction is one way:
+ * `lessons.ts` → `storm.ts` (a type, erased), `storms.ts` → both.
+ *
+ * ── And why the seed is here too ─────────────────────────────────────────────
+ * A Hailstorm level is a **level**: the same weather every time it is opened
+ * (decision 58). So the wave a child meets at lesson 45 is a function of the
+ * ladder and nothing else — not of the visit, not of the clock — which is what
+ * lets the no-strobe rule (§8.10) be measured on the twenty waves that
+ * actually ship rather than on a sample of what the generator might roll.
+ */
+
+/**
+ * A lesson that is a storm, with its wave in the type rather than in a comment.
+ *
+ * Every function below takes one of these, so "this lesson has a wave" is
+ * checked once, at the door, by `isStormLesson`. The alternative is each of
+ * them handing back `null` for a lesson that is a passage, and four callers
+ * deciding what to do about an answer that cannot happen.
+ */
+export type StormLesson = Lesson & {
+  kind: Extract<Lesson["kind"], { type: "storm" }>;
+};
+
+/**
+ * Is this rung a Hailstorm level?
+ *
+ * Takes `null` and `undefined` because that is what its callers hold: a route
+ * param resolved through `lessonById` is a lesson, a lesson that is not a
+ * storm, or nothing at all, and all three are answered "no" here rather than
+ * at three call sites.
+ */
+export const isStormLesson = (
+  lesson: Lesson | null | undefined,
+): lesson is StormLesson => lesson?.kind.type === "storm";
+
+/** The twenty, in ladder order. */
+export const STORM_LESSONS: readonly StormLesson[] =
+  LESSONS.filter(isStormLesson);
+
+/**
+ * What each `focus` name matches, as a test over one character.
+ *
+ * Named classes rather than character lists, because the list is always "the
+ * ones this child has met" — `unlockedAt(n)` filtered, never a set written
+ * down beside it. Lesson 53 is the case that makes the difference: the digits
+ * a child has at lesson 53 are `3 4 5 6`, because 54, 55 and 56 are still
+ * ahead of them, and a hand-written `0123456789` would rain four keys the
+ * ladder has not taught.
+ *
+ * `marks` is everything that is neither a letter nor a digit nor the space —
+ * which is what "punctuation and symbols" is, and is stated as the complement
+ * so that a symbol added to the layout is in it without an edit here.
+ */
+const FOCUS: Record<StormFocus, (ch: string) => boolean> = {
+  capitals: (ch) => /^[A-Z]$/.test(ch),
+  digits: (ch) => /^[0-9]$/.test(ch),
+  marks: (ch) => ch.trim() !== "" && !/^[A-Za-z0-9]$/.test(ch),
+};
+
+/**
+ * How much of a focused level is its focus: **about half**.
+ *
+ * A share rather than a fixed multiplier, and the reason is lesson 53. Four
+ * digits have arrived by then — `3 4 5 6` — against a good sixty letters and
+ * marks, so "three copies of each digit" would put 17% of "Hailstorm · Digits"
+ * on the number row and the level would be a review lesson wearing a title.
+ * At lesson 34 the opposite is true: 26 capitals against 30 other characters
+ * means the alphabet is already nearly half capitals and a multiplier that
+ * ignored that would rain almost nothing else.
+ *
+ * So the number of copies is solved for rather than chosen: repeat the focus
+ * until it is about as much of the pool as everything else put together. It is
+ * still a weighting and never a replacement — a storm is practice at
+ * everything the child has, and a "Digits" that rained only digits would be a
+ * number-row drill with a shield in front of it.
+ */
+const FOCUS_SHARE = 0.5;
+
+/**
+ * The characters this level can drop: everything unlocked by its rung, with
+ * the level's focus repeated up to `FOCUS_SHARE` of the pool.
+ *
+ * The space is left in exactly as `unlockedAt` hands it over. `buildWave`
+ * drops it — the shield has no thumb segment for it to damage (§8.5) — and
+ * dropping it here as well would be a second copy of that rule, in the module
+ * least likely to be re-read when the first one changes.
+ */
+export function stormPool(lesson: StormLesson): string[] {
+  const alphabet = [...unlockedAt(lesson.n)];
+  const focus = lesson.kind.wave.focus;
+  if (!focus) return alphabet;
+
+  const matches = alphabet.filter(FOCUS[focus]);
+  // A focus the ladder has not taught yet is no focus at all, and the level
+  // still has to be playable: an empty match list would divide by zero here
+  // and hand `buildWave` an empty pool, which is a wave of nothing (§8.3).
+  // Today no storm is focused on a class its rung has not reached — the test
+  // pins that — so this is the safe direction rather than a live case.
+  if (matches.length === 0) return alphabet;
+
+  // Solve `copies × m / (rest + copies × m) = FOCUS_SHARE` for `copies`, and
+  // never go below doubling: a level that says what it is about has to rain
+  // more of it than a level that does not.
+  const rest = alphabet.length - matches.length;
+  const share = FOCUS_SHARE / (1 - FOCUS_SHARE);
+  const copies = Math.max(2, Math.round((rest * share) / matches.length));
+
+  const pool = [...alphabet];
+  for (let copy = 1; copy < copies; copy++) pool.push(...matches);
+  return pool;
+}
+
+/**
+ * This level's `WaveSpec`: the shape the table wrote, with the pool the ladder
+ * decides.
+ *
+ * The spread is `shape` last so that a level cannot override `keys`, which is
+ * the guarantee this module exists for — and `focus` and `seed` ride along
+ * into the spec harmlessly. They are inert to `buildWave` (it reads `count`,
+ * `gap`, `fall` and `keys`, and carries the rest for the reducer), and having
+ * them on the spec means a wave in hand can still say which level it is —
+ * which is what a retry rebuilds from (§8.3).
+ */
+export function waveSpecFor(lesson: StormLesson): WaveSpec {
+  return { ...lesson.kind.wave, keys: stormPool(lesson) };
+}
+
+/**
+ * This level's storm, built.
+ *
+ * One call, so that nothing outside this module has to hold both halves of
+ * `(spec, seed)` and no screen can build lesson 45's spec at lesson 39's seed.
+ * It is not memoised: a wave is a few dozen small objects and it is built once
+ * per run, where a cache would be a second place a level's weather lives.
+ */
+export function stormWave(lesson: StormLesson): Wave {
+  return buildWave(waveSpecFor(lesson), lesson.kind.wave.seed);
+}

--- a/src/engine/typing/storms.ts
+++ b/src/engine/typing/storms.ts
@@ -10,10 +10,11 @@ import { buildWave, type Wave, type WaveSpec } from "./storm";
  * is where that becomes a `WaveSpec` the engine can build. The split is not
  * bookkeeping. It is the whole of the acceptance criterion that **a storm can
  * never ask for a key the ladder has not taught** (decision 56): a
- * `StormShape` has no `keys` field, so there is nowhere on the table to write a character, and the
- * pool can only ever come from `unlockedAt(n)` — the same computed alphabet
- * every lesson's words are drawn from (§5.2). Move lesson 39's storm to rung
- * 12 and it rains what a child at lesson 12 has met, with nothing to edit.
+ * `StormShape` has no `keys` field and the table `satisfies` it, so there is
+ * nowhere to write a character down, and the pool can only ever come from
+ * `unlockedAt(n)` — the same computed alphabet every lesson's words are drawn
+ * from (§5.2). Move lesson 39's storm to rung 12 and it rains what a child at
+ * lesson 12 has met, with nothing to edit.
  *
  * ── Why it is not in `lessons.ts` ────────────────────────────────────────────
  * That module is the one file in `engine/typing/` the deck layer may import
@@ -136,12 +137,17 @@ export function stormPool(lesson: StormLesson): string[] {
  * This level's `WaveSpec`: the shape the table wrote, with the pool the ladder
  * decides.
  *
- * The spread is `shape` last so that a level cannot override `keys`, which is
- * the guarantee this module exists for — and `focus` and `seed` ride along
- * into the spec harmlessly. They are inert to `buildWave` (it reads `count`,
- * `gap`, `fall` and `keys`, and carries the rest for the reducer), and having
- * them on the spec means a wave in hand can still say which level it is —
- * which is what a retry rebuilds from (§8.3).
+ * **The level's shape is spread first and `keys` is written last**, so the
+ * pool this module computes is the last word and a level cannot override it —
+ * which is the guarantee this module exists for (decision 56). The ordering is
+ * the enforcement at runtime; `satisfies StormShape` on the table in
+ * `lessons.ts` is what makes writing a stray `keys` there a type error rather
+ * than an inert field that this line quietly discards.
+ *
+ * `focus` and `seed` ride along into the spec harmlessly. They are inert to
+ * `buildWave` (it reads `count`, `gap`, `fall` and `keys`, and carries the rest
+ * for the reducer), and having them on the spec means a wave in hand can still
+ * say which level it is — which is what a retry rebuilds from (§8.3).
  */
 export function waveSpecFor(lesson: StormLesson): WaveSpec {
   return { ...lesson.kind.wave, keys: stormPool(lesson) };

--- a/src/engine/typing/verdict.test.ts
+++ b/src/engine/typing/verdict.test.ts
@@ -85,14 +85,32 @@ const lessonWith = (over: Partial<Lesson> = {}): Lesson => ({
   ...over,
 });
 
+/**
+ * A storm level, dictated like the lesson above it rather than read off the
+ * ladder — what is on trial here is the criteria and not the table.
+ *
+ * `wordCount` is the wave's length (§8.3), which is what `survived` reads back
+ * off a run's own config; twelve is a first storm's shape and every case below
+ * says which of the twelve a run faced.
+ */
 const stormWith = (over: Partial<Lesson> = {}): Lesson => ({
   n: 4,
   id: "L04",
   block: 1,
   title: "Hailstorm · First ice",
   introduces: [],
-  kind: { type: "storm" },
-  wordCount: 0,
+  kind: {
+    type: "storm",
+    wave: {
+      count: 12,
+      gap: [1500, 1900],
+      fall: [900, 1200],
+      shield: 4,
+      repairAt: 4,
+      seed: 6,
+    },
+  },
+  wordCount: 12,
   keyboard: "guide",
   pass: { kind: "storm", survive: true, accuracy: 0.9 },
   ...over,

--- a/src/games/typing/App.tsx
+++ b/src/games/typing/App.tsx
@@ -76,9 +76,12 @@ function Shell() {
         <Route path="/p/:profileId/go" element={<TypingTrack />} />
         {/* Hailstorm (docs/typing.md §9). Its own route rather than a mode of
             `/go`, because it shares none of that screen's machinery — no
-            passage, no input, no ghost — and all of its own. Nothing links
-            here until the storm tiles land on the ladder (STM10). */}
-        <Route path="/p/:profileId/storm" element={<StormRun />} />
+            passage, no input, no ghost — and all of its own. The lesson is in
+            the path because a storm is a rung of the ladder: twenty levels,
+            one route, and the tile a child pressed is what says which. A
+            `lessonId` that names no storm goes back to the ladder rather than
+            opening an empty sky (`StormRun`). */}
+        <Route path="/p/:profileId/storm/:lessonId" element={<StormRun />} />
         <Route path="/p/:profileId/results" element={<TypingResults />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/src/games/typing/LessonBrief.tsx
+++ b/src/games/typing/LessonBrief.tsx
@@ -187,9 +187,10 @@ function NewKeys({ lesson }: { lesson: Lesson }) {
  */
 function Asks({ lesson }: { lesson: Lesson }) {
   // A Hailstorm level is marked on surviving a wave rather than on three bars,
-  // and has no passage to ask anything about (§6.1). Its tile cannot open this
-  // screen until #159 builds the wave; this is the arm that keeps that true
-  // rather than a promise that it is.
+  // and has no passage to ask anything about (§6.1). A storm's tile opens
+  // `StormBrief` instead (decision 60), so this arm is the type-level half of
+  // that rather than a screen a child reaches — and it is what narrows the
+  // three bars below to the criteria that have them.
   if (lesson.pass.kind !== "lesson") return null;
   const { accuracy, wpm, keyAccuracy, keyStrikes } = lesson.pass;
 

--- a/src/games/typing/LessonLadder.test.tsx
+++ b/src/games/typing/LessonLadder.test.tsx
@@ -130,8 +130,16 @@ describe("LessonLadder", () => {
     expect(drawn[9].label).toBe(
       "Lesson 10, Checkpoint · Home row. Checkpoint — always open, whatever you have passed. Open.",
     );
+    // A storm says its own sentence first and then the same state every other
+    // tile says out loud (#156) — here a rung this child has not reached, so
+    // it carries what would open it as well.
     expect(drawn[8].label).toBe(
-      "Lesson 9, Hailstorm · Home row. Hailstorm — worth playing, never required. Coming soon.",
+      "Lesson 9, Hailstorm · Home row. Hailstorm — worth playing, never required. Locked. Pass lesson 8 to open this one.",
+    );
+    // And a storm this child has played fills like any other rung: `at(7, 8)`
+    // clears the first seven, lesson 4 among them.
+    expect(drawn[3].label).toBe(
+      "Lesson 4, Hailstorm · First ice. Hailstorm — worth playing, never required. Passed.",
     );
   });
 
@@ -162,15 +170,40 @@ describe("LessonLadder", () => {
   });
 
   /**
-   * A storm level has no passage and no wave until #159 builds one, so its
-   * tile is drawn — the map is wrong without lesson 4 on it — and cannot be
-   * entered. Same stand-down the lesson results screen makes.
+   * A storm is a rung of the ladder with a shape of its own, and — on a device
+   * with keys — a door that opens (#156). Both halves matter: the diamond is
+   * what says "not the course" without a word, and being enterable is what it
+   * is there for.
+   *
+   * The twenty are drawn at the top of the ladder, where every rung is behind
+   * the child, so a shut tile here could only be a storm that had stopped
+   * being playable.
    */
-  it("draws the storms as diamonds that cannot be entered yet", () => {
+  it("draws the storms as diamonds a child can enter", () => {
     const drawn = tiles(at(99, 100));
     const storms = drawn.filter((tile) => tile.classes.includes("is-storm"));
     expect(storms).toHaveLength(STORMS.length);
-    for (const storm of storms) expect(storm.shut).toBe(true);
+    for (const storm of storms) {
+      expect(storm.shut).toBe(false);
+      expect(storm.label).toContain("worth playing, never required");
+    }
+  });
+
+  /**
+   * And a storm a child has not climbed to yet is locked like any other rung —
+   * with the way out of it on the tile, because "Locked" alone is a state and
+   * not a way out of one (#145).
+   *
+   * The rung it names is never the storm's own neighbour: `lockNote` walks
+   * down past any storm in the way, so lesson 9's tile asks for lesson 8 and
+   * never for a wave a tablet cannot play (§8.8).
+   */
+  it("locks a storm a child has not reached, and says what opens it", () => {
+    const storm = tiles(FRESH).find((tile) =>
+      tile.classes.includes("is-storm"),
+    )!;
+    expect(storm.shut).toBe(true);
+    expect(storm.label).toContain("Locked. Pass lesson 3 to open this one.");
   });
 
   /**
@@ -219,6 +252,8 @@ describe("LessonLadder", () => {
       <LessonLadder progress={FRESH} hasKeyboard onOpen={() => {}} />,
     );
     expect(open).not.toContain("Press any key");
-    expect(open).toContain("Coming soon");
+    // What the legend says instead, on a device that can play them: the one
+    // fact about a storm a child needs before pressing one (§8.8).
+    expect(open).toContain("Nothing on the ladder waits on one");
   });
 });

--- a/src/games/typing/LessonLadder.tsx
+++ b/src/games/typing/LessonLadder.tsx
@@ -150,7 +150,7 @@ export function LessonLadder({
               advice — and it corrects itself the instant a key is pressed,
               with nothing to reload. */}
           {hasKeyboard
-            ? `${STORM_NOTE} Coming soon`
+            ? `${STORM_NOTE} Nothing on the ladder waits on one`
             : `${STORM_NOTE} It needs a keyboard, so these stay shut here. Press any key if you have one`}
         </li>
       </ul>

--- a/src/games/typing/LessonTile.tsx
+++ b/src/games/typing/LessonTile.tsx
@@ -73,27 +73,25 @@ export const STORM_NOTE = "Hailstorm — worth playing, never required.";
 /**
  * Why a Hailstorm tile cannot be entered, or `null` when it can be.
  *
- * **Two reasons, and the keyboard one wins** (docs/typing.md §8.8, #155). A
- * storm tile is shut today for everybody, because there is no wave behind it
- * yet — and shut on a tablet for a reason that will still be true long after
- * #156 builds one. Told only "coming soon", a child on an iPad would press it
- * again in a month and find it still doing nothing, with no more idea why. So
- * the reason a child is given is the one that is about them and their device,
- * and the reason about the calendar is what is left when it does not apply.
- *
- * #156 deletes the second arm and returns `null` there: a keyboard is then the
- * only thing between a child and a wave, and `LessonTile` opens the tile off
- * this same answer without knowing that anything changed.
+ * **One reason now, and it is about the child's device** (docs/typing.md §8.8,
+ * #155, #156). The "coming soon" arm this had while the twenty waves were
+ * being built is gone with them: a keyboard is the only thing between a child
+ * and a storm, and the tile opens off this same answer.
  *
  * It is deliberately not "you have no keyboard" said as a fact. The detection
  * is a guess (`useKeyboardPresence`), and a guess that has been wrong is
  * undone by one keystroke — which is why the ladder's legend, where there is
  * room to say it once rather than a hundred times, offers exactly that.
+ *
+ * The lock is only ever the reason a storm cannot be *entered*, and never a
+ * reason it cannot be skipped: nothing on the ladder waits on a storm (§8.8,
+ * decision 24), so a device with no keys costs a child twenty tiles and not
+ * one rung of the course.
  */
 export function stormReason(hasKeyboard: boolean): string | null {
-  if (!hasKeyboard)
-    return "Hailstorm needs a keyboard, so this one stays shut.";
-  return "Coming soon.";
+  return hasKeyboard
+    ? null
+    : "Hailstorm needs a keyboard, so this one stays shut.";
 }
 
 /** The state, said out loud. Read after the lesson's number and title. */
@@ -120,12 +118,26 @@ function tileLabel(
 ): string {
   const what = `Lesson ${lesson.n}, ${lesson.title}`;
 
+  // What unlocks it, on the tile as well as in the brief (#145). The tile is
+  // the only place a locked rung is met by a child who never presses it, and
+  // "Locked" on its own is a state rather than a way out of one. One
+  // definition for both kinds of tile: a diamond a child has not climbed to
+  // yet needs the same sentence a square does, and `lockNote` is already the
+  // one that walks down past any storm in the way.
+  const how = state === "locked" ? ` ${lockNote(lesson)}` : "";
+
   // A storm level says what it is, and — where there is one — why it cannot be
   // entered, rather than being a tile that does nothing when pressed. Its
   // place on the map is worth drawing either way: it is what makes lesson 4
   // arriving before the first word look deliberate.
+  //
+  // Its state is the same `tileState` every other rung is drawn from, which is
+  // what a storm this far up the ladder needs. What it can never say is that
+  // something is waiting on it — a storm opens no door and closes none (§8.8),
+  // and `STORM_NOTE` is the sentence that carries that, first, on every one of
+  // the twenty.
   if (lesson.kind.type === "storm")
-    return `${what}. ${STORM_NOTE} ${blocked ?? `${SAID[state]}.`}`;
+    return `${what}. ${STORM_NOTE} ${blocked ?? `${SAID[state]}.${how}`}`;
 
   // Only worth saying while it is ahead of the child: a checkpoint they have
   // already passed is just a lesson they passed, and "always open" on it would
@@ -134,11 +146,6 @@ function tileLabel(
     lesson.checkpoint && state !== "cleared"
       ? " Checkpoint — always open, whatever you have passed."
       : "";
-
-  // What unlocks it, on the tile as well as in the brief (#145). The tile is
-  // the only place a locked lesson is met by a child who never presses it, and
-  // "Locked" on its own is a state rather than a way out of one.
-  const how = state === "locked" ? ` ${lockNote(lesson)}` : "";
 
   return `${what}.${note} ${SAID[state]}.${how}`;
 }

--- a/src/games/typing/StormBrief.test.tsx
+++ b/src/games/typing/StormBrief.test.tsx
@@ -1,0 +1,141 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ladderProgress, type LadderProgress } from "@/engine/typing/ladder";
+import { lessonById } from "@/engine/typing/lessons";
+import { isStormLesson, type StormLesson } from "@/engine/typing/storms";
+
+import { StormBrief } from "./StormBrief";
+
+/**
+ * What is written on a storm's door (docs/typing.md §8.1, §8.8, §9).
+ *
+ * A storm gets a brief of its own rather than an arm inside `LessonBrief`,
+ * because the three things that screen is made of — the bars, the best and the
+ * keyboard control — are three things a storm does not have. What this one has
+ * to carry instead is on trial here:
+ *
+ *   - **How it is played**, for the child meeting a falling-letter game at
+ *     lesson 4 who cannot guess §8.4's rule by watching.
+ *   - **What THIS storm is**, so that "First ice" and "Whiteout" are not the
+ *     same screen with different numbers behind them.
+ *   - **That nothing waits on it** (§8.8, decision 24), which is the promise
+ *     the tile can only carry as a phrase.
+ */
+
+const storm = (id: string): StormLesson => {
+  const lesson = lessonById(id);
+  if (!isStormLesson(lesson)) throw new Error(`${id} is not a storm`);
+  return lesson;
+};
+
+/** Lesson 4 — the first storm, six keys, repairs on. */
+const L04 = storm("L04");
+/** Lesson 59 — digits, mid-ladder, repairs on. */
+const L59 = storm("L59");
+/** Lesson 79 — "No repairs", the level the block turns on. */
+const L79 = storm("L79");
+
+/** A profile that has never run anything: everything above rung 1 is locked. */
+const FRESH = ladderProgress([]);
+
+/** Progress with a pointer put where a test needs it. */
+const at = (best: number, next: number): LadderProgress => ({
+  cleared: new Set(Array.from({ length: best }, (_, i) => i + 1)),
+  best,
+  next,
+});
+
+const render = (lesson: StormLesson, progress: LadderProgress = at(99, 100)) =>
+  renderToStaticMarkup(
+    <StormBrief
+      lesson={lesson}
+      progress={progress}
+      onStart={() => {}}
+      onClose={() => {}}
+    />,
+  );
+
+/** The panel's text, with the markup taken out. */
+const words = (lesson: StormLesson, progress?: LadderProgress) =>
+  render(lesson, progress)
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ");
+
+describe("StormBrief", () => {
+  it("names the rung and says how a storm is played", () => {
+    const text = words(L04);
+    expect(text).toContain("Lesson 4");
+    expect(text).toContain("Hailstorm · First ice");
+    // §8.4's rule, which decides everything and is not guessable: any key but
+    // the lowest letter's is a miss.
+    expect(text).toContain("Shoot the lowest one");
+  });
+
+  it("says what this storm is, and no two the same", () => {
+    const first = words(L04);
+    const last = words(storm("L99"));
+
+    expect(first).toContain(`${L04.kind.wave.count} letters`);
+    expect(first).toContain(`${L04.kind.wave.shield} per finger`);
+    expect(last).toContain(`${storm("L99").kind.wave.count} letters`);
+    // The point of showing the numbers at all: the twenty are different levels
+    // and the brief is where a child finds out how.
+    expect(first).not.toBe(last);
+  });
+
+  it("says when the repairs stop, and does not promise them when they have", () => {
+    expect(words(L59)).toContain(
+      `every ${L59.kind.wave.repairAt} in a row mends`,
+    );
+    expect(words(L79)).toContain("No repairs");
+    expect(words(L79)).toContain("what breaks stays broken");
+    expect(words(L79)).not.toContain("in a row mends");
+  });
+
+  it("says what mostly falls, when the level is about something", () => {
+    expect(words(L59)).toContain("mostly numbers");
+    expect(words(storm("L34"))).toContain("mostly capital letters");
+    expect(words(storm("L65"))).toContain("mostly punctuation");
+    // And a level about everything says nothing, rather than "mostly letters".
+    expect(words(storm("L49"))).not.toContain("mostly");
+  });
+
+  /**
+   * §8.8, said in full on the one screen with room for it. The tile carries
+   * "worth playing, never required" and this says what that MEANS: the rung
+   * above opens off the rung below, so a storm can be skipped, failed or never
+   * opened at no cost at all.
+   */
+  it("promises that nothing on the ladder waits on it", () => {
+    expect(words(L04)).toContain("worth playing, never required");
+    expect(words(L04)).toContain("Lesson 5 opens whether you play this or not");
+    expect(words(storm("L99"))).toContain("Lesson 100 opens");
+  });
+
+  it("offers Play on a storm the child has reached", () => {
+    expect(render(L04, at(3, 5))).toContain(">Play<");
+    expect(render(L04, at(3, 5))).not.toContain("to open this one");
+  });
+
+  /**
+   * And refuses on one they have not — the same `tileState` the tile is drawn
+   * from, asked twice on purpose: a screen that can say "locked" must not also
+   * be able to start the thing it just called locked.
+   */
+  it("refuses a storm above the pointer, and says what opens it", () => {
+    const shut = render(L04, FRESH);
+    expect(shut).not.toContain(">Play<");
+    expect(words(L04, FRESH)).toContain("Pass lesson 3 to open this one");
+    // The express lane is offered here as it is on every other locked rung.
+    expect(words(L04, FRESH)).toContain("try a checkpoint");
+  });
+
+  it("is a dialog with a name, and a way out that is not Play", () => {
+    const html = render(L04);
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('aria-modal="true"');
+    expect(html).toContain("aria-labelledby");
+    expect(html).toContain(">Not now<");
+  });
+});

--- a/src/games/typing/StormBrief.tsx
+++ b/src/games/typing/StormBrief.tsx
@@ -140,7 +140,7 @@ export function StormBrief({
  * table's.
  *
  * `focus` is a class of character (`storms.ts` decides what each one matches)
- * and this is the only place it is said out loud, so the four names cannot
+ * and this is the only place it is said out loud, so the three names cannot
  * drift apart across screens — there is one screen.
  */
 const FALLS: Record<

--- a/src/games/typing/StormBrief.tsx
+++ b/src/games/typing/StormBrief.tsx
@@ -1,0 +1,153 @@
+import { useId } from "react";
+
+import { Button, Scrim } from "@/components/ui/kit";
+import { plural } from "@/engine/format";
+import { lessonNumbered } from "@/engine/typing/lessons";
+import type { LadderProgress } from "@/engine/typing/ladder";
+import type { StormLesson } from "@/engine/typing/storms";
+
+import { lockNote } from "./lessonNotes";
+import { STORM_NOTE, tileState } from "./LessonTile";
+
+/**
+ * What a Hailstorm level is, before a child presses Play (docs/typing.md §8.1,
+ * §8.8, §9).
+ *
+ * The other eighty rungs open `LessonBrief`, which is three bars, a best and a
+ * keyboard control — and a storm has none of the three. It is marked on
+ * surviving a wave, it holds no record at all (decision 50), and its keyboard
+ * is not a hint under a passage but the gun itself (§8.2), so there is nothing
+ * on that screen a storm could honestly fill in. Hence a second door rather
+ * than a fourth arm inside the first: what the two briefs share is a shape, and
+ * what they say is entirely different.
+ *
+ * Three things are on it and each earns its line:
+ *
+ *   - **How it is played.** A child arriving at lesson 4 has never seen a
+ *     falling-letter game and the rule that decides everything — only the
+ *     lowest letter can be shot (§8.4) — is not guessable from watching.
+ *   - **What this storm is.** How many letters, how deep the shield, whether
+ *     it repairs, and what it mostly rains. The twenty levels differ in
+ *     exactly those four things (§5.6's storm table), so they are what makes
+ *     "First ice" and "Whiteout" different screens rather than the same screen
+ *     with different numbers behind it.
+ *   - **That it is not required.** Said here in full, because the tile can only
+ *     carry it as a phrase: nothing on the ladder waits on a storm, and the
+ *     lesson above it opens off the lesson *below* it (§8.8, decision 24).
+ *
+ * There is deliberately no "your best". A storm is unranked everywhere on the
+ * site (`isRanked`), so a brief that quoted one would be inventing a record
+ * that `bestRun` refuses to hold — and a run that ended early would hold it.
+ */
+export function StormBrief({
+  lesson,
+  progress,
+  onStart,
+  onClose,
+}: {
+  lesson: StormLesson;
+  progress: LadderProgress;
+  onStart: () => void;
+  onClose: () => void;
+}) {
+  const titleId = useId();
+  // The same `tileState` the tile is drawn from, for the same reason
+  // `LessonBrief` asks it: a screen that can say "locked" must not also be able
+  // to start the thing it just called locked. A storm is never `next` — the
+  // pointer is carried over it — so this only ever reads back one of three.
+  const locked = tileState(lesson, progress) === "locked";
+  const { count, shield, repairAt, focus } = lesson.kind.wave;
+
+  /* The rung above this one, which is what "nothing waits on it" is about. No
+     two storms are adjacent on the ladder (§5.5), so this is always an ordinary
+     lesson; the fallback is written rather than asserted because the ladder is
+     data and a brief is not a place to throw. */
+  const above = lessonNumbered(lesson.n + 1);
+
+  return (
+    <div
+      className="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <Scrim onClose={onClose} label="Close" />
+      <div className="modal__panel panel anim-pop brief">
+        <p className="u-eyebrow">Lesson {lesson.n}</p>
+        <h2 className="panel__title" id={titleId}>
+          {lesson.title}
+        </h2>
+
+        <p className="brief__new">
+          Letters fall down the column of the key that types them. Shoot the
+          lowest one before it reaches your shield — any other key is a miss.
+        </p>
+
+        <section className="brief__asks" aria-label="This storm">
+          <h3 className="brief__askshead">This storm</h3>
+          <ul>
+            <li>
+              <b>{plural(count, "letter")}</b>
+              {focus ? `, mostly ${FALLS[focus]}.` : "."}
+            </li>
+            <li>
+              <b>Shield</b> — {shield} per finger, and a finger at nothing is a
+              hole.
+            </li>
+            <li>
+              <b>{repairAt > 0 ? "Repairs" : "No repairs"}</b>
+              {repairAt > 0
+                ? ` — every ${repairAt} in a row mends your weakest finger.`
+                : " — what breaks stays broken."}
+            </li>
+          </ul>
+        </section>
+
+        {/* The promise, in the two sentences it takes: what it is, and what it
+            cannot cost. A child who is afraid of losing their place is a child
+            who does not press Play. */}
+        <p className="brief__best">
+          {STORM_NOTE}{" "}
+          {above
+            ? `Lesson ${above.n} opens whether you play this or not.`
+            : "Nothing on the ladder waits on it."}
+        </p>
+
+        {locked && (
+          <p className="brief__locked">
+            {lockNote(lesson)} Or try a checkpoint — every one of those is open
+            already, and getting one wrong costs you nothing.
+          </p>
+        )}
+
+        <div className="modal__actions">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Not now
+          </Button>
+          {!locked && (
+            <Button variant="go" onClick={onStart}>
+              Play
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * What a focused level mostly rains, in the child's words rather than the
+ * table's.
+ *
+ * `focus` is a class of character (`storms.ts` decides what each one matches)
+ * and this is the only place it is said out loud, so the four names cannot
+ * drift apart across screens — there is one screen.
+ */
+const FALLS: Record<
+  NonNullable<StormLesson["kind"]["wave"]["focus"]>,
+  string
+> = {
+  capitals: "capital letters",
+  digits: "numbers",
+  marks: "punctuation",
+};

--- a/src/games/typing/TypingSetup.tsx
+++ b/src/games/typing/TypingSetup.tsx
@@ -14,12 +14,14 @@ import {
 import { bestRun, ghostsFor, sessionsFor } from "@/engine/records";
 import { randomSeed } from "@/engine/random";
 import { ladderProgress } from "@/engine/typing/ladder";
+import { isStormLesson } from "@/engine/typing/storms";
 import { RivalList } from "@/games/race";
 import { sfx } from "@/services/sound";
 import { KeyboardSetting } from "./keyboard/KeyboardSetting";
 import { useKeyboardPresence } from "./keyboard/useKeyboardPresence";
 import { LessonBrief } from "./LessonBrief";
 import { LessonLadder } from "./LessonLadder";
+import { StormBrief } from "./StormBrief";
 import { lessonConfig, lessonKey } from "./lessonRun";
 import type { Lesson } from "@/engine/typing/lessons";
 import type { KeyboardMode, TypingConfig } from "@/engine/types";
@@ -66,6 +68,11 @@ export default function TypingSetup() {
    * brief be mounted per lesson below, which is how the keyboard control gets
    * seeded afresh each time instead of carrying the last lesson's choice onto
    * one that suggests something else.
+   *
+   * One piece of state for both kinds of rung, and the lesson itself decides
+   * which brief opens over it (`isStormLesson`). Two flags would be two ways
+   * to have both open at once, over a ladder where a tile is exactly one of
+   * the two.
    */
   const [briefing, setBriefing] = useState<Lesson | null>(null);
 
@@ -184,11 +191,27 @@ export default function TypingSetup() {
         onOpen={setBriefing}
       />
 
+      {/* A storm's door is its own (`StormBrief`, decision 60): no three bars,
+          no best and no keyboard control, because a storm has none of the
+          three. Play sends the child to the level's own route, which is where
+          the wave is built — this screen never holds one. */}
+      {isStormLesson(briefing) && (
+        <StormBrief
+          lesson={briefing}
+          progress={progress}
+          onStart={() => {
+            sfx.whoosh();
+            navigate(`/p/${profile.id}/storm/${briefing.id}`);
+          }}
+          onClose={() => setBriefing(null)}
+        />
+      )}
+
       {/* Keyed by the lesson, so a second brief is a second mount: the
           keyboard control is seeded from the lesson on mount, and a component
           held across two openings would show lesson 12's suggestion under
           lesson 40's title. */}
-      {briefing && (
+      {briefing && !isStormLesson(briefing) && (
         <LessonBrief
           key={briefing.id}
           lesson={briefing}

--- a/src/games/typing/storm/StormHud.test.tsx
+++ b/src/games/typing/storm/StormHud.test.tsx
@@ -90,14 +90,27 @@ describe("StormHud", () => {
 
   it("flashes once per miss, and mounts nothing before the first one", () => {
     // The no-strobe mechanism, at the altitude a unit test can hold it: the
-    // flash is one element keyed by a counter that only goes up (§8.10,
-    // decision 42), so an unchanged count is the same node and cannot restart
-    // the animation. A run starts with no element at all, or every HUD would
-    // flash red on its first frame.
+    // flash is one element keyed by `missTintAt`, a wave-time stamp that only
+    // ever goes forward (§8.10, decisions 42 and 57), so an unchanged stamp is
+    // the same node and cannot restart the animation. A run starts with no
+    // element at all, or every HUD would flash red on its first frame.
     expect(flashes(played(0))).toBe(0);
     expect(flashes(played(2))).toBe(0);
     expect(flashes(played(2, 1))).toBe(1);
     expect(flashes(played(2, 4)), "one element, not one per miss").toBe(1);
+  });
+
+  it("mounts the flash off the stamp and not off the count", () => {
+    // Which is the difference that matters, and it is invisible in the markup
+    // — a React key is not an attribute. So it is asked the other way round:
+    // the reducer holds the flash back when a hand is going too fast to be
+    // flashed at (`MIN_TINT_GAP_MS`), and this screen must be reading THAT
+    // field. A HUD still keyed on `misses` would draw an element for a state
+    // whose stamp is null, and would not for one whose stamp is set.
+    const four = played(2, 4);
+    expect(four.misses, "the premise: four wrong keys").toBe(4);
+    expect(flashes({ ...four, missTintAt: null })).toBe(0);
+    expect(flashes({ ...four, misses: 0, missTintAt: 900 })).toBe(1);
   });
 
   it("carries no `data-stone`, so the fall loop steps over it", () => {

--- a/src/games/typing/storm/StormHud.tsx
+++ b/src/games/typing/storm/StormHud.tsx
@@ -74,14 +74,14 @@ import type { StormState } from "@/engine/typing/storm";
  * and there is no timer here to be left mid-flash by a screen that unmounted.
  *
  * **The stamp rather than `misses`, and that is the whole of decision 57.** A
- * wave's tint rate is a property of its own schedule, held under three a
- * second by the twenty levels themselves — but a miss is a child pressing a
- * wrong key, and eight or ten a second is a hand rather than a bug. The gun
- * already ignores key auto-repeat (decision 44), which takes 30Hz off the
- * table; what keeps the rest of it under WCAG 2.3.1's three flashes a second
- * is `MIN_TINT_GAP_MS` in the reducer, where the clock is. So this element
- * mounts at most once every 340ms however fast the keys come, and every other
- * cost of a miss is charged in full whether it lights or not.
+ * wave's tint rate is a property of its own schedule, and each of the twenty
+ * levels ships at two a second — but a miss is a child pressing a wrong key,
+ * and eight or ten a second is a hand rather than a bug. The gun already
+ * ignores key auto-repeat (decision 44), which takes 30Hz off the table; what
+ * holds the rest of it to the same two a second, under WCAG 2.3.1's line of
+ * more than three, is `MIN_TINT_GAP_MS` in the reducer, where the clock is. So
+ * this element mounts at most once every 500ms however fast the keys come, and
+ * every other cost of a miss is charged in full whether it lights or not.
  */
 export function StormHud({
   state,

--- a/src/games/typing/storm/StormHud.tsx
+++ b/src/games/typing/storm/StormHud.tsx
@@ -24,8 +24,8 @@ import type { StormState } from "@/engine/typing/storm";
  * flash card at, so the figure a child watches climb here is the figure their
  * XP is worth (`stormXp`). One streak, one multiplier, two currencies.
  *
- * Nothing here decides any of that. `score`, `combo` and `misses` are read off
- * the reducer, which is where every rule about them lives (§8.9): a HUD that
+ * Nothing here decides any of that. `score`, `combo` and the miss stamp are
+ * read off the reducer, where every rule about them lives (§8.9): a HUD that
  * worked out what a hit was worth would be a second opinion about it at sixty
  * frames a second, and the one on screen is the one a child would believe.
  *
@@ -67,13 +67,21 @@ import type { StormState } from "@/engine/typing/storm";
  * be two answers to "how do I leave" on one screen.
  *
  * ── One flash per miss, and never a sequence ─────────────────────────────────
- * The `--flare` wash over the score is a child element keyed by `misses`, a
- * counter that only ever goes up — the mechanism the shield's damage tint
- * already uses (§8.10, decision 42). A fresh node runs its animation once, an
- * unchanged key is the same node and does not restart it, and there is no
- * timer here to be left mid-flash by a screen that unmounted. The gun ignores
- * key auto-repeat (decision 44), so the fastest this can mount is a child's
- * own keystrokes.
+ * The `--flare` wash over the score is a child element keyed by `missTintAt`,
+ * a wave-time stamp that only ever goes forward — the mechanism the shield's
+ * damage tint already uses (§8.10, decision 42). A fresh node runs its
+ * animation once, an unchanged key is the same node and does not restart it,
+ * and there is no timer here to be left mid-flash by a screen that unmounted.
+ *
+ * **The stamp rather than `misses`, and that is the whole of decision 57.** A
+ * wave's tint rate is a property of its own schedule, held under three a
+ * second by the twenty levels themselves — but a miss is a child pressing a
+ * wrong key, and eight or ten a second is a hand rather than a bug. The gun
+ * already ignores key auto-repeat (decision 44), which takes 30Hz off the
+ * table; what keeps the rest of it under WCAG 2.3.1's three flashes a second
+ * is `MIN_TINT_GAP_MS` in the reducer, where the clock is. So this element
+ * mounts at most once every 340ms however fast the keys come, and every other
+ * cost of a miss is charged in full whether it lights or not.
  */
 export function StormHud({
   state,
@@ -83,15 +91,18 @@ export function StormHud({
   /** Ask to leave mid-run. Absent on a screen that offers no way out. */
   onQuit?: () => void;
 }) {
-  const { combo, misses, score } = state;
+  const { combo, missTintAt, score } = state;
 
   return (
     <div className="storm__hud">
       <p className="storm__score u-mono" aria-hidden="true">
         {score}
-        {/* Mounted by the counter — see the header. Only above zero, so a run
-            does not start with a flash of red over a score of nothing. */}
-        {misses > 0 && <span key={`miss${misses}`} className="storm__miss" />}
+        {/* Mounted by the stamp — see the header. Absent until the first miss,
+            so a run does not start with a flash of red over a score of
+            nothing. */}
+        {missTintAt !== null && (
+          <span key={`miss${missTintAt}`} className="storm__miss" />
+        )}
       </p>
 
       {onQuit && state.ending === null && (

--- a/src/games/typing/storm/StormOver.tsx
+++ b/src/games/typing/storm/StormOver.tsx
@@ -32,8 +32,8 @@ import type { StormState } from "@/engine/typing/storm";
  *
  * Two of the four figures on the panel come from somewhere else, for two
  * different reasons. XP cannot be in the report: `stormXp` lives in
- * `progress.ts`, which reaches `decks/index.ts`, and `storm.ts` is one hop
- * from the deck layer from STM10 on. It is read here instead, where the deck
+ * `progress.ts`, which reaches `decks/index.ts`, and `storm.ts` is one
+ * type-only hop from the deck layer (`lessons.ts` names a `WaveSpec`). It is read here instead, where the deck
  * layer is already in the graph — this screen builds a drill through
  * `buildDrill`, which is that same front door. The score need not be in it:
  * it is the run's own live number, taken straight off `state`, and it was on

--- a/src/games/typing/storm/StormRun.tsx
+++ b/src/games/typing/storm/StormRun.tsx
@@ -5,8 +5,8 @@ import { useHub, usePlayer } from "@/components/state/HubContext";
 import { useRace } from "@/components/state/RaceContext";
 import { typingMode } from "@/engine/decks/typing";
 import { sessionsFor } from "@/engine/records";
-import { unlockedAt } from "@/engine/typing/keys";
-import { buildWave } from "@/engine/typing/storm";
+import { lessonById } from "@/engine/typing/lessons";
+import { isStormLesson, stormWave } from "@/engine/typing/storms";
 import { QuitSheet, SaveFailed, useRaceFinish } from "@/games/race";
 
 import { StormField } from "./StormField";
@@ -14,11 +14,11 @@ import { StormOver } from "./StormOver";
 import { stormConfig, stormTally } from "./stormSession";
 import { useStormClock } from "./useStormClock";
 
-import type { WaveSpec } from "@/engine/typing/storm";
+import type { StormLesson } from "@/engine/typing/storms";
 import type { Profile } from "@/engine/types";
 
 /**
- * The Hailstorm route (docs/typing.md §9), playing one wave.
+ * The Hailstorm route (docs/typing.md §9), playing one of the twenty levels.
  *
  * The screen is six things joined: a field that draws a `StormState`, a clock
  * that produces one per animation frame, a keyboard that shoots, the way out
@@ -26,75 +26,18 @@ import type { Profile } from "@/engine/types";
  * of that finger's keys (`StormOver`), and — the moment the storm stops — the
  * run written to the record book as a `Session` (§8.7, `stormSession.ts`).
  *
- * What it is still not is a whole game. STM10 replaces the stand-in wave below
- * with the twenty the ladder actually names.
+ * **Which storm is in the URL** (`#/p/:profileId/storm/:lessonId`), because a
+ * level is a rung of the ladder and the ladder is where a child chose it. The
+ * lesson is the whole of what this route reads: the wave comes from it
+ * (`stormWave`, which draws the pool from `unlockedAt(n)` — §5.6), the run
+ * files itself under it (`typing:L39`, §8.7), and nothing here holds a spec of
+ * its own for the two to drift apart from.
  *
- * Unlinked on purpose. Nothing on the ladder points here until STM10 puts the
- * storm tiles on it, so the only way in is the URL.
+ * A `lessonId` that is not a storm — a passage, a level id, a typo — goes back
+ * to the ladder rather than rendering an empty sky. It is not an error case so
+ * much as the ordinary end of a hand-edited URL, and the ladder is where the
+ * answer to "which storms are there" is drawn.
  */
-
-/**
- * Which lesson this stand-in stands in for: 39, "Hailstorm · Shift under
- * fire" — the last of block 4's two storm levels.
- *
- * One number for the pool AND the id, so the two cannot drift: the wave draws
- * on the alphabet lesson 39 is played at, and the run files itself under
- * `typing:L39` exactly as a lesson run does (§8.7). STM10 replaces all of this
- * with the lesson the ladder tile named.
- */
-const PREVIEW_LESSON = 39;
-
-/**
- * The id that identifies the run — in `Session.mode`, in `configKey`, and in
- * the config the run is saved with. Written once here and read by both
- * `typingMode` and `stormConfig`, because a mode and a config that disagreed
- * about which lesson this is would file the run in one place and look for it
- * in another.
- */
-const PREVIEW_LESSON_ID = `L${PREVIEW_LESSON}`;
-
-/**
- * A stand-in storm: everything a child has met by lesson 39, falling one after
- * another.
- *
- * `unlockedAt` rather than a hand-written pool, because "a wave draws only on
- * keys the ladder has already taught" is the rule STM10 has to keep and a
- * stand-in that broke it would be a stand-in nobody could reason from.
- *
- * The gap and the fall are single values rather than ranges, so this wave is a
- * ruler where a real level is a roll of the dice (§8.3): twelve letters, one
- * every 300ms, each taking four seconds to cross — which puts all twelve in
- * the air together from 3.3s until the first one lands at 4s. That overlap is
- * the point as much as the ruler is. §8.9 promises sixty frames a second with
- * ten letters, the shield and the keyboard on screen, and a stand-in that only
- * ever showed one would be a stand-in that never asked the question.
- */
-const PREVIEW_SPEC: WaveSpec = {
-  keys: [...unlockedAt(PREVIEW_LESSON)],
-  count: 12,
-  gap: [300, 300],
-  fall: [4000, 4000],
-  shield: 3,
-  repairAt: 0,
-};
-
-/**
- * The seed, picked so the twelve letters land on twelve different keys across
- * both hands rather than stuttering on three — and so that the two this epic
- * is named after, `f` and `y`, are among the first to fall, right above the
- * caps they are claimed to line up with.
- *
- * A wave is replayable from `(spec, seed)` (§8.3), so this storm is the same
- * storm on every machine and in every session: "does `y` fall between `g` and
- * `h`" stays a question anybody can go and look at rather than one that
- * depends on a lucky roll. It is also what "try this wave again" means — the
- * retry below rebuilds from these same two values and meets the same twelve
- * letters in the same lanes.
- */
-const PREVIEW_SEED = 353;
-
-/** The mode a run of it files under, and the drill's family (§8.7). */
-const PREVIEW_MODE = typingMode(PREVIEW_LESSON_ID);
 
 /**
  * The route, which owns nothing but which attempt is being played.
@@ -119,23 +62,35 @@ const PREVIEW_MODE = typingMode(PREVIEW_LESSON_ID);
  *     one.
  *
  * The wave itself is rebuilt from the same `(spec, seed)`, so "try this wave
- * again" means the same twelve letters in the same lanes at the same speeds
- * (§8.3) — a different run of the same storm, which is the only version of
- * beating it that means a child got better.
+ * again" means the same letters in the same lanes at the same speeds (§8.3) —
+ * a different run of the same storm, which is the only version of beating it
+ * that means a child got better.
  */
 export default function StormRun() {
-  const { profileId } = useParams();
+  const { profileId, lessonId } = useParams();
   const profile = usePlayer(profileId);
+  const lesson = lessonById(lessonId);
   const [attempt, setAttempt] = useState(0);
 
   // Same guard as the other run screens: a URL naming a player who isn't on
   // this device goes back to the picker rather than rendering half a game.
   // Below the hooks, so they are called in the same order on every render.
   if (!profile) return <Navigate to="/" replace />;
+  if (!isStormLesson(lesson))
+    return <Navigate to={`/p/${profile.id}`} replace />;
 
+  /* **The key carries the lesson as well as the attempt**, and the lesson half
+     is not decoration. `StormPlay` builds its wave in a `useState` initialiser,
+     which runs once per mount — so a route that stayed mounted across
+     `#/…/storm/L39` → `#/…/storm/L45` (same pattern, different param, no
+     remount) would go on playing lesson 39's storm under lesson 45's name, and
+     save it under lesson 45's id. Every reason a retry is a remount is a
+     reason a different level is one too (see below); the difference is that a
+     retry means to meet the same wave and this must not. */
   return (
     <StormPlay
-      key={attempt}
+      key={`${lesson.id}:${attempt}`}
+      lesson={lesson}
       profile={profile}
       onRetry={() => setAttempt((n) => n + 1)}
     />
@@ -176,9 +131,12 @@ export default function StormRun() {
  *     would, and moves nothing.
  */
 function StormPlay({
+  lesson,
   profile,
   onRetry,
 }: {
+  /** The rung this storm is, and therefore the wave and the id (§5.6, §8.7). */
+  lesson: StormLesson;
   profile: Profile;
   /** Play the same storm again, as a new run. See `StormRun`. */
   onRetry: () => void;
@@ -212,10 +170,13 @@ function StormPlay({
    *
    * Built once per mount and never rebuilt: a run's wave is fixed for its
    * whole life (`StormState.wave`), and the config is its length and its
-   * lesson, both of which are decided before the first letter falls.
+   * lesson, both of which are decided before the first letter falls. Which is
+   * safe only because a different lesson is a different mount — see the key in
+   * `StormRun`, without which this initialiser would keep the first storm a
+   * child opened for as long as they stayed on the route.
    */
-  const [wave] = useState(() => buildWave(PREVIEW_SPEC, PREVIEW_SEED));
-  const config = useMemo(() => stormConfig(PREVIEW_LESSON_ID, wave), [wave]);
+  const [wave] = useState(() => stormWave(lesson));
+  const config = useMemo(() => stormConfig(lesson.id, wave), [lesson.id, wave]);
   const { state, skyRef } = useStormClock(wave, {
     paused: quitting,
     // The keyboard's way to the same sheet the button opens. It is taken
@@ -243,7 +204,7 @@ function StormPlay({
     finish,
     notify,
     navigate,
-    resultsPath: `/p/${profile.id}/storm`,
+    resultsPath: `/p/${profile.id}/storm/${lesson.id}`,
     // Nothing to disarm. The gun dies with the run inside `useStormClock` and
     // the field is frozen where the clock stopped, so there is no phase a
     // saving storm is in that it is not in already.
@@ -295,7 +256,7 @@ function StormPlay({
         over={
           <StormOver
             state={state}
-            mode={PREVIEW_MODE}
+            mode={typingMode(lesson.id)}
             profileId={profile.id}
             onRetry={onRetry}
           />

--- a/src/games/typing/storm/stormSession.test.ts
+++ b/src/games/typing/storm/stormSession.test.ts
@@ -13,8 +13,10 @@ import {
 import { summariseRun } from "@/engine/run";
 import { lessonById } from "@/engine/typing/lessons";
 import { fire, startStorm, stormReport, tick } from "@/engine/typing/storm";
+import { STORM_LESSONS, stormWave } from "@/engine/typing/storms";
 import { verdictFor } from "@/engine/typing/verdict";
 
+import { lessonKey } from "../lessonRun";
 import { stormCards, stormConfig, stormTally } from "./stormSession";
 
 import type { StormLetter, StormState, WaveSpec } from "@/engine/typing/storm";
@@ -250,7 +252,7 @@ describe("what a storm files itself as", () => {
     expect(key).toBe("typing|L39|6");
   });
 
-  it("carries the wave's length rather than the ladder's placeholder", () => {
+  it("carries the wave's length, not the rung's", () => {
     const config = stormConfig(LESSON, drumbeat(12).wave);
 
     expect(config).toEqual({
@@ -263,10 +265,14 @@ describe("what a storm files itself as", () => {
       storm: true,
       wordCount: 12,
     });
-    // The rung itself still says 0 — a storm level's `wordCount` is its wave's
-    // `count` (§8.3) and the twenty `WaveSpec`s land in STM10 — so the wave in
-    // hand is the only honest place to read a run's length from today.
-    expect(lessonById(LESSON)?.wordCount).toBe(0);
+    // The rung has a wave of its own now (§5.6, #156) and it is not twelve
+    // letters long — which is the point of reading the length off the wave in
+    // hand. A saved run outlives the ladder it was played on (§5.4): re-tune
+    // lesson 39 and this run is still a run of the twelve it actually faced,
+    // and `survived` still asks the right question of it.
+    const rung = lessonById(LESSON);
+    expect(rung?.kind.type).toBe("storm");
+    expect(rung?.wordCount).toBeGreaterThan(0);
   });
 
   it("names itself in a record book years later", () => {
@@ -312,14 +318,18 @@ describe("a storm holds no record", () => {
   };
 
   /**
-   * A lesson run at the identical key — STM10's trap, dry-run.
+   * A lesson run at the identical key — the trap, no longer a dry run.
    *
-   * Once lesson 39 carries a `WaveSpec`, `lessonKey(lesson)` is
-   * `typing|L39|12`: the exact string `stormConfig` already writes, because
-   * `storm` is inert in `configKey` and must stay so. `TypingSetup`'s brief and
-   * its rival list then read this run and the two storms as one group. It is
-   * SLOWER than either storm and still has to be the best of the three, which
-   * it can only be if the other two are refused.
+   * Lesson 39 carries a `WaveSpec` now (#156), so `lessonKey(lesson)` and
+   * `configKey(stormConfig(...))` really are one string — `storm` is inert in
+   * `configKey` and must stay so, or every storm already saved is orphaned.
+   * `TypingSetup`'s brief and its rival list read this run and the two storms
+   * as one group. It is SLOWER than either storm and still has to be the best
+   * of the three, which it can only be if the other two are refused.
+   *
+   * Its twelve letters are the hand-built wave above rather than the rung's
+   * own count, which is why the key here is `typing|L39|12`; the twenty rungs
+   * are checked against `lessonKey` for real at the bottom of this file.
    */
   const lessonRun: Session = {
     ...died,
@@ -461,9 +471,11 @@ describe("the `unbroken` badge, over a wave the reducer really played", () => {
    * touches `progress.ts`. These two pin the meaning that shipped.
    *
    * The rung's own `wordCount` is lent for the length of the test, exactly as
-   * `progress.test.ts` does: the badge is guarded on the wave having a length
-   * (decision 29) and the twenty `WaveSpec`s land in STM10, so nothing can
-   * earn it today.
+   * `progress.test.ts` does. Lesson 39's wave is a real length now (§5.6), and
+   * borrowing it is what keeps these two about the badge's meaning rather than
+   * about the table: they are ten-letter runs, and the rung is asked to say
+   * ten so that `survived` is the thing being tested and not the difficulty
+   * pass that last edited the row.
    */
   const withWave = (count: number, body: () => void) => {
     const of = lessonById(LESSON);
@@ -586,5 +598,47 @@ describe("nothing downstream needs a line of new code", () => {
       "l",
       "o",
     ]);
+  });
+});
+
+describe("every storm keys exactly as its own rung does", () => {
+  /**
+   * **The trap above, over the twenty as they ship** (§5.4, §8.7, decision
+   * 50).
+   *
+   * A storm's `configKey` is built from the wave in hand and a lesson's from
+   * the rung, and #156 made those the same number — `wordCount` IS the wave's
+   * `count`. That is deliberate and load-bearing: retries of a level have to
+   * compare with each other, so they must share a bucket. It is also exactly
+   * what makes `config.storm` necessary, because sharing a bucket with a
+   * lesson is sharing it with `bestRun`.
+   *
+   * So both halves are asserted here, on the real waves rather than on a
+   * fixture: the keys match, and the storm still holds nothing at that key.
+   */
+  it("shares its bucket with the lesson, and holds no best in it", () => {
+    for (const lesson of STORM_LESSONS) {
+      const wave = stormWave(lesson);
+      const config = stormConfig(lesson.id, wave);
+
+      expect(configKey(config), lesson.id).toBe(lessonKey(lesson));
+      expect(configKey(config), lesson.id).toBe(
+        `typing|${lesson.id}|${lesson.wordCount}`,
+      );
+
+      // And a run of it is refused a record at that shared key, which is the
+      // whole reason the flag is on the run rather than derived from the rung.
+      const session: Session = {
+        ...asSaved(startStorm(wave)),
+        id: lesson.id,
+        config,
+        configKey: configKey(config),
+      };
+      expect(bestRun([session]), lesson.id).toBeNull();
+      expect(
+        ghostsFor([session], [PLAYER], session.configKey, PLAYER.id),
+        lesson.id,
+      ).toEqual([]);
+    }
   });
 });

--- a/src/games/typing/storm/stormSession.ts
+++ b/src/games/typing/storm/stormSession.ts
@@ -22,8 +22,8 @@ import type { CardResult, TypingConfig } from "@/engine/types";
  * the screen that runs a lesson, and for the same two reasons. It needs
  * `stormXp`, which lives in `progress.ts`, which imports `decks/index.ts` —
  * and `storm.ts` is deliberately kept a hop clear of the deck layer, because
- * STM10 puts a `WaveSpec` on each storm lesson and `lessons.ts` is reachable
- * from `decks/index.ts` (§5.3, decision 7). And what a run of a lesson is
+ * each storm lesson names a `WaveSpec` and `lessons.ts` is reachable from
+ * `decks/index.ts` (§5.3, decision 7). And what a run of a lesson is
  * filed as is the island's answer to give: the engine is handed a config, it
  * does not compose one.
  *
@@ -36,7 +36,7 @@ import type { CardResult, TypingConfig } from "@/engine/types";
  *
  * `lessonId` is the identity of the run and the one field `modeOf` and
  * `configKey` prefer (§5.4), so a storm is `typing:L39` and keys as
- * `typing|L39|12`. `levelId` carries the same id for the same reason
+ * `typing|L39|28`. `levelId` carries the same id for the same reason
  * `lessonConfig` does: both fields are read through `lessonId` on a ladder run,
  * and putting anything else in the level would only invite a screen to read it.
  *
@@ -49,9 +49,11 @@ import type { CardResult, TypingConfig } from "@/engine/types";
  * (`verdict.ts`): "you faced every letter the wave had" is `cards.length >=
  * wordCount`, which only means anything if the second number is the wave's.
  *
- * A storm lesson's own `wordCount` is that same figure (§8.3) but is `0` on
- * every row until STM10 writes the `WaveSpec`s, so the wave in hand is the
- * only place the length can honestly be read from today.
+ * A storm lesson's own `wordCount` is that same figure (§5.7), so the two
+ * agree — which is what makes this key and `lessonKey(lesson)` one string. The
+ * wave in hand is still where the run reads it, because a saved run outlives
+ * the ladder it was played on (§5.4): re-tune lesson 39 from twelve letters to
+ * forty and this run is still a run of twelve.
  *
  * **`storm: true` is what keeps it out of the record book's ranking**
  * (decision 50). The key above is deliberately the lesson's, so retries
@@ -60,7 +62,7 @@ import type { CardResult, TypingConfig } from "@/engine/types";
  * so without the flag the run that died first would hold the record. It is the
  * only thing here a `lessonConfig` does not also write, and it is inert in
  * `configKey`, so the two configs still key identically — which they must, or
- * STM10 would orphan every storm already saved.
+ * the twenty waves landing would have orphaned every storm already saved.
  */
 export function stormConfig(lessonId: string, wave: Wave): TypingConfig {
   return {

--- a/src/games/typing/storm/useStormClock.test.ts
+++ b/src/games/typing/storm/useStormClock.test.ts
@@ -207,6 +207,7 @@ describe("the shape the clock is watching", () => {
     combo: true,
     ending: true,
     misses: true,
+    missTintAt: true,
     resolved: true,
     score: true,
     shield: true,
@@ -215,11 +216,12 @@ describe("the shape the clock is watching", () => {
   };
 
   it("pins the shape of a StormState, so a new field is decided about here", () => {
-    // `redrawn` compares six of these — `score` and `misses` arrived with the
-    // HUD and are drawn in it — derives two more from the clock, and leaves
-    // `wave` out because a run's wave is fixed. A story that adds a ninth
-    // (STM07's tally) has to come here and say which of those three it is; the
-    // alternative is finding out from a HUD that quietly stopped updating.
+    // `redrawn` compares seven of these — `score`, `misses` and `missTintAt`
+    // are the HUD's, and the last of them is what its `--flare` wash is
+    // mounted from (decision 57) — derives two more from the clock, and leaves
+    // `wave` out because a run's wave is fixed. A story that adds a tenth has
+    // to come here and say which of those three it is; the alternative is
+    // finding out from a HUD that quietly stopped updating.
     expect(Object.keys(startStorm(buildWave(spec, 7))).sort()).toEqual(
       Object.keys(FIELDS).sort(),
     );

--- a/src/games/typing/storm/useStormClock.ts
+++ b/src/games/typing/storm/useStormClock.ts
@@ -153,12 +153,13 @@ function onField(state: StormState): number {
  * the board goes on marking a child's keys against a letter that is no longer
  * the lowest.
  *
- * `score` and `misses` move together on every miss and would each be covered
- * by the other today; both are compared anyway, because "the score happens to
- * change whenever the flash does" is a coincidence of two constants in
- * `storm.ts` rather than a property of the screen. A `MISS_POINTS` of zero
+ * `score`, `misses` and `missTintAt` move together on a miss and would each be
+ * covered by another today; all three are compared anyway, because "the score
+ * happens to change whenever the flash does" is a coincidence of two constants
+ * in `storm.ts` rather than a property of the screen. A `MISS_POINTS` of zero
  * would leave the HUD's `--flare` flash undrawn, which is a bug nobody would
- * think to look for here.
+ * think to look for here — and `missTintAt` is the one the HUD now mounts that
+ * flash from (decision 57), so it is the field whose absence would be silent.
  *
  * `wave` is the field left out, and deliberately: a run's wave is fixed for
  * its whole life, so it cannot change under a running loop, and a screen
@@ -182,6 +183,7 @@ export function redrawn(drawn: StormState, next: StormState): boolean {
     drawn.combo !== next.combo ||
     drawn.score !== next.score ||
     drawn.misses !== next.misses ||
+    drawn.missTintAt !== next.missTintAt ||
     drawn.ending !== next.ending ||
     aimedAt(drawn) !== aimedAt(next) ||
     onField(drawn) !== onField(next)

--- a/src/games/typing/storm/useStormClock.ts
+++ b/src/games/typing/storm/useStormClock.ts
@@ -153,13 +153,16 @@ function onField(state: StormState): number {
  * the board goes on marking a child's keys against a letter that is no longer
  * the lowest.
  *
- * `score`, `misses` and `missTintAt` move together on a miss and would each be
- * covered by another today; all three are compared anyway, because "the score
- * happens to change whenever the flash does" is a coincidence of two constants
- * in `storm.ts` rather than a property of the screen. A `MISS_POINTS` of zero
- * would leave the HUD's `--flare` flash undrawn, which is a bug nobody would
- * think to look for here — and `missTintAt` is the one the HUD now mounts that
- * flash from (decision 57), so it is the field whose absence would be silent.
+ * `score` and `misses` move on **every** miss; `missTintAt` moves only on the
+ * ones the throttle lets light, which is `MIN_TINT_GAP_MS` apart at the most
+ * (decision 57). So the stamp is covered by the other two today — a frame it
+ * moves on is a frame the score moved on as well — and all three are compared
+ * anyway, because "the score happens to change whenever the flash does" is a
+ * coincidence of two constants in `storm.ts` rather than a property of the
+ * screen. A `MISS_POINTS` of zero would leave the HUD's `--flare` flash
+ * undrawn, which is a bug nobody would think to look for here — and
+ * `missTintAt` is the field the HUD actually mounts that flash from, so it is
+ * the one whose absence would be silent.
  *
  * `wave` is the field left out, and deliberately: a run's wave is fixed for
  * its whole life, so it cannot change under a running loop, and a screen

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1431,8 +1431,8 @@ label.segmented__btn {
   transform: scale(1.12);
 }
 
-/* Locked, and the storms until #159 gives them a wave to be. Dim rather than
-   hidden: the point of a map is that it shows you the ground you have not
+/* Locked, and a storm on a device with no keys to play it with. Dim rather
+   than hidden: the point of a map is that it shows you the ground you have not
    walked yet. */
 .ladder__tile[aria-disabled] {
   cursor: default;
@@ -1497,6 +1497,14 @@ label.segmented__btn {
 .ladder__tile.is-storm {
   transform: rotate(45deg) scale(0.82);
   border-radius: 5px;
+}
+
+/* A storm a child can play reads as one, and the four states above colour it
+   like any other rung — filled when it is behind them, outlined when it is
+   open. What stays dim is a diamond this device cannot enter: on a tablet the
+   twenty are shut (§8.8) and there is no reason to draw them as an invitation.
+   The rung after it is unaffected either way, which is the whole of §8.8. */
+.ladder__tile.is-storm[aria-disabled]:not(.is-locked) {
   color: var(--chalk-dim);
 }
 
@@ -2543,8 +2551,13 @@ label.segmented__btn {
    single `tick` move that counter by two, which is still one element and
    therefore still one tint (§8.10). What that rules out is the tint
    restarting on a frame where nothing happened; how often a WAVE may land on
-   one zone is a separate question, and one the generator does not yet answer
-   — see §8.10 for what is measured and what STM10 still owes it.
+   one zone is a separate question, and it is answered by the twenty levels
+   rather than here — no zone starts more than three tints in a second at any
+   seed, and the twenty that ship peak at two (`storms.test.ts`, §8.10).
+
+   The score's `--flare` below is the third of the three, and the one no wave
+   can shape: its cadence is a child's own keystrokes, so its floor is in the
+   reducer instead (`MIN_TINT_GAP_MS`, decision 57).
 
    Both rest at `opacity: 0` and animate down to it, so the animation adds
    nothing to the picture once it is over — which is why the reduced-motion

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -2552,8 +2552,9 @@ label.segmented__btn {
    therefore still one tint (§8.10). What that rules out is the tint
    restarting on a frame where nothing happened; how often a WAVE may land on
    one zone is a separate question, and it is answered by the twenty levels
-   rather than here — no zone starts more than three tints in a second at any
-   seed, and the twenty that ship peak at two (`storms.test.ts`, §8.10).
+   rather than here — each of them ships at a seed whose wave starts no more
+   than two tints on one zone in a second, under WCAG 2.3.1's line of more than
+   three (`storms.test.ts`, §8.10).
 
    The score's `--flare` below is the third of the three, and the one no wave
    can shape: its cadence is a child's own keystrokes, so its floor is in the


### PR DESCRIPTION
Closes #156

The final story of epic #159. Hailstorm stops being a thing you can reach and becomes a thing on the ladder: twenty levels, woven in at fixed rungs, each one a wave the child has the keys for.

## Twenty `WaveSpec`s, as a second table

`STORM_WAVES` (`src/engine/typing/storms.ts`) puts a storm at lessons **4, 9, 13, 19, 23, 29, 34, 39, 45, 49, 53, 59, 65, 69, 73, 79, 83, 89, 93, 99** — a second table beside the lesson table, mirrored in the new **§5.7** of `docs/typing.md` and diffed against it by a test, so the doc cannot drift from the ship.

**A row is a `WaveSpec` minus `keys`** (decision 56). A level has nowhere to write a character, so the pool can only ever be `unlockedAt(n)` — reachability is not a rule anyone has to remember, it is structural. That is now enforced by `satisfies StormShape`, verified in both directions: without it a row carrying `keys: ["z"]` type-checks clean; with it the compiler raises **TS2353**.

## The curve

| | lesson 4 | → | lesson 99 |
| --- | --- | --- | --- |
| length | 12 | | 50 |
| `gap` | 1500–1900ms | | 300–500ms |
| repairs | 4 | 8 | off at 79 ("No repairs") |
| shield | 4 | 3 | 2 |

`fall` sits at or above `MIN_FALL_MS` everywhere. Lessons **4, 9 and 13 keep `gap >= fall`** — one letter on screen at a time, which is the whole difference between a first storm and a game — and that is asserted off the **built** schedule at 5,000 seeds rather than off the numbers in the table. From **19 onward the letters overlap**. Measured on screen: **1 letter at L04, 3 at L45, 7 at L89**.

The curve test asserts that each **quarter** climbs, not each row, because the ladder itself dips and should: 53 eases off after the number row arrives, and 73 is long where 79 is dense. A per-row monotonic assert would be a test demanding a worse ladder.

Focus levels repeat their class to about half the pool as a **share, not a multiplier** — at lesson 53 only `3 4 5 6` exist, and a multiplier there would be asking for more of nearly everything.

## The strobe guarantee, both halves

**Zone tints.** Starts per zone per second, read off the **built** schedule, with each level's **seed derived** rather than hand-picked: the first seed at or above its rung that keeps the rate <= 2, uses **>= 6 of 8 fingers**, and gives no finger more than a third of the letters. Fourteen levels take their unbumped seed; **six** are bumped, none by more than six. The test re-derives all twenty from the same rule, so a future change to `buildWave` fails loudly instead of silently orphaning the guarantee.

**The bound, stated honestly:** this is a property of the **shipped seeds**, not of the specs. At unshipped seeds lessons 83/89/93/99 reach 4–5 starts per zone per second. That is written down in §5.7 rather than papered over — decision 58 is what makes it a real guarantee, because a storm's seed is the level's, not the visit's, so the twenty waves measured are the twenty a child meets.

**`.storm__miss` needed the other half**, because no `WaveSpec` can bound it — its cadence is a child's hand, not a schedule (decision 57). `StormState.missTintAt` is a wave-time stamp advanced **at most once per `MIN_TINT_GAP_MS` = 500ms**, while every other cost of a miss — score, combo, the flare on the board — is charged in full every time.

The review caught that the original **340ms permitted three flashes a second** — exactly WCAG 2.3.1's ceiling with zero headroom — while the comments beside it promised "room to spare". Reproduced across **23 cadences from 10ms to 750ms**: 340ms peaked at **3 starts/second at 15 of them**, and the worst cadences are the ones landing just inside the gap, not the fastest hands. **500ms peaks at 2 at every cadence**, with all 60 presses charged each time.

## Storm levels never gate

Lesson 46 unlocks when 44 is cleared, whatever happened at 45. Tested at **all twenty rungs**, and verified in a browser both before and after a failed run of 45.

## `buildTypingDrill`, fixed in scope

Decision 59. `ladderProgress` now requires `config.lessonId` to match, not just the mode. Putting storms on the ladder made the drill button reachable from a storm tile, and a flawless 40-word drill filed under `typing:L39` would otherwise have marked the storm **"Passed"** *and* earned `unbroken`.

Verified: a flawless **L04 storm** earns **483 XP** and `unbroken` and clears rung 4; a flawless **40-card drill** under `typing:L04` clears nothing and earns nothing.

## Decisions recorded

| | |
| --- | --- |
| 56 | A storm level cannot name its own keys |
| 57 | The miss flash has a floor, in the reducer |
| 58 | A storm's seed is the level's, not the visit's |
| 59 | A lesson is cleared only by a run that says it is that lesson |
| 60 | A storm's brief is its own screen |

## Verification scale

- Tint rate over **20 specs x 20,000 seeds**.
- Miss throttle stressed at **11+ cadences x 60 keys**.
- **Eight sabotages** caught — including an RNG-order change inside `buildWave`, which also demonstrates the frozen seeds self-correct rather than silently drifting.

Gates: `type-check`, `build`, lint, unit tests (103 files / 2160 passing) and the browser smoke test all green.
