### PR TITLE
Take the keyboard off the hailstorm, and give the sky back

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -21,9 +21,10 @@ Three things get built, in this order:
 | **STORM**  | Hailstorm — the falling-letter game                       | §8          |
 
 The order is not arbitrary: the lessons need the keyboard because half of them
-turn it on or off deliberately, and the game needs it because in the game the
-keyboard _is_ the weapon and a key's horizontal position _is_ the lane a letter
-falls down. KEY is a dependency of both, and shippable on its own — dropped
+turn it on or off deliberately, and the game needs the same model because a
+key's horizontal position _is_ the lane a letter falls down — the storm draws
+no keyboard at all (decision 64), but every lane and every shield segment in it
+is a reading of the same table. KEY is a dependency of both, and shippable on its own — dropped
 under today's passage it makes today's typing game better with nothing else
 changed.
 
@@ -332,7 +333,8 @@ different product — a hunt-and-peck trainer — and building it would undo the
 whole point.
 
 Hailstorm is the exception that cannot be papered over: it needs raw key
-events and there is no software keyboard on screen during it. See §8.8.
+events, it draws no board of its own (decision 64), and there is no software
+keyboard on screen during it either. See §8.8.
 
 ### 4.6 · Colour
 
@@ -405,14 +407,17 @@ Three things had to give for the real number to fit:
   lanes. The board is the only thing on it that reads `--key` at all, and a
   screen only ever sees one of the two values.
 
-Hailstorm needs none of the three — its field is already full width, and the
-sky is the flexible track that absorbs whatever the board takes — but it gets
-the bigger board, because `--key` is one dial (decision 37) and a storm's gun is
-the same picture as a lesson's map. What it costs is sky: on a 1512×850 laptop
-the field goes from about 600px of fall to about 430px. That is the trade §8.2
-already names — the board is the gun, so the sky is what shrinks — and the fall
-is timed rather than distance-based (`--drop` is `progressAt`), so a letter is
-on screen for exactly as long as its spec says either way.
+Hailstorm needs none of the three, and briefly wanted none of them: it drew the
+same board at the same pitch for one release, which cost it about 45% of its
+height and took the fall from roughly 600px to 430px on a laptop. The answer
+turned out not to be a smaller keyboard but no keyboard (§8.2, decision 64), so
+the storm's own dial is the root value above and its only readers are lanes,
+hailstones and shield segments.
+
+It keeps the same 4.5rem ceiling for the same reason the board has it, which is
+worth being explicit about since there is no keycap left to measure: a lane
+claims to be **where that key is**, so a field wider than a keyboard would be
+teaching a reach nobody's hand makes.
 
 ---
 
@@ -1082,13 +1087,14 @@ practice, which is exactly what a child needs and exactly what a child will not
 do. Hailstorm is how those forty lessons stay survivable — and it is not a
 bribe stapled on the side, because the thing it drills is real:
 
-- It forces **eyes up**. The letters are at the top of the screen; the keyboard
-  is not. You cannot look down and see what is coming.
+- It forces **eyes up**. The letters are at the top of the screen and there is
+  no keyboard drawn anywhere on it (decision 64), so there is nothing to look
+  down at that will tell you where a key is.
 - It drills **single-key reaction** rather than word rhythm, which is the one
   thing the passage lessons cannot exercise.
 - It shows you **which finger is weak** as a hole in your own defences (§8.5).
 
-### 8.2 · The field is the keyboard
+### 8.2 · The field is the keyboard, and draws none
 
 A letter falls down **the column of the key that produces it**. `f` falls onto
 `f`. `y` falls between `g` and `h`, because that is where `y` is.
@@ -1099,17 +1105,35 @@ is, given a second or two before it has to be found — so the game is not merel
 themed around a keyboard, it is _teaching the layout geometrically_ the entire
 time it is being played.
 
-The keyboard component sits at the bottom of the field, lit by the same
-`useKeyEcho` the lessons use. It is literally the gun.
+**And there is no keyboard drawn on this screen** (decision 64). The field had
+one at the bottom until #197 — the same component the lessons put under the
+passage, lit by the same `useKeyEcho`, and it was called the gun. It went for
+the reason §8.1 gives for the whole mode existing: a storm is the exam for the
+forty lessons that taught the layout, and a picture of the keyboard on the exam
+is the answer sheet. The quickest way to shoot a falling `y` becomes reading
+the board for where `y` is, which is hunt-and-peck with a countdown on it.
 
-Lanes are key units, not pixels, so the field and the board scale together off
-one `--key` custom property — **declared once, at the root**. It lived on
-`.keyboard` until the field was built, and could not stay there: a custom
+What is left at the bottom is the shield, and it is a better teacher for being
+the only thing there: eight finger zones rather than forty-odd keys, so what a
+child watches crumble is a **finger** (§8.5). The lane still says which key;
+the zone under it still says which finger.
+
+It bought the fall, too. The board was five rows of keycaps at real pitch
+(§4.7) and it was taking about 45% of the height from the only track that gives
+— so on a 1512×850 laptop the sky went from about 430px to about 720px, on the
+screen whose entire job is giving a child time to read a letter and find its
+key.
+
+Lanes are key units, not pixels, so the stones and the shield scale together
+off one `--key` custom property — **declared once, at the root**. It lived on
+`.keyboard` while the field had one, and could not stay there: a custom
 property inherits downwards only, so a value declared on the board is a value
 the sky above it cannot read. The alternative was a second clamp with the same
 numbers in the storm's own block, which is precisely the drift this is supposed
-to rule out — a lane and the cap it names, free to disagree about how wide a
-key is (decision 37).
+to rule out — a lane and the segment it lands on, free to disagree about how
+wide a key is (decision 37). The root value is now the storm's alone; the
+passage screen overrides it, because that screen has a board to budget height
+for and this one has nothing under the sky (§4.7).
 
 They scale off it differently, though, and the difference had to be resolved
 rather than inherited. `keyX` returns the centre of a key's **slot**, while the
@@ -1140,13 +1164,23 @@ Sub-pixel, and therefore worth being explicit about what it is not: this is not
 a fudge factor found by nudging until it looked right. It is the difference
 between two positions the stylesheet computes, and `StormField.test.tsx`
 computes both of them the way a browser would — reading the field's `left` and
-the board's `left` and `width` out of `game.css` and evaluating them with
+the keycap's `left` and `width` out of `game.css` and evaluating them with
 `--key` as the unit. `stoneCentre` and `capCentre` come out equal to ten
 decimal places, and stop being equal the moment either declaration moves
 without the other: inset the caps by `var(--key-gap) * 2` and the test fails by
-the half gap the lane no longer matches, rather than the board quietly drifting
-1.7px off every letter. In key units, so nothing here can be satisfied by a
-pixel that happened to round the right way at one size.
+the half gap the lane no longer matches, rather than the lanes quietly drifting
+off every letter. In key units, so nothing here can be satisfied by a pixel that
+happened to round the right way at one size.
+
+That the storm no longer DRAWS those caps does not retire the check, and this is
+the one place worth saying why. The correction exists because a lane is a slot
+centre and the eight shield segments step back by the same half gap (§8.5) — so
+the two claims that have to stay true are that a lane and its segment share the
+offset, and that both are still the geometry a keycap would have had. The board
+under the passage is drawn from the same declarations, so the arithmetic is
+live either way, and the browser-level check in `e2e/smoke.mjs` now asks the
+question the storm can still answer: that the eight segments tile the field
+edge to edge, with no gap for a letter to fall through unjudged.
 
 ### 8.3 · A wave, from a seed
 
@@ -1274,18 +1308,19 @@ the run ends, the screen says which finger let it through, and offers a drill
 of exactly the keys that zone covers — which is the trouble-facts machinery
 already in `records.ts`, pointed at a different question.
 
-**The ending is a screen, and it stands where the board stood** (decision 47).
-`.storm` is two tracks — a sky that gives and a board that never does — so the
-panel takes the board's, because the board is the gun and the gun is dead. That
-is what leaves the sky whole: the hail frozen where the clock stopped, and the
-shield with the hole still open under the finger being named. Drawn over the
-sky it would have covered the one picture that explains its own sentence, and
-added as a third row it would have taken the space out of the sky instead —
-which on a short viewport is the whole of it (§8.2). The gun stops listening
-with the run for the same reason: `Space` and `Enter` are keys this board
-carries, and a dead gun that went on swallowing them would leave a child on the
-keyboard unable to press the buttons that replaced it — three after a breach,
-two after a cleared wave, and on every ending the only way off this screen.
+**The ending is a screen, and it stands under the sky** (decision 47). `.storm`
+is two tracks — a sky that gives and a second one that is empty while a wave is
+falling — so the panel is the only thing this screen ever puts below the sky.
+That is what leaves the sky whole: the hail frozen where the clock stopped, and
+the shield with the hole still open under the finger being named. Drawn over
+the sky it would have covered the one picture that explains its own sentence,
+and there is nothing else in that track to displace — the board that used to
+stand there is gone (decision 64), which is why an ending taller than five rows
+of keycaps no longer costs the sky anything. The gun stops listening with the
+run: `Space` and `Enter` are keys it swallows, and a dead gun that went on
+swallowing them would leave a child on the keyboard unable to press the buttons
+that replaced it — three after a breach, two after a cleared wave, and on every
+ending the only way off this screen.
 
 What it concludes is decided in `stormReport(state)` and rendered in
 `StormOver`, which holds no rules at all:
@@ -1343,13 +1378,15 @@ at 3.25 on the bottom row, and a vertical seam can honour one of the four. The
 home row wins because it is the row the hands are ON: `a s d f` and `j k l ;`
 is where the fingers rest and what every reach returns to, so "your right ring
 finger" and "the column over `l`" are the same sentence to the child being told
-it. The eight spans tile the board exactly — 2.75 + 1 + 1 + 2 + 2 + 1 + 1 +
-4.25 = 15 — which is what makes a hole a gap in a wall rather than a dark patch
-beside one. Every other row is then off by the stagger and no further: a lane
-is never more than a quarter unit outside its own segment, which
-`keyboard.test.ts` pins at exactly that. `6` is the case to know — right index,
-but a quarter unit left of where the right index's segment starts, because that
-is where `6` really is.
+it. The eight spans tile the full fifteen units exactly — 2.75 + 1 + 1 + 2 + 2
+
+- 1 + 1 + 4.25 = 15 — which is what makes a hole a gap in a wall rather than a
+  dark patch beside one, and what `e2e/smoke.mjs` checks in real pixels now that
+  there are no keycaps under it to measure against. Every other row is then off by the stagger and no further: a lane
+  is never more than a quarter unit outside its own segment, which
+  `keyboard.test.ts` pins at exactly that. `6` is the case to know — right index,
+  but a quarter unit left of where the right index's segment starts, because that
+  is where `6` really is.
 
 The segments take the same half-`--key-gap` step back the lanes do (§8.2), so a
 seam falls in the gutter between two keycaps instead of down the middle of one
@@ -1425,16 +1462,25 @@ The score is allowed to go negative, and is drawn negative. It is the run's own
 number, it ends with the run, and a floor on it would be the game declining to
 say what just happened.
 
-**A stroke at an empty sky is a miss (§8.4), and the board says so**
-(decision 43). That needed deciding rather than inheriting: with nothing in the
-air there is no expected character, and `useKeyEcho` marks nothing wrong when
-nothing is expected — so every key would have lit `--lime` for "that was
-right" while the score fell by ten. The field passes `emptyIsWrong`, which
-turns the echo's "nothing to judge" into "nothing that could be right", and
-every key flares. It is unconditional because the board is: a run with an
-ending has handed the board's place to the ending screen (§8.5, decision 47),
-so there is no keyboard left to mark a child's keys against a letter nothing
-can shoot.
+**A stroke at an empty sky is a miss (§8.4), and the score says so**
+(decision 43). It costs ten points and the streak like any other miss, and what
+shows it is the `--flare` wash over the score — one per miss, throttled so a
+hammering hand cannot strobe it (decision 57).
+
+This used to be the board's job and was the sharper signal: the key under the
+child's own finger went red, which named the mistake where the mistake was
+made. Getting it right there needed a flag, because with nothing in the air
+there is no expected character and `useKeyEcho` marks nothing wrong when
+nothing is expected — so every key would have lit `--lime` for "that was right"
+while the score fell by ten. The field passed `emptyIsWrong` to turn the echo's
+"nothing to judge" into "nothing that could be right".
+
+The board went with decision 64 and the flag went with it, because the storm was
+its only caller and a lesson never wanted it: the beat between two words is not
+a mistake. What is lost is real and was weighed — a wash over a number is a
+quieter answer than a red key — and the trade is §8.1's: on the screen that is
+supposed to make a child find a key without being shown one, a board that
+flares is still a board.
 
 **Key auto-repeat is not a shot** (decision 44). A held key repeats about
 thirty times a second, and a gun that fired on it would let a child spray by
@@ -1446,9 +1492,12 @@ list.
 
 The HUD lives **inside the sky**, absolutely positioned over it and painted
 behind the stones (decision 45). `.storm` is a two-track grid whose only
-flexible track is the sky, and the sky is down to a few dozen pixels on a short
-viewport (§8.2) — so a HUD row would come out of the one thing with nothing
-left to give. It carries the two numbers a live run keeps and no more: what a
+flexible track is the sky, so a HUD row is height taken from the one thing that
+gives. That was near-fatal when a board stood under the sky and left it a few
+dozen pixels on a short viewport; with the board gone (decision 64) the sky is
+the whole field and the pressure is off — but the reasoning is unchanged and so
+is the HUD, because a row of its own would still be the fall paying for it, and
+the numbers are readable over a sky that is mostly empty by design. It carries the two numbers a live run keeps and no more: what a
 run PAID is the ending screen's line (§8.5), where there is room to put it
 beside the finger that let the storm through.
 
@@ -1703,11 +1752,17 @@ Neither an empty `tick` nor a missed `fire` returns the object it was handed,
 so `===` on the state says "changed" sixty times a second and means nothing.
 What React is re-rendered for is every field of a `StormState` except the
 clock and the wave — `resolved`, `shield`, `combo`, `score`, `misses` and
-`ending` — plus the two things the clock alone moves: a letter appearing,
-which no field records because it is a time crossing, and the target changing,
-which two letters at different speeds can do mid-air with nothing happening at
-all (decision 32). Miss that second one and the board goes on marking a child's
-keys against a letter that is no longer the lowest. The wave is the field left
+`ending` — plus the one thing the clock alone moves: a letter appearing, which
+no field records because it is a time crossing.
+
+The target changing was the second (decision 32), which two letters at
+different speeds can do mid-air with nothing else happening at all, and missing
+it left the board marking a child's keys against a letter that was no longer
+the lowest. With the board gone (decision 64) nothing on this screen is a
+function of which letter is the target — a stone carries no target class and
+the HUD does not name it — so the crossing changes no picture and is no longer
+a redraw. `redrawn` stopped comparing it, and `useStormClock.test.ts` pins that
+it does not. The wave is the field left
 out on purpose: it is fixed for the life of a run, so it cannot change under a
 running loop, and a screen handed a different wave is a different run — which
 the effect notices for itself, starting the new storm from zero rather than
@@ -1881,15 +1936,16 @@ doors, and they are two because neither reaches everyone:
   matter are the low ones. It is the one thing in the sky that gets
   `pointer-events` back, because the sky refuses them so that a drag cannot
   select a hailstorm and a tap cannot land on a letter. It goes when the gun
-  does: after an ending the panel standing where the board did carries the way
-  out (§8.5), and two exits on one screen are two answers to one question.
+  does: after an ending the panel under the sky carries the way out (§8.5), and
+  two exits on one screen are two answers to one question.
 - **`Escape`** (decision 55), because the button cannot be tabbed to: `Tab` is
-  a key the board carries and the gun swallows it while the run is live. It is
+  a key the LAYOUT carries — `KEY_ROWS`, not a picture; this screen draws no
+  keyboard (decision 64) — and the gun swallows it while the run is live. It is
   taken inside the gun's own listener and **before the trigger** — every other
   keydown while a run is live is a shot, so a way out handled by a second
   listener beside it would still be fired at as a miss on the way past, and a
   child reaching for the door would be charged ten points and their streak for
-  reaching. `Escape` is the key to spend on it precisely because the board does
+  reaching. `Escape` is the key to spend on it precisely because the layout does
   not carry it: `keyX` says so, which is also what keeps it out of the
   `preventDefault` and out of every letter a wave can draw.
 
@@ -1913,7 +1969,7 @@ hidden would look identical from the outside — and the count does not move.
 
 Because the way out lives in the HUD, the sky is no longer `aria-hidden` as a
 whole. The attribute sits on each of its churning parts instead — the two HUD
-numbers, every stone, the shield — for the reason the board carries one (§4.4).
+numbers, every stone, the shield — for the reason a board carries one (§4.4).
 A screen whose only exit sat inside a hidden subtree would be a trap for
 exactly the child least able to get out of it.
 
@@ -1995,71 +2051,72 @@ which is what every run saved before this is.
 
 ## 11 · Decisions, recorded
 
-|     | Decision                                                                                     | Because                                                                                                                                           |
-| --- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | The keyboard layout is engine, not view                                                      | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture                                             |
-| 2   | `code`, not `key`                                                                            | Shift+`4` produces `$` and there is no `$` key to light up                                                                                        |
-| 3   | Keys release on a timer, not `keyup`                                                         | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                                                                   |
-| 4   | The board is `aria-hidden`                                                                   | Sixty announcing spans is not accessibility; the passage already carries the state                                                                |
-| 5   | The visual keyboard is never tappable                                                        | A tappable board is a hunt-and-peck trainer, which is the thing this is against                                                                   |
-| 6   | Lesson text is generated, not written                                                        | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                                                               |
-| 7   | The lexicon must not be reachable from `decks/index.ts`                                      | The same import took the shared chunk 46 KB → 222 KB once already                                                                                 |
-| 8   | Ghost identity is the lesson, not the passage                                                | Every run generates different words; keying on them buckets every run alone                                                                       |
-| 9   | Three pass bars, not one score                                                               | A single number says you failed; three say what to fix                                                                                            |
-| 10  | Accuracy is flat and high; speed scales                                                      | An accuracy bar you can hammer past teaches hammering                                                                                             |
-| 11  | The speed bar dips when a key arrives                                                        | You have just got slower and you should have                                                                                                      |
-| 12  | The new-key gate                                                                             | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                                                                |
-| 13  | Per-key stats come from cards, not keystrokes                                                | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven                                               |
-| 14  | Progress is derived, never stored                                                            | No migration, self-heals when criteria change, cannot disagree with the record book                                                               |
-| 15  | Unlock is `max(cleared) + 1`                                                                 | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                                                                   |
-| 16  | Any checkpoint, any time                                                                     | It is a placement test, a skip-ahead and an ordering rule in one sentence                                                                         |
-| 17  | A lesson has no ghost and no time penalty                                                    | A penalty double-counts accuracy and makes the wpm number a lie                                                                                   |
-| 18  | Hailstorm is a route in the typing island                                                    | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard                                          |
-| 19  | Letters fall down their key's column                                                         | The lane is a spatial hint — the game teaches the layout the whole time it is played                                                              |
-| 20  | Only the lowest letter can be shot                                                           | Otherwise spraying the keyboard is a winning strategy                                                                                             |
-| 21  | The shield is eight finger zones                                                             | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise                                                 |
-| 22  | Score can fall, XP cannot                                                                    | XP is cumulative across years and four games; a bad five minutes must not lower a level                                                           |
-| 23  | A Hailstorm run is a `Session`                                                               | Record book, XP, badges and the drill builder all work with no new code                                                                           |
-| 24  | Hailstorm never gates the ladder                                                             | A tablet has no keys, and a reward that blocks you is not a reward                                                                                |
-| 25  | DOM, not canvas                                                                              | Eleven custom properties change the whole app's biome; a canvas is a hole in that                                                                 |
-| 26  | US ANSI only, and say so                                                                     | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                                                                     |
-| 27  | A lesson's keyboard seeds; it does not overrule                                              | All hundred name a mode, so an override beats the player's own setting on every rung                                                              |
-| 28  | `eyes-up` reads the board the run was typed under                                            | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory                                                |
-| 29  | `unbroken` is gated on the wave having a length                                              | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete                                           |
-| 30  | A falling letter is on the field on `[spawn, land)`                                          | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two                                               |
-| 31  | A letter carries its key, finger and lane                                                    | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift                                                |
-| 32  | The target is the greatest fall progress, not `landMs`                                       | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen                                                    |
-| 33  | An exact tie goes to the earlier spawn                                                       | The index is the letter's identity, so a replay resolves the same dead heat the same way                                                          |
-| 34  | A repair never lifts a zone above `spec.shield`                                              | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                                                          |
-| 35  | A tick resolves every landing inside it                                                      | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's                                                     |
-| 36  | The field's lanes step back half a `--key-gap`                                               | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference                                        |
-| 37  | `--key` is declared once, at the root                                                        | It lived on the board, which the field above it cannot read — and a second clamp is two ideas of a key                                            |
-| 38  | A frame is clamped to 100ms of wave time                                                     | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield                                            |
-| 39  | The loop writes `--drop`; the stylesheet owns the fall                                       | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either                                         |
-| 40  | The field re-renders on the picture, not on the frame                                        | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal                                              |
-| 41  | A shield segment is its finger's home-row span                                               | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on                                       |
-| 42  | A tint is an element keyed by a counter, not a class                                         | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe                                         |
-| 43  | A stroke at an empty sky flares the whole board                                              | It costs ten points and the streak, and a key that costs a child points must not light `--lime`                                                   |
-| 44  | Key auto-repeat is not a shot                                                                | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                                                         |
-| 45  | The HUD is drawn inside the sky, not as a row of its own                                     | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give                                                    |
-| 46  | A wrong key costs score; a letter through costs shield                                       | One failure, one cost — the landing has already taken the thing that ends runs                                                                    |
-| 47  | The ending stands where the board did                                                        | The gun is dead, and the sky it leaves whole is the shield with the hole in it that the sentence is about                                         |
-| 48  | A storm's cards are its letters, not its keystrokes                                          | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both                                         |
-| 49  | A letter that got through is a `timedOut` card                                               | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped                                          |
-| 50  | A storm has no ghost and holds no record                                                     | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it                                                |
-| 51  | A retry is a new run, so it is a remount                                                     | The finish guard, the history snapshot and the clock all have to start again; one instance is one run                                             |
-| 52  | Fall time has a floor, in the generator                                                      | The twenty specs are a table, and a table gets tightened a row at a time until a level nobody can read ships                                      |
-| 53  | A keystroke proves a keyboard; the pointer only guesses                                      | Every proxy is wrong about somebody, and wrongly shut is a child locked out where wrongly open is a dud tile                                      |
-| 54  | The quit sheet is the storm's pause                                                          | A wave falling behind it would break a shield while a child read "it won't be saved"                                                              |
-| 55  | `Escape` leaves, and is taken before the trigger                                             | Every other key while a run is live is a shot, so a way out on a second listener would cost ten points                                            |
-| 56  | A storm level cannot name its own keys                                                       | The row holds a `WaveSpec` minus `keys`, so the pool can only be `unlockedAt(n)` and reachability is structural                                   |
-| 57  | The miss flash has a floor, in the reducer                                                   | A zone's tint rate is the schedule's and the specs keep it; a wrong key's is a hand's, and no spec can                                            |
-| 58  | A storm's seed is the level's, not the visit's                                               | A level is the same weather twice, and the twenty waves measured for strobe are the twenty a child meets                                          |
-| 59  | A lesson is cleared only by a run that says it is that lesson                                | A drill files under the lesson's mode, so mode alone would let practising a lesson clear it                                                       |
-| 60  | A storm's brief is its own screen                                                            | Three bars, a best and a keyboard control are three things a storm does not have, and it has three of its own                                     |
-| 61  | The board is drawn at 19.05mm key pitch                                                      | It is a map read while the hands are on the real thing; at half scale the child does the scaling, which is the work looking down would have saved |
-| 62  | The board may overflow the 720px race column                                                 | 720px is a reading measure and a keyboard is not read; a screen with a wider keyboard under it is the desk it depicts                             |
-| 63  | The passage screen's `--key` subtracts its chrome rather than taking a share of the viewport | The HUD, the bars and the line you type on are a constant, so a dvh fraction that fits at 850px of viewport grows the page at 700                 |
+|     | Decision                                                                                     | Because                                                                                                                                                       |
+| --- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | The keyboard layout is engine, not view                                                      | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture                                                         |
+| 2   | `code`, not `key`                                                                            | Shift+`4` produces `$` and there is no `$` key to light up                                                                                                    |
+| 3   | Keys release on a timer, not `keyup`                                                         | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                                                                               |
+| 4   | The board is `aria-hidden`                                                                   | Sixty announcing spans is not accessibility; the passage already carries the state                                                                            |
+| 5   | The visual keyboard is never tappable                                                        | A tappable board is a hunt-and-peck trainer, which is the thing this is against                                                                               |
+| 6   | Lesson text is generated, not written                                                        | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                                                                           |
+| 7   | The lexicon must not be reachable from `decks/index.ts`                                      | The same import took the shared chunk 46 KB → 222 KB once already                                                                                             |
+| 8   | Ghost identity is the lesson, not the passage                                                | Every run generates different words; keying on them buckets every run alone                                                                                   |
+| 9   | Three pass bars, not one score                                                               | A single number says you failed; three say what to fix                                                                                                        |
+| 10  | Accuracy is flat and high; speed scales                                                      | An accuracy bar you can hammer past teaches hammering                                                                                                         |
+| 11  | The speed bar dips when a key arrives                                                        | You have just got slower and you should have                                                                                                                  |
+| 12  | The new-key gate                                                                             | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                                                                            |
+| 13  | Per-key stats come from cards, not keystrokes                                                | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven                                                           |
+| 14  | Progress is derived, never stored                                                            | No migration, self-heals when criteria change, cannot disagree with the record book                                                                           |
+| 15  | Unlock is `max(cleared) + 1`                                                                 | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                                                                               |
+| 16  | Any checkpoint, any time                                                                     | It is a placement test, a skip-ahead and an ordering rule in one sentence                                                                                     |
+| 17  | A lesson has no ghost and no time penalty                                                    | A penalty double-counts accuracy and makes the wpm number a lie                                                                                               |
+| 18  | Hailstorm is a route in the typing island                                                    | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard                                                      |
+| 19  | Letters fall down their key's column                                                         | The lane is a spatial hint — the game teaches the layout the whole time it is played                                                                          |
+| 20  | Only the lowest letter can be shot                                                           | Otherwise spraying the keyboard is a winning strategy                                                                                                         |
+| 21  | The shield is eight finger zones                                                             | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise                                                             |
+| 22  | Score can fall, XP cannot                                                                    | XP is cumulative across years and four games; a bad five minutes must not lower a level                                                                       |
+| 23  | A Hailstorm run is a `Session`                                                               | Record book, XP, badges and the drill builder all work with no new code                                                                                       |
+| 24  | Hailstorm never gates the ladder                                                             | A tablet has no keys, and a reward that blocks you is not a reward                                                                                            |
+| 25  | DOM, not canvas                                                                              | Eleven custom properties change the whole app's biome; a canvas is a hole in that                                                                             |
+| 26  | US ANSI only, and say so                                                                     | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                                                                                 |
+| 27  | A lesson's keyboard seeds; it does not overrule                                              | All hundred name a mode, so an override beats the player's own setting on every rung                                                                          |
+| 28  | `eyes-up` reads the board the run was typed under                                            | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory                                                            |
+| 29  | `unbroken` is gated on the wave having a length                                              | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete                                                       |
+| 30  | A falling letter is on the field on `[spawn, land)`                                          | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two                                                           |
+| 31  | A letter carries its key, finger and lane                                                    | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift                                                            |
+| 32  | The target is the greatest fall progress, not `landMs`                                       | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen                                                                |
+| 33  | An exact tie goes to the earlier spawn                                                       | The index is the letter's identity, so a replay resolves the same dead heat the same way                                                                      |
+| 34  | A repair never lifts a zone above `spec.shield`                                              | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                                                                      |
+| 35  | A tick resolves every landing inside it                                                      | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's                                                                 |
+| 36  | The field's lanes step back half a `--key-gap`                                               | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference                                                    |
+| 37  | `--key` is declared at the root, once per screen                                             | It lived on the board, which the field above it cannot read — and two clamps inside one screen are two ideas of a key                                         |
+| 38  | A frame is clamped to 100ms of wave time                                                     | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield                                                        |
+| 39  | The loop writes `--drop`; the stylesheet owns the fall                                       | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either                                                     |
+| 40  | The field re-renders on the picture, not on the frame                                        | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal                                                          |
+| 41  | A shield segment is its finger's home-row span                                               | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on                                                   |
+| 42  | A tint is an element keyed by a counter, not a class                                         | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe                                                     |
+| 43  | A stroke at an empty sky is a miss, and the score says so                                    | It costs ten points and the streak; with the board gone the `--flare` wash over the score is what shows it                                                    |
+| 44  | Key auto-repeat is not a shot                                                                | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                                                                     |
+| 45  | The HUD is drawn inside the sky, not as a row of its own                                     | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give                                                                |
+| 46  | A wrong key costs score; a letter through costs shield                                       | One failure, one cost — the landing has already taken the thing that ends runs                                                                                |
+| 47  | The ending stands in the track under the sky                                                 | The sky it leaves whole is the frozen hail and the shield with the hole in it that the sentence is about                                                      |
+| 48  | A storm's cards are its letters, not its keystrokes                                          | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both                                                     |
+| 49  | A letter that got through is a `timedOut` card                                               | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped                                                      |
+| 50  | A storm has no ghost and holds no record                                                     | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it                                                            |
+| 51  | A retry is a new run, so it is a remount                                                     | The finish guard, the history snapshot and the clock all have to start again; one instance is one run                                                         |
+| 52  | Fall time has a floor, in the generator                                                      | The twenty specs are a table, and a table gets tightened a row at a time until a level nobody can read ships                                                  |
+| 53  | A keystroke proves a keyboard; the pointer only guesses                                      | Every proxy is wrong about somebody, and wrongly shut is a child locked out where wrongly open is a dud tile                                                  |
+| 54  | The quit sheet is the storm's pause                                                          | A wave falling behind it would break a shield while a child read "it won't be saved"                                                                          |
+| 55  | `Escape` leaves, and is taken before the trigger                                             | Every other key while a run is live is a shot, so a way out on a second listener would cost ten points                                                        |
+| 56  | A storm level cannot name its own keys                                                       | The row holds a `WaveSpec` minus `keys`, so the pool can only be `unlockedAt(n)` and reachability is structural                                               |
+| 57  | The miss flash has a floor, in the reducer                                                   | A zone's tint rate is the schedule's and the specs keep it; a wrong key's is a hand's, and no spec can                                                        |
+| 58  | A storm's seed is the level's, not the visit's                                               | A level is the same weather twice, and the twenty waves measured for strobe are the twenty a child meets                                                      |
+| 59  | A lesson is cleared only by a run that says it is that lesson                                | A drill files under the lesson's mode, so mode alone would let practising a lesson clear it                                                                   |
+| 60  | A storm's brief is its own screen                                                            | Three bars, a best and a keyboard control are three things a storm does not have, and it has three of its own                                                 |
+| 61  | The board is drawn at 19.05mm key pitch                                                      | It is a map read while the hands are on the real thing; at half scale the child does the scaling, which is the work looking down would have saved             |
+| 62  | The board may overflow the 720px race column                                                 | 720px is a reading measure and a keyboard is not read; a screen with a wider keyboard under it is the desk it depicts                                         |
+| 63  | The passage screen's `--key` subtracts its chrome rather than taking a share of the viewport | The HUD, the bars and the line you type on are a constant, so a dvh fraction that fits at 850px of viewport grows the page at 700                             |
+| 64  | Hailstorm draws no keyboard                                                                  | A storm is the exam for the lessons that taught the layout, and a picture of the keyboard on the exam is the answer sheet — and it was taking 45% of the fall |
 
 ---
 

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -554,51 +554,51 @@ try {
   );
 
   /*
-   * The shield, measured against the board it is defending.
+   * The shield, measured against the sky it closes off.
    *
-   * "Segments align with the finger zones of the keyboard beneath them" is an
-   * acceptance criterion with a number behind it, and this is the only place
-   * that number exists. `StormField.test.tsx` runs game.css's arithmetic in
-   * key units, which is the right altitude for the claim but resolves no
-   * `--key` and lays out no boxes; only a browser turns both into pixels at a
-   * viewport and can be asked whether one is actually over the other.
+   * "Segments align with the finger zones of the keyboard" is an acceptance
+   * criterion with a number behind it, and a browser is the only place both
+   * sides of it become pixels at a real viewport.
    *
-   * Each segment is compared with the HOME-ROW keycaps of its own finger,
-   * because the home row is where the zones are cut (docs/typing.md §8.5,
-   * decision 41) — `a` and Caps under the left pinky's segment, `f` and `g`
-   * under the left index's. Half a pixel of tolerance, which is a rounding
-   * error and not room for a segment to have drifted a key.
+   * It used to be checked against the drawn keycaps under the shield. There
+   * are none now (docs/typing.md §8.2, decision 64), and what is left is the
+   * stronger half of the claim anyway: the eight segments must TILE the field
+   * — no gap for a letter to fall through unjudged, no overlap for two fingers
+   * to be blamed for one landing — and together they must be the full fifteen
+   * key units the lanes are laid out in. Which segment belongs to which finger
+   * is `StormField.test.tsx`'s, in key units off the same stylesheet, along
+   * with "every letter lands within a quarter unit of its own segment"; what
+   * only a browser can answer is whether the boxes actually meet.
+   *
+   * Half a pixel of tolerance, which is a rounding error and not room for a
+   * segment to have drifted a key. The whole strip sits half a `--key-gap`
+   * left of the sky, which is the correction a lane takes too (decision 36),
+   * so the span is compared and the origin is not.
    */
   const shield = await page.evaluate(() => {
-    const home = document.querySelector(".keyboard__row:nth-child(3)");
-    return [...document.querySelectorAll(".storm__zone")].map((zone) => {
-      const box = zone.getBoundingClientRect();
-      const caps = [
-        ...home.querySelectorAll(
-          `.keyboard__key[data-finger="${zone.dataset.finger}"]`,
-        ),
-      ].map((cap) => cap.getBoundingClientRect());
-      return {
-        finger: zone.dataset.finger,
-        left: box.left,
-        right: box.right,
-        capLeft: Math.min(...caps.map((cap) => cap.left)),
-        capRight: Math.max(...caps.map((cap) => cap.right)),
-        keys: caps.length,
-      };
-    });
+    const sky = document.querySelector(".storm__sky").getBoundingClientRect();
+    return {
+      skyWidth: sky.width,
+      zones: [...document.querySelectorAll(".storm__zone")].map((zone) => {
+        const box = zone.getBoundingClientRect();
+        return {
+          finger: zone.dataset.finger,
+          left: box.left,
+          right: box.right,
+        };
+      }),
+    };
   });
   check(
-    "each segment covers the home keys of its own finger, edge to edge",
-    shield.length === 8 &&
-      shield.every(
+    "the eight segments tile the field edge to edge, with nothing between them",
+    shield.zones.length === 8 &&
+      shield.zones.every(
         (zone, i) =>
-          zone.keys > 0 &&
-          zone.left <= zone.capLeft + 0.5 &&
-          zone.right >= zone.capRight - 0.5 &&
-          (i === 0 || Math.abs(zone.left - shield[i - 1].right) < 0.5),
-      ),
-    shield
+          i === 0 || Math.abs(zone.left - shield.zones[i - 1].right) < 0.5,
+      ) &&
+      Math.abs(shield.zones[7].right - shield.zones[0].left - shield.skyWidth) <
+        0.5,
+    shield.zones
       .map((z) => `${z.finger} ${z.left.toFixed(1)}→${z.right.toFixed(1)}`)
       .join(" "),
   );
@@ -771,10 +771,14 @@ try {
       buttons: [...document.querySelectorAll(".storm__over .btn")].map((b) =>
         b.textContent.trim(),
       ),
+      // No board on this screen, live or ended (decision 64). Counted rather
+      // than assumed, because the component that draws one is still imported
+      // two files away and a storm that quietly grew a keyboard back would
+      // change nothing else this walk can see.
       keys: document.querySelectorAll(".keyboard__key").length,
       zones: document.querySelectorAll(".storm__zone").length,
-      // The panel is inside the field and in the track the board had, so the
-      // sky is still the sky: same element, same shield, nothing overlapping.
+      // The panel is inside the field, in the track below the sky, so the sky
+      // is still the sky: same element, same shield, nothing overlapping.
       belowSky:
         panel &&
         panel.getBoundingClientRect().top >=
@@ -782,7 +786,7 @@ try {
     };
   });
   check(
-    "a run that ends says what the storm did, where the board was",
+    "a run that ends says what the storm did, under the sky it froze",
     over.text?.includes("Wave cleared") &&
       over.text.includes("Shield left") &&
       // Twelve landed, and lesson 4's shield is eight zones of four deep.
@@ -792,7 +796,7 @@ try {
       over.zones === 8 &&
       over.belowSky === true,
     `${JSON.stringify(over.buttons)} over ${over.zones} zones, ` +
-      `${over.keys} keycaps left: ${over.text}`,
+      `${over.keys} keycaps anywhere: ${over.text}`,
   );
 
   /*
@@ -845,19 +849,23 @@ try {
    */
   await page.evaluate(() => {
     window.__tints = [];
-    // Every cap that goes red, kept rather than caught: `useKeyEcho` releases
-    // a key 120ms after the press (§4.3), and a check that read the DOM after
-    // a round trip would be racing that timer for its evidence.
+    // Every `--flare` wash over the score, kept rather than caught: the wash
+    // is a 220ms animation on a node React mounts and drops (`StormHud`), and
+    // a check that read the DOM after a round trip would be racing it.
+    //
+    // This is where a wrong key SHOWS now. It used to be the keycap going red
+    // under the child's finger, which was the better signal and is gone with
+    // the board (decision 64) — so the one that is left is worth watching
+    // exactly as closely.
     window.__flares = [];
-    new window.MutationObserver((records) => {
-      for (const record of records)
-        if (record.target.classList.contains("is-wrong"))
-          window.__flares.push(record.target.textContent);
-    }).observe(document.body, {
-      subtree: true,
-      attributes: true,
-      attributeFilter: ["class"],
-    });
+    document.addEventListener(
+      "animationstart",
+      (event) => {
+        if (event.animationName === "storm-miss")
+          window.__flares.push(Math.round(window.performance.now()));
+      },
+      true,
+    );
   });
 
   /**
@@ -970,9 +978,9 @@ try {
         combo: combo.textContent,
         hot: combo.hasAttribute("data-hot"),
         stones: document.querySelectorAll(".storm__letter").length,
-        // The payout is on the ending panel, which stands where the board did
-        // once the gun is dead (§8.5) — so it is null for the whole of a run
-        // and a number the instant one is over.
+        // The payout is on the ending panel, which stands in the track under
+        // the sky once the gun is dead (§8.5) — so it is null for the whole of
+        // a run and a number the instant one is over.
         xp:
           document.querySelector(".storm__over .stat--xp .stat__value")
             ?.textContent ?? null,
@@ -1112,18 +1120,35 @@ try {
   const wrongKey = missKey(aimedAt.chars);
   await press(wrongKey);
   await scored(combo.score);
+
+  /*
+   * And then wait for the wash, which the score settling does NOT imply.
+   *
+   * `scored` returns on the re-render that moved the number; the `--flare`
+   * element mounts in that same render but its `animationstart` does not
+   * dispatch until the frame after it is painted. Reading `__flares` on the
+   * round trip straight after `scored` is therefore a coin flip, and it landed
+   * tails: 0 washes for a miss that had plainly happened.
+   *
+   * Waited for rather than slept on, and swallowed rather than thrown, so that
+   * the check below is what reports a wash that never came — with the score
+   * and the combo beside it, which is what says whether the miss was scored at
+   * all or only drawn quietly.
+   */
+  await page
+    .waitForFunction(() => window.__flares.length > 0, { timeout: 2000 })
+    .catch(() => {});
   const missed = await hud();
   check(
-    "a wrong key costs a hit's worth, breaks the combo, and flares the board",
+    "a wrong key costs a hit's worth, breaks the combo, and washes the score",
     aimedAt.chars.length > 0 &&
       missed.score === combo.score - 10 &&
       missed.combo === "×1.0" &&
       !missed.hot &&
-      missed.flares.length === 1 &&
-      missed.flares[0].toLowerCase() === wrongKey,
+      missed.flares.length === 1,
     `"${wrongKey}" into a sky of ${aimedAt.chars.join("")}: ` +
       `${combo.score} → ${missed.score} at ${missed.combo}, ` +
-      `flared ${JSON.stringify(missed.flares)}`,
+      `${missed.flares.length} score wash(es)`,
   );
 
   // Seven more, at a rate a child could actually hammer at. The point of them

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -856,8 +856,9 @@ describe("a wrong key costs", () => {
 
   it("charges the same for a shot at an empty sky", () => {
     // Spraying between letters is the same strategy by another route (§8.4),
-    // so it costs the same. The screen has to say so too, which is what
-    // `emptyIsWrong` is for — a key that costs points must not light `--lime`.
+    // so it costs the same. The screen says so with the `--flare` wash over the
+    // score, which is every miss's signal now that the storm draws no board to
+    // turn red (decision 64).
     const empty = runOf([at("f", 1000, 500)]);
     expect(targetIndex(empty), "the premise: nothing is falling").toBeNull();
 

--- a/src/games/typing/keyboard/Keyboard.test.tsx
+++ b/src/games/typing/keyboard/Keyboard.test.tsx
@@ -137,7 +137,9 @@ describe("Keyboard", () => {
 
   it("draws a key at the pitch of a real one", () => {
     const sheet = css("game.css").replace(/\/\*[\s\S]*?\*\//g, "");
-    const dial = /:root\s*{[^}]*--key:\s*([^;]+)/.exec(sheet)![1];
+    const ceilings = [
+      ...sheet.matchAll(/--key:\s*clamp\([^;]*?,\s*([^,;]+)\s*\);/g),
+    ].map(([, ceiling]) => ceiling.trim());
 
     // 19.05mm of key pitch is three quarters of an inch, which CSS defines as
     // exactly 72px, which is 4.5rem. The board is a map a child glances at
@@ -145,12 +147,22 @@ describe("Keyboard", () => {
     // measurement and not a taste — at half of it they do the scaling, which
     // is the work looking down would have saved them (§4.7, decision 61).
     //
-    // Written out whole rather than as a `toContain("4.5rem")`, because the
-    // two floor terms are load-bearing too: `6vw` is what keeps fifteen units
-    // inside 90% of a narrow viewport whatever the column under them says, and
-    // `9dvh` is what leaves a landscape phone a sky to fall through.
-    expect(dial.replace(/\s+/g, " ")).toBe(
-      "clamp(1.05rem, min(6vw, 9dvh), 4.5rem)",
+    // Asserted of EVERY declaration rather than of the board's, because the
+    // storm has no board and is capped at pitch for the same reason anyway: a
+    // lane claims to be where that key is, so a field wider than a keyboard
+    // teaches a reach nobody's hand makes (decision 64).
+    expect(ceilings.length).toBeGreaterThan(0);
+    for (const ceiling of ceilings) expect(ceiling).toBe("4.5rem");
+
+    // The root value is the storm's — the lanes, the stones and the shield —
+    // and the passage screen overrides it. Written out whole because the two
+    // floor terms are load-bearing too: `6vw` is what keeps fifteen units
+    // inside 90% of a narrow viewport whatever is under them, and the dvh term
+    // is what stops a hailstone growing until there is no sky to read it
+    // against.
+    const root = /:root\s*{[^}]*--key:\s*([^;]+)/.exec(sheet)![1];
+    expect(root.replace(/\s+/g, " ")).toBe(
+      "clamp(1.05rem, min(6vw, 15dvh), 4.5rem)",
     );
   });
 

--- a/src/games/typing/keyboard/LiveKeyboard.tsx
+++ b/src/games/typing/keyboard/LiveKeyboard.tsx
@@ -32,7 +32,6 @@ import type { KeyboardMode } from "@/engine/types";
 export function LiveKeyboard({
   mode,
   next,
-  emptyIsWrong = false,
 }: {
   /**
    * How much board to draw. "off" is absent because that decision belongs to
@@ -44,15 +43,6 @@ export function LiveKeyboard({
    * on one — before the countdown clears, and once the run is over.
    */
   next: string | null;
-  /**
-   * What a `null` `next` means for a key that was struck anyway.
-   *
-   * A passage leaves it alone: the beat between two words is not a mistake.
-   * Hailstorm sets it while the gun is live, because there a stroke with
-   * nothing to shoot at is a miss that costs score, and a key that costs a
-   * child points must not light `--lime` (§8.4, decision 43).
-   */
-  emptyIsWrong?: boolean;
 }) {
   /**
    * The expectation is the real next character in BOTH modes, and only the
@@ -64,7 +54,7 @@ export function LiveKeyboard({
    * that is the rung of the ladder they are on. Passing `null` here to match
    * the hint would turn every wrong key green.
    */
-  const { down, wrong } = useKeyEcho({ expect: next, emptyIsWrong });
+  const { down, wrong } = useKeyEcho({ expect: next });
 
   return (
     <Keyboard down={down} wrong={wrong} next={mode === "guide" ? next : null} />

--- a/src/games/typing/keyboard/useKeyEcho.test.ts
+++ b/src/games/typing/keyboard/useKeyEcho.test.ts
@@ -149,30 +149,6 @@ describe("createKeyEcho", () => {
     expect(keys.wrong()).toEqual([]);
   });
 
-  it("blames everything when the caller says nothing is right", () => {
-    // Hailstorm's empty sky (§8.4, decision 43). The same `null` a lesson
-    // means "there is nothing to judge" by, the storm means "there is nothing
-    // that COULD be right" — the stroke was a shot, it hit nothing, and it
-    // cost points. A key that costs a child points must not light `--lime`.
-    const keys = board();
-    keys.press("KeyQ", null, true);
-    expect(keys.down()).toEqual(["KeyQ"]);
-    expect(keys.wrong()).toEqual(["KeyQ"]);
-
-    // Held keys are still never wrong, whatever the caller says: reaching for
-    // the far shift is the technique, not the mistake, and in the storm it is
-    // not a shot either (`useStormClock`).
-    keys.press("ShiftRight", null, true);
-    expect(keys.wrong()).toEqual(["KeyQ"]);
-
-    // And a real target still marks against itself rather than against the
-    // flag — which is what stops the storm flaring every key it is aimed with.
-    keys.press("KeyF", "f", true);
-    expect(keys.wrong()).toEqual(["KeyQ"]);
-    keys.press("KeyD", "f", true);
-    expect(keys.wrong()).toEqual(["KeyD", "KeyQ"]);
-  });
-
   it("clears a wrong key's flare when that key is struck correctly", () => {
     const keys = board();
     keys.press("KeyD", "f");

--- a/src/games/typing/keyboard/useKeyEcho.ts
+++ b/src/games/typing/keyboard/useKeyEcho.ts
@@ -84,34 +84,28 @@ export const HELD = new Set([
  * flash is late enough to belong to the next keystroke. The keydown handler
  * already holds the code; the comparison here is immediate and exact.
  *
- * Nothing is wrong when there is nothing to be wrong about: free play between
- * words has no expected character, and a character this layout cannot produce
- * (a curly quote that escaped the passage filter) has no key to blame.
+ * Nothing is wrong when there is nothing to be wrong about: the beat between
+ * two words has no expected character, and a character this layout cannot
+ * produce (a curly quote that escaped the passage filter) has no key to blame.
+ * Neither is a mistake, so neither flares.
  *
- * `emptyIsWrong` is the caller saying that its own nothing means the opposite:
- * not "there is nothing to judge" but "there is nothing that could be right".
- * Hailstorm is the case — a stroke at a sky with no letter in it is a miss
- * that costs score (§8.4), and a key that costs a child points must not light
- * `--lime` at them, because `--lime` means "that was right" everywhere else on
- * this site (decision 43). A lesson never passes it: the pause between two
- * words is not a mistake.
+ * There used to be an `emptyIsWrong` for the caller whose nothing meant the
+ * opposite — "there is nothing that could be RIGHT" — and Hailstorm was the
+ * only one, because a stroke at an empty sky costs score there (§8.4). The
+ * storm no longer draws a board (decision 64), so the flag had no caller left
+ * to mean anything for; a wrong key is answered by the score, which flashes
+ * `--flare` for exactly that (§8.6). The passage is the only consumer now, and
+ * a passage never wanted it.
  */
-function isWrong(
-  code: string,
-  expect: string | null,
-  emptyIsWrong: boolean,
-): boolean {
+function isWrong(code: string, expect: string | null): boolean {
   if (HELD.has(code)) return false;
   const stroke = expect === null ? null : strokeFor(expect);
-  return stroke === null ? emptyIsWrong : code !== stroke.code;
+  return stroke !== null && code !== stroke.code;
 }
 
 export type KeyEchoBoard = {
-  /**
-   * Light `code`, flaring it if it wasn't the key `expect` needed — or, with
-   * nothing expected and `emptyIsWrong`, flaring it for being a stroke at all.
-   */
-  press: (code: string, expect: string | null, emptyIsWrong?: boolean) => void;
+  /** Light `code`, flaring it if it wasn't the key `expect` needed. */
+  press: (code: string, expect: string | null) => void;
   /** Drop every pending release. What unmounting does. */
   stop: () => void;
 };
@@ -137,9 +131,9 @@ export function createKeyEcho(emit: (echo: KeyEcho) => void): KeyEchoBoard {
   const publish = () => emit({ down: new Set(down), wrong: new Set(wrong) });
 
   return {
-    press(code, expect, emptyIsWrong = false) {
+    press(code, expect) {
       down.add(code);
-      if (isWrong(code, expect, emptyIsWrong)) wrong.add(code);
+      if (isWrong(code, expect)) wrong.add(code);
       else wrong.delete(code);
 
       // One release per code, re-armed rather than stacked: every keydown for
@@ -178,21 +172,15 @@ export function createKeyEcho(emit: (echo: KeyEcho) => void): KeyEchoBoard {
  * The echo, wired to the window.
  *
  * `keydown` on the window rather than on the input, because the board has to
- * stay honest wherever focus went — and because Hailstorm has no input at all
- * (§8.2), where this same hook is the gun.
+ * stay honest wherever focus went — a click on the page background moves focus
+ * off the field, and a board that stopped echoing there would read as a
+ * keyboard that had stopped working.
  *
  * Both sets change at most ten times a second, so a `useState` per keystroke
  * costs nothing next to the race clock already re-rendering this screen
  * sixteen times a second.
  */
-export function useKeyEcho({
-  expect,
-  emptyIsWrong = false,
-}: {
-  expect: string | null;
-  /** See `isWrong`. Hailstorm's empty sky; never a lesson's. */
-  emptyIsWrong?: boolean;
-}): KeyEcho {
+export function useKeyEcho({ expect }: { expect: string | null }): KeyEcho {
   const [echo, setEcho] = useState<KeyEcho>(SILENT);
 
   /**
@@ -212,19 +200,10 @@ export function useKeyEcho({
   const expected = useRef(expect);
   expected.current = expect;
 
-  /**
-   * Read by the listener for the same reason `expected` is, and it moves for
-   * the same kind of reason: Hailstorm turns it off the moment a run ends, and
-   * a listener bound to the old value would go on flaring at a child whose
-   * storm is over.
-   */
-  const blame = useRef(emptyIsWrong);
-  blame.current = emptyIsWrong;
-
   useEffect(() => {
     const board = createKeyEcho(setEcho);
     const onKeyDown = (event: KeyboardEvent) =>
-      board.press(event.code, expected.current, blame.current);
+      board.press(event.code, expected.current);
 
     // Capture, not bubble — the third argument is load-bearing.
     //

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -16,7 +16,7 @@ import {
   tick,
 } from "@/engine/typing/storm";
 
-import { StormField, aimedAt } from "./StormField";
+import { StormField } from "./StormField";
 import { StormOver } from "./StormOver";
 
 import type { FingerZone, KeyDef } from "@/engine/keyboard";
@@ -595,30 +595,25 @@ describe("StormField", () => {
     expect(stones(frameOf(only("j"), 750))[0].drop).toBeCloseTo(0.75, 10);
   });
 
-  it("mounts the board as the gun, and lets it point at nothing", () => {
-    const html = draw(frameOf(only("f"), 500));
+  it("draws no keyboard at all, live or ended", () => {
+    // A storm is the exam for the lessons that taught the layout (§8.1), so
+    // the picture of the answer is the one thing this screen must not show:
+    // the quickest way to shoot a falling `y` would become reading the board
+    // for where `y` is, which is hunt-and-peck with a countdown on it
+    // (decision 64).
+    const live = draw(frameOf(only("f"), 500));
+    expect(live).not.toContain("keyboard__key");
+    expect(live).not.toContain('class="keyboard"');
 
-    // The same picture the lessons put under the passage — one board, one
-    // layout, one echo listener.
-    expect(html.match(/class="keyboard__key/g)).toHaveLength(KEYS.length);
-
-    // But no hint, ever. A board that pointed at the next key would be
-    // playing the game for the child (§8.1).
-    expect(html).not.toContain("is-next");
-  });
-
-  it("marks presses against the lowest letter, and against none once dead", () => {
-    const state = frameOf(only("f", 3), 500);
-    expect(aimedAt(state)).toBe("f");
-
-    // `targetIndex` answers "which is lowest", not "is this run alive", so it
-    // still names a letter on a dead run. The screen is where that has to be
-    // caught, or the board goes on flaring at a child who has already lost.
-    const dead: StormState = {
-      ...state,
+    // Nor once the run is over, when the track it would have stood in is the
+    // ending's. `KEYS` is imported for the lanes below and named here so that
+    // a board creeping back in has a number to fail against.
+    expect(KEYS.length).toBeGreaterThan(0);
+    const dead = draw({
+      ...frameOf(only("f", 3), 500),
       ending: { kind: "breached", finger: "l-index", index: 0 },
-    };
-    expect(aimedAt(dead)).toBeNull();
+    } as StormState);
+    expect(dead).not.toContain("keyboard__key");
   });
 
   it("hands the way out to the HUD, and says which key does it too", () => {
@@ -649,16 +644,15 @@ describe("StormField", () => {
 
     expect(html).toContain("Hailstorm");
 
-    // Everything that moves is hidden: the two HUD numbers, every stone, the
-    // eight shield segments and the board's sixty spans. None of it is an
-    // announcement anybody could act on, and a live region reading out a
-    // hailstorm is a denial of service rather than an accommodation (§4.4).
+    // Everything that moves is hidden: the two HUD numbers, every stone and
+    // the eight shield segments. None of it is an announcement anybody could
+    // act on, and a live region reading out a hailstorm is a denial of service
+    // rather than an accommodation (§4.4).
     for (const cls of [
       "storm__score",
       "storm__combo",
       "storm__letter",
       "storm__shield",
-      "keyboard",
     ])
       expect(tag(cls), cls).toContain('aria-hidden="true"');
 

--- a/src/games/typing/storm/StormField.tsx
+++ b/src/games/typing/storm/StormField.tsx
@@ -1,6 +1,4 @@
-import { isAirborne, progressAt, targetIndex } from "@/engine/typing/storm";
-
-import { LiveKeyboard } from "../keyboard/LiveKeyboard";
+import { isAirborne, progressAt } from "@/engine/typing/storm";
 
 import { StormHud } from "./StormHud";
 import { StormShield } from "./StormShield";
@@ -9,8 +7,8 @@ import type { StormState } from "@/engine/typing/storm";
 import type { CSSProperties } from "react";
 
 /**
- * Hailstorm's field: the sky the letters fall through, and the gun under it
- * (docs/typing.md §8.2, decision 19).
+ * Hailstorm's field: the sky the letters fall through, and the shield they
+ * land on (docs/typing.md §8.2, decision 19).
  *
  * ── A letter falls down the column of its own key ────────────────────────────
  * `f` falls onto `f`. `y` falls between `g` and `h`, because that is where `y`
@@ -23,23 +21,28 @@ import type { CSSProperties } from "react";
  *
  * Nothing here computes a lane. `StormLetter.lane` is `keyX(code)` resolved
  * once when the wave was built (§8.3), and this writes it into a custom
- * property that `game.css` multiplies by `--key`. So the field and the drawn
- * board cannot disagree about where a key is: they read one `KEY_ROWS` table
- * and one `--key` unit, and neither of them holds a pixel.
+ * property that `game.css` multiplies by `--key`. So a lane and the finger
+ * zone it lands on cannot disagree about where a key is: they read one
+ * `KEY_ROWS` table and one `--key` unit, and neither of them holds a pixel.
  *
- * ── The board is the gun ─────────────────────────────────────────────────────
- * `LiveKeyboard` — the same component and the same `useKeyEcho` the lessons
- * put under the passage — rather than a second keyboard drawn for the game.
- * One board means one layout, one echo listener and one set of finger colours;
- * a child who has spent forty lessons learning to glance at that picture
- * should meet the same picture here.
+ * ── There is no board here, and that is the point ────────────────────────────
+ * The lessons draw one under the passage; this does not (§8.2, decision 64).
+ * A storm is the exam for the forty lessons that taught the layout, and §8.1's
+ * whole claim is that it drills the one thing a passage cannot — finding a key
+ * nobody told you about, at speed. A picture of the keyboard on that screen is
+ * the answer sheet: the fastest way to shoot a falling `y` becomes reading the
+ * board for where `y` is, which is hunt-and-peck with a countdown on it.
  *
- * `mode="keys"` is doing real work. It keeps the echo's expectation — so the
- * key you fire with lights `--lime` and a wrong one flares `--flare` — while
- * withholding the next-key HINT, which the storm must never show: a board that
- * pointed at the answer would be playing the game for the child, and §8.1's
- * whole claim is that this drills the one thing a passage cannot, which is
- * finding a key you were not told about.
+ * What is left at the bottom is the shield, and it is a better teacher for
+ * being the only thing there. Eight finger zones rather than forty-odd keys,
+ * so what a child watches crumble is a FINGER — the thing that is a lesson, a
+ * drill and a habit (§8.5). The lane still says which key; the zone under it
+ * still says which finger; nothing that was doing work has gone.
+ *
+ * It buys the sky, too. The board was five rows of keycaps at real pitch
+ * (§4.7) and it was taking about 45% of the screen from the only track that
+ * gives — so the fall is now roughly twice as long as it was, on the screen
+ * whose entire job is giving a child time to read a letter and find its key.
  *
  * ── Still a pure function of one frame ───────────────────────────────────────
  * Hand it a `StormState` and it draws that state; it holds no clock of its
@@ -90,36 +93,9 @@ export function isDrawn(state: StormState, index: number): boolean {
 }
 
 /**
- * The character the gun is marked against, or `null` for none.
- *
- * Only the lowest letter on screen can be shot (§8.4), so it is the only one a
- * key can be right for — and the echo needs exactly that character to tell a
- * hit from a miss on the press, before anything has re-rendered (§4.3).
- *
- * The `ending` guard is the whole reason this is a function. `targetIndex`
- * deliberately does not read it: the reducer's question is "which letter is
- * lowest", not "is this run still alive", and a run that ended mid-wave still
- * has letters in the air for it to answer with — frozen where the clock
- * stopped, which is exactly what the ending screen leaves on show. So
- * anything drawn off that index has to guard for itself, and this is where
- * that guard lives for the whole screen.
- *
- * The board is no longer the caller that needs it: a run with an ending hands
- * the board's place to `over` (below), so there is no keyboard left to mark a
- * child's keys against a letter nothing can shoot. It is still the honest
- * answer to "what is the gun on", which is a question `redrawn` asks on every
- * frame and the next screen to ask will be asking of a run that may be over.
- */
-export function aimedAt(state: StormState): string | null {
-  if (state.ending !== null) return null;
-  const index = targetIndex(state);
-  return index === null ? null : state.wave.letters[index].ch;
-}
-
-/**
- * The field, as markup: the HUD, the sky, whatever is falling through it, the
- * shield they land on and the board at the bottom. A pure function of one
- * `StormState` — see the file header for why.
+ * The field, as markup: the HUD, the sky, whatever is falling through it and
+ * the shield they land on. A pure function of one `StormState` — see the file
+ * header for why.
  */
 export function StormField({
   state,
@@ -139,17 +115,18 @@ export function StormField({
    */
   onQuit?: () => void;
   /**
-   * What stands where the board does once the run is over (§8.5, STM07).
+   * What stands under the sky once the run is over (§8.5, STM07).
    *
-   * The board is the gun, so it goes when the gun does — and the ending takes
-   * its track rather than being drawn over the sky, which leaves the hail
-   * frozen where it stopped and the hole still open under the finger that let
-   * it through. The panel itself is the route's, because everything it offers
-   * is navigation: a drill, a retry, the way out.
+   * The ending takes a track of its own rather than being drawn over the sky,
+   * which leaves the hail frozen where it stopped and the hole still open
+   * under the finger that let it through. While the run is live that track is
+   * empty and the sky has the whole field; the ending is the only thing this
+   * screen ever puts below it. The panel itself is the route's, because
+   * everything it offers is navigation: a drill, a retry, the way out.
    *
    * WHEN it appears is decided here and not by the caller, off the same
-   * `ending` the gun dies on — one rule, in the file that draws both halves of
-   * it.
+   * `ending` the gun dies on — one rule, in the file that draws the sky it
+   * appears under.
    */
   over?: React.ReactNode;
 }) {
@@ -224,22 +201,12 @@ export function StormField({
         <StormShield state={state} />
       </div>
 
-      {/*
-        The board while the gun is live, and the ending in its place afterwards
-        (see `over`). `emptyIsWrong` is the honest answer to firing at an empty
-        sky (§8.4, decision 43): the reducer charges that stroke `MISS_POINTS`
-        and breaks the streak, so the board cannot be allowed to light it
-        `--lime` for "that was right" — with nothing in the air there is
-        nothing that could be right, and every key flares. It is `true`
-        wherever this is drawn at all, because this is drawn while the run is
-        live and only then; `aimedAt` is what goes null on the last letter of a
-        wave that is still being played.
-      */}
-      {state.ending === null ? (
-        <LiveKeyboard mode="keys" next={aimedAt(state)} emptyIsWrong />
-      ) : (
-        over
-      )}
+      {/* Nothing at all while the run is live — the sky has the whole field,
+          and what a child looks at is the letters and their own hands (see
+          the header). The ending is the one thing this screen ever puts below
+          the sky, and it is rendered rather than overlaid so the frozen hail
+          and the broken shield stay readable above it. */}
+      {state.ending !== null && over}
     </main>
   );
 }

--- a/src/games/typing/storm/StormOver.tsx
+++ b/src/games/typing/storm/StormOver.tsx
@@ -55,12 +55,18 @@ import type { StormState } from "@/engine/typing/storm";
  * whole time anyway; the XP beside it can only ever have gone up (§8.6),
  * which is the honest thing a losing run has to say.
  *
- * ── Where the board was ──────────────────────────────────────────────────────
- * The panel stands in the board's own grid track, because the board is the gun
- * (`StormField`) and the gun is dead. That leaves the sky above it whole: the
- * hail frozen where it was, and the shield with the hole still in it under the
- * finger this screen is naming. A panel drawn over the sky would have covered
- * the one picture that explains the sentence.
+ * ── Under the sky, not over it ───────────────────────────────────────────────
+ * The panel stands in `.storm`'s second grid track, which is empty for the
+ * whole of a live run — this is the only thing the screen ever puts below the
+ * sky (`StormField`). That leaves the sky above it whole: the hail frozen
+ * where it was, and the shield with the hole still in it under the finger this
+ * screen is naming. A panel drawn over the sky would have covered the one
+ * picture that explains the sentence.
+ *
+ * It used to share that track with the keyboard, which stood there while the
+ * gun was live and handed it over on the ending. There is no board now
+ * (decision 64), so the track is the panel's alone and an ending taller than
+ * five rows of keycaps costs the sky nothing.
  */
 export function StormOver({
   state,

--- a/src/games/typing/storm/useStormClock.test.ts
+++ b/src/games/typing/storm/useStormClock.test.ts
@@ -178,16 +178,21 @@ describe("redrawn", () => {
     expect(redrawn(dead, fire(dead, "KeyQ"))).toBe(false);
   });
 
-  it("says yes when the target changes mid-air with nothing else", () => {
-    // Two letters at different speeds cross (decision 32), and from that
-    // instant the board is marked against a different key. Nothing is
-    // resolved, nothing spawns, and the count of stones on the field is the
-    // same on both sides of it.
+  it("says no when only the target changes mid-air", () => {
+    // Two letters at different speeds cross (decision 32), and nothing else
+    // moves: nothing is resolved, nothing spawns, and the count of stones on
+    // the field is the same on both sides of it.
+    //
+    // That crossing used to be a redraw, because the board was marked against
+    // the lowest letter and would go on marking against the wrong one. There
+    // is no board now (decision 64) and nothing else on the screen names the
+    // target — a stone carries no target class and the HUD does not print it —
+    // so the picture is identical and React is not asked to draw it again.
     const before = tick(startStorm(crossing), 600);
     const after = tick(before, 200);
 
     expect(after.resolved).toBe(before.resolved);
-    expect(redrawn(before, after)).toBe(true);
+    expect(redrawn(before, after)).toBe(false);
   });
 });
 

--- a/src/games/typing/storm/useStormClock.ts
+++ b/src/games/typing/storm/useStormClock.ts
@@ -5,7 +5,7 @@ import { fire, progressAt, startStorm, tick } from "@/engine/typing/storm";
 
 import { HELD } from "../keyboard/useKeyEcho";
 
-import { aimedAt, isDrawn } from "./StormField";
+import { isDrawn } from "./StormField";
 
 import type { StormState, Wave } from "@/engine/typing/storm";
 
@@ -146,12 +146,16 @@ function onField(state: StormState): number {
  * state says "changed" sixty times a second and means nothing. What the screen
  * is actually a function of is every field of a run except the clock and the
  * wave — so `resolved`, `shield`, `combo`, `score`, `misses` and `ending`,
- * compared here — plus the two things the clock alone moves: a letter
- * appearing (no field of `StormState` records a spawn; it is a time crossing)
- * and the target changing, which two letters at different speeds can do
- * mid-air with nothing else happening at all (decision 32). Miss that one and
- * the board goes on marking a child's keys against a letter that is no longer
- * the lowest.
+ * compared here — plus the one thing the clock alone moves: a letter appearing,
+ * which no field of `StormState` records because it is a time crossing.
+ *
+ * The target used to be compared here as well, because two letters at
+ * different speeds can cross mid-air with nothing else happening at all
+ * (decision 32) and the board went on marking a child's keys against a letter
+ * that was no longer the lowest. There is no board now (decision 64), and
+ * nothing else on this screen is a function of which letter is the target —
+ * the stones carry no target class and the HUD does not name it — so the
+ * crossing changes no picture and is no longer a redraw.
  *
  * `score` and `misses` move on **every** miss; `missTintAt` moves only on the
  * ones the throttle lets light, which is `MIN_TINT_GAP_MS` apart at the most
@@ -188,7 +192,6 @@ export function redrawn(drawn: StormState, next: StormState): boolean {
     drawn.misses !== next.misses ||
     drawn.missTintAt !== next.missTintAt ||
     drawn.ending !== next.ending ||
-    aimedAt(drawn) !== aimedAt(next) ||
     onField(drawn) !== onField(next)
   );
 }
@@ -311,18 +314,19 @@ export function useStormClock(
      * The default is taken for the keys the board draws, and only those: this
      * screen has no input to swallow a space that would otherwise scroll the
      * page, or a `/` that opens Firefox's quick-find mid-run. `keyX` answers
-     * "is this key on the board" without a second list of codes. Anything else
+     * "is this key on the layout" without a second list of codes — the layout
+     * being the engine's table, since this screen draws no board (decision 64). Anything else
      * — F5, F12, the browser's own — is left alone, because a game screen that
      * ate the reload key would be a screen with no way out.
      */
     const onKeyDown = (event: KeyboardEvent) => {
       // The gun dies with the run, and the listener has to know it rather than
       // leaning on `fire` refusing an ended state. What it would otherwise
-      // still do is swallow the default, and by then the board's place is
-      // taken by the ending's buttons (`StormField`) — three after a breach,
-      // two after a cleared wave, and never none: `Tab`, `Space` and `Enter`
-      // are all keys this board carries, so all three of those keys pass the
-      // very test that calls `preventDefault` below. A gun still eating them
+      // still do is swallow the default, and by then the track under the sky
+      // holds the ending's buttons (`StormField`) — three after a breach, two
+      // after a cleared wave, and never none: `Tab`, `Space` and `Enter` are
+      // all keys the LAYOUT carries, so all three of those keys pass the very
+      // test that calls `preventDefault` below. A gun still eating them
       // after the storm has stopped would leave a child who is not holding a
       // mouse unable to focus a button, let alone press one.
       if (live.current.ending !== null) return;

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1872,14 +1872,13 @@ label.segmented__btn {
    legends are its chalk, and the eight hues on top are the same in all of
    them because a finger doesn't change biome.                             */
 
-/* The one dial, and it is at the ROOT because two screens now scale off it.
+/* The one dial, and it is at the ROOT because two screens scale off it.
 
-   The board is fifteen key units wide and every key knows its own left edge
-   in those units, so a key is a fifteenth of the room there is — floored so
-   it stays legible on a narrow phone. The dvh term is what makes a phone in
-   landscape work: five rows and whatever they are under — the passage, or a
-   sky full of falling letters — are sharing about 390px of height, and width
-   alone would happily spend all of it.
+   Fifteen key units is the width of a keyboard, and everything either screen
+   draws knows its own left edge in those units — a keycap from `KeyDef.x`, a
+   falling letter from `keyX(code)`, a shield segment from `FINGER_ZONES`. So
+   one number sets the scale of all of it, floored so it stays legible on a
+   narrow phone.
 
    **The cap is the real thing's measurement, not a taste.** Key pitch on
    every full-size keyboard a child will ever meet is 19.05mm — three quarters
@@ -1888,28 +1887,37 @@ label.segmented__btn {
    since CSS pins an inch to 96px) so that a child who has turned their text
    up gets a board that grew with everything else.
 
-   Why it matters that this is life-size rather than merely large: the board
-   is not an illustration of a keyboard, it is a map a child glances at while
-   their hands are on the actual one. A map at half scale asks them to do the
-   scaling — to see that the gap between `f` and `j` on screen is the gap
-   their two index fingers are already holding — and that translation is
+   Why life-size rather than merely large, on the screen that draws a board:
+   it is not an illustration of a keyboard, it is a map a child glances at
+   while their hands are on the actual one. A map at half scale asks them to
+   do the scaling — to see that the gap between `f` and `j` on screen is the
+   gap their two index fingers are already holding — and that translation is
    exactly the work looking down at their hands would have saved them. At
    pitch, the picture and the plastic are the same shape, so the glance costs
    nothing and the reach it teaches is the reach they make.
 
-   It was capped at 2.4rem — about half pitch — until this, which on any
-   laptop drew a keyboard the size of a phone in the middle of an empty half
-   screen. On a laptop the room was simply there, in the passage row that
-   gives (`minmax(0, 1fr)`); on a shorter window it was not, which is what the
-   passage screen's own height term below is for.
+   And on the screen that draws no board, the cap is doing the same job for
+   the same reason. Hailstorm has lanes rather than keycaps now (decision 64),
+   but a lane still claims to be where that key IS — so a field wider than a
+   keyboard would be teaching a reach nobody's hand makes.
 
-   It lived on `.keyboard` until Hailstorm, which positions falling letters in
-   key units in the sky ABOVE the board (docs/typing.md §8.2): a custom
-   property inherits downwards only, so a value declared on the board is a
-   value the field cannot read. The alternative was a second clamp with the
-   same five numbers in the storm's own block, and that is the one thing this
-   must not be — a lane and the cap it names would then be free to drift
-   apart, which is a spatial hint teaching the wrong geometry.
+   ── What this value is, and what overrides it ──────────────────────────────
+   THIS one is the storm's: the lanes, the hailstones and the eight shield
+   segments, which is every reader of `--key` that is not a keycap. Its height
+   term is loose (`15dvh`) because the storm's only other track is the ending
+   panel, which is absent while a wave is falling — the sky is the whole field,
+   so what the dvh term is protecting is not the layout but the FALL: a stone
+   is 1.15 units, and past about a sixth of the viewport per unit a letter is
+   big enough that there is no sky left to read it against.
+
+   The passage screen overrides it below, because that screen draws five rows
+   of keycaps under a HUD, three bars and a line of words. It lived on
+   `.keyboard` until Hailstorm and could not stay there — a custom property
+   inherits downwards only, so a value declared on the board is a value the
+   sky above it cannot read (docs/typing.md §8.2, decision 37). At the root
+   both screens can reach it and each is one value, which is the property that
+   matters: within a screen a lane and the segment it lands on are never free
+   to disagree about how wide a key is.
 
    `--key-gap` is here for the same reason and one more: it is the inset that
    turns a key's slot into the keycap drawn inside it, so it is also what the
@@ -1917,7 +1925,7 @@ label.segmented__btn {
    the slot (decision 36). One declaration, and both halves of that stay
    true at every size. */
 :root {
-  --key: clamp(1.05rem, min(6vw, 9dvh), 4.5rem);
+  --key: clamp(1.05rem, min(6vw, 15dvh), 4.5rem);
   --key-gap: calc(var(--key) * 0.09);
 }
 
@@ -2242,17 +2250,19 @@ label.segmented__btn {
   overflow: hidden;
 
   display: grid;
-  /* The sky gives, the board never does. `minmax(0, 1fr)` is what lets the
-     sky be shorter than its content wants (the stones are absolutely
-     positioned inside it, so it has no content of its own to insist on) and
-     `auto` hands the board its five rows at whatever `--key` currently is.
+  /* The sky takes the field, and the second track is empty until the run ends.
 
-     That order is the opposite of the passage screen's, where a viewport too
-     short for both hides the board and lets the words carry on (the
-     `max-height` rule above, scoped to `.typing` and therefore not this).
-     Here the board is the gun: a child who cannot see it is not being asked
-     to read faster, they are being asked to shoot with nothing. So the sky is
-     what shrinks, down to nothing if it has to. */
+     `minmax(0, 1fr)` is what lets the sky be shorter than its content wants
+     (the stones are absolutely positioned inside it, so it has no content of
+     its own to insist on), and `auto` is where `.storm__over` stands once
+     there is an ending to show — nothing before that, so an `auto` track with
+     no child in it is zero and the sky has the whole screen.
+
+     There was a board in that track until #197 and it was taking about 45% of
+     the height (decision 64). What it was taking it from is the fall, which is
+     the only thing on this screen that gives a child time to read a letter and
+     find its key — so the sky roughly doubled when it went, and the row it
+     left behind is the one the ending was already using. */
   grid-template-rows: minmax(0, 1fr) auto;
   gap: clamp(0.35rem, 1.5vh, 1rem);
   padding: clamp(0.4rem, 1.5vh, 1rem) clamp(0.5rem, 2vw, 1rem);


### PR DESCRIPTION
## Why

A storm is the exam for the forty lessons that taught the layout. A picture of the keyboard on that screen is the answer sheet: the quickest way to shoot a falling `y` becomes reading the board for where `y` is, which is hunt-and-peck with a countdown on it.

It was also expensive. Drawn at real key pitch (#196) it was five rows of keycaps taking about **45% of the height**, and what it took it from is the only track that gives — the fall, which is the whole of what this screen sells a child: time to read a letter and find its key.

| 1512×850 laptop | before | after |
| --- | --- | --- |
| sky (the fall) | ~430px | **~720px** |
| keycaps on screen | 61 | 0 |

## What is left

The shield, and it is a better teacher for being the only thing there: eight finger zones rather than forty-odd keys, so what a child watches crumble is a **finger** — a thing that is a lesson, a drill and a habit. The lane still says which key; the zone under it still says which finger. Nothing that was doing work has gone.

**The lessons are untouched** — the board under the passage is the same board at the same pitch.

## Three things fell out with it

All existed only for the board:

- **`emptyIsWrong`.** A stroke at an empty sky is a miss that costs ten points, and a key that costs a child points must not light `--lime` — so the storm turned the echo's "nothing to judge" into "nothing that could be right". No board, no caller, and a lesson never wanted it: the beat between two words is not a mistake. A wrong key is now shown by the `--flare` wash over the score, which was already there and already throttled against strobing (decision 57). **This is a real loss and was weighed**: a wash over a number is a quieter answer than the key under your own finger going red.
- **`aimedAt`, and the target-change clause in `redrawn`.** The mid-air crossing was a redraw because the board went on marking keys against a letter that was no longer the lowest. Nothing else on the screen is a function of the target — a stone carries no target class, the HUD does not name it — so the crossing changes no picture.
- **The storm's height budget.** `--key` at the root is now the storm's alone (lanes, hailstones, shield), so its dvh term is loose: `9dvh` existed to fit five rows of keycaps, and what it guards now is only that a hailstone cannot grow until there is no sky to read it against. The `4.5rem` pitch ceiling stays — a lane claims to be *where that key is*, so a field wider than a keyboard teaches a reach nobody's hand makes.

## The smoke walk's shield check

It used to measure each segment against the home-row keycaps beneath it. There are none, so it asks the stronger half in real pixels instead: that the eight segments **tile the field edge to edge**, with no gap for a letter to fall through unjudged and no overlap for two fingers to be blamed for one landing. Which segment belongs to which finger, and "every letter lands within a quarter unit of its own segment", were already `StormField.test.tsx`'s in key units.

One check needed a genuine fix rather than a rewrite: the score wash is an `animationstart` a frame *after* the score settles, so reading it on the round trip straight after `scored()` was a coin flip. It now waits for the wash.

## Validation

`type-check`, `lint`, `build`, **2160 unit tests** and the **full `test:smoke` walk** all pass. Storm driven in Chromium at laptop, landscape phone, portrait phone and portrait tablet — no scroll, shield tiles at every size, zero keycaps.

Docs: `docs/typing.md` §8.2 (retitled *The field is the keyboard, and draws none*), §4.5, §4.7, §8.1, §8.5, §8.6, §8.9, §8.11, decisions 37/43/45/47 revised and 64 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)