### PR TITLE
Stand the letter still before it falls, and give the storm a voice

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1124,6 +1124,59 @@ It bought the fall, too. The board was five rows of keycaps at real pitch
 screen whose entire job is giving a child time to read a letter and find its
 key.
 
+**What that bought was distance, and distance at a fixed time is speed.** A
+wave says how LONG a letter falls for and never how far, so the same 900ms fall
+that used to cross 430px now crosses 720px — and more again on a bigger
+monitor. At around 12px a frame the display's own persistence smears a 43px
+glyph across a quarter of its own height, and `i` and `l` stop being different
+letters. The first storm on the ladder has the shortest fall of the twenty
+(900–1200ms, §5.6), so the level a five-year-old meets first is the one it hurts
+most.
+
+**The answer is not to slow the fall down, it is to stand the letter still
+first** (§8.3, decision 67). A letter appears at the top of the sky, hangs
+there for `QUEUE_MS` while a child reads it, and only then drops. Reading and
+racing become two moments instead of one, and the one moment a glyph is new is
+the one moment it is not moving — which is worth more than any amount of
+slowing down, because a letter you have already identified does not need to be
+legible on the way down.
+
+What is left for the geometry is a **backstop**, in the same spirit as the
+generator's `MIN_FALL_MS` (decision 65):
+
+```css
+--hail-speed: 9; /* stone heights per second */
+--fall: min(
+  var(--sky-fall),
+  calc(var(--fall-ms, 1000) / 1000 * var(--hail-speed) * var(--stone))
+);
+```
+
+Nine is a shade above what the tallest ordinary screen asks for, so on anything
+a child is likely to be sitting at the stone uses the whole sky and this changes
+nothing. On a display taller than that it stops the level quietly becoming a
+different game because of the monitor it was opened on. It is in **stone
+heights** and not pixels because what smears a moving glyph is how far it
+travels against its own size, so a cap written in pixels would mean something
+different at every `--key`. And it **changes no clock**: a letter still falls
+for exactly the `fallMs` its wave drew, so every level's timing, and therefore
+its difficulty, is what §5.6's table says it is.
+
+A capped stone **comes into view lower** rather than falling faster: `top` is
+the sky's whole travel minus this letter's, so the fall still ends exactly on
+the shield. `--fall-ms` is written inline by `StormField` beside the lane, never
+by the loop — it is fixed when the wave is built, where `--drop` moves every
+frame (§8.9).
+
+Two smaller things go with all this, and both are about the same quarter-second
+of smear. The glyph is **bold**, because what survives motion blur is stroke
+width, and `l` and `i` are told apart by a thick stem long after a thin one has
+washed out. And the stone gets `will-change: transform`, so it is rasterised
+once and composited rather than re-rasterised at a new sub-pixel offset sixty
+times a second — the cost is greyscale antialiasing, slightly softer standing
+still and much steadier moving, which is the right way round for the one element
+on this site that is always moving.
+
 Lanes are key units, not pixels, so the stones and the shield scale together
 off one `--key` custom property — **declared once, at the root**. It lived on
 `.keyboard` while the field had one, and could not stay there: a custom
@@ -1257,10 +1310,57 @@ reducer's "which are in the air" or under a React key.
 
 A letter is on the field over the **half-open** interval `[spawnMs, landMs)`:
 there the instant it spawns, gone the instant it lands, because landing is the
-tick that turns it into shield damage. That is what makes the early levels'
-guarantee `gap[0] >= fall[1]` rather than `>` — at exactly equal, the outgoing
-letter lands on the same millisecond the next one spawns, which is a handover
-and not two letters on screen.
+tick that turns it into shield damage.
+
+#### A letter hangs before it falls
+
+It does not start moving at `spawnMs`. It appears, stands perfectly still for
+`QUEUE_MS` — a second — and only then drops (decision 67). That beat is the
+whole of how this mode stays legible: a glyph is hardest to read at exactly the
+moment it is new, and this is the moment it is not moving. Reading the letter
+and racing it down become two things instead of one, and a child who has
+already identified an `i` does not need it to be legible on the way past.
+
+Four things about it, and the first is the one that matters most:
+
+- **A queued letter is shootable.** `isAirborne` says it is on the field,
+  `targetIndex` will aim at it and `fire` will take it. Anything else is a game
+  that shows a child a letter and then charges them ten points for pressing it.
+- **It is time added, and it has to be.** The cheaper-looking version — hang for
+  a beat, then cover the same sky in what is left of the same `fallMs` — is
+  strictly worse than doing nothing, because the same distance in less time is
+  a _faster_ drop at the most urgent point of it.
+- **It disturbs no level.** The value is the same for every letter of every
+  level, so it shifts the whole schedule and warps no part of it: `gap` and
+  `fall` are untouched, the generator draws in the same order from the same
+  seed, and every level rains the same letters in the same lanes at the same
+  speeds it did before.
+- **`CardResult.ms` still means what it did** (§8.7). It is `atMs - spawnMs` —
+  time from a child first _seeing_ the letter — so a fast player's card is the
+  number it always was and only a slow one has longer to be slow in.
+
+`progressAt` is floored at zero, which is what a queued letter is. Both its
+readers need that: the renderer would otherwise carry a queued stone _up_ out of
+the sky, since `--drop` is multiplied by the travel; and `targetIndex` would
+rank two letters hanging side by side — visibly at the same height — by how long
+each has left before it drops divided by how long its own fall is, which is a
+number nothing on screen shows. Floored, they tie, and a tie goes to the earlier
+spawn like every other dead heat (decision 33).
+
+**"One letter at a time" survives, as a claim about falling.** Lessons 4, 9 and
+13 promise pure reaction, and what that has always meant is that no two letters
+are coming _down_ at once — which `gap[0] >= fall[1]` still buys exactly,
+because every fall is shifted by the same amount and the beat cancels out of the
+arithmetic. What is beside a falling letter on those levels is the next one
+waiting its turn, which is what makes it a queue rather than a crowd:
+`storms.test.ts` holds them to one falling and at most two on the field, at
+every seed. `isFalling` is the engine's own name for the narrower interval, so a
+test asking that question does not restate `QUEUE_MS`.
+
+The guarantee is `gap[0] >= fall[1]` rather than `>` for the same reason it
+always was — at exactly equal, the outgoing letter lands on the same
+millisecond the next one starts to drop, which is a handover and not two letters
+falling.
 
 Two characters never fall, whatever `spec.keys` says: one this board cannot
 produce (§3.3's null), because it could never be shot, and one typed with a
@@ -1973,6 +2073,76 @@ numbers, every stone, the shield — for the reason a board carries one (§4.4).
 A screen whose only exit sat inside a hidden subtree would be a trap for
 exactly the child least able to get out of it.
 
+### 8.12 · What a storm sounds like
+
+Hailstorm is the one screen on this site a child can be looking away from at
+the moment it needs them — their hands are on a keyboard and their eyes are on
+the letters, and the shield is at the bottom of the screen where nobody is
+looking until it is too late. So it is the one screen that has to be playable
+by ear as well, and six sounds carry it (`services/sound.ts`):
+
+| Sound         | When                                                | Length |
+| ------------- | --------------------------------------------------- | ------ |
+| `shoot`       | Every stroke the gun takes, hit or miss             | 50ms   |
+| `shatter`     | A hailstone shot out of the sky — pitched by streak | 80ms   |
+| `misfire`     | A stroke that hit nothing, including an empty sky   | 90ms   |
+| `shieldHit`   | A letter got through; that finger's armour took it  | 160ms  |
+| `shieldBreak` | …and that was the zone's last point: a hole         | 340ms  |
+| `breach`      | A stone came through the hole. The run is over      | 750ms  |
+
+They are laid out along two axes a five-year-old can hear without being taught
+either. **Pitch says whose it is** — the gun and the stones are bright and
+short, the shield is low and long — so "I did something" and "something
+happened to me" never have to be told apart by timbre alone. **Length says what
+it cost**, and nothing else on the screen is allowed to be longer than the end
+of the run.
+
+The shot and its answer are **layered, not alternatives**: a stroke plays
+`shoot` and then `shatter` or `misfire` over the top of it. So the answer to a
+keypress arrives within a frame whatever else is true, and the quietest,
+shortest thing on the screen is the one that happens most often. Gains sit
+below the rest of the kit for the same reason — a race plays a handful of
+sounds a minute and a storm plays one per keystroke.
+
+**The sounds are a diff over two frames, not events the reducer raises**
+(decision 66). `fire` and `tick` are the only two things that move a run and
+neither returns an event list; every sound worth playing is a difference
+between the state they returned and the one before it — a hit is the combo
+going up, a miss is the miss count going up, a letter through is a shield zone
+going down, an ending is `ending` arriving. `soundsFor(before, after)` in
+`stormSounds.ts` is that diff, and it is a pure function a unit test drives a
+whole wave through in a millisecond. The alternative is the model handing back
+"and here is what happened", which is a second description of the run living
+beside the run — and the copy is the one that drifts (§8.9).
+
+It is called from beside `tick` and `fire` in `useStormClock`, and not from a
+hook watching the state React rendered. Every event here does change the
+picture, so a hook on the rendered state would see all of them today — but it
+would be one batching decision away from not seeing them, and a sound that
+never plays is a bug nobody can reproduce.
+
+Two edges the diff has to get right, both pinned by tests:
+
+- **A tick that lands a dozen letters is still one shield sound.** A
+  backgrounded tab hands the loop a second of wave at once (§8.9), and twelve
+  crunches inside one frame says nothing about which zone or how many — the
+  same reasoning that makes several landings on one zone a single tint
+  (decision 42).
+- **A mended zone is not a damaged one.** `repaired` hands back a new shield
+  when a streak puts a point back (§8.5), so a diff that only asked whether the
+  shield had changed would hear armour growing back as armour breaking.
+
+**And a storm does not play `finish`.** A race ends by being finished; a storm
+can end by being lost, and a major triad over a broken shield is the game
+congratulating a child for dying. `useRaceFinish` takes a `fanfare` — its
+default is `sfx.finish` and every race uses it — and the storm passes one that
+does nothing, announcing its own ending off the frame the reducer stamped it:
+`sfx.finish` for a wave cleared, `sfx.breach` for a shield that failed.
+
+Nothing here needs a guard for the player who has sound off. `sfx` is silent
+when `soundOn` is false and in any environment with no `AudioContext`, which is
+also why the storm's tests never stub it.
+
 ---
 
 ## 9 · Routes and screens
@@ -2117,6 +2287,9 @@ which is what every run saved before this is.
 | 62  | The board may overflow the 720px race column                                                 | 720px is a reading measure and a keyboard is not read; a screen with a wider keyboard under it is the desk it depicts                                         |
 | 63  | The passage screen's `--key` subtracts its chrome rather than taking a share of the viewport | The HUD, the bars and the line you type on are a constant, so a dvh fraction that fits at 850px of viewport grows the page at 700                             |
 | 64  | Hailstorm draws no keyboard                                                                  | A storm is the exam for the lessons that taught the layout, and a picture of the keyboard on the exam is the answer sheet — and it was taking 45% of the fall |
+| 65  | A hailstone's speed has a ceiling in stone heights, not left to the sky                      | A wave says how long a letter falls and never how far, so a taller monitor would be a faster level; a backstop like `MIN_FALL_MS`, not a difficulty knob      |
+| 66  | A storm's sounds are a diff over two frames                                                  | `fire` and `tick` return states, not events; a model that raised events would be a second description of the run, and the copy is the one that drifts         |
+| 67  | A letter hangs at the top for a second before it falls                                       | A glyph is hardest to read exactly when it is new; standing it still first beats any amount of slowing it down, and it costs the twenty levels nothing        |
 
 ---
 

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -478,6 +478,21 @@ try {
    * through a whole wave is why the FIRST storm is the one measured.
    */
   const STORM_LESSON = "L04";
+
+  /*
+   * `QUEUE_MS` from `engine/typing/storm.ts` — how long a letter hangs at the
+   * top of the sky, perfectly still, before it starts to fall (§8.3, decision
+   * 67). Restated rather than imported because this file is plain Node driving
+   * a built page and cannot reach the engine's TypeScript; if the two ever
+   * part company the fall check below fails on a resting stone, which is the
+   * right way for that to be found.
+   *
+   * Three things here have to wait it out: the two that measure a stone moving
+   * (a resting one gives one position and no travel, which reads exactly like
+   * a broken loop) and the card times a landed letter saves, which are its
+   * whole life on screen and therefore include the beat.
+   */
+  const STORM_QUEUE_MS = 1000;
   const storm = async () => {
     // Out to the ladder first, so this is a fresh mount every time it is
     // called: a hash set to the one it already holds fires no navigation, and
@@ -514,12 +529,16 @@ try {
    * as its letter is airborne — and this level's first letter falls for 900ms,
    * which is why the window below is 700 and not a second.
    */
-  const fall = await page.evaluate(async () => {
+  const fall = await page.evaluate(async (queueMs) => {
     // The first stone in DOM order, which is wave-index (spawn) order because
     // the sky renders `wave.letters` in place — NOT lane order, and the lanes
     // in DOM order are not sorted. All this relies on is that the wave never
     // reorders, so it is the same element on every reading below.
     const stone = document.querySelector(".storm__letter");
+    // Let the beat pass first. A queued stone is doing exactly what it should
+    // by not moving, and sampling across it would report a working loop as a
+    // dead one. A little over, so the first reading is already falling.
+    await new Promise((done) => window.setTimeout(done, queueMs + 60));
     const tops = [];
     for (let i = 0; i < 28; i++) {
       tops.push(stone.getBoundingClientRect().top);
@@ -540,7 +559,7 @@ try {
       attached: stone.isConnected,
       pending: window.__pendingFrames(),
     };
-  });
+  }, STORM_QUEUE_MS);
   check(
     "a stone moves on every frame, not once per spawn",
     fall.distinct >= 12 && fall.forwards && fall.attached,
@@ -1370,12 +1389,18 @@ try {
     "a wave nobody pressed at saves twelve letters that all got through",
     untouched?.correct === 0 &&
       untouched?.incorrect === 12 &&
-      // `ms` is the letter's own time in the air and the total is the sum of
+      // `ms` is the letter's own time on screen and the total is the sum of
       // them, not a wall clock — which is the whole of §8.7's `durationMs` for
       // a wave whose letters can overlap. Derived rather than a number written
       // here, because every level draws its falls from a range (§8.3): what is
       // asserted is that each is one of lesson 4's, and that the total is
       // exactly what they add up to.
+      //
+      // On screen, not falling: a letter nobody pressed at was there for the
+      // beat it hung as well as the fall it took, and `ms` is `atMs -
+      // spawnMs` — time from a child first SEEING it, which is what it has
+      // always been (§8.7). A letter that is shot during the beat still saves
+      // the small number it took.
       untouched?.durationMs ===
         untouched?.cards.reduce((sum, c) => sum + c.ms, 0) &&
       untouched?.cards.every(
@@ -1385,8 +1410,8 @@ try {
           c.given === null &&
           c.ok === false &&
           c.timedOut === true &&
-          c.ms >= 900 &&
-          c.ms <= 1200,
+          c.ms >= STORM_QUEUE_MS + 900 &&
+          c.ms <= STORM_QUEUE_MS + 1200,
       ),
     `${untouched?.correct}/${untouched?.incorrect} in ${untouched?.durationMs}ms`,
   );
@@ -1449,12 +1474,14 @@ try {
   await page.evaluate(() => (window.__tints = []));
   await storm();
 
-  const calm = await page.evaluate(async () => {
+  const calm = await page.evaluate(async (queueMs) => {
     // The same measurement as the fall at the top of section 9, on a page that
     // has asked for less motion: distinct positions are what a re-render alone
     // cannot fake, because without the loop a stone would not move at all
-    // between two spawns a second and a half apart.
+    // between two spawns a second and a half apart. The beat is waited out
+    // here for the same reason it is there.
     const stone = document.querySelector(".storm__letter");
+    await new Promise((done) => window.setTimeout(done, queueMs + 60));
     const tops = [];
     for (let i = 0; i < 20; i++) {
       tops.push(stone.getBoundingClientRect().top);
@@ -1485,7 +1512,7 @@ try {
         .transform,
       particles: document.querySelectorAll(".confetti, .confetti__bit").length,
     };
-  });
+  }, STORM_QUEUE_MS);
   check(
     "a stone still falls, frame by frame, for a child who asked for less motion",
     calm.distinct >= 12 && calm.forwards && calm.travelled > 0,

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -9,12 +9,14 @@ import {
   MIN_FALL_MS,
   MIN_TINT_GAP_MS,
   MISS_POINTS,
+  QUEUE_MS,
   SHIELD_FINGERS,
   buildWave,
   fallRange,
   fire,
   hasLanded,
   isAirborne,
+  isFalling,
   progressAt,
   startStorm,
   stormReport,
@@ -144,17 +146,32 @@ const REACTION = SPECS.filter(([, s]) => s.gap[0] >= fallRange(s)[1]);
 const STACKING = SPECS.filter(([, s]) => s.gap[1] < fallRange(s)[0]);
 
 /**
- * The most letters on the field at any one moment.
+ * The most letters *coming down* at any one moment.
  *
- * The count on screen only ever goes up at a spawn, so asking `isAirborne` at
- * every spawn instant finds the maximum without a sweep. Reading the half-open
- * interval out of the engine rather than restating it here is what makes the
- * boundary pair at the bottom of this file — `gap` exactly `fall`, and one
- * millisecond the other side — a test of the rule the reducer actually fires
- * and damages by, instead of a test of a second copy of it that happens to
- * live in the test file.
+ * The count only ever goes up when a letter starts to drop, so asking
+ * `isFalling` at every drop instant finds the maximum without a sweep. Reading
+ * the half-open interval out of the engine rather than restating it here is
+ * what makes the boundary pair at the bottom of this file — `gap` exactly
+ * `fall`, and one millisecond the other side — a test of the rule the reducer
+ * actually fires and damages by, instead of a test of a second copy of it that
+ * happens to live in the test file.
+ *
+ * Falling and not merely on the field, because that is what `gap >= fall`
+ * buys: every letter waits the same beat at the top before it moves
+ * (`QUEUE_MS`), so a reaction level has one letter coming down with the next
+ * one queued above it. `maxOnField` below is the other count, and the pair of
+ * them is what says the queue is a queue.
  */
-const maxOnScreen = (wave: Wave): number =>
+const maxFalling = (wave: Wave): number =>
+  Math.max(
+    0,
+    ...wave.letters.map(
+      (l) => wave.letters.filter((other) => isFalling(other, l.dropMs)).length,
+    ),
+  );
+
+/** The most letters drawn at once — queued and falling together. */
+const maxOnField = (wave: Wave): number =>
   Math.max(
     0,
     ...wave.letters.map(
@@ -450,7 +467,8 @@ describe("the schedule the wave hands the reducer", () => {
         const wave = buildWave(s, seed);
         wave.letters.forEach((letter, i) => {
           const where = `${name} @ ${seed}: letter ${i}`;
-          expect(letter.landMs, where).toBe(letter.spawnMs + letter.fallMs);
+          expect(letter.dropMs, where).toBe(letter.spawnMs + QUEUE_MS);
+          expect(letter.landMs, where).toBe(letter.dropMs + letter.fallMs);
           if (i > 0)
             expect(letter.spawnMs, where).toBeGreaterThanOrEqual(
               wave.letters[i - 1].spawnMs,
@@ -513,7 +531,7 @@ describe("when gap clears fall, one letter falls at a time", () => {
         fallRange(s)[1],
       );
       for (const seed of SEEDS)
-        expect(maxOnScreen(buildWave(s, seed)), `${name} @ ${seed}`).toBe(1);
+        expect(maxFalling(buildWave(s, seed)), `${name} @ ${seed}`).toBe(1);
     }
   });
 
@@ -522,7 +540,7 @@ describe("when gap clears fall, one letter falls at a time", () => {
     // the next one spawns, which is a handover and not an overlap.
     const s = spec({ count: 30, gap: [900, 900], fall: [900, 900] });
     for (const seed of SEEDS)
-      expect(maxOnScreen(buildWave(s, seed)), `@ ${seed}`).toBe(1);
+      expect(maxFalling(buildWave(s, seed)), `@ ${seed}`).toBe(1);
   });
 
   it("is not a reaction level just because the row says so", () => {
@@ -542,7 +560,7 @@ describe("when gap clears fall, one letter falls at a time", () => {
     );
     expect(s.gap[0], "and is not one").toBeLessThan(fallRange(s)[1]);
     for (const seed of SEEDS)
-      expect(maxOnScreen(buildWave(s, seed)), `@ ${seed}`).toBe(2);
+      expect(maxFalling(buildWave(s, seed)), `@ ${seed}`).toBe(2);
   });
 
   it("stops holding one millisecond the other side of it", () => {
@@ -552,7 +570,7 @@ describe("when gap clears fall, one letter falls at a time", () => {
     // this pair.
     const s = spec({ count: 30, gap: [899, 899], fall: [900, 900] });
     for (const seed of SEEDS)
-      expect(maxOnScreen(buildWave(s, seed)), `@ ${seed}`).toBe(2);
+      expect(maxFalling(buildWave(s, seed)), `@ ${seed}`).toBe(2);
   });
 
   it("stacks letters up on the levels that mean to", () => {
@@ -567,7 +585,7 @@ describe("when gap clears fall, one letter falls at a time", () => {
     for (const [name, s] of STACKING)
       for (const seed of SEEDS)
         expect(
-          maxOnScreen(buildWave(s, seed)),
+          maxFalling(buildWave(s, seed)),
           `${name} @ ${seed}`,
         ).toBeGreaterThan(1);
   });
@@ -600,6 +618,12 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
     finger: stroke.finger,
     lane: keyX(stroke.code) ?? 0,
     spawnMs,
+    // No queue: a hand-placed letter falls the instant it appears, so every
+    // absolute moment below is the one the test wrote down. The beat a real
+    // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it is tested
+    // where it is added rather than folded into the arithmetic of every
+    // reducer test that only cares about what a landing costs.
+    dropMs: spawnMs,
     fallMs,
     landMs: spawnMs + fallMs,
   };
@@ -626,6 +650,125 @@ const landed = (state: StormState) =>
   state.resolved.flatMap((outcome, index) =>
     outcome?.outcome === "landed" ? [index] : [],
   );
+
+describe("a letter hangs before it falls", () => {
+  /*
+   * The queue (§8.3, decision 67). A letter appears, stands perfectly still
+   * for `QUEUE_MS` while a child reads it, and only then starts to drop.
+   *
+   * Everything here is about what that beat must NOT disturb, because the
+   * whole reason it can be a single constant is that it disturbs nothing: it
+   * is added to every letter of every level, so it shifts the schedule and
+   * warps no part of it.
+   */
+
+  it("is drawn and shootable from the moment it appears", () => {
+    // The point of the beat is that a child can read the letter — and a game
+    // that showed them one and then charged ten points for pressing it would
+    // be punishing them for doing exactly that (`QUEUE_MS`).
+    const wave = buildWave(spec({ count: 1, keys: ["f"] }), 3);
+    const [letter] = wave.letters;
+    const half = letter.spawnMs + QUEUE_MS / 2;
+
+    expect(isAirborne(letter, half)).toBe(true);
+    expect(isFalling(letter, half)).toBe(false);
+
+    const early = fire(to(startStorm(wave), half), "KeyF");
+    expect(early.resolved[0]?.outcome).toBe("shot");
+    expect(early.score).toBeGreaterThan(0);
+  });
+
+  it("does not move while it hangs, and lands a fall after it drops", () => {
+    const wave = buildWave(
+      spec({ count: 1, keys: ["f"], fall: [1200, 1200] }),
+      3,
+    );
+    const [letter] = wave.letters;
+
+    expect(progressAt(letter, letter.spawnMs)).toBe(0);
+    expect(progressAt(letter, letter.dropMs - 1)).toBe(0);
+    expect(progressAt(letter, letter.dropMs)).toBe(0);
+    expect(progressAt(letter, letter.dropMs + 600)).toBe(0.5);
+    expect(progressAt(letter, letter.landMs)).toBe(1);
+  });
+
+  it("floors progress at zero, so a queued stone cannot fly up out of the sky", () => {
+    // `--drop` is multiplied by the travel, so a negative one is a negative
+    // offset — a letter drawn ABOVE where it appeared, climbing as it waits.
+    const wave = buildWave(spec({ count: 4 }), 5);
+    for (const letter of wave.letters)
+      for (let t = letter.spawnMs; t < letter.dropMs; t += 100)
+        expect(progressAt(letter, t)).toBe(0);
+  });
+
+  it("gives two letters hanging side by side to the earlier spawn", () => {
+    // Floored, they tie at the top of the sky, and a tie goes to the index
+    // like every other dead heat (decision 33). Unfloored they would be ranked
+    // by how long each had left divided by how long its own fall is, which is
+    // a number nothing on screen shows a child.
+    const slow = {
+      ...at("f", 0, 4000),
+      dropMs: QUEUE_MS,
+      landMs: QUEUE_MS + 4000,
+    };
+    const quick = {
+      ...at("j", 0, 900),
+      dropMs: QUEUE_MS,
+      landMs: QUEUE_MS + 900,
+    };
+    const state = to(runOf([slow, quick], { shield: 3 }), QUEUE_MS / 2);
+
+    expect(progressAt(slow, QUEUE_MS / 2)).toBe(
+      progressAt(quick, QUEUE_MS / 2),
+    );
+    expect(targetIndex(state)).toBe(0);
+  });
+
+  it("shifts the schedule and warps no part of it", () => {
+    // The three things that make the beat a constant rather than a re-tune:
+    // which letters fall, how far apart they spawn, and how long each falls
+    // for are all exactly what they were, at every seed.
+    for (const [name, s] of SPECS)
+      for (const seed of SEEDS) {
+        const wave = buildWave(s, seed);
+        const where = `${name} @ ${seed}`;
+
+        // Spawns are untouched — the queue is time added to a letter's life,
+        // not a head start on the wave. The first letter is still the instant
+        // the wave begins, and every gap after it is still a draw from the
+        // level's own range.
+        expect(wave.letters[0].spawnMs, where).toBe(0);
+        for (const gap of gapsOf(wave)) {
+          expect(gap, where).toBeGreaterThanOrEqual(s.gap[0]);
+          expect(gap, where).toBeLessThanOrEqual(s.gap[1]);
+        }
+        wave.letters.forEach((letter, i) => {
+          expect(letter.dropMs, `${where}: ${i}`).toBe(
+            letter.spawnMs + QUEUE_MS,
+          );
+          expect(letter.landMs - letter.dropMs, `${where}: ${i}`).toBe(
+            letter.fallMs,
+          );
+        });
+        expect(wave.durationMs, where).toBe(
+          Math.max(...wave.letters.map((l) => l.landMs)),
+        );
+      }
+  });
+
+  it("costs a level nothing it did not already have on the field", () => {
+    // A reaction level shows one letter falling with the next queued above it
+    // — two on the field, never three. A third would mean the beat had grown
+    // past the gaps these levels are spaced at, which is the shape of the
+    // failure a bigger `QUEUE_MS` would have.
+    for (const [name, s] of REACTION)
+      for (const seed of SEEDS) {
+        const wave = buildWave(s, seed);
+        expect(maxFalling(wave), `${name} @ ${seed}`).toBe(1);
+        expect(maxOnField(wave), `${name} @ ${seed}`).toBeLessThanOrEqual(2);
+      }
+  });
+});
 
 describe("where a letter is at time t", () => {
   const letter = at("f", 1000, 500);

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -64,10 +64,13 @@ export type ShieldFinger = Exclude<Finger, "thumb">;
  * spawn delay and its own fall time. The relationship between the two ranges is
  * the level's whole difficulty shape:
  *
- *   - `gap` at or above `fall` → a letter lands before the next one spawns, so
- *     there is never more than one on screen and the game is pure reaction.
- *     That is what the early levels are (see `buildWave` for the arithmetic).
- *   - `gap` below `fall` → two or three in the air at once, and the child has
+ *   - `gap` at or above `fall` → a letter lands before the next one starts to
+ *     drop, so there is never more than one FALLING and the game is pure
+ *     reaction. That is what the early levels are (see `buildWave` for the
+ *     arithmetic). There may still be one queued above it — every letter waits
+ *     a beat before it moves (`QUEUE_MS`) — which is the next one waiting its
+ *     turn rather than a second thing to track.
+ *   - `gap` below `fall` → two or three coming down at once, and the child has
  *     to work bottom-up. Which is reading ahead, which is the thing that makes
  *     a fast typist.
  */
@@ -144,10 +147,17 @@ export type StormLetter = {
   lane: number;
   /** ms from the start of the wave to this letter appearing at the top. */
   spawnMs: number;
+  /**
+   * `spawnMs + QUEUE_MS` — when it stops hanging and starts to fall.
+   *
+   * A letter is **on the field, and shootable, from `spawnMs`**; it does not
+   * move until this. See `QUEUE_MS` for why there is a difference at all.
+   */
+  dropMs: number;
   /** ms it takes to cross the field, drawn from `spec.fall`. */
   fallMs: number;
   /**
-   * `spawnMs + fallMs` — when it reaches the shield.
+   * `dropMs + fallMs` — when it reaches the shield.
    *
    * A letter occupies the field on the **half-open** interval
    * `[spawnMs, landMs)`: it is there the instant it spawns and gone the instant
@@ -158,7 +168,7 @@ export type StormLetter = {
    *
    * Derived, and stored anyway, because it is read on every tick. One warning
    * belongs with it: the *lowest* letter on screen is the one with the greatest
-   * `(t - spawnMs) / fallMs`, which is not the same order as `landMs` once two
+   * `(t - dropMs) / fallMs`, which is not the same order as `landMs` once two
    * letters fall at different speeds. Two orderings that look interchangeable
    * and part company exactly where it matters are worth a sentence — and, now
    * that something depends on the difference, a function: `targetIndex` aims by
@@ -263,6 +273,66 @@ function fallable(ch: string): Fallable | null {
 export const MIN_FALL_MS = 800;
 
 /**
+ * How long a letter hangs at the top of the sky before it starts to fall
+ * (decision 67).
+ *
+ * ── The problem it solves ────────────────────────────────────────────────────
+ * A letter has to be **read** before it can be aimed at, and until this it had
+ * to be read while moving. That is the hardest possible moment to do it: the
+ * display smears a moving glyph across whatever it crosses in one frame, and
+ * the letters a child confuses — `i` and `l`, `1` and `l`, `O` and `0` — are
+ * exactly the ones told apart by a detail that survives least. Capping the
+ * fall speed (§8.2, decision 65) makes the smear smaller; this removes it for
+ * the one moment it matters most, which is the moment a letter is new.
+ *
+ * So a letter appears, hangs perfectly still for this long, and only then
+ * falls. What a child does in that beat is the actual skill the mode teaches:
+ * read the character, and find the key.
+ *
+ * ── It is time added, and it has to be ───────────────────────────────────────
+ * The obvious cheaper version is to hold a letter inside its own fall time —
+ * hang for a beat, then cover the same distance in what is left. That is
+ * strictly worse than doing nothing: the same sky in less time is a FASTER
+ * drop, which is the problem it was meant to fix, at its most urgent point.
+ * There is no version of this that does not add time to the letter's life.
+ *
+ * ── Shootable the whole time ─────────────────────────────────────────────────
+ * A queued letter is on the field: `isAirborne` says so, `targetIndex` will
+ * aim at it, and `fire` will take it. That is not a detail. A game that showed
+ * a child a letter and then charged them ten points for pressing it too early
+ * would be punishing them for doing the thing the queue exists to let them do.
+ * What the queue is NOT is a head start on the schedule — the letters still
+ * arrive at the same intervals, so a child who reads fast simply gets to spend
+ * the beat, and one who does not still has the whole fall.
+ *
+ * ── What it does not disturb ─────────────────────────────────────────────────
+ * The value is the same for every letter of every level, so it shifts the
+ * whole schedule and warps none of it. Three things fall out of that, and each
+ * is a thing that would otherwise have needed re-tuning:
+ *
+ *   - **The twenty levels keep their shapes.** `gap` against `fall` is the
+ *     difficulty (`WaveSpec`), both are untouched, and the seeds are drawn in
+ *     the same order from the same generator — so every level rains the same
+ *     letters in the same lanes at the same speeds it did before.
+ *   - **"One at a time" survives, as a claim about falling.** Levels 4, 9 and
+ *     13 promise pure reaction, and what that has always meant is that no two
+ *     letters are coming DOWN at once — which `gap[0] >= fall[1]` still buys
+ *     exactly, because every fall is shifted by the same amount. A letter
+ *     queued above a falling one is the next one waiting its turn, which is
+ *     what makes it a queue.
+ *   - **A run's own times mean what they did.** `CardResult.ms` is
+ *     `atMs - spawnMs` (§8.7) — time from a child first *seeing* the letter,
+ *     which is what it always was. A fast player's card is the same number it
+ *     would have been; only a slow one has longer to be slow in.
+ *
+ * A second is a judgement, not a measurement, and it is the same order as the
+ * fastest fall on the ladder (900ms, lessons 4, 9 and 13). Round, long enough
+ * to read an unfamiliar glyph without hurrying, and short enough that a level
+ * with a 300ms gap still has a queue rather than a crowd.
+ */
+export const QUEUE_MS = 1000;
+
+/**
  * The fall times a spec can actually produce — its own range, floored at
  * `MIN_FALL_MS`.
  *
@@ -295,19 +365,20 @@ export function fallRange(spec: WaveSpec): [number, number] {
  * which is free today and is not free the moment a level's seed is written down
  * beside a saved run (STM08).
  *
- * ── Why `gap ≥ fall` means one letter at a time ──────────────────────────────
- * Letter _i_ is on the field over `[spawn_i, spawn_i + fall_i)` and letter
- * _i+1_ spawns at `spawn_i + gap_{i+1}`, so the two share the screen exactly
- * when `gap_{i+1} < fall_i`. If every gap a spec can draw is at least every
- * fall it can draw — `gap[0] ≥ fall[1]` — that is never true, and since spawn
- * times only increase, no *later* letter can overlap letter _i_ either. So the
- * early levels' "never more than one on screen" is a property of the spec, not
- * a hope about the draw.
+ * ── Why `gap ≥ fall` means one letter falling at a time ──────────────────────
+ * Letter _i_ is coming down over `[drop_i, drop_i + fall_i)` and letter _i+1_
+ * drops at `drop_i + gap_{i+1}` — the queue shifts both by the same
+ * `QUEUE_MS`, so it cancels out of this entirely — and the two are therefore
+ * falling together exactly when `gap_{i+1} < fall_i`. If every gap a spec can
+ * draw is at least every fall it can draw — `gap[0] ≥ fall[1]` — that is never
+ * true, and since spawn times only increase, no *later* letter can overlap
+ * letter _i_ either. So the early levels' "never more than one falling" is a
+ * property of the spec, not a hope about the draw.
  *
  * The boundary goes to safety: `gap` exactly equal to `fall` still leaves one
- * letter on screen, because the interval is half-open — the outgoing letter
- * lands on the same millisecond the next one spawns, and landing is the tick
- * that takes it off the field.
+ * letter coming down, because the interval is half-open — the outgoing letter
+ * lands on the same millisecond the next one starts to drop, and landing is
+ * the tick that takes it off the field.
  *
  * That arithmetic is read against `fallRange(spec)` and not against
  * `spec.fall`: the fall a letter gets is floored at `MIN_FALL_MS`, and a floor
@@ -338,7 +409,11 @@ export function buildWave(spec: WaveSpec, seed: number): Wave {
     if (i > 0) spawnMs += between(spec.gap[0], spec.gap[1], rand);
     const from = pool[between(0, pool.length - 1, rand)];
     const fallMs = between(fall[0], fall[1], rand);
-    letters.push({ ...from, spawnMs, fallMs, landMs: spawnMs + fallMs });
+    // Every letter waits the same beat before it moves (`QUEUE_MS`), so this
+    // shifts the whole schedule and warps none of it — and draws nothing from
+    // `rand`, which is what keeps every level's weather exactly what it was.
+    const dropMs = spawnMs + QUEUE_MS;
+    letters.push({ ...from, spawnMs, dropMs, fallMs, landMs: dropMs + fallMs });
   }
 
   return {
@@ -360,7 +435,7 @@ export function buildWave(spec: WaveSpec, seed: number): Wave {
  */
 
 /**
- * Is this letter on the field at `timeMs`?
+ * Is this letter on the field at `timeMs` — queued or falling?
  *
  * A letter occupies the **half-open** interval `[spawnMs, landMs)`: there the
  * instant it spawns, gone the instant it lands, because landing is the tick
@@ -369,11 +444,17 @@ export function buildWave(spec: WaveSpec, seed: number): Wave {
  * That convention is exported as a pair of predicates rather than written out
  * where it is needed, because it is one `<` against one `<=` and more than one
  * thing reads it: `targetIndex` decides what can be shot with `isAirborne`,
- * `tick` decides what damages the shield with `hasLanded`, and the field will
- * draw whatever `isAirborne` says is there (STM03). Spelled out at each of
- * those, it would be three chances to pick the wrong side of a millisecond —
- * and the wrong side of a millisecond is a letter that is both shootable and
- * already spent.
+ * `tick` decides what damages the shield with `hasLanded`, and the field draws
+ * whatever `isAirborne` says is there (STM03). Spelled out at each of those,
+ * it would be three chances to pick the wrong side of a millisecond — and the
+ * wrong side of a millisecond is a letter that is both shootable and already
+ * spent.
+ *
+ * **Airborne, and not yet falling, is a real state** (`QUEUE_MS`): a letter
+ * hangs at the top of the sky for a beat before it moves. It is on the field
+ * throughout — drawn, aimed at and shootable — because a queue a child may not
+ * shoot into is a letter the game shows them and then charges them ten points
+ * for pressing.
  *
  * `hasLanded` is deliberately not `!isAirborne`: a letter that has not spawned
  * yet is neither on the field nor landed, and the reducer must not charge the
@@ -381,6 +462,23 @@ export function buildWave(spec: WaveSpec, seed: number): Wave {
  */
 export function isAirborne(letter: StormLetter, timeMs: number): boolean {
   return letter.spawnMs <= timeMs && timeMs < letter.landMs;
+}
+
+/**
+ * Is this letter actually coming down at `timeMs`, rather than waiting to?
+ *
+ * The narrower half of `isAirborne`, and what "one letter at a time" is a
+ * claim about: the early levels promise pure reaction, and what that has
+ * always meant is that no two letters are FALLING at once (`buildWave`). A
+ * letter queued above a falling one is the next one waiting its turn.
+ *
+ * Nothing in the reducer reads it — the rules care about what is on the field
+ * and what has landed, and neither of those is this. It is here because the
+ * property it names is one the twenty levels are held to, and a test that
+ * restated the interval would be a second opinion about `QUEUE_MS`.
+ */
+export function isFalling(letter: StormLetter, timeMs: number): boolean {
+  return letter.dropMs <= timeMs && timeMs < letter.landMs;
 }
 
 /** Has this letter reached the shield by `timeMs`? See `isAirborne`. */
@@ -397,13 +495,22 @@ export function hasLanded(letter: StormLetter, timeMs: number): boolean {
  * what the gun is aimed at. A child aims by looking, so the letter the game
  * thinks is lowest has to be the letter that is drawn lowest.
  *
- * `fallMs` cannot be 0 while a letter is airborne — `spawn <= t < spawn +
- * fall` has no solutions at `fall = 0` — so the division is safe everywhere
- * the value is a position. Off the interval it still answers, and answers
- * honestly: negative before the spawn, past 1 after the landing.
+ * **Floored at zero, which is what a queued letter is** (`QUEUE_MS`). Both
+ * readers need that and for the same reason. The renderer would otherwise
+ * carry a queued stone UP out of the sky, since `--drop` is multiplied by the
+ * travel and a negative one is a negative offset. And `targetIndex` would rank
+ * two letters hanging side by side at the top — visibly at the same height —
+ * by how long each has left before it drops divided by how long its fall is,
+ * which is a number nothing on screen shows. Floored, they tie, and a tie goes
+ * to the earlier spawn like every other dead heat (decision 33).
+ *
+ * `fallMs` cannot be 0 while a letter is falling — `drop <= t < drop + fall`
+ * has no solutions at `fall = 0` — so the division is safe everywhere the
+ * value is a position. Past the landing it still answers, and answers
+ * honestly: greater than 1.
  */
 export function progressAt(letter: StormLetter, timeMs: number): number {
-  return (timeMs - letter.spawnMs) / letter.fallMs;
+  return Math.max(0, (timeMs - letter.dropMs) / letter.fallMs);
 }
 
 /**

--- a/src/engine/typing/storms.test.ts
+++ b/src/engine/typing/storms.test.ts
@@ -10,6 +10,7 @@ import {
   buildWave,
   fallRange,
   isAirborne,
+  isFalling,
   startStorm,
   type ShieldFinger,
   type Wave,
@@ -158,13 +159,30 @@ function peakZonesLit(wave: Wave, windowMs = 150): number {
 }
 
 /**
- * The most letters on the field at once.
+ * The most letters *coming down* at once.
  *
- * The count only ever rises at a spawn, so asking `isAirborne` at every spawn
- * instant finds the maximum without sweeping the clock — and it asks the
- * engine's own half-open interval rather than restating it (§8.3).
+ * The count only ever rises when a letter starts to drop, so asking
+ * `isFalling` at every drop instant finds the maximum without sweeping the
+ * clock — and it asks the engine's own half-open interval rather than
+ * restating it (§8.3).
+ *
+ * Falling and not merely drawn, because that is the claim the early levels
+ * make. Every letter hangs at the top for the same beat before it moves
+ * (`QUEUE_MS`), so a reaction level shows one letter coming down with the next
+ * queued above it — which is a queue, not a second thing to track. `maxOnField`
+ * is the other count, and the pair of them is what says so.
  */
-const maxOnScreen = (wave: Wave): number =>
+const maxFalling = (wave: Wave): number =>
+  Math.max(
+    0,
+    ...wave.letters.map(
+      (letter) =>
+        wave.letters.filter((other) => isFalling(other, letter.dropMs)).length,
+    ),
+  );
+
+/** The most letters drawn at once — queued and falling together. */
+const maxOnField = (wave: Wave): number =>
   Math.max(
     0,
     ...wave.letters.map(
@@ -413,27 +431,34 @@ describe("no zone can strobe", () => {
 });
 
 describe("the ladder's difficulty climbs", () => {
-  it("drops one letter at a time until lesson 19", () => {
+  it("drops one letter at a time until lesson 19, with the next one queued", () => {
     // Pure reaction (§8.3): `gap` clears `fall`, so a letter lands before the
-    // next one spawns and there is never a second on screen. Read off the
-    // built schedule at every seed rather than off the declared range, because
-    // `MIN_FALL_MS` can raise a fall and turn a promise into an overlap.
+    // next one starts to drop and there is never a second one coming down.
+    // Read off the built schedule at every seed rather than off the declared
+    // range, because `MIN_FALL_MS` can raise a fall and turn a promise into an
+    // overlap.
     for (const [name, lesson, wave] of SHIPPED) {
       if (lesson.n >= 19) continue;
-      expect(maxOnScreen(wave), name).toBe(1);
+      expect(maxFalling(wave), name).toBe(1);
       for (const seed of SEEDS)
         expect(
-          maxOnScreen(buildWave(waveSpecFor(lesson), seed)),
+          maxFalling(buildWave(waveSpecFor(lesson), seed)),
           `${name} @ ${seed}`,
         ).toBe(1);
+
+      // And what IS beside it is the next letter, waiting its turn. Two on the
+      // field where one is falling is the queue (`QUEUE_MS`); a third would
+      // mean the beat had grown past the gap these levels are spaced at, and
+      // the reaction levels would have quietly become reading-ahead ones.
+      expect(maxOnField(wave), name).toBeLessThanOrEqual(2);
     }
   });
 
   it("stacks them from lesson 19 on, and four deep at the top", () => {
     for (const [name, lesson, wave] of SHIPPED) {
       if (lesson.n < 19) continue;
-      expect(maxOnScreen(wave), name).toBeGreaterThan(1);
-      if (lesson.n >= 83) expect(maxOnScreen(wave), name).toBeGreaterThan(3);
+      expect(maxFalling(wave), name).toBeGreaterThan(1);
+      if (lesson.n >= 83) expect(maxFalling(wave), name).toBeGreaterThan(3);
     }
   });
 

--- a/src/games/race/useRaceFinish.ts
+++ b/src/games/race/useRaceFinish.ts
@@ -34,6 +34,7 @@ export function useRaceFinish({
   navigate,
   resultsPath,
   onSaving,
+  fanfare = sfx.finish,
 }: {
   profile: Profile;
   config: RaceConfig;
@@ -50,6 +51,24 @@ export function useRaceFinish({
   /** Where the finished run is shown. Each game has its own results screen. */
   resultsPath: string;
   onSaving: () => void;
+  /**
+   * What a finished run sounds like. `sfx.finish` unless a game says
+   * otherwise, which is every race: reaching the end of a deck is good news
+   * whatever the time on the clock.
+   *
+   * Hailstorm is the one that says otherwise, because it is the one run that
+   * can end by being LOST — a wave gets through the shield and the storm
+   * stops there. A major triad over a broken shield is the game congratulating
+   * a child for dying, so the storm passes a fanfare that does nothing and
+   * announces its own ending from the frame that stamped it, where the
+   * difference between clearing the wave and being breached is still in hand
+   * (`stormSounds.ts`).
+   *
+   * It is here and not at the call site of `complete()` because this hook owns
+   * the once-per-run guard: a sound played beside a call that may be refused
+   * is a sound that can play twice.
+   */
+  fanfare?: () => void;
 }) {
   const [saveError, setSaveError] = useState<string | null>(null);
   const finishing = useRef(false);
@@ -98,7 +117,7 @@ export function useRaceFinish({
       if (finishing.current) return;
       finishing.current = true;
       onSaving();
-      sfx.finish();
+      fanfare();
       await save();
     },
     retry() {

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -9,6 +9,7 @@ import { RaceProvider } from "@/components/state/RaceContext";
 import { FINGER_ZONES, KEYS, keyX, strokeFor } from "@/engine/keyboard";
 import {
   MIN_FALL_MS,
+  QUEUE_MS,
   SHIELD_FINGERS,
   buildWave,
   fire,
@@ -166,8 +167,15 @@ const only = (ch: string, count = 1, fallMs = 1000): WaveSpec => ({
   repairAt: 0,
 });
 
+/*
+ * Every absolute moment in this file is measured from the instant the first
+ * letter starts to DROP, not from the start of the wave — hence the offset.
+ * A real letter hangs at the top for `QUEUE_MS` before it moves (§8.3), and
+ * that beat is the same for every letter of every level, so folding it in here
+ * once leaves each schedule below saying exactly what it always said.
+ */
 const frameOf = (spec: WaveSpec, atMs: number): StormState =>
-  tick(startStorm(buildWave(spec, 7)), atMs);
+  tick(startStorm(buildWave(spec, 7)), QUEUE_MS + atMs);
 
 /**
  * A frame of the field, on its own. The `skyRef` is where `useStormClock`
@@ -177,15 +185,16 @@ const frameOf = (spec: WaveSpec, atMs: number): StormState =>
 const draw = (state: StormState) =>
   renderToStaticMarkup(<StormField state={state} skyRef={{ current: null }} />);
 
-/** Every falling letter in a rendered field, as `{ ch, lane }`. */
+/** Every falling letter in a rendered field, as `{ ch, lane, fallMs, drop }`. */
 const stones = (state: StormState) =>
   [
     ...draw(state).matchAll(
-      /class="storm__letter" style="--lane:([\d.]+);--drop:([\d.e-]+)"[^>]*>(.)</g,
+      /class="storm__letter" style="--lane:([\d.]+);--fall-ms:(\d+);--drop:([\d.e-]+)"[^>]*>(.)</g,
     ),
-  ].map(([, lane, drop, ch]) => ({
+  ].map(([, lane, fallMs, drop, ch]) => ({
     ch,
     lane: Number(lane),
+    fallMs: Number(fallMs),
     drop: Number(drop),
   }));
 
@@ -316,19 +325,52 @@ describe("StormField", () => {
     expect(declaration(".storm__letter", "transform")).toBe(
       "translateY(calc(var(--drop) * var(--fall)))",
     );
-    // `top` anchors the stone at the top of the sky and nothing else; the fall
-    // is not written there.
-    expect(declaration(".storm__letter", "top")).toBe("0");
+    // `top` is where the fall begins and nothing else; the fall itself is not
+    // written there. It is the sky's whole travel minus this letter's, so a
+    // stone that is capped comes into view lower — and `top + --fall` is
+    // `--sky-fall` for every letter, which is the promise that a capped stone
+    // still lands exactly on the shield rather than short of it.
+    expect(declaration(".storm__letter", "top")).toBe(
+      "calc(var(--sky-fall) - var(--fall))",
+    );
 
     // A percentage inside a transform resolves against the element being
-    // moved, so the travel is the sky's own height — which is only a length a
+    // moved, so the sky's travel is its own height — which is only a length a
     // stone can read because the sky is a size container. Floored at zero,
     // because the sky minus a stone goes negative on a viewport shorter than
     // about 265px, and an unfloored travel runs the storm upwards.
     expect(declaration(".storm__sky", "container-type")).toBe("size");
+    expect(
+      declaration(".storm__letter", "--sky-fall").replace(/\s+/g, " "),
+    ).toBe("max(0cqh, 100cqh - var(--stone))");
+  });
+
+  it("caps how fast a stone falls, in stone heights rather than pixels", () => {
+    // The travel is the SHORTER of the sky and what the speed cap allows
+    // (decision 65). Without the `min` the fall is whatever the viewport
+    // happens to be, so the same level is faster on a bigger monitor — which
+    // is how a 900ms fall came to cross about 720px a second once #197 took
+    // the board off the screen, and how `i` and `l` stopped being different
+    // letters at speed.
     expect(declaration(".storm__letter", "--fall").replace(/\s+/g, " ")).toBe(
-      "max(0cqh, 100cqh - var(--stone))",
+      "min( var(--sky-fall), " +
+        "calc(var(--fall-ms, 1000) / 1000 * var(--hail-speed) * var(--stone)) )",
     );
+
+    // In stone heights a second, and therefore a number with no unit: what
+    // blurs a moving glyph is how far it travels against its own size, so a
+    // cap written in pixels would mean something different at every `--key`.
+    // High enough that an ordinary screen uses the whole sky — the reading
+    // time is the beat a letter hangs for first (`QUEUE_MS`), not a slower
+    // fall — and low enough that a very tall one cannot run away with it.
+    expect(declaration(".storm", "--hail-speed")).toBe("9");
+
+    // And the letter's own fall time is a render's to write, not the loop's:
+    // it is fixed when the wave is built, where `--drop` moves every frame.
+    for (const fallMs of [900, 2600]) {
+      const [stone] = stones(frameOf(only("f", 1, fallMs), 100));
+      expect(stone.fallMs).toBe(fallMs);
+    }
   });
 
   it("draws one key unit, shared with the board it is aiming at", () => {

--- a/src/games/typing/storm/StormField.tsx
+++ b/src/games/typing/storm/StormField.tsx
@@ -84,6 +84,13 @@ import type { CSSProperties } from "react";
  * reducer damages the shield on (decision 30), and re-deciding which side of a
  * millisecond a landing falls on is how a stone becomes both shootable and
  * already spent.
+ *
+ * It is `isAirborne` and never `isFalling`: a letter hangs at the top of the
+ * sky for a beat before it moves (`QUEUE_MS`, decision 67), and that beat is
+ * the whole reason it is legible — the one moment it is new is the one moment
+ * it is standing still. A field that drew only what was falling would hide the
+ * letter exactly while a child was meant to be reading it, and would still let
+ * them shoot it, which the gun would have no way to explain.
  */
 export function isDrawn(state: StormState, index: number): boolean {
   return (
@@ -184,6 +191,15 @@ export function StormField({
               style={
                 {
                   "--lane": letter.lane,
+                  // How long this letter falls for, which the stylesheet turns
+                  // into how FAR: a stone is capped at `--hail-speed` stone
+                  // heights a second, so a short fall uses less of the sky
+                  // rather than crossing all of it faster (decision 65).
+                  // Written here beside the lane because it is the same kind
+                  // of fact — fixed when the wave was built, and never the
+                  // loop's to touch. The loop writes `--drop` and nothing
+                  // else.
+                  "--fall-ms": letter.fallMs,
                   "--drop": progressAt(letter, state.timeMs),
                 } as CSSProperties
               }

--- a/src/games/typing/storm/StormOver.test.tsx
+++ b/src/games/typing/storm/StormOver.test.tsx
@@ -34,6 +34,11 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
     lane: keyX(stroke.code) ?? 0,
     spawnMs,
     fallMs,
+    // No queue: a hand-placed letter falls the instant it appears, so every
+    // absolute moment below is the one the test wrote down. The beat a real
+    // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it belongs to the
+    // tests of the schedule rather than to every test of what a landing costs.
+    dropMs: spawnMs,
     landMs: spawnMs + fallMs,
   };
 };

--- a/src/games/typing/storm/StormRun.tsx
+++ b/src/games/typing/storm/StormRun.tsx
@@ -209,6 +209,12 @@ function StormPlay({
     // the field is frozen where the clock stopped, so there is no phase a
     // saving storm is in that it is not in already.
     onSaving: () => {},
+    // And nothing to play. A storm can end by being lost, so the sound of an
+    // ending is decided off the ending itself, on the frame the reducer
+    // stamped it — `sfx.finish` for a wave cleared, `sfx.breach` for a shield
+    // that failed (`stormSounds.ts`). The race's default would congratulate a
+    // child for dying.
+    fanfare: () => {},
   });
 
   /**

--- a/src/games/typing/storm/StormShield.test.tsx
+++ b/src/games/typing/storm/StormShield.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { FINGER_ZONES } from "@/engine/keyboard";
 import {
   MIN_FALL_MS,
+  QUEUE_MS,
   SHIELD_FINGERS,
   buildWave,
   fire,
@@ -40,8 +41,15 @@ const only = (ch: string, over: Partial<WaveSpec> = {}): WaveSpec => ({
   ...over,
 });
 
+/*
+ * Every absolute moment in this file is measured from the instant the first
+ * letter starts to DROP, not from the start of the wave — hence the offset.
+ * A real letter hangs at the top for `QUEUE_MS` before it moves (§8.3), and
+ * that beat is the same for every letter of every level, so folding it in here
+ * once leaves each schedule below saying exactly what it always said.
+ */
 const frameOf = (spec: WaveSpec, atMs: number): StormState =>
-  tick(startStorm(buildWave(spec, 7)), atMs);
+  tick(startStorm(buildWave(spec, 7)), QUEUE_MS + atMs);
 
 /** One rendered segment, as the attributes the stylesheet reads. */
 type Drawn = {
@@ -145,7 +153,7 @@ describe("StormShield", () => {
     // 30ms of gap and an 800ms fall puts two landings inside one 16ms frame.
     const together = tick(
       startStorm(buildWave(only("f", { gap: [30, 30] }), 7)),
-      830,
+      QUEUE_MS + 830,
     );
     expect(together.resolved.filter(Boolean)).toHaveLength(2);
     expect(zoneTally(together)["l-index"].hit).toBe(2);

--- a/src/games/typing/storm/stormSession.test.ts
+++ b/src/games/typing/storm/stormSession.test.ts
@@ -54,6 +54,11 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
     lane: keyX(stroke.code) ?? 0,
     spawnMs,
     fallMs,
+    // No queue: a hand-placed letter falls the instant it appears, so every
+    // absolute moment below is the one the test wrote down. The beat a real
+    // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it belongs to the
+    // tests of the schedule rather than to every test of what a landing costs.
+    dropMs: spawnMs,
     landMs: spawnMs + fallMs,
   };
 };

--- a/src/games/typing/storm/stormSounds.test.ts
+++ b/src/games/typing/storm/stormSounds.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import { keyX, strokeFor } from "@/engine/keyboard";
+import { fire, startStorm, tick } from "@/engine/typing/storm";
+
+import { soundsFor } from "./stormSounds";
+
+import type { StormLetter, StormState, WaveSpec } from "@/engine/typing/storm";
+
+/**
+ * What a storm sounds like (docs/typing.md §8.12).
+ *
+ * The whole point of `soundsFor` being a diff over two states is that this can
+ * be asked without a mixer, a browser or a clock: every run below is built
+ * from `fire` and `tick` — the same two functions the game is played through —
+ * and the assertion is on the list of names that comes back. Nothing here
+ * stubs `sfx`, because nothing here calls it; `playStormSounds` is a `switch`
+ * over exactly these names and has no decision left in it.
+ */
+
+/** One letter, placed by hand, off the same board the game is played on. */
+const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
+  const stroke = strokeFor(ch);
+  if (!stroke || stroke.finger === "thumb")
+    throw new Error(`${ch} cannot fall`);
+  return {
+    ch,
+    code: stroke.code,
+    finger: stroke.finger,
+    lane: keyX(stroke.code) ?? 0,
+    spawnMs,
+    fallMs,
+    // No queue: a hand-placed letter falls the instant it appears, so every
+    // absolute moment below is the one the test wrote down. The beat a real
+    // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it belongs to the
+    // tests of the schedule rather than to every test of what a landing costs.
+    dropMs: spawnMs,
+    landMs: spawnMs + fallMs,
+  };
+};
+
+const runOf = (letters: StormLetter[], over: Partial<WaveSpec> = {}) =>
+  startStorm({
+    spec: {
+      keys: ["f", "j"],
+      count: letters.length,
+      gap: [100, 100],
+      fall: [1000, 1000],
+      shield: 2,
+      repairAt: 0,
+      ...over,
+    },
+    seed: 11,
+    letters,
+    durationMs: letters.reduce((last, l) => Math.max(last, l.landMs), 0),
+  });
+
+/**
+ * The same wave with a letter added far enough out that the run cannot end.
+ *
+ * A wave is `cleared` the instant its last letter is accounted for, however
+ * that letter went (`settled`) — so a one-letter run announces its own ending
+ * on the same frame as the thing under test, and every assertion below about
+ * a shot or a crunch would be an assertion about the ending as well. This is
+ * how a test says "the run is still going", and the tests that ARE about the
+ * ending do not use it.
+ */
+const stillFalling = (letters: StormLetter[], over: Partial<WaveSpec> = {}) =>
+  runOf([...letters, at("j", 60_000, 1000)], over);
+
+/** Advance a run and say what it sounded like on the way. */
+const heardOnTick = (state: StormState, dtMs: number) => {
+  const next = tick(state, dtMs);
+  return { next, sounds: soundsFor(state, next) };
+};
+
+/** Press a key and say what it sounded like. */
+const heardOnKey = (state: StormState, code: string) => {
+  const next = fire(state, code);
+  return { next, sounds: soundsFor(state, next) };
+};
+
+describe("a stroke is heard as the shot plus its answer", () => {
+  it("plays the trigger and then the stone, in that order", () => {
+    // The shot first: a stroke's own sound must never arrive after the sound
+    // of what it did.
+    const mid = tick(stillFalling([at("f", 0, 1000)]), 300);
+    expect(heardOnKey(mid, "KeyF").sounds).toEqual(["shoot", "hit"]);
+  });
+
+  it("plays the trigger and then the miss, for a wrong key", () => {
+    const mid = tick(stillFalling([at("f", 0, 1000)]), 300);
+    expect(heardOnKey(mid, "KeyJ").sounds).toEqual(["shoot", "miss"]);
+  });
+
+  it("plays the trigger and a miss at an empty sky", () => {
+    // Nothing is falling at 50ms into a wave whose first letter spawns at 200,
+    // and a stroke into that costs ten points like any other (§8.6). What it
+    // must not do is sound like a hit, or sound like nothing at all.
+    const early = tick(stillFalling([at("f", 200, 1000)]), 50);
+    expect(heardOnKey(early, "KeyF").sounds).toEqual(["shoot", "miss"]);
+  });
+
+  it("is silent for a stroke the rules refuse", () => {
+    // `fire` on an ended run returns the state it was handed. The gun is
+    // already dead by then (`useStormClock`), so this is the belt to that
+    // brace rather than a case the screen can reach.
+    const done = tick(runOf([at("f", 0, 1000)]), 5000);
+    expect(done.ending).not.toBeNull();
+    expect(heardOnKey(done, "KeyF").sounds).toEqual([]);
+  });
+
+  it("says nothing on a frame where nothing happened", () => {
+    // Sixty of these a second, and the reason `soundsFor` compares the shield
+    // by identity before it compares its eight zones.
+    const mid = tick(stillFalling([at("f", 0, 1000)]), 300);
+    expect(heardOnTick(mid, 16).sounds).toEqual([]);
+  });
+});
+
+describe("a letter that gets through is heard on the shield", () => {
+  it("crunches once when armour takes it", () => {
+    // Shield of 2, one letter: the zone goes to 1, which is damage and not a
+    // hole.
+    const run = stillFalling([at("f", 0, 1000)], { shield: 2 });
+    expect(heardOnTick(run, 1000).sounds).toEqual(["shieldHit"]);
+  });
+
+  it("cracks when that was the zone's last point", () => {
+    // The second letter on the same finger empties it. Louder than the first,
+    // and instead of it rather than on top of it.
+    const run = stillFalling([at("f", 0, 1000), at("f", 100, 1000)], {
+      shield: 2,
+    });
+    const first = heardOnTick(run, 1000);
+    expect(first.sounds).toEqual(["shieldHit"]);
+    expect(heardOnTick(first.next, 100).sounds).toEqual(["shieldBreak"]);
+  });
+
+  it("is one sound however many letters a single tick lands", () => {
+    // A backgrounded tab hands the loop a second of wave at once, and a dozen
+    // crunches inside one frame says nothing about which zone or how many —
+    // the same reasoning that makes several landings on one zone a single
+    // tint (§8.10, decision 42).
+    const many = stillFalling(
+      Array.from({ length: 4 }, (_, i) => at("f", i * 20, 1000)),
+      { shield: 9 },
+    );
+    const heard = heardOnTick(many, 1100);
+    expect(heard.next.shield["l-index"]).toBe(5);
+    expect(heard.sounds).toEqual(["shieldHit"]);
+  });
+});
+
+describe("the end of a run says which end it was", () => {
+  it("breaches without a crunch under it", () => {
+    // The fatal landing damages nothing — the zone it fell on was already a
+    // hole — so a breach is never a crunch followed by a breach.
+    const run = runOf([at("f", 0, 1000)], { shield: 0 });
+    expect(heardOnTick(run, 1000).sounds).toEqual(["breach"]);
+  });
+
+  it("clears when the last letter is shot", () => {
+    const mid = tick(runOf([at("f", 0, 1000)]), 300);
+    expect(heardOnKey(mid, "KeyF").sounds).toEqual(["shoot", "hit", "cleared"]);
+  });
+
+  it("announces an ending exactly once", () => {
+    // `ending` is stamped once and then left alone, so every frame after it is
+    // silent — which is what stops a frozen field from playing the same
+    // fanfare sixty times a second.
+    const run = runOf([at("f", 0, 1000)], { shield: 0 });
+    const dead = heardOnTick(run, 1000);
+    expect(heardOnTick(dead.next, 16).sounds).toEqual([]);
+  });
+});
+
+describe("a mended zone is not a damaged one", () => {
+  it("stays quiet when a streak puts a point back", () => {
+    // Every second clean hit repairs the weakest zone (§8.5). The shield
+    // object changes on that frame, and a diff that only asked whether it had
+    // would hear armour growing back as armour breaking.
+    // An `f` gets through first, so the left index zone is genuinely down a
+    // point and there is something for the repair to put back. Without that
+    // the zones are all at the cap, `repaired` hands the same shield back, and
+    // this test passes without ever exercising the case.
+    const run = stillFalling(
+      [at("f", 0, 1000), at("j", 1200, 1000), at("j", 1300, 1000)],
+      { shield: 2, repairAt: 2 },
+    );
+    const landed = heardOnTick(run, 1000);
+    expect(landed.sounds).toEqual(["shieldHit"]);
+    expect(landed.next.shield["l-index"]).toBe(1);
+
+    const airborne = tick(landed.next, 400);
+    const hit = heardOnKey(airborne, "KeyJ");
+    const mend = heardOnKey(hit.next, "KeyJ");
+
+    expect(mend.next.shield["l-index"]).toBe(2);
+    expect(mend.sounds).toEqual(["shoot", "hit"]);
+  });
+});

--- a/src/games/typing/storm/stormSounds.ts
+++ b/src/games/typing/storm/stormSounds.ts
@@ -1,0 +1,139 @@
+import { SHIELD_FINGERS } from "@/engine/typing/storm";
+import { sfx } from "@/services/sound";
+
+import type { StormState } from "@/engine/typing/storm";
+
+/**
+ * What a storm sounds like, as a function of two frames (docs/typing.md §8.12).
+ *
+ * ── Read off the state, not raised by the code that changed it ───────────────
+ * `fire` and `tick` are the only two things that move a run, and neither of
+ * them returns an event list — they return the next `StormState`, and every
+ * event worth a sound is a difference between that and the one before it: a
+ * hit is the combo going up, a miss is the miss count going up, a letter
+ * getting through is a shield zone going down, and the end of the run is
+ * `ending` arriving. So the sound is a diff, and the diff is a pure function
+ * that a unit test can drive a whole wave through in a millisecond.
+ *
+ * The alternative is the reducer handing back "and here is what happened",
+ * which is a second description of the run living beside the run — and the
+ * copy is the one that drifts. `storm.ts` is deliberately a model with no
+ * events in it (§8.9); this is the view asking it what changed.
+ *
+ * ── Why it is not derived from what the screen draws ─────────────────────────
+ * `useStormClock` publishes to React only when the PICTURE changes, and every
+ * event here does change it — so a hook watching rendered states would see all
+ * of them today. It would be one React batching decision away from not seeing
+ * them, though: two publishes inside one flush render once, and the sound for
+ * the first would simply never play. Diffing where the state is produced has
+ * no such window, which is why the clock calls this and the field does not.
+ */
+
+/** One thing a run can be heard doing. */
+export type StormSound =
+  "shoot" | "hit" | "miss" | "shieldHit" | "shieldBreak" | "breach" | "cleared";
+
+/**
+ * Everything that happened between two frames, in the order it should be
+ * heard.
+ *
+ * The shot comes first and the answer to it second, so a hit is a `pew` with a
+ * chime on top rather than the other way round — a stroke's own sound must
+ * never arrive after the sound of what it did.
+ *
+ * At most three: a stroke is `shoot` plus exactly one of `hit`/`miss`, and a
+ * tick is at most one shield sound plus the ending. **A tick that resolves
+ * several landings is still one shield sound.** A backgrounded tab hands the
+ * loop a second's worth of wave at once (`MAX_STEP_MS`), and a dozen crunches
+ * fired inside one frame is a burst of noise that says nothing about which
+ * zone or how many — the same reasoning that makes several landings on one
+ * zone a single tint rather than several (§8.10, decision 42).
+ */
+export function soundsFor(
+  before: StormState,
+  after: StormState,
+): readonly StormSound[] {
+  const sounds: StormSound[] = [];
+
+  // Every stroke the gun takes moves exactly one of these two: `fire` either
+  // resolves the lowest letter, which is the combo going up, or charges a
+  // miss. So the trigger does not have to be reported separately — a shot is
+  // recoverable from its own outcome, and a `shoot` with no outcome would be
+  // a keydown the rules refused (an ended run, a held modifier, the way out).
+  if (after.combo > before.combo) sounds.push("shoot", "hit");
+  else if (after.misses > before.misses) sounds.push("shoot", "miss");
+
+  // Identity first, and it is a real short-circuit rather than a micro-
+  // optimisation: `tick` keeps the same shield object on every frame that
+  // resolves no landing, which is all but a handful of the sixty a second.
+  if (after.shield !== before.shield) {
+    let damaged = false;
+    let emptied = false;
+    for (const finger of SHIELD_FINGERS) {
+      if (after.shield[finger] >= before.shield[finger]) continue;
+      damaged = true;
+      // The zone's last point. Checked against zero rather than against the
+      // spec, because a zone that has been mended back up and knocked down
+      // again is a hole for the second time and is worth saying so twice.
+      if (after.shield[finger] === 0) emptied = true;
+    }
+    // The louder one replaces the crunch instead of stacking on it — a hole
+    // opening is a turning point in the run, and two shield sounds at once is
+    // one muddy sound rather than two clear ones.
+    if (emptied) sounds.push("shieldBreak");
+    else if (damaged) sounds.push("shieldHit");
+  }
+
+  // The fatal landing damages nothing — `tick` breaks before the decrement,
+  // because the zone it fell on was already a hole — so a breach is only ever
+  // this branch, and never a crunch followed by it.
+  if (before.ending === null && after.ending !== null)
+    sounds.push(after.ending.kind === "breached" ? "breach" : "cleared");
+
+  return sounds;
+}
+
+/**
+ * Play what changed.
+ *
+ * Split from the diff above so the rules stay testable without a mixer: every
+ * question worth asking — "does mashing at an empty sky make a shield noise",
+ * "does dying crunch first" — is a question about `soundsFor`, and this half
+ * is a `switch` with nothing in it to get wrong.
+ *
+ * `sfx` is silent when the player has sound off and in any environment with no
+ * `AudioContext`, so neither this nor its callers carry a guard of their own.
+ */
+export function playStormSounds(before: StormState, after: StormState): void {
+  for (const sound of soundsFor(before, after))
+    switch (sound) {
+      case "shoot":
+        sfx.shoot();
+        break;
+      case "hit":
+        // Pitched off the streak the hit LANDED on, which is the multiplier
+        // the HUD is showing by the time a child hears it (§8.6).
+        sfx.shatter(after.combo);
+        break;
+      case "miss":
+        sfx.misfire();
+        break;
+      case "shieldHit":
+        sfx.shieldHit();
+        break;
+      case "shieldBreak":
+        sfx.shieldBreak();
+        break;
+      case "breach":
+        sfx.breach();
+        break;
+      case "cleared":
+        // The race's own fanfare, because surviving a wave is the same good
+        // news as finishing a race and should not have a second tune. What is
+        // different is that a storm can also end badly, which is why the run
+        // screen takes `fanfare` off `useRaceFinish` and the ending is
+        // announced from here instead (`sfx.breach`).
+        sfx.finish();
+        break;
+    }
+}

--- a/src/games/typing/storm/useStormClock.test.ts
+++ b/src/games/typing/storm/useStormClock.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import { keyX, strokeFor } from "@/engine/keyboard";
-import { buildWave, fire, startStorm, tick } from "@/engine/typing/storm";
+import {
+  QUEUE_MS,
+  buildWave,
+  fire,
+  startStorm,
+  tick,
+} from "@/engine/typing/storm";
 
 import { MAX_STEP_MS, QUIT_KEY, redrawn, stepMs } from "./useStormClock";
 
@@ -33,6 +39,14 @@ const spec: WaveSpec = {
   repairAt: 0,
 };
 
+/**
+ * The fixture wave at an absolute moment of wave time.
+ *
+ * Spawns are at 0, 300, 600 and 900 — the queue shifts no spawn (§8.3) — and
+ * each letter then hangs for `QUEUE_MS` before falling for a second, so the
+ * landings are at 2000, 2300, 2600 and 2900. Both clocks are used below and
+ * the call sites say which they mean.
+ */
 const run = (atMs: number): StormState =>
   tick(startStorm(buildWave(spec, 7)), atMs);
 
@@ -110,6 +124,11 @@ const letterOf = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
     lane: keyX(stroke.code)!,
     spawnMs,
     fallMs,
+    // No queue: a hand-placed letter falls the instant it appears, so every
+    // absolute moment below is the one the test wrote down. The beat a real
+    // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it belongs to the
+    // tests of the schedule rather than to every test of what a landing costs.
+    dropMs: spawnMs,
     landMs: spawnMs + fallMs,
   };
 };
@@ -151,13 +170,14 @@ describe("redrawn", () => {
   });
 
   it("says yes when a letter lands, and when one is shot", () => {
-    const before = run(999);
+    // A hair before the first landing, which is a fall after the drop.
+    const before = run(QUEUE_MS + 999);
     expect(redrawn(before, tick(before, 2))).toBe(true);
     expect(redrawn(before, fire(before, "KeyF"))).toBe(true);
   });
 
   it("says yes to a miss, streak or no streak", () => {
-    const hit = fire(run(999), "KeyF");
+    const hit = fire(run(QUEUE_MS + 999), "KeyF");
     expect(hit.combo).toBe(1);
     expect(redrawn(hit, fire(hit, "KeyQ"))).toBe(true);
 

--- a/src/games/typing/storm/useStormClock.ts
+++ b/src/games/typing/storm/useStormClock.ts
@@ -6,6 +6,7 @@ import { fire, progressAt, startStorm, tick } from "@/engine/typing/storm";
 import { HELD } from "../keyboard/useKeyEcho";
 
 import { isDrawn } from "./StormField";
+import { playStormSounds } from "./stormSounds";
 
 import type { StormState, Wave } from "@/engine/typing/storm";
 
@@ -15,8 +16,8 @@ import type { StormState, Wave } from "@/engine/typing/storm";
  *
  * ── The loop holds no rules ──────────────────────────────────────────────────
  * All it does per frame is measure the delta, hand it to `tick`, write each
- * drawn stone's `--drop`, and re-render when the picture — rather than the
- * clock — has changed. Which letters exist, where they are, what a landing
+ * drawn stone's `--drop`, play whatever the frame turned out to sound like,
+ * and re-render when the picture — rather than the clock — has changed. Which letters exist, where they are, what a landing
  * costs, what a hit is worth, what a wrong key costs and when a run is over
  * were all settled in `engine/typing/storm.ts` before the first frame. That is
  * what makes the shield's rules answerable by a unit test in a millisecond
@@ -24,6 +25,15 @@ import type { StormState, Wave } from "@/engine/typing/storm";
  * this file is a rule that has stopped being testable. The two engine
  * predicates called here — `progressAt` for where a stone is, `isDrawn` for
  * whether it is on the field — are asked, never restated.
+ *
+ * The sound is the same shape of thing. `playStormSounds` is handed the frame
+ * before and the frame after and works out what changed between them
+ * (`stormSounds.ts`); nothing here decides what a hit or a breach sounds like,
+ * and nothing in `storm.ts` has grown an event list to tell it. It is called
+ * from beside `tick` and `fire` rather than from a hook watching the rendered
+ * state for the same reason the trigger is here: those two are the only things
+ * that move a run, and a state that never reaches a render is still a state
+ * something happened in.
  *
  * ── The trigger is here because the clock is ─────────────────────────────────
  * A shot is fired at `live.current` — the run as this frame left it — and not
@@ -341,6 +351,7 @@ export function useStormClock(
       if (!event.altKey && keyX(event.code) !== null) event.preventDefault();
 
       const next = fire(live.current, event.code);
+      playStormSounds(live.current, next);
       live.current = next;
       publish(next);
     };
@@ -355,6 +366,7 @@ export function useStormClock(
       frame = 0;
       const next = tick(live.current, stepMs(now, last));
       last = now;
+      playStormSounds(live.current, next);
       live.current = next;
 
       const sky = skyRef.current;

--- a/src/services/sound.ts
+++ b/src/services/sound.ts
@@ -212,4 +212,141 @@ export const sfx = {
     tone({ freq: C.a4, dur: 0.12, wave: "triangle", gain: 0.3 });
     tone({ freq: C.e5, dur: 0.3, delay: 0.1, wave: "triangle", gain: 0.3 });
   },
+
+  /* ── Hailstorm ───────────────────────────────────────────────────────────
+   *
+   * Six sounds for one screen, and what makes them a set rather than six
+   * effects is that they have to stay apart from each other while three or
+   * four of them happen a second (docs/typing.md §8.12).
+   *
+   * They are laid out along two axes a five-year-old can hear without being
+   * taught either. **Pitch says whose it is**: the gun and the stones are
+   * bright and short, the shield is low and long, so "I did something" and
+   * "something happened to me" never have to be told apart by timbre alone.
+   * **Length says how much it cost**: 50ms for a shot, 90 for a stone, 160
+   * for armour absorbing a letter, 340 for the last point of a zone, and
+   * three quarters of a second for the run ending. Nothing else on the
+   * screen is allowed to be the longest sound in it.
+   *
+   * Gains are deliberately below the rest of the kit. A race plays a handful
+   * of sounds a minute; a storm plays one per keystroke, and a mixer summing
+   * six of those into a limiter is a mush that teaches nothing.
+   */
+
+  /**
+   * The trigger, on every stroke the gun takes — the hit and the miss are
+   * layered over the top of it rather than replacing it.
+   *
+   * That layering is the point. A child who presses a key gets an answer
+   * within a frame whatever else is true, so the sound never has to wait on
+   * whether the shot landed, and the quietest, shortest thing on the screen
+   * is the one that happens most often.
+   *
+   * Two parts, because a single glide read as a blip rather than as a shot.
+   * The click is what makes it one — a 20ms burst of high noise is the report,
+   * and the ear places it as a *release* rather than as a note. The glide
+   * under it is the shot leaving: fast, an octave and a half, and over before
+   * the next key can be pressed. Deliberately not dramatic — it fires several
+   * times a second and anything with a tail would be a drone.
+   */
+  shoot: () => {
+    noise({ dur: 0.02, gain: 0.16, sweepFrom: 7000, sweepTo: 4200 });
+    tone({ freq: 1700, dur: 0.07, wave: "square", gain: 0.16, glideTo: 480 });
+  },
+
+  /**
+   * A hailstone shot out of the sky: a bright tone and a glassy noise burst.
+   *
+   * The pitch climbs with the streak exactly as `correct` does, and for the
+   * same reason — it is the same streak, and the multiplier it is paying at
+   * is the number the HUD is already showing (§8.6). Capped at an octave, so
+   * a long run stops climbing rather than ending up somewhere only a dog can
+   * hear it.
+   */
+  shatter: (streak = 1) => {
+    const step = Math.min(streak - 1, 11);
+    tone({
+      freq: C.e5 * Math.pow(2, step / 12),
+      dur: 0.08,
+      wave: "triangle",
+      gain: 0.3,
+    });
+    noise({ dur: 0.11, gain: 0.1, sweepFrom: 7000, sweepTo: 2200 });
+  },
+
+  /**
+   * A stroke that hit nothing — the wrong key, or any key at an empty sky
+   * (§8.6).
+   *
+   * **A shot going past**, and the shape is the whole of how it reads that
+   * way. A thing that passes you gets brighter as it comes and darker as it
+   * goes, so this is two noise sweeps back to back — up through the near
+   * field, then down and away, the second longer than the first because that
+   * is what receding sounds like. Nothing else in the set moves in two
+   * directions, which is what makes a miss unmistakable next to the shot that
+   * caused it.
+   *
+   * Under it, a short low fall: the sound has to *cost* something as well as
+   * describe something, and ten points off is not a neutral event. Quiet
+   * enough not to be the thing you hear, present enough that a run of misses
+   * sags.
+   *
+   * `wrong`'s 260ms sawtooth would be both the wrong length and the wrong
+   * feeling. A child losing a storm mashes, and eight harsh buzzes a second is
+   * a drone; a flurry of whizzes is a flurry.
+   */
+  misfire: () => {
+    noise({ dur: 0.05, gain: 0.13, sweepFrom: 800, sweepTo: 2800 });
+    noise({
+      dur: 0.17,
+      delay: 0.045,
+      gain: 0.13,
+      sweepFrom: 2800,
+      sweepTo: 500,
+    });
+    tone({ freq: 190, dur: 0.1, wave: "triangle", gain: 0.12, glideTo: 120 });
+  },
+
+  /** A letter got through, and that finger's armour took it (§8.5). */
+  shieldHit: () => {
+    tone({ freq: 160, dur: 0.16, wave: "sine", gain: 0.3, glideTo: 84 });
+    noise({ dur: 0.22, gain: 0.15, sweepFrom: 1500, sweepTo: 220 });
+  },
+
+  /**
+   * …and that was the zone's last point: there is a hole under one finger now.
+   *
+   * The loudest thing that is not the end of the run, because it is the
+   * moment a child can still do something about — the next letter on that
+   * finger ends the storm, and every clean hit from here is a chance to mend
+   * it (§8.5). A sound that were merely a bigger crunch would leave the one
+   * turning point in a run indistinguishable from the four hits before it.
+   */
+  shieldBreak: () => {
+    tone({ freq: 300, dur: 0.34, wave: "sawtooth", gain: 0.26, glideTo: 88 });
+    noise({ dur: 0.4, gain: 0.2, sweepFrom: 3200, sweepTo: 150 });
+  },
+
+  /**
+   * A stone came through the hole. The run is over.
+   *
+   * A falling minor figure under a long collapse of noise, and it is the one
+   * sound on this screen that is allowed to be sad. It is also why the storm
+   * does not play `finish`: a race ends by being finished and a storm can end
+   * by being lost, and a major triad over a broken shield would be the game
+   * congratulating a child for dying (`useRaceFinish`'s `fanfare`).
+   */
+  breach: () => {
+    noise({ dur: 0.75, gain: 0.24, sweepFrom: 4800, sweepTo: 110 });
+    [392, 311, 233].forEach((freq, i) =>
+      tone({
+        freq,
+        dur: 0.34,
+        delay: i * 0.11,
+        wave: "triangle",
+        gain: 0.3,
+        glideTo: freq * 0.5,
+      }),
+    );
+  },
 };

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -2240,6 +2240,33 @@ label.segmented__btn {
      bottom rather than half off each end. */
   --stone: calc(var(--key) * 1.15);
 
+  /* The fastest a hailstone is ever allowed to fall, in **stone heights per
+     second** (decision 65).
+
+     A backstop rather than a knob, and the same kind of thing as the
+     generator's `MIN_FALL_MS`: what makes a letter readable while it moves is
+     the beat it spends standing still first (`QUEUE_MS`, decision 67), and
+     this only has to stop the one case that beat cannot cover.
+
+     That case is real. A wave says how LONG a letter falls for and never how
+     far, so the distance is whatever sky there is — and since #197 took the
+     keyboard off the screen, that is the whole viewport. A 900ms fall crosses
+     about 640px on a 1512×850 laptop and about 1100px on a 27-inch monitor, so
+     without a ceiling the same level is a different game depending on what a
+     child opens it on. Nine stone heights a second is a shade above what the
+     tallest ordinary screen asks for, so on anything a child is likely to be
+     sitting at the stone uses the full sky and this changes nothing; on a
+     display taller than that it starts lower and falls at the ceiling.
+
+     Stone heights and not pixels, because what smears a moving glyph is how
+     far it travels against its own size — a cap written in pixels would mean
+     something different at every `--key`.
+
+     **It caps the speed and does not change the clock.** A letter still falls
+     for exactly the `fallMs` its wave drew (§8.3), so every level's timing,
+     and therefore its difficulty, is untouched. */
+  --hail-speed: 9;
+
   /* One viewport minus the ad band above it, exactly as `.race` is sized and
      for a sharper version of the same reason. `height`, not `min-height`: a
      field that may grow is a field that scrolls, and a page that scrolls
@@ -2330,11 +2357,13 @@ label.segmented__btn {
   left: calc(var(--lane) * var(--key) - var(--key-gap) / 2);
 
   /* ── The fall ──────────────────────────────────────────────────────────
-     `--drop` is `progressAt`: 0 the instant a letter spawns, 1 the instant it
-     reaches the shield. `useStormClock` writes it onto each stone every frame
-     and nothing else — the whole fall is this one multiplication, so the loop
-     never learns how tall the sky is and cannot hold a second opinion about
-     it (§8.9).
+     `--drop` is `progressAt`: 0 for as long as a letter hangs at the top
+     waiting to go (`QUEUE_MS`, decision 67), then 0 → 1 across its fall.
+     `useStormClock` writes it onto each stone every frame and nothing else —
+     the whole fall is this one multiplication, so the loop never learns how
+     tall the sky is and cannot hold a second opinion about it (§8.9). The
+     queue therefore costs this rule nothing at all: a stone that is not
+     moving is a stone whose `--drop` is not moving.
 
      A transform rather than `top` — the same trade `.fuse__fill` takes when it
      scales instead of setting a width: the layout property is the honest one
@@ -2345,21 +2374,51 @@ label.segmented__btn {
      down the sky by two independent declarations, and the loop can own one of
      them without touching the other.
 
-     The travel is the sky minus one stone, which is what leaves a letter whole
-     at the top and resting on the line at the bottom rather than half off each
-     end. Floored at zero because that subtraction goes NEGATIVE once the sky
-     is shorter than a hailstone — around 265px of viewport height, below
-     anything real, but the difference between a still frame and a loop is that
-     a loop would animate it, and a storm that falls upwards is not a
-     degradation anybody would read as one.
+     `--sky-fall` is the whole travel the sky can offer: its height minus one
+     stone, which is what leaves a letter whole at the top and resting on the
+     line at the bottom rather than half off each end. Floored at zero because
+     that subtraction goes NEGATIVE once the sky is shorter than a hailstone —
+     around 265px of viewport height, below anything real, but the difference
+     between a still frame and a loop is that a loop would animate it, and a
+     storm that falls upwards is not a degradation anybody would read as one.
+
+     **`--fall` is the shorter of that and what `--hail-speed` allows** — the
+     cap declared on `.storm`, in stone heights a second, which is what stops
+     a bigger monitor from being a faster storm (decision 65). `--fall-ms` is
+     the letter's own fall time, written inline by `StormField` beside its
+     lane: it is fixed for the life of a letter, so it is a render's to write
+     and never the loop's. The fallback is a second rather than nothing on
+     purpose — a `min()` over a missing variable is invalid at computed-value
+     time, and an invalid `--fall` is a stone that does not move at all.
+
+     `top` is where the fall BEGINS and the transform is the fall itself, so
+     a capped stone comes into view lower in the sky and still lands exactly
+     on the shield. Two declarations, one moving and one not, which is the
+     same split `translate: -50% 0` takes for the lane: the loop owns the
+     transform and touches neither of the others.
 
      No clamp on `--drop` itself: `isDrawn` mounts a stone only on the
      half-open `[spawnMs, landMs)` the reducer resolves it over (decision 30),
      so every stone this rule can apply to has a fraction in [0, 1). */
-  --fall: max(0cqh, 100cqh - var(--stone));
-  top: 0;
+  --sky-fall: max(0cqh, 100cqh - var(--stone));
+  --fall: min(
+    var(--sky-fall),
+    calc(var(--fall-ms, 1000) / 1000 * var(--hail-speed) * var(--stone))
+  );
+  top: calc(var(--sky-fall) - var(--fall));
   transform: translateY(calc(var(--drop) * var(--fall)));
   translate: -50% 0;
+
+  /* A layer of its own, for the one element on this site that moves every
+     frame and carries text. Without it the glyph is re-rasterised at a new
+     sub-pixel offset sixty times a second, and sub-pixel antialiasing puts
+     the colour fringes somewhere different each time — which is a shimmer on
+     top of the smear the cap above is already fighting. Promoted, it is
+     rasterised once and the compositor moves the texture; the cost is
+     greyscale antialiasing, which is very slightly softer standing still and
+     much steadier moving. Twelve stones at the very most, and only while a
+     wave is running. */
+  will-change: transform;
 
   display: grid;
   place-items: center;
@@ -2368,12 +2427,25 @@ label.segmented__btn {
 
   border: 1px solid color-mix(in oklab, var(--accent) 42%, transparent);
   border-radius: calc(var(--key) * 0.3);
-  background: color-mix(in oklab, var(--ink-800) 88%, transparent);
+  /* Opaque, where it used to be 88% of the ink. The only thing a stone ever
+     crosses is the HUD (see below), and the glyph inside it is the one thing
+     on this screen that has to be read at a glance while it is moving — a
+     score showing faintly through the `l` a child is trying to tell from an
+     `i` is a contrast cost for no gain. The HUD is still legible: what it is
+     drawn in is `--chalk-dim`, and what passes over it is one stone. */
+  background: var(--ink-800);
   box-shadow: 0 0 calc(var(--key) * 0.45)
     color-mix(in oklab, var(--accent) 18%, transparent);
 
   font-family: var(--font-mono);
   font-size: calc(var(--key) * 0.6);
+  /* Bold, and this is legibility rather than emphasis. A moving glyph is
+     smeared across however far it travels in one frame, and what survives
+     that is stroke WIDTH — so the two letters this game confuses, `l` and
+     `i`, are told apart by a thicker stem long after a thin one has washed
+     out. Space Mono ships 700 and the storm is the one screen that needs it;
+     everything else on the site reads standing still. */
+  font-weight: 700;
   line-height: 1;
   color: var(--chalk);
 }


### PR DESCRIPTION
## What

A hailstone was hardest to read at exactly the moment it was new. #197 took the
keyboard off the screen and the sky roughly doubled — but a wave says how LONG a
letter falls for and never how far, so the same 900ms fall went from crossing
about 430px to about 720px, and more again on a bigger monitor. At twelve pixels
a frame the display's own persistence smears a 43px glyph across a quarter of
its own height, and `i` and `l` stop being different letters. Lesson 4 has the
shortest fall of the twenty, so the first storm a five-year-old meets was the one
it hurt most.

**A letter now hangs at the top of the sky for a second before it drops**
(decision 67), so reading it and racing it are two moments instead of one. A
child who has already identified an `i` does not need it to be legible on the way
past. A queued letter is drawn, aimed at and **shootable** throughout — anything
else is a game that shows a child a letter and then charges them ten points for
pressing it.

The beat is time added, and it has to be: hanging inside the existing `fallMs`
is the same sky in less time, which is a faster drop at its most urgent point.
Because `QUEUE_MS` is the same for every letter of every level it shifts the
schedule and warps no part of it — `gap`, `fall`, the draw order and every seed
are untouched, so the twenty levels rain exactly what they did before. "One
letter at a time" survives as a claim about *falling*: `gap[0] >= fall[1]` still
buys it exactly, because the beat cancels out of the arithmetic. `CardResult.ms`
still means what it did.

What is left for the geometry is a **backstop**, in the spirit of `MIN_FALL_MS`:
`--hail-speed: 9` stone heights a second, a shade above what the tallest
ordinary screen asks for. On anything a child is likely to be sitting at, the
stone uses the whole sky and this changes nothing; on a taller display it stops
the level quietly becoming a different game because of the monitor. Stone heights
and not pixels, because what smears a glyph is how far it moves against its own
size. The glyph is also **bold** — stroke width is what survives motion blur,
which is exactly what separates `l` from `i` — and each stone is composited
rather than re-rasterised at a new sub-pixel offset sixty times a second.

**And the storm had no voice**, on the one screen a child can be looking away
from at the moment it needs them. Six sounds carry it (§8.12):

| Sound | When | Length |
| --- | --- | --- |
| `shoot` | every stroke, hit or miss | 70ms |
| `shatter` | a hailstone shot down — pitched by streak | 80ms |
| `misfire` | a stroke that hit nothing — a shot whizzing past | 210ms |
| `shieldHit` | a letter got through; that finger's armour took it | 160ms |
| `shieldBreak` | …and that was the zone's last point: a hole | 340ms |
| `breach` | a stone came through the hole; the run is over | 750ms |

Pitch says whose it is — bright and short for the gun and the stones, low and
long for the shield — and length says what it cost. They are a **diff over two
frames** (`stormSounds.ts`, decision 66) rather than events the reducer raises:
`fire` and `tick` return states, and a model handing back "here is what
happened" would be a second description of the run living beside the run. Called
from beside those two in the clock and not from a hook watching the rendered
state, which would be one batching decision away from silence.

A storm no longer plays `finish` when it is **lost**. `useRaceFinish` takes a
`fanfare` — default unchanged, every race uses it — and the storm passes one
that does nothing, announcing its own ending off the frame the reducer stamped
it.

## Issue

None — follow-up to #197.

## Checks

- [x] `npm run type-check`, `npm run lint`, `npm run build` pass locally
- [x] `npm run test:unit` — 2179 tests, 104 files
- [x] `npm run test:smoke` — all checks passed, console errors: none
- [x] Acceptance criteria on the issue are all met — n/a
- [x] No new architecture-boundary suppressions
- [x] If a content page changed: title, description and canonical are still correct — n/a

New coverage: `stormSounds.test.ts` (12) drives whole waves through `fire`/`tick`
and asserts the names that come back — a tick landing a dozen letters is one
crunch, a mended zone is not a damaged one, a breach has no crunch under it.
`storm.test.ts` grows a queue block: shootable while it hangs, progress floored
at zero, two letters side by side tie to the earlier spawn, and the schedule is
shifted but not warped at every seed. Three smoke checks now wait the beat out —
a resting stone gives one position and no travel, which reads exactly like a
broken loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
