### PR TITLE
Point Play at the map, and land it on the cards

### DIFF
--- a/src/components/site/SiteHeader.astro
+++ b/src/components/site/SiteHeader.astro
@@ -57,9 +57,24 @@ const { world } = Astro.props;
           </a>
         ))
       }
-      <a class="mast__link" href="/#for-parents">For parents</a>
+      <a class="mast__link" href="/#for-parents" data-scroll>For parents</a>
     </nav>
 
-    <a class="mast__play" href="/flash-cards">Play</a>
+    {
+      /*
+       * Play goes to the map, not into a game.
+       *
+       * It used to open /flash-cards, which made the times tables the default
+       * meaning of "play" on every page of the site — including the spelling
+       * one. The named links to its left already go straight into a world for
+       * anyone who knows which they want; this is the button for everyone
+       * else, so it should ask rather than choose.
+       *
+       * Absolute, because this bar is on every page. From the home page it
+       * scrolls (the `data-scroll` script lives there); from anywhere else
+       * there is no map on screen to scroll to, so it navigates.
+       */
+    }
+    <a class="mast__play" href="/#worlds" data-scroll>Play</a>
   </div>
 </header>

--- a/src/components/site/WorldMap.astro
+++ b/src/components/site/WorldMap.astro
@@ -60,7 +60,15 @@ const BADGES: Partial<Record<World, string>> = {
       restores the list semantics that base.css's `list-style: none` strips in
       Safari. */
   }
-  <ul class="map__route" role="list">
+  {
+    /* `data-scroll-centre` marks the row as the thing the home page's Play
+      button is actually aiming at, so it can centre the cards rather than
+      park the heading at the top and cut them off at the fold. It is a marker
+      for that script and nothing else — see index.astro, which also decides
+      when centring is the wrong answer (a phone, where these stack two
+      thousand pixels tall). */
+  }
+  <ul class="map__route" role="list" data-scroll-centre>
     {
       WORLDS.map((w) => (
         <li class="map__node" data-world={w.id}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -79,18 +79,60 @@ const verse = passage("the-plans-of-the-diligent");
       homeschool and after-school practice at home &mdash; free, with no account
       and nothing about your child ever leaving the device it&rsquo;s on.
     </p>
+    {
+      /*
+       * The button goes down the page, not into a game.
+       *
+       * It used to open /flash-cards, which quietly said the times tables were
+       * the site and the other three worlds were extras. They aren't — the map
+       * is the thesis, and a child who came to practise spellings shouldn't
+       * have to back out of a multiplication race to find it. So the primary
+       * action is "choose", and the map is one scroll away rather than one
+       * navigation away.
+       *
+       * Both buttons are in-page jumps now, so both carry `data-scroll`. The
+       * arrow is only on this one: it is the button that used to leave the
+       * page, and it is the one whose destination is off screen, so it is the
+       * one that has to say it goes downwards rather than away. See the script
+       * at the foot of this page for why the scroll is animated in JavaScript
+       * rather than by `scroll-behavior: smooth`.
+       */
+    }
     <div class="hero__actions">
-      <a class="cta" href="/flash-cards">Start the times tables</a>
-      <a class="cta cta--quiet" href="#limits">What it isn&rsquo;t</a>
+      <a class="cta" href="#worlds" data-scroll>
+        Pick a world
+        <svg
+          class="cta__down"
+          viewBox="0 0 24 24"
+          width="18"
+          height="18"
+          aria-hidden="true"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.6"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M12 5v13M5.5 12l6.5 6.5 6.5-6.5"></path>
+        </svg>
+      </a>
+      <a class="cta cta--quiet" href="#limits" data-scroll
+        >What it isn&rsquo;t</a
+      >
     </div>
   </header>
 
-  <section class="band band--tight wrap">
+  {
+    /* `tabindex="-1"` so the scroll can hand focus over with it. Without that a
+      keyboard user's next Tab carries on from the hero button they just left,
+      several screens above where the page now is. */
+  }
+  <section class="band band--tight wrap" id="worlds" tabindex="-1">
     <WorldMap />
   </section>
 
   <div class="wrap"><AdSlot name="article" /></div>
-  <section class="band band--inset" id="limits">
+  <section class="band band--inset" id="limits" tabindex="-1">
     <div class="wrap">
       <h2 class="h2">What this is, and what it isn&rsquo;t</h2>
       <p class="h2__sub">
@@ -267,7 +309,7 @@ const verse = passage("the-plans-of-the-diligent");
     </div>
   </section>
 
-  <section class="band" id="for-parents">
+  <section class="band" id="for-parents" tabindex="-1">
     <div class="wrap">
       <h2 class="h2">For parents</h2>
       <div class="prose">
@@ -308,4 +350,151 @@ const verse = passage("the-plans-of-the-diligent");
       </div>
     </div>
   </section>
+
+  <!--
+    Why this isn't `scroll-behavior: smooth` on <html>.
+
+    That property is global to the document, and it also applies to the scroll
+    the browser performs when a page *loads* at a fragment. The masthead links
+    to /#for-parents from every other page, so a global rule would make that
+    arrival animate three screens down from the top on every load — and it
+    would put the same animation on the skip link, which exists to get a
+    keyboard user somewhere immediately.
+
+    So the smoothing is opt-in per link, via `data-scroll`, and lives here
+    rather than in the layout because the map is the only page whose primary
+    action is a scroll. Without JavaScript both links still work: they are real
+    anchors to real ids, and the browser jumps as it always has.
+  -->
+  <script is:inline>
+    /**
+     * How much of the top of the viewport the masthead is covering.
+     *
+     * Read off the element rather than repeating chrome.css's 760px
+     * breakpoint here: below it the bar scrolls away with the page and covers
+     * nothing, and a number written down twice is a number that drifts.
+     */
+    const coveredByMasthead = () => {
+      const mast = document.querySelector(".mast");
+      if (!mast || getComputedStyle(mast).position !== "sticky") return 0;
+      return mast.getBoundingClientRect().height;
+    };
+
+    /**
+     * Where a scroll to `target` should leave the page, or null for "the
+     * browser's own anchor behaviour is already right".
+     *
+     * Where a section names something worth centring, centre it — but only
+     * when the whole of it fits on screen.
+     *
+     * The map is the case this exists for. Its heading and the paragraph
+     * under it are 240px, so landing on the top of the section spends the
+     * arrival on prose and cuts the fourth card off at the fold. Centring the
+     * row of cards instead means the thing the button promised is the thing
+     * you land on, whole.
+     *
+     * The fits test is the whole safety of it. Under 760px those four cards
+     * stop being a row and become a two-thousand-pixel column, and a centred
+     * column puts you in the middle of the third card with no heading
+     * anywhere — so below that width, and on any short window, this returns
+     * null and the ordinary landing at the top of the section stands.
+     */
+    const landingFor = (target) => {
+      const centre = target.querySelector("[data-scroll-centre]");
+      if (!centre) return null;
+      const box = centre.getBoundingClientRect();
+      const reserved = coveredByMasthead();
+      const room = window.innerHeight - reserved;
+      if (box.height > room) return null;
+      return box.top + window.scrollY - reserved - (room - box.height) / 2;
+    };
+
+    /** `#worlds` → the section, without letting a typed hash throw. */
+    const sectionFor = (hash) =>
+      hash.length > 1 ? document.getElementById(hash.slice(1)) : null;
+
+    for (const link of document.querySelectorAll("a[data-scroll]")) {
+      link.addEventListener("click", (event) => {
+        // Leave the modified clicks alone — cmd/ctrl-click opens the section
+        // in its own tab, and that is a reasonable thing to want.
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+          return;
+        }
+        // The masthead's two are absolute — /#worlds and /#for-parents,
+        // because that bar is on every page. Here they point at this page, so
+        // they scroll; the guard is what stops that assumption travelling if
+        // this script ever moves into the layout.
+        if (link.pathname !== location.pathname) return;
+        const target = sectionFor(link.hash);
+        if (!target) return;
+        event.preventDefault();
+
+        const behavior = window.matchMedia("(prefers-reduced-motion: reduce)")
+          .matches
+          ? "auto"
+          : "smooth";
+
+        const top = landingFor(target);
+        if (top === null) {
+          target.scrollIntoView({ behavior, block: "start" });
+        } else {
+          window.scrollTo({ top, behavior });
+        }
+        // `preventScroll` so handing focus over doesn't jump straight to the
+        // destination and cancel the animation that just started.
+        target.focus({ preventScroll: true });
+        // A pushed entry, the same as the anchor would have left behind, so
+        // Back still returns to the top of the page.
+        history.pushState(null, "", link.hash);
+      });
+    }
+
+    /*
+     * Arriving at a section instead of scrolling to one.
+     *
+     * The masthead's Play button is on every page, so from /privacy it is a
+     * real navigation to /#worlds and none of the above runs — the browser
+     * does its own fragment landing and parks the heading at the top, which
+     * is not where the click that started it was aiming.
+     *
+     * So the same landing is applied on arrival — and it is applied twice, in
+     * two different ways, because scrolling the page here does not stay put.
+     * The browser performs its own scroll-to-the-fragment on a schedule of
+     * its own, and it will happily do it again after this script has run: at
+     * end of parse, and again around load. Whichever of those lands last
+     * wins, so a plain scrollTo here is overwritten about half the time —
+     * which half depending on whether the fonts came from cache.
+     *
+     * So rather than fight it, tell it where the anchor is. `scroll-margin`
+     * is exactly the "land this far off the top" control the browser already
+     * consults, and a negative one moves the landing further down the page.
+     * Set it and the browser's own scroll arrives where the click was aiming,
+     * whenever it happens and however many times. The scrollTo alongside is
+     * for the case where it has already been and gone.
+     *
+     * Instantly, not smoothly: a page that loads and then animates itself
+     * somewhere else looks broken, and there is no starting position to
+     * travel from anyway.
+     *
+     * Both are redone once the fonts have settled, because every number here
+     * is a measurement and a font swapping under the heading moves the cards.
+     * In practice the faces are preloaded and this is a no-op; when it isn't,
+     * being right a moment late beats being wrong.
+     */
+    const arrival = location.hash && sectionFor(location.hash);
+    if (arrival) {
+      const land = () => {
+        const top = landingFor(arrival);
+        // null means the cards don't fit and the stylesheet's own
+        // scroll-margin — the one that clears the masthead — is right.
+        if (top === null) return;
+        const sectionTop = arrival.getBoundingClientRect().top + window.scrollY;
+        arrival.style.scrollMarginTop = `${sectionTop - top}px`;
+        window.scrollTo({ top, behavior: "auto" });
+      };
+      land();
+      if (document.fonts) document.fonts.ready.then(land);
+      window.addEventListener("load", land, { once: true });
+    }
+  </script>
 </Content>

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -19,10 +19,29 @@
   display: block;
 }
 
-/* The masthead is sticky from 760px up, so an in-page jump has to clear it or
-   it lands with the heading hidden underneath. */
-:target {
-  scroll-margin-top: 5.5rem;
+/* An in-page jump has to clear the masthead or it lands with the heading
+   hidden underneath — but only where the masthead is actually sticky, which
+   is 760px up (see chrome.css). Below that it scrolls away with the rest of
+   the page, and reserving room for it instead leaves the *previous* section
+   parked at the top of the phone, which reads as a scroll that stopped short.
+
+   `.band[id]` is here as well as `:target` because the home page's hero
+   buttons scroll their section into view themselves rather than letting the
+   browser navigate to it (see index.astro), and a section reached that way
+   never becomes `:target`. Any band carrying an id is a jump destination by
+   definition, so both routes to it clear the same masthead. */
+@media (width >= 760px) {
+  :target,
+  .band[id] {
+    scroll-margin-top: 5.5rem;
+  }
+}
+
+/* Focus is moved to a section after a scripted scroll, and a section is not a
+   control — the ring would outline a third of the page for no purpose. The
+   scroll itself is the feedback that something happened. */
+.band[id]:focus {
+  outline: none;
 }
 
 .band {
@@ -158,6 +177,18 @@
 
 .cta:active {
   transform: translateY(1px);
+}
+
+/* The arrow on a button that scrolls rather than navigates. It nudges down
+   while the button lifts, so the two move apart on hover and the direction
+   reads before the click — this one goes further into the page, not away from
+   it. */
+.cta__down {
+  transition: transform 0.14s var(--ease-out);
+}
+
+.cta:hover .cta__down {
+  transform: translateY(3px);
 }
 
 .cta--quiet {


### PR DESCRIPTION
Both of the site's main buttons opened `/flash-cards`: the masthead's **Play**, which is on every page, and the home page's hero CTA. Between them they made the times tables the default meaning of "play" here, with the other three worlds as extras — including on the spelling page. The map is the thesis, so the buttons now go to it.

## What changed

| File | Change |
| --- | --- |
| `src/components/site/SiteHeader.astro` | Play → `/#worlds`. Absolute, because the bar is on every page: from the map it scrolls, from anywhere else it navigates. "For parents" gets the same treatment so the two behave alike when you are already home. |
| `src/pages/index.astro` | Hero CTA → "Pick a world" (`#worlds`) with a down arrow. Ids and `tabindex="-1"` on the three destination bands, and the scroll script. |
| `src/components/site/WorldMap.astro` | `data-scroll-centre` on the card row — the marker for what the button is actually aiming at. |
| `src/styles/content.css` | Anchor offset scoped to the width where the masthead is sticky; no focus ring on the destination sections; the arrow's hover nudge. |

## Three decisions worth the review

**Smoothing is per link, not `scroll-behavior: smooth` on `<html>`.** That property is document-wide and also governs the scroll a browser performs when a page *loads* at a fragment, so a global rule would animate three screens on every arrival at `/#for-parents`, and would put the same animation on the skip link — whose whole job is to get somewhere immediately. Without JavaScript every link still works: they are real anchors to real ids.

**The cards are centred, but only when the whole row fits.** The map's heading and blurb are 240px, so landing on the top of the section spends the arrival on prose and cuts the fourth card off at the fold. Under 760px those cards stop being a row and become a 2,115px column, where centring would drop you in the middle of the third card with no heading anywhere — so below that, and on any short window, the ordinary landing stands.

**Arriving from another page needed a second mechanism.** The browser runs its own scroll-to-the-fragment on a schedule of its own and repeats it after the script has run, so a plain `scrollTo` was overwritten about half the time — which half depending on whether the fonts came from cache. The section is given a negative `scroll-margin-top` instead, which is the control the browser already consults, so its own scroll arrives where the click was aiming however many times it fires.

## Verified in a browser

| Case | Result |
| --- | --- |
| Hero CTA and Play, on the map | animates 0 → 642 over ~350ms, focus moves to `#worlds`, URL `/#worlds`, Back returns to 0 |
| Play from `/privacy`, `/about`, `/spelling`, `/printables` | lands at 642 — identical to the in-page click |
| 12 arrivals, fonts cold and cached | 0 showed a jump after first paint; the transient lands ~25ms and is corrected ~2ms later, against a first paint at 44ms |
| 1440×900 / 1280×800 / 1280×1024 | centred, all four cards whole, air above and below within 2px |
| 1024×768 and narrower | falls back to the section top, heading visible |
| `prefers-reduced-motion: reduce` | lands instantly, no animation |
| `#limits` (no centre marker) | unchanged — section top, clear of the masthead |

The three game islands are unaffected: they render `Base.astro` directly and have no masthead at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)