### PR TITLE
Draw the board at the pitch of the keyboard it is a map of

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -348,6 +348,72 @@ meaning borrow from the five — a pressed-and-correct key flashes `--lime`, a
 pressed-and-wrong key flashes `--flare`, the next-key hint uses `--go`
 (per-world, and it already means "press this").
 
+### 4.7 · The board is life-size
+
+Key pitch on every full-size keyboard a child will meet is **19.05mm** — three
+quarters of an inch, which CSS defines as exactly 72px, which is `4.5rem`. That
+is the ceiling of `--key`, and it is a measurement rather than a taste.
+
+The reason is what the board is _for_. It is not an illustration of a keyboard;
+it is a map a child glances at while their hands are on the real one. A map at
+half scale asks them to do the scaling — to see that the distance between `f`
+and `j` on screen is the distance their two index fingers are already holding —
+and that translation is exactly the work that looking down at their hands would
+have saved them. At pitch, the picture and the plastic are the same shape, so
+the glance costs nothing and the reach it teaches is the reach they make.
+
+Written in `rem` rather than `mm`, which are identical lengths (CSS pins an inch
+to 96px), so that a child who has turned their text up gets a board that grew
+with everything else.
+
+The ceiling was `2.4rem` — about half pitch — through #133–#156, which on any
+laptop drew a keyboard the size of a phone in the middle of a half-empty screen.
+Three things had to give for the real number to fit:
+
+- **The `vw` term**, 5.6 → 6, so the board is 90% of a narrow viewport rather
+  than 84%. On a phone and a portrait tablet the width still decides, and the
+  ceiling is never reached.
+- **The race column.** `.race` is `min(720px, 100%)` because that is a
+  comfortable measure for a clock, a rival's gap and a line of words. A
+  life-size board is 1080px, so on the passage screen it is centred on its grid
+  area and overflows it evenly — which is also how the desk it depicts is
+  arranged, a screen with a wider keyboard under it. The centring is
+  `margin-inline: calc(50% - 7.5 * var(--key))` and not an alignment property:
+  `margin-inline: auto` is defined to resolve to zero against negative free
+  space, and `justify-self: center` is start-aligned by Chrome for an
+  overflowing grid item. Half the column minus half the board means the same
+  thing in both directions.
+- **The height term, on the passage screen only.** `9dvh` is a fraction of the
+  viewport and what the board competes with there is not one: the HUD, the pass
+  bars or the ghost lane, the line you type on, four grid gaps and the race's
+  own padding come to about 365px at every height, and two lines of passage left
+  to read is another 60. A coefficient that clears 425px of chrome at an 850px
+  viewport does not clear it at 700, and `.race` is `min-height` — so the board
+  grew the page instead of itself, and a race that scrolls under a thumb
+  mid-word is the one thing that `min-height` is there to prevent. At half pitch
+  the ceiling hid this; the dvh term was never the governor it looked like. So
+  `.race.typing` re-declares `--key` with the constant subtracted and the
+  remainder divided by the board's own height in key units, `5 + 4 × 0.09`:
+
+  ```css
+  min(6vw, 9dvh, calc((100dvh - var(--ad-h) - 26.5rem) / 5.36))
+  ```
+
+  This is the second declaration of `--key` that decision 37 rules out, and it
+  is not the one it rules out. What may never happen is a falling letter's lane
+  and the cap it names coming from two numbers — and the passage screen has no
+  lanes. The board is the only thing on it that reads `--key` at all, and a
+  screen only ever sees one of the two values.
+
+Hailstorm needs none of the three — its field is already full width, and the
+sky is the flexible track that absorbs whatever the board takes — but it gets
+the bigger board, because `--key` is one dial (decision 37) and a storm's gun is
+the same picture as a lesson's map. What it costs is sky: on a 1512×850 laptop
+the field goes from about 600px of fall to about 430px. That is the trade §8.2
+already names — the board is the gun, so the sky is what shrinks — and the fall
+is timed rather than distance-based (`--drop` is `progressAt`), so a letter is
+on screen for exactly as long as its spec says either way.
+
 ---
 
 ## 5 · The ladder
@@ -1052,8 +1118,8 @@ drawn keycap is inset inside that slot: `game.css` gives it
 `calc(var(--key) * 0.09)`. So a cap's visual centre is `--key * (x + w/2 -
 0.045)` while its lane is `--key * (x + w/2)` — a letter placed at
 `left: calc(var(--lane) * var(--key))` and centred on that point would sit
-**0.045 key units right of the centre of the cap it names**, about 1.7px at the
-2.4rem ceiling of `--key` and about 0.8px at the 1.05rem floor.
+**0.045 key units right of the centre of the cap it names**, about 3.2px at the
+4.5rem ceiling of `--key` and about 0.8px at the 1.05rem floor.
 
 **The field subtracts it** (decision 36):
 
@@ -1929,68 +1995,71 @@ which is what every run saved before this is.
 
 ## 11 · Decisions, recorded
 
-|     | Decision                                                      | Because                                                                                                         |
-| --- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| 1   | The keyboard layout is engine, not view                       | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture           |
-| 2   | `code`, not `key`                                             | Shift+`4` produces `$` and there is no `$` key to light up                                                      |
-| 3   | Keys release on a timer, not `keyup`                          | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                                 |
-| 4   | The board is `aria-hidden`                                    | Sixty announcing spans is not accessibility; the passage already carries the state                              |
-| 5   | The visual keyboard is never tappable                         | A tappable board is a hunt-and-peck trainer, which is the thing this is against                                 |
-| 6   | Lesson text is generated, not written                         | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                             |
-| 7   | The lexicon must not be reachable from `decks/index.ts`       | The same import took the shared chunk 46 KB → 222 KB once already                                               |
-| 8   | Ghost identity is the lesson, not the passage                 | Every run generates different words; keying on them buckets every run alone                                     |
-| 9   | Three pass bars, not one score                                | A single number says you failed; three say what to fix                                                          |
-| 10  | Accuracy is flat and high; speed scales                       | An accuracy bar you can hammer past teaches hammering                                                           |
-| 11  | The speed bar dips when a key arrives                         | You have just got slower and you should have                                                                    |
-| 12  | The new-key gate                                              | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                              |
-| 13  | Per-key stats come from cards, not keystrokes                 | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven             |
-| 14  | Progress is derived, never stored                             | No migration, self-heals when criteria change, cannot disagree with the record book                             |
-| 15  | Unlock is `max(cleared) + 1`                                  | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                                 |
-| 16  | Any checkpoint, any time                                      | It is a placement test, a skip-ahead and an ordering rule in one sentence                                       |
-| 17  | A lesson has no ghost and no time penalty                     | A penalty double-counts accuracy and makes the wpm number a lie                                                 |
-| 18  | Hailstorm is a route in the typing island                     | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard        |
-| 19  | Letters fall down their key's column                          | The lane is a spatial hint — the game teaches the layout the whole time it is played                            |
-| 20  | Only the lowest letter can be shot                            | Otherwise spraying the keyboard is a winning strategy                                                           |
-| 21  | The shield is eight finger zones                              | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise               |
-| 22  | Score can fall, XP cannot                                     | XP is cumulative across years and four games; a bad five minutes must not lower a level                         |
-| 23  | A Hailstorm run is a `Session`                                | Record book, XP, badges and the drill builder all work with no new code                                         |
-| 24  | Hailstorm never gates the ladder                              | A tablet has no keys, and a reward that blocks you is not a reward                                              |
-| 25  | DOM, not canvas                                               | Eleven custom properties change the whole app's biome; a canvas is a hole in that                               |
-| 26  | US ANSI only, and say so                                      | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                                   |
-| 27  | A lesson's keyboard seeds; it does not overrule               | All hundred name a mode, so an override beats the player's own setting on every rung                            |
-| 28  | `eyes-up` reads the board the run was typed under             | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory              |
-| 29  | `unbroken` is gated on the wave having a length               | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete         |
-| 30  | A falling letter is on the field on `[spawn, land)`           | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two             |
-| 31  | A letter carries its key, finger and lane                     | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift              |
-| 32  | The target is the greatest fall progress, not `landMs`        | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen                  |
-| 33  | An exact tie goes to the earlier spawn                        | The index is the letter's identity, so a replay resolves the same dead heat the same way                        |
-| 34  | A repair never lifts a zone above `spec.shield`               | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                        |
-| 35  | A tick resolves every landing inside it                       | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's                   |
-| 36  | The field's lanes step back half a `--key-gap`                | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference      |
-| 37  | `--key` is declared once, at the root                         | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key          |
-| 38  | A frame is clamped to 100ms of wave time                      | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield          |
-| 39  | The loop writes `--drop`; the stylesheet owns the fall        | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either       |
-| 40  | The field re-renders on the picture, not on the frame         | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal            |
-| 41  | A shield segment is its finger's home-row span                | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on     |
-| 42  | A tint is an element keyed by a counter, not a class          | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe       |
-| 43  | A stroke at an empty sky flares the whole board               | It costs ten points and the streak, and a key that costs a child points must not light `--lime`                 |
-| 44  | Key auto-repeat is not a shot                                 | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                       |
-| 45  | The HUD is drawn inside the sky, not as a row of its own      | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give                  |
-| 46  | A wrong key costs score; a letter through costs shield        | One failure, one cost — the landing has already taken the thing that ends runs                                  |
-| 47  | The ending stands where the board did                         | The gun is dead, and the sky it leaves whole is the shield with the hole in it that the sentence is about       |
-| 48  | A storm's cards are its letters, not its keystrokes           | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both       |
-| 49  | A letter that got through is a `timedOut` card                | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped        |
-| 50  | A storm has no ghost and holds no record                      | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it              |
-| 51  | A retry is a new run, so it is a remount                      | The finish guard, the history snapshot and the clock all have to start again; one instance is one run           |
-| 52  | Fall time has a floor, in the generator                       | The twenty specs are a table, and a table gets tightened a row at a time until a level nobody can read ships    |
-| 53  | A keystroke proves a keyboard; the pointer only guesses       | Every proxy is wrong about somebody, and wrongly shut is a child locked out where wrongly open is a dud tile    |
-| 54  | The quit sheet is the storm's pause                           | A wave falling behind it would break a shield while a child read "it won't be saved"                            |
-| 55  | `Escape` leaves, and is taken before the trigger              | Every other key while a run is live is a shot, so a way out on a second listener would cost ten points          |
-| 56  | A storm level cannot name its own keys                        | The row holds a `WaveSpec` minus `keys`, so the pool can only be `unlockedAt(n)` and reachability is structural |
-| 57  | The miss flash has a floor, in the reducer                    | A zone's tint rate is the schedule's and the specs keep it; a wrong key's is a hand's, and no spec can          |
-| 58  | A storm's seed is the level's, not the visit's                | A level is the same weather twice, and the twenty waves measured for strobe are the twenty a child meets        |
-| 59  | A lesson is cleared only by a run that says it is that lesson | A drill files under the lesson's mode, so mode alone would let practising a lesson clear it                     |
-| 60  | A storm's brief is its own screen                             | Three bars, a best and a keyboard control are three things a storm does not have, and it has three of its own   |
+|     | Decision                                                                                     | Because                                                                                                                                           |
+| --- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | The keyboard layout is engine, not view                                                      | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture                                             |
+| 2   | `code`, not `key`                                                                            | Shift+`4` produces `$` and there is no `$` key to light up                                                                                        |
+| 3   | Keys release on a timer, not `keyup`                                                         | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                                                                   |
+| 4   | The board is `aria-hidden`                                                                   | Sixty announcing spans is not accessibility; the passage already carries the state                                                                |
+| 5   | The visual keyboard is never tappable                                                        | A tappable board is a hunt-and-peck trainer, which is the thing this is against                                                                   |
+| 6   | Lesson text is generated, not written                                                        | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                                                               |
+| 7   | The lexicon must not be reachable from `decks/index.ts`                                      | The same import took the shared chunk 46 KB → 222 KB once already                                                                                 |
+| 8   | Ghost identity is the lesson, not the passage                                                | Every run generates different words; keying on them buckets every run alone                                                                       |
+| 9   | Three pass bars, not one score                                                               | A single number says you failed; three say what to fix                                                                                            |
+| 10  | Accuracy is flat and high; speed scales                                                      | An accuracy bar you can hammer past teaches hammering                                                                                             |
+| 11  | The speed bar dips when a key arrives                                                        | You have just got slower and you should have                                                                                                      |
+| 12  | The new-key gate                                                                             | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                                                                |
+| 13  | Per-key stats come from cards, not keystrokes                                                | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven                                               |
+| 14  | Progress is derived, never stored                                                            | No migration, self-heals when criteria change, cannot disagree with the record book                                                               |
+| 15  | Unlock is `max(cleared) + 1`                                                                 | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                                                                   |
+| 16  | Any checkpoint, any time                                                                     | It is a placement test, a skip-ahead and an ordering rule in one sentence                                                                         |
+| 17  | A lesson has no ghost and no time penalty                                                    | A penalty double-counts accuracy and makes the wpm number a lie                                                                                   |
+| 18  | Hailstorm is a route in the typing island                                                    | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard                                          |
+| 19  | Letters fall down their key's column                                                         | The lane is a spatial hint — the game teaches the layout the whole time it is played                                                              |
+| 20  | Only the lowest letter can be shot                                                           | Otherwise spraying the keyboard is a winning strategy                                                                                             |
+| 21  | The shield is eight finger zones                                                             | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise                                                 |
+| 22  | Score can fall, XP cannot                                                                    | XP is cumulative across years and four games; a bad five minutes must not lower a level                                                           |
+| 23  | A Hailstorm run is a `Session`                                                               | Record book, XP, badges and the drill builder all work with no new code                                                                           |
+| 24  | Hailstorm never gates the ladder                                                             | A tablet has no keys, and a reward that blocks you is not a reward                                                                                |
+| 25  | DOM, not canvas                                                                              | Eleven custom properties change the whole app's biome; a canvas is a hole in that                                                                 |
+| 26  | US ANSI only, and say so                                                                     | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                                                                     |
+| 27  | A lesson's keyboard seeds; it does not overrule                                              | All hundred name a mode, so an override beats the player's own setting on every rung                                                              |
+| 28  | `eyes-up` reads the board the run was typed under                                            | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory                                                |
+| 29  | `unbroken` is gated on the wave having a length                                              | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete                                           |
+| 30  | A falling letter is on the field on `[spawn, land)`                                          | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two                                               |
+| 31  | A letter carries its key, finger and lane                                                    | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift                                                |
+| 32  | The target is the greatest fall progress, not `landMs`                                       | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen                                                    |
+| 33  | An exact tie goes to the earlier spawn                                                       | The index is the letter's identity, so a replay resolves the same dead heat the same way                                                          |
+| 34  | A repair never lifts a zone above `spec.shield`                                              | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                                                          |
+| 35  | A tick resolves every landing inside it                                                      | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's                                                     |
+| 36  | The field's lanes step back half a `--key-gap`                                               | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference                                        |
+| 37  | `--key` is declared once, at the root                                                        | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key                                            |
+| 38  | A frame is clamped to 100ms of wave time                                                     | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield                                            |
+| 39  | The loop writes `--drop`; the stylesheet owns the fall                                       | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either                                         |
+| 40  | The field re-renders on the picture, not on the frame                                        | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal                                              |
+| 41  | A shield segment is its finger's home-row span                                               | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on                                       |
+| 42  | A tint is an element keyed by a counter, not a class                                         | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe                                         |
+| 43  | A stroke at an empty sky flares the whole board                                              | It costs ten points and the streak, and a key that costs a child points must not light `--lime`                                                   |
+| 44  | Key auto-repeat is not a shot                                                                | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                                                         |
+| 45  | The HUD is drawn inside the sky, not as a row of its own                                     | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give                                                    |
+| 46  | A wrong key costs score; a letter through costs shield                                       | One failure, one cost — the landing has already taken the thing that ends runs                                                                    |
+| 47  | The ending stands where the board did                                                        | The gun is dead, and the sky it leaves whole is the shield with the hole in it that the sentence is about                                         |
+| 48  | A storm's cards are its letters, not its keystrokes                                          | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both                                         |
+| 49  | A letter that got through is a `timedOut` card                                               | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped                                          |
+| 50  | A storm has no ghost and holds no record                                                     | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it                                                |
+| 51  | A retry is a new run, so it is a remount                                                     | The finish guard, the history snapshot and the clock all have to start again; one instance is one run                                             |
+| 52  | Fall time has a floor, in the generator                                                      | The twenty specs are a table, and a table gets tightened a row at a time until a level nobody can read ships                                      |
+| 53  | A keystroke proves a keyboard; the pointer only guesses                                      | Every proxy is wrong about somebody, and wrongly shut is a child locked out where wrongly open is a dud tile                                      |
+| 54  | The quit sheet is the storm's pause                                                          | A wave falling behind it would break a shield while a child read "it won't be saved"                                                              |
+| 55  | `Escape` leaves, and is taken before the trigger                                             | Every other key while a run is live is a shot, so a way out on a second listener would cost ten points                                            |
+| 56  | A storm level cannot name its own keys                                                       | The row holds a `WaveSpec` minus `keys`, so the pool can only be `unlockedAt(n)` and reachability is structural                                   |
+| 57  | The miss flash has a floor, in the reducer                                                   | A zone's tint rate is the schedule's and the specs keep it; a wrong key's is a hand's, and no spec can                                            |
+| 58  | A storm's seed is the level's, not the visit's                                               | A level is the same weather twice, and the twenty waves measured for strobe are the twenty a child meets                                          |
+| 59  | A lesson is cleared only by a run that says it is that lesson                                | A drill files under the lesson's mode, so mode alone would let practising a lesson clear it                                                       |
+| 60  | A storm's brief is its own screen                                                            | Three bars, a best and a keyboard control are three things a storm does not have, and it has three of its own                                     |
+| 61  | The board is drawn at 19.05mm key pitch                                                      | It is a map read while the hands are on the real thing; at half scale the child does the scaling, which is the work looking down would have saved |
+| 62  | The board may overflow the 720px race column                                                 | 720px is a reading measure and a keyboard is not read; a screen with a wider keyboard under it is the desk it depicts                             |
+| 63  | The passage screen's `--key` subtracts its chrome rather than taking a share of the viewport | The HUD, the bars and the line you type on are a constant, so a dvh fraction that fits at 850px of viewport grows the page at 700                 |
 
 ---
 

--- a/src/games/typing/keyboard/Keyboard.test.tsx
+++ b/src/games/typing/keyboard/Keyboard.test.tsx
@@ -135,6 +135,65 @@ describe("Keyboard", () => {
       expect(block).not.toContain(`var(${name})`);
   });
 
+  it("draws a key at the pitch of a real one", () => {
+    const sheet = css("game.css").replace(/\/\*[\s\S]*?\*\//g, "");
+    const dial = /:root\s*{[^}]*--key:\s*([^;]+)/.exec(sheet)![1];
+
+    // 19.05mm of key pitch is three quarters of an inch, which CSS defines as
+    // exactly 72px, which is 4.5rem. The board is a map a child glances at
+    // while their hands are on the real thing, so the ceiling is that
+    // measurement and not a taste — at half of it they do the scaling, which
+    // is the work looking down would have saved them (§4.7, decision 61).
+    //
+    // Written out whole rather than as a `toContain("4.5rem")`, because the
+    // two floor terms are load-bearing too: `6vw` is what keeps fifteen units
+    // inside 90% of a narrow viewport whatever the column under them says, and
+    // `9dvh` is what leaves a landscape phone a sky to fall through.
+    expect(dial.replace(/\s+/g, " ")).toBe(
+      "clamp(1.05rem, min(6vw, 9dvh), 4.5rem)",
+    );
+  });
+
+  it("centres the board on the arithmetic when it overflows the race column", () => {
+    const sheet = css("game.css").replace(/\/\*[\s\S]*?\*\//g, "");
+
+    // A life-size board is fifteen units of 72px — 1080px — and `.race` is
+    // `min(720px, 100%)`, a measure chosen for reading a line of words. So on
+    // the passage screen the board overflows its column, evenly, on purpose
+    // (decision 62).
+    //
+    // Half the column minus half of fifteen units, and NOT `margin-inline:
+    // auto`: an auto margin is defined to resolve to zero against negative
+    // free space, so the board would hug the left edge and hang off the right.
+    // `justify-self: center` loses the same way — Chrome start-aligns an
+    // overflowing grid item. This expression is the one that means the same
+    // thing in both directions.
+    //
+    // Filtered rather than taken first, because `.typing .keyboard` is written
+    // twice: the other one is the short-viewport rule that drops the board
+    // altogether. Exactly one of them may say where the board sits.
+    const centring = [...sheet.matchAll(/\.typing \.keyboard\s*{([^}]*)}/g)]
+      .map(([, body]) => body)
+      .filter((body) => /margin-inline/.test(body));
+
+    expect(centring).toHaveLength(1);
+    expect(centring[0]).toMatch(
+      /margin-inline:\s*calc\(50% - 7\.5 \* var\(--key\)\)/,
+    );
+
+    // And the height budget on the same screen is divided by the board's own
+    // height in key units — five rows, and the four gaps between them at
+    // whatever the board insets its caps by. Read out of `--key-gap` rather
+    // than pinned at 5.36, so a chunkier keycap moves the budget with it
+    // instead of leaving the board a fraction too tall on a short window and
+    // scrolling a race under a child's thumb (decision 63).
+    const gap = Number(
+      /--key-gap:\s*calc\(var\(--key\) \* ([\d.]+)\)/.exec(sheet)![1],
+    );
+    const divisor = /\.race\.typing\s*{[^}]*\/\s*([\d.]+)\s*\)/.exec(sheet)![1];
+    expect(Number(divisor)).toBeCloseTo(5 + 4 * gap, 5);
+  });
+
   it("flashes a struck key green and a wrong one red, and nothing else", () => {
     const game = css("game.css");
     const echo = game.slice(game.indexOf(ECHO_BLOCK));

--- a/src/games/typing/keyboard/Keyboard.tsx
+++ b/src/games/typing/keyboard/Keyboard.tsx
@@ -36,6 +36,12 @@ const NONE: ReadonlySet<string> = new Set();
  * different sizes rather than two layouts — there is no breakpoint here to keep
  * in step with the row stagger.
  *
+ * That dial tops out at real key pitch — 19.05mm, which is 4.5rem (§4.7) —
+ * because this is a map read while the hands are on the actual keyboard, and a
+ * map at half scale makes the child do the scaling. On a wide screen the board
+ * is therefore wider than the 720px column the race is written in, and is
+ * allowed to overflow it; the CSS says how.
+ *
  * ── The echo arrives as props, not as a hook ──────────────────────────────
  * Which keys are lit is `useKeyEcho`'s answer, passed in (§4.3). Calling the
  * hook in here would look tidier and would cost the two things that matter:

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -333,11 +333,28 @@ describe("StormField", () => {
 
   it("draws one key unit, shared with the board it is aiming at", () => {
     // The AC's "one source of truth" is the `KEY_ROWS` table for the lanes and
-    // this custom property for the scale. Two declarations of it — one on the
-    // board, one on the field — is exactly how a lane and a cap start
-    // disagreeing about how wide a key is.
-    expect(css.match(/--key:\s/g)).toHaveLength(1);
-    expect(/:root\s*{\s*--key:/.test(css)).toBe(true);
+    // this custom property for the scale. Two declarations of it reachable
+    // from THIS screen — one on the board, one on the field — is exactly how a
+    // lane and a cap start disagreeing about how wide a key is. So the storm's
+    // own block declares it nowhere at all: every rule under `.storm` reads
+    // the root's value, and a falling letter has no second opinion available
+    // to land by.
+    expect(storm).not.toMatch(/--key:\s/);
+    expect(/:root\s*{\s*--key:/.test(sheet)).toBe(true);
+
+    // There is one other declaration in the stylesheet, and it is deliberately
+    // not on a screen with lanes. `.race.typing` re-scales the dial to subtract
+    // the chrome a passage screen carries above the board — the HUD, the bars,
+    // the line you type on — because that chrome is a constant and a share of
+    // the viewport cannot express it (§4.7, decision 63). It may, because the
+    // board is the only thing on that screen that reads `--key` at all.
+    //
+    // Pinned at two rather than left open, so that a third has to be argued
+    // for here first. The count is taken off `sheet` and not `css`: the prose
+    // in this stylesheet quotes the property by name, and a test that counted
+    // comments would be marking the explanation.
+    expect(sheet.match(/--key:\s/g)).toHaveLength(2);
+    expect(/\.race\.typing\s*{\s*--key:/.test(sheet)).toBe(true);
   });
 
   it("fills the viewport minus the ad band, and does not scroll while the storm is falling", () => {

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1876,11 +1876,32 @@ label.segmented__btn {
 
    The board is fifteen key units wide and every key knows its own left edge
    in those units, so a key is a fifteenth of the room there is — floored so
-   it stays legible on a narrow phone, capped so it doesn't become furniture
-   on a desktop. The dvh term is what makes a phone in landscape work: five
-   rows and whatever they are under — the passage, or a sky full of falling
-   letters — are sharing about 390px of height, and width alone would happily
-   spend all of it.
+   it stays legible on a narrow phone. The dvh term is what makes a phone in
+   landscape work: five rows and whatever they are under — the passage, or a
+   sky full of falling letters — are sharing about 390px of height, and width
+   alone would happily spend all of it.
+
+   **The cap is the real thing's measurement, not a taste.** Key pitch on
+   every full-size keyboard a child will ever meet is 19.05mm — three quarters
+   of an inch, which CSS defines as exactly 72px, which is 4.5rem. That is the
+   number, and it is written in rem rather than in `mm` (identical lengths,
+   since CSS pins an inch to 96px) so that a child who has turned their text
+   up gets a board that grew with everything else.
+
+   Why it matters that this is life-size rather than merely large: the board
+   is not an illustration of a keyboard, it is a map a child glances at while
+   their hands are on the actual one. A map at half scale asks them to do the
+   scaling — to see that the gap between `f` and `j` on screen is the gap
+   their two index fingers are already holding — and that translation is
+   exactly the work looking down at their hands would have saved them. At
+   pitch, the picture and the plastic are the same shape, so the glance costs
+   nothing and the reach it teaches is the reach they make.
+
+   It was capped at 2.4rem — about half pitch — until this, which on any
+   laptop drew a keyboard the size of a phone in the middle of an empty half
+   screen. On a laptop the room was simply there, in the passage row that
+   gives (`minmax(0, 1fr)`); on a shorter window it was not, which is what the
+   passage screen's own height term below is for.
 
    It lived on `.keyboard` until Hailstorm, which positions falling letters in
    key units in the sky ABOVE the board (docs/typing.md §8.2): a custom
@@ -1896,8 +1917,42 @@ label.segmented__btn {
    the slot (decision 36). One declaration, and both halves of that stay
    true at every size. */
 :root {
-  --key: clamp(1.05rem, min(5.6vw, 9dvh), 2.4rem);
+  --key: clamp(1.05rem, min(6vw, 9dvh), 4.5rem);
   --key-gap: calc(var(--key) * 0.09);
+}
+
+/* …and one extra term on the passage screen: what is left after the words.
+
+   `9dvh` is a FRACTION of the viewport, and what the board is competing with
+   here is not a fraction. The HUD, the pass bars or the ghost lane, the line
+   you type on, four grid gaps and the race's own padding come to about 365px
+   at every height — they are type and borders, and none of them grows with
+   the window — and two lines of passage left to read is another 60. A dvh
+   coefficient that clears 425px of that at an 850px viewport does not clear
+   it at 700, which is how the board could grow the PAGE: `.race` is
+   `min-height`, so a grid whose rows stop fitting simply gets taller, and a
+   race that scrolls under a child's thumb mid-word is the exact thing that
+   `min-height` is there to prevent. At half pitch the ceiling hid this —
+   a 2.4rem board fitted anywhere, so the dvh term was never the governor it
+   looked like.
+
+   So the height term is a subtraction, not a proportion: take the constant
+   off the viewport and divide by the board's own height in key units — five
+   rows and the four gaps between them, `5 + 4 × 0.09`. The board is handed
+   what is actually left rather than a guess at it.
+
+   This is a second declaration of `--key`, which the note above rules out —
+   and it is not the one it rules out. What the storm may never do is let a
+   falling letter's lane and the cap it names come from two numbers. The
+   passage screen has no lanes: the board is the only thing on it that reads
+   `--key` at all, and a screen only ever sees one of these two values. There
+   is nothing here left to disagree.                                       */
+.race.typing {
+  --key: clamp(
+    1.05rem,
+    min(6vw, 9dvh, calc((100dvh - var(--ad-h) - 26.5rem) / 5.36)),
+    4.5rem
+  );
 }
 
 .keyboard {
@@ -1913,6 +1968,37 @@ label.segmented__btn {
      should not offer to copy the letter `f`. */
   pointer-events: none;
   user-select: none;
+}
+
+/* A board at pitch is wider than the column it sits in, and is allowed to be.
+
+   `.race` is `min(720px, 100%)` because that is a comfortable measure for the
+   things above it — a clock, a rival's gap, a line of words to read. A
+   life-size keyboard is 1080px, and squeezing it back into 720 would be
+   letting a column width that exists for reading decide the size of a piece
+   of hardware. So it doesn't: the board is centred on its grid area and
+   overflows it evenly on both sides, which is also how the desk it is a
+   picture of is arranged — a screen, and a wider keyboard underneath it.
+
+   The centring is arithmetic rather than an alignment property, because
+   neither alignment property survives the overflow. `margin-inline: auto` is
+   defined to resolve to ZERO against negative free space, so the board would
+   hug the left edge of the column and hang off the right; `justify-self:
+   center` is start-aligned by Chrome for the same overflowing item, measured
+   rather than assumed. Half the column minus half the board is the one
+   expression that means the same thing in both directions — a positive margin
+   on a phone where the board still fits inside the column, the same number
+   negative on a laptop where it doesn't.
+
+   Nothing ends up off screen, because `--key` is capped by `6vw` first: the
+   widest the board can be is 90vw, whatever the column underneath it says.
+
+   The storm is not scoped in here on purpose. Its board is already centred in
+   a full-width field, so it has nothing to break out of, and `.storm__sky`
+   centres itself at the same fifteen units by the same `margin-inline: auto`
+   — a lane and its cap stay one column of the screen (§8.2).             */
+.typing .keyboard {
+  margin-inline: calc(50% - 7.5 * var(--key));
 }
 
 .keyboard__row {


### PR DESCRIPTION
## The problem

`--key` was capped at `2.4rem` — about half a real key — so on any laptop the typing board rendered **576×206px** in the middle of a half-empty screen.

A map at half scale asks a child to do the scaling: to see that the gap between `f` and `j` on screen is the gap their two index fingers are already holding. That translation is exactly the work that looking down at their hands would have saved them.

## The change

The ceiling is now **key pitch — 19.05mm**, three quarters of an inch, which CSS defines as 72px, which is `4.5rem`. Written in `rem` rather than `mm` (identical lengths, since CSS pins an inch to 96px) so a child who has turned their text up gets a board that grew with it.

Three things had to give for the real number to fit:

- **The `vw` term**, 5.6 → 6, so fifteen units are 90% of a narrow viewport rather than 84%. On a phone and a portrait tablet the width still decides and the ceiling is never reached.
- **The race column.** `.race` is `min(720px, 100%)` because that is a measure for reading a line of words, and a keyboard is not read — so the board centres on `calc(50% - 7.5 * var(--key))` and overflows it evenly, which is also how the desk it depicts is arranged. Not `margin-inline: auto`, which is *defined* to resolve to zero against negative free space, and not `justify-self: center`, which Chrome start-aligns for an overflowing grid item. Both measured in the browser, not assumed.
- **A height term on the passage screen.** This one wasn't visible before: the HUD, the pass bars, the line you type on, four gaps and the padding cost a *constant* ~365px, so a `dvh` fraction that cleared them at an 850px viewport did not at 700 — and `.race` is `min-height`, so the board grew the **page** instead of itself and the race started to scroll. `.race.typing` now subtracts that constant and divides by the board's own height in key units, read out of `--key-gap` so a chunkier keycap moves the budget with it.

## Sizes

| viewport | before | after |
| --- | --- | --- |
| 1512×850 laptop | 576×206 | **1080×386** |
| 1024×700 window | 576×206, page scrolled 25px | 772×279, no scroll |
| 820×1180 tablet | 576×206 | 738×264 |
| 390×844 phone | 328×117 | 351×125 |
| 844×390 landscape | hidden (unchanged) | hidden (unchanged) |

## Hailstorm

It gets the bigger board too, because `--key` is one dial (decision 37) and a storm's gun is the same picture as a lesson's map. It pays in sky — about 600px of fall down to about 430px on a laptop — which is the trade §8.2 already names: *the board is the gun, so the sky is what shrinks.* The fall is timed rather than distance-based (`--drop` is `progressAt`), so a letter is on screen for exactly as long as its spec says either way.

## One guard test was widened

`StormField.test.tsx` pinned `--key` to exactly one declaration. The invariant it defends is that a falling letter's lane and the cap it names never come from two numbers — so the storm's own block still may not declare it, and the count is still pinned. The passage screen has no lanes, and the board is the only thing on it that reads `--key` at all.

Two new tests in `Keyboard.test.tsx` pin the pitch ceiling and the centring expression.

## Validation

`type-check`, `lint`, `build`, 2162 unit tests and the full `test:smoke` run all pass — including the shield zones, which now read edge-to-edge at 96.8→1176.8. Driven in Chromium across nine viewports on all three screens (lesson, free-play race, Hailstorm): no horizontal or vertical scroll anywhere, board centred everywhere.

Docs: `docs/typing.md` §4.7 and decisions 61–63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)