### PR TITLE
Release: A voice for the board, and a shift for the storm

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -85,6 +85,7 @@ src/engine/typing/
 src/games/typing/
   keyboard/Keyboard.tsx         The picture.
   keyboard/useKeyEcho.ts        Which keys are down, and which were wrong.
+  keyboard/keySounds.ts         What a keystroke sounds like. Typewriter.
   ladder/                       The hundred tiles, and the brief for one.
   lesson/                       The lesson run — the track, the bars.
   storm/                        The game — field, shield, falling letters.
@@ -418,6 +419,71 @@ It keeps the same 4.5rem ceiling for the same reason the board has it, which is
 worth being explicit about since there is no keycap left to measure: a lane
 claims to be **where that key is**, so a field wider than a keyboard would be
 teaching a reach nobody's hand makes.
+
+### 4.8 · The board clacks
+
+The keyboard on screen has a voice as well as a picture. Every keystroke made
+while the board is up sounds like a typewriter: a strike for a key, a deeper
+one for the space bar, and the bell and carriage on Return.
+
+**It is on when the board is on, and off when the board is off.** There is no
+fourth setting — `keyboard: "off"` never mounts `LiveKeyboard`, so nothing is
+bound and nothing sounds, and the site's one sound toggle silences it with
+everything else. That is the whole rule, and it lands where you would want it
+to: the ten checkpoints force the board off (§4.2), so the runs that are
+measuring whether a child can type without help are also the quiet ones.
+
+Three properties make it survivable at eight a second, which is what a child
+who has got good will produce.
+
+**It is the quietest thing in the kit**, below even Hailstorm's gun (§8.12).
+
+**It carries no pitch.** Every other sound on the site means something — the
+streak chime climbs, the miss falls, the fanfare resolves. A clack means only
+"that key went down", so it is percussion: three short bursts of filtered
+noise and no oscillator anywhere, which is the one thing that can sit under a
+melody eight times a second without joining it. The bell on Return is the
+single exception, because a bell is a bell.
+
+**It does not know whether the key was right.** `soundForKey` takes the event
+and nothing else — no expectation, no verdict — and a wrong key clacks exactly
+like a right one. That is a decision, not an omission. The board already flares
+the wrong key `--flare` (§4.3), the passage already goes red behind you, and
+the run already plays `wrong` at the word. A fourth opinion, arriving before
+any of the three knew the answer, would turn the one sound a child hears
+constantly into a running commentary on their mistakes. What they get instead
+is the sound of a machine working.
+
+Three keystrokes make no sound at all, and each is the same shape of argument:
+
+- **Auto-repeat.** A held key is one stroke. The board relights on every repeat
+  because its light is a timer that has to be re-armed by something (§4.3); a
+  clack re-fired every 33 ms is a drone. Hailstorm's gun refuses a repeat for
+  the same reason (decision 44).
+- **Held modifiers**, the same `HELD` set the echo never flares. A capital is
+  right-shift plus a left-hand letter (§3.3) — one character, so one sound, on
+  the letter. It also keeps a child pressing Cmd-Tab from typing at their own
+  desktop.
+- **Anything the board does not draw.** A numpad key, a media key, `F7`. The
+  clack is the picture's voice, so it says what the picture says and nothing
+  else; `keyFor` in `engine/keyboard.ts` is the one place that asks.
+
+Backspace clacks like any other key, deliberately. A typewriter has no undo,
+and a quieter correction would be the board passing judgement on one.
+
+Hailstorm draws no board (decision 64) and therefore has none of this. It is
+already one sound per stroke down there, and its gun says something the clack
+never does — `shoot` is a _shot_, with a hit or a miss layered over it (§8.12).
+
+```
+games/typing/keyboard/keySounds.ts    soundForKey — the rule, one event in
+                                      useKeyClack — the window listener
+services/sound.ts                     keyStrike / keySpace / keyReturn
+```
+
+The rule is split from the mixer the way `stormSounds.ts` is, and for the same
+reason: every question worth asking is a question about `soundForKey`, and it
+answers all of them in Node with no `AudioContext` in the room.
 
 ---
 
@@ -2221,75 +2287,77 @@ which is what every run saved before this is.
 
 ## 11 · Decisions, recorded
 
-|     | Decision                                                                                     | Because                                                                                                                                                       |
-| --- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | The keyboard layout is engine, not view                                                      | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture                                                         |
-| 2   | `code`, not `key`                                                                            | Shift+`4` produces `$` and there is no `$` key to light up                                                                                                    |
-| 3   | Keys release on a timer, not `keyup`                                                         | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                                                                               |
-| 4   | The board is `aria-hidden`                                                                   | Sixty announcing spans is not accessibility; the passage already carries the state                                                                            |
-| 5   | The visual keyboard is never tappable                                                        | A tappable board is a hunt-and-peck trainer, which is the thing this is against                                                                               |
-| 6   | Lesson text is generated, not written                                                        | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                                                                           |
-| 7   | The lexicon must not be reachable from `decks/index.ts`                                      | The same import took the shared chunk 46 KB → 222 KB once already                                                                                             |
-| 8   | Ghost identity is the lesson, not the passage                                                | Every run generates different words; keying on them buckets every run alone                                                                                   |
-| 9   | Three pass bars, not one score                                                               | A single number says you failed; three say what to fix                                                                                                        |
-| 10  | Accuracy is flat and high; speed scales                                                      | An accuracy bar you can hammer past teaches hammering                                                                                                         |
-| 11  | The speed bar dips when a key arrives                                                        | You have just got slower and you should have                                                                                                                  |
-| 12  | The new-key gate                                                                             | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                                                                            |
-| 13  | Per-key stats come from cards, not keystrokes                                                | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven                                                           |
-| 14  | Progress is derived, never stored                                                            | No migration, self-heals when criteria change, cannot disagree with the record book                                                                           |
-| 15  | Unlock is `max(cleared) + 1`                                                                 | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                                                                               |
-| 16  | Any checkpoint, any time                                                                     | It is a placement test, a skip-ahead and an ordering rule in one sentence                                                                                     |
-| 17  | A lesson has no ghost and no time penalty                                                    | A penalty double-counts accuracy and makes the wpm number a lie                                                                                               |
-| 18  | Hailstorm is a route in the typing island                                                    | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard                                                      |
-| 19  | Letters fall down their key's column                                                         | The lane is a spatial hint — the game teaches the layout the whole time it is played                                                                          |
-| 20  | Only the lowest letter can be shot                                                           | Otherwise spraying the keyboard is a winning strategy                                                                                                         |
-| 21  | The shield is eight finger zones                                                             | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise                                                             |
-| 22  | Score can fall, XP cannot                                                                    | XP is cumulative across years and four games; a bad five minutes must not lower a level                                                                       |
-| 23  | A Hailstorm run is a `Session`                                                               | Record book, XP, badges and the drill builder all work with no new code                                                                                       |
-| 24  | Hailstorm never gates the ladder                                                             | A tablet has no keys, and a reward that blocks you is not a reward                                                                                            |
-| 25  | DOM, not canvas                                                                              | Eleven custom properties change the whole app's biome; a canvas is a hole in that                                                                             |
-| 26  | US ANSI only, and say so                                                                     | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                                                                                 |
-| 27  | A lesson's keyboard seeds; it does not overrule                                              | All hundred name a mode, so an override beats the player's own setting on every rung                                                                          |
-| 28  | `eyes-up` reads the board the run was typed under                                            | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory                                                            |
-| 29  | `unbroken` is gated on the wave having a length                                              | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete                                                       |
-| 30  | A falling letter is on the field on `[spawn, land)`                                          | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two                                                           |
-| 31  | A letter carries its key, finger and lane                                                    | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift                                                            |
-| 32  | The target is the greatest fall progress, not `landMs`                                       | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen                                                                |
-| 33  | An exact tie goes to the earlier spawn                                                       | The index is the letter's identity, so a replay resolves the same dead heat the same way                                                                      |
-| 34  | A repair never lifts a zone above `spec.shield`                                              | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                                                                      |
-| 35  | A tick resolves every landing inside it                                                      | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's                                                                 |
-| 36  | The field's lanes step back half a `--key-gap`                                               | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference                                                    |
-| 37  | `--key` is declared at the root, once per screen                                             | It lived on the board, which the field above it cannot read — and two clamps inside one screen are two ideas of a key                                         |
-| 38  | A frame is clamped to 100ms of wave time                                                     | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield                                                        |
-| 39  | The loop writes `--drop`; the stylesheet owns the fall                                       | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either                                                     |
-| 40  | The field re-renders on the picture, not on the frame                                        | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal                                                          |
-| 41  | A shield segment is its finger's home-row span                                               | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on                                                   |
-| 42  | A tint is an element keyed by a counter, not a class                                         | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe                                                     |
-| 43  | A stroke at an empty sky is a miss, and the score says so                                    | It costs ten points and the streak; with the board gone the `--flare` wash over the score is what shows it                                                    |
-| 44  | Key auto-repeat is not a shot                                                                | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                                                                     |
-| 45  | The HUD is drawn inside the sky, not as a row of its own                                     | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give                                                                |
-| 46  | A wrong key costs score; a letter through costs shield                                       | One failure, one cost — the landing has already taken the thing that ends runs                                                                                |
-| 47  | The ending stands in the track under the sky                                                 | The sky it leaves whole is the frozen hail and the shield with the hole in it that the sentence is about                                                      |
-| 48  | A storm's cards are its letters, not its keystrokes                                          | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both                                                     |
-| 49  | A letter that got through is a `timedOut` card                                               | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped                                                      |
-| 50  | A storm has no ghost and holds no record                                                     | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it                                                            |
-| 51  | A retry is a new run, so it is a remount                                                     | The finish guard, the history snapshot and the clock all have to start again; one instance is one run                                                         |
-| 52  | Fall time has a floor, in the generator                                                      | The twenty specs are a table, and a table gets tightened a row at a time until a level nobody can read ships                                                  |
-| 53  | A keystroke proves a keyboard; the pointer only guesses                                      | Every proxy is wrong about somebody, and wrongly shut is a child locked out where wrongly open is a dud tile                                                  |
-| 54  | The quit sheet is the storm's pause                                                          | A wave falling behind it would break a shield while a child read "it won't be saved"                                                                          |
-| 55  | `Escape` leaves, and is taken before the trigger                                             | Every other key while a run is live is a shot, so a way out on a second listener would cost ten points                                                        |
-| 56  | A storm level cannot name its own keys                                                       | The row holds a `WaveSpec` minus `keys`, so the pool can only be `unlockedAt(n)` and reachability is structural                                               |
-| 57  | The miss flash has a floor, in the reducer                                                   | A zone's tint rate is the schedule's and the specs keep it; a wrong key's is a hand's, and no spec can                                                        |
-| 58  | A storm's seed is the level's, not the visit's                                               | A level is the same weather twice, and the twenty waves measured for strobe are the twenty a child meets                                                      |
-| 59  | A lesson is cleared only by a run that says it is that lesson                                | A drill files under the lesson's mode, so mode alone would let practising a lesson clear it                                                                   |
-| 60  | A storm's brief is its own screen                                                            | Three bars, a best and a keyboard control are three things a storm does not have, and it has three of its own                                                 |
-| 61  | The board is drawn at 19.05mm key pitch                                                      | It is a map read while the hands are on the real thing; at half scale the child does the scaling, which is the work looking down would have saved             |
-| 62  | The board may overflow the 720px race column                                                 | 720px is a reading measure and a keyboard is not read; a screen with a wider keyboard under it is the desk it depicts                                         |
-| 63  | The passage screen's `--key` subtracts its chrome rather than taking a share of the viewport | The HUD, the bars and the line you type on are a constant, so a dvh fraction that fits at 850px of viewport grows the page at 700                             |
-| 64  | Hailstorm draws no keyboard                                                                  | A storm is the exam for the lessons that taught the layout, and a picture of the keyboard on the exam is the answer sheet — and it was taking 45% of the fall |
-| 65  | A hailstone's speed has a ceiling in stone heights, not left to the sky                      | A wave says how long a letter falls and never how far, so a taller monitor would be a faster level; a backstop like `MIN_FALL_MS`, not a difficulty knob      |
-| 66  | A storm's sounds are a diff over two frames                                                  | `fire` and `tick` return states, not events; a model that raised events would be a second description of the run, and the copy is the one that drifts         |
-| 67  | A letter hangs at the top for a second before it falls                                       | A glyph is hardest to read exactly when it is new; standing it still first beats any amount of slowing it down, and it costs the twenty levels nothing        |
+|     | Decision                                                                                     | Because                                                                                                                                                                 |
+| --- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | The keyboard layout is engine, not view                                                      | The curriculum, the generator and the game's lanes all need it; only the fourth consumer is a picture                                                                   |
+| 2   | `code`, not `key`                                                                            | Shift+`4` produces `$` and there is no `$` key to light up                                                                                                              |
+| 3   | Keys release on a timer, not `keyup`                                                         | A missed `keyup` leaves a key stuck lit, which is a lie about where the hand is                                                                                         |
+| 4   | The board is `aria-hidden`                                                                   | Sixty announcing spans is not accessibility; the passage already carries the state                                                                                      |
+| 5   | The visual keyboard is never tappable                                                        | A tappable board is a hunt-and-peck trainer, which is the thing this is against                                                                                         |
+| 6   | Lesson text is generated, not written                                                        | A hundred hand-written pools is a hundred chances to use a key the child hasn't met                                                                                     |
+| 7   | The lexicon must not be reachable from `decks/index.ts`                                      | The same import took the shared chunk 46 KB → 222 KB once already                                                                                                       |
+| 8   | Ghost identity is the lesson, not the passage                                                | Every run generates different words; keying on them buckets every run alone                                                                                             |
+| 9   | Three pass bars, not one score                                                               | A single number says you failed; three say what to fix                                                                                                                  |
+| 10  | Accuracy is flat and high; speed scales                                                      | An accuracy bar you can hammer past teaches hammering                                                                                                                   |
+| 11  | The speed bar dips when a key arrives                                                        | You have just got slower and you should have                                                                                                                            |
+| 12  | The new-key gate                                                                             | 95% and 12 wpm can both be met while getting the lesson's own key wrong every time                                                                                      |
+| 13  | Per-key stats come from cards, not keystrokes                                                | Raw keystrokes would need a `Session` field for one game's benefit; corrections are fairly forgiven                                                                     |
+| 14  | Progress is derived, never stored                                                            | No migration, self-heals when criteria change, cannot disagree with the record book                                                                                     |
+| 15  | Unlock is `max(cleared) + 1`                                                                 | Session pruning drops the oldest runs; counting would silently re-lock lesson 1                                                                                         |
+| 16  | Any checkpoint, any time                                                                     | It is a placement test, a skip-ahead and an ordering rule in one sentence                                                                                               |
+| 17  | A lesson has no ghost and no time penalty                                                    | A penalty double-counts accuracy and makes the wpm number a lie                                                                                                         |
+| 18  | Hailstorm is a route in the typing island                                                    | It is a level inside the ladder; a second island means a page load mid-progression and a second keyboard                                                                |
+| 19  | Letters fall down their key's column                                                         | The lane is a spatial hint — the game teaches the layout the whole time it is played                                                                                    |
+| 20  | Only the lowest letter can be shot                                                           | Otherwise spraying the keyboard is a winning strategy                                                                                                                   |
+| 21  | The shield is eight finger zones                                                             | A hole under `o` tells you nothing; a hole under the right ring finger tells you what to practise                                                                       |
+| 22  | Score can fall, XP cannot                                                                    | XP is cumulative across years and four games; a bad five minutes must not lower a level                                                                                 |
+| 23  | A Hailstorm run is a `Session`                                                               | Record book, XP, badges and the drill builder all work with no new code                                                                                                 |
+| 24  | Hailstorm never gates the ladder                                                             | A tablet has no keys, and a reward that blocks you is not a reward                                                                                                      |
+| 25  | DOM, not canvas                                                                              | Eleven custom properties change the whole app's biome; a canvas is a hole in that                                                                                       |
+| 26  | US ANSI only, and say so                                                                     | A UK keyboard would fail lessons 62 and 67 for a child doing everything right                                                                                           |
+| 27  | A lesson's keyboard seeds; it does not overrule                                              | All hundred name a mode, so an override beats the player's own setting on every rung                                                                                    |
+| 28  | `eyes-up` reads the board the run was typed under                                            | Checkpoints force it off, so the resolved mode alone awards it for the ten where it was compulsory                                                                      |
+| 29  | `unbroken` is gated on the wave having a length                                              | "The wave exists" retires itself when STM10 lands; "no screen starts one" is a line someone must delete                                                                 |
+| 30  | A falling letter is on the field on `[spawn, land)`                                          | Landing is the tick that resolves a letter, so `gap` exactly equal to `fall` is a handover, not two                                                                     |
+| 31  | A letter carries its key, finger and lane                                                    | Resolved against the layout once, so the lane, the shot and the finger named at death cannot drift                                                                      |
+| 32  | The target is the greatest fall progress, not `landMs`                                       | Letters at different speeds cross; landing order aims at a letter visibly higher up the screen                                                                          |
+| 33  | An exact tie goes to the earlier spawn                                                       | The index is the letter's identity, so a replay resolves the same dead heat the same way                                                                                |
+| 34  | A repair never lifts a zone above `spec.shield`                                              | "Untouched" has to keep meaning the eight-of-`shield` a run started with                                                                                                |
+| 35  | A tick resolves every landing inside it                                                      | A backgrounded tab hands back seconds; clamping the delta is the clock's call, not the rule's                                                                           |
+| 36  | The field's lanes step back half a `--key-gap`                                               | `keyX` centres a key's slot; the child aims at the cap drawn inside it, and half the gap is the difference                                                              |
+| 37  | `--key` is declared at the root, once per screen                                             | It lived on the board, which the field above it cannot read — and two clamps inside one screen are two ideas of a key                                                   |
+| 38  | A frame is clamped to 100ms of wave time                                                     | A hidden tab hands back seconds; running slow below 10fps beats teleporting letters through the shield                                                                  |
+| 39  | The loop writes `--drop`; the stylesheet owns the fall                                       | Geometry stays off one `--key` and the sky's own height, so the loop holds no second opinion about either                                                               |
+| 40  | The field re-renders on the picture, not on the frame                                        | `tick` and `fire` hand back a fresh object either way, so identity is not a "nothing changed" signal                                                                    |
+| 41  | A shield segment is its finger's home-row span                                               | All four rows divide into eight, but the stagger moves the seams; the home row is the one the hands rest on                                                             |
+| 42  | A tint is an element keyed by a counter, not a class                                         | A single-pass animation on a new node cannot restart on a frame where nothing happened, which is a strobe                                                               |
+| 43  | A stroke at an empty sky is a miss, and the score says so                                    | It costs ten points and the streak; with the board gone the `--flare` wash over the score is what shows it                                                              |
+| 44  | Key auto-repeat is not a shot                                                                | A held key is one stroke, not thirty a second of spraying, drained score and flashing red                                                                               |
+| 45  | The HUD is drawn inside the sky, not as a row of its own                                     | `.storm`'s only flexible track is the sky, and on a short viewport it has nothing left to give                                                                          |
+| 46  | A wrong key costs score; a letter through costs shield                                       | One failure, one cost — the landing has already taken the thing that ends runs                                                                                          |
+| 47  | The ending stands in the track under the sky                                                 | The sky it leaves whole is the frozen hail and the shield with the hole in it that the sentence is about                                                                |
+| 48  | A storm's cards are its letters, not its keystrokes                                          | `survived` counts cards, `unbroken` reads "nothing wrong" as "nothing through"; a card per key moves both                                                               |
+| 49  | A letter that got through is a `timedOut` card                                               | The clock it ran out is its own fall, and it ranks the keys never reached above the ones merely mistyped                                                                |
+| 50  | A storm has no ghost and holds no record                                                     | Any best is `compareRuns`, i.e. time — so it goes to dying at letter three; XP was only half of it                                                                      |
+| 51  | A retry is a new run, so it is a remount                                                     | The finish guard, the history snapshot and the clock all have to start again; one instance is one run                                                                   |
+| 52  | Fall time has a floor, in the generator                                                      | The twenty specs are a table, and a table gets tightened a row at a time until a level nobody can read ships                                                            |
+| 53  | A keystroke proves a keyboard; the pointer only guesses                                      | Every proxy is wrong about somebody, and wrongly shut is a child locked out where wrongly open is a dud tile                                                            |
+| 54  | The quit sheet is the storm's pause                                                          | A wave falling behind it would break a shield while a child read "it won't be saved"                                                                                    |
+| 55  | `Escape` leaves, and is taken before the trigger                                             | Every other key while a run is live is a shot, so a way out on a second listener would cost ten points                                                                  |
+| 56  | A storm level cannot name its own keys                                                       | The row holds a `WaveSpec` minus `keys`, so the pool can only be `unlockedAt(n)` and reachability is structural                                                         |
+| 57  | The miss flash has a floor, in the reducer                                                   | A zone's tint rate is the schedule's and the specs keep it; a wrong key's is a hand's, and no spec can                                                                  |
+| 58  | A storm's seed is the level's, not the visit's                                               | A level is the same weather twice, and the twenty waves measured for strobe are the twenty a child meets                                                                |
+| 59  | A lesson is cleared only by a run that says it is that lesson                                | A drill files under the lesson's mode, so mode alone would let practising a lesson clear it                                                                             |
+| 60  | A storm's brief is its own screen                                                            | Three bars, a best and a keyboard control are three things a storm does not have, and it has three of its own                                                           |
+| 61  | The board is drawn at 19.05mm key pitch                                                      | It is a map read while the hands are on the real thing; at half scale the child does the scaling, which is the work looking down would have saved                       |
+| 62  | The board may overflow the 720px race column                                                 | 720px is a reading measure and a keyboard is not read; a screen with a wider keyboard under it is the desk it depicts                                                   |
+| 63  | The passage screen's `--key` subtracts its chrome rather than taking a share of the viewport | The HUD, the bars and the line you type on are a constant, so a dvh fraction that fits at 850px of viewport grows the page at 700                                       |
+| 64  | Hailstorm draws no keyboard                                                                  | A storm is the exam for the lessons that taught the layout, and a picture of the keyboard on the exam is the answer sheet — and it was taking 45% of the fall           |
+| 65  | A hailstone's speed has a ceiling in stone heights, not left to the sky                      | A wave says how long a letter falls and never how far, so a taller monitor would be a faster level; a backstop like `MIN_FALL_MS`, not a difficulty knob                |
+| 66  | A storm's sounds are a diff over two frames                                                  | `fire` and `tick` return states, not events; a model that raised events would be a second description of the run, and the copy is the one that drifts                   |
+| 67  | A letter hangs at the top for a second before it falls                                       | A glyph is hardest to read exactly when it is new; standing it still first beats any amount of slowing it down, and it costs the twenty levels nothing                  |
+| 68  | The board's clack is on exactly when the board is                                            | One rule, no fourth setting — and it falls out that the checkpoints, which force the board off, are the runs that go quiet                                              |
+| 69  | A clack has no pitch and does not know if the key was right                                  | It plays eight times a second under `correct` and `wrong`; a fourth opinion on a keystroke, arriving before the other three knew, is a commentary on a child's mistakes |
 
 ---
 

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1458,6 +1458,33 @@ resolve a dead heat the same way every time.
 Firing at an empty field is a miss too. It is the same spray by another route,
 and a streak that survived it would have found the strategy again.
 
+**A shot is a key and a shift, because between them that is what a character
+is** (decision 70). `A` and `a` are one key and two letters (§3.3), so a target
+is matched on `code` _and_ on whether its character is that key's shifted
+legend. Shift-`a` shoots a falling `A`; bare `a` at the same letter is a miss;
+and shift-`f` at a falling `f` is a miss too, because what that produced was an
+`F`. The same holds for every shifted mark — `?` is shift-`/`, and lessons 65
+and 69 rain them.
+
+The storm compared the code alone to begin with, which made lessons 34 and 39 —
+"Capitals" and "Shift under fire" — waves that never once asked for a shift,
+and credited a child with typing a character they had not typed. The passage
+lessons were always strict about it: they judge what arrived in a real
+`<input>`, so `a` for `A` is simply wrong there. The exam does not get to be
+easier than the course it examines.
+
+**Either shift, and never a named one.** `strokeFor` returns the shift on the
+opposite hand because that is the technique worth teaching, and the passage's
+next-key hint highlights exactly that key (§3.3) — but a capital typed with the
+near shift still produces the character, and the lessons take it. A storm that
+marked the same stroke wrong would be stricter than the course that taught it,
+on the one screen with no board to explain itself with (decision 64).
+
+Whether a shift was down is read off `event.shiftKey` on the keydown itself,
+never tracked across keydown and keyup. A shift released while the tab was in
+the background is a `keyup` this window never saw, and a gun trusting its own
+bookkeeping would go on demanding a shift nobody was holding.
+
 ### 8.5 · The shield is your fingers
 
 The shield spans the bottom of the field in **eight segments, one per finger**
@@ -2209,6 +2236,71 @@ Nothing here needs a guard for the player who has sound off. `sfx` is silent
 when `soundOn` is false and in any environment with no `AudioContext`, which is
 also why the storm's tests never stub it.
 
+### 8.13 · The beat before it falls
+
+**A storm does not begin on mount. It waits for a key** (decision 71).
+
+Every other run on this site opens with the 3·2·1 (`useCountdown`), and there
+that works because a race is entered with the hands already where they are
+going to be: a flash card is answered on the number row or with a tap, and a
+passage lesson puts the caret in an input the child has just clicked into. A
+storm is entered from a tile with a mouse and then asks, in its first second,
+for eight fingers on the home row and a reaction time. Three seconds of counter
+is three seconds of a child moving one hand off a trackpad while the first
+letter is already scheduled.
+
+A clock cannot fix that, because the thing being waited on is not an amount of
+time — it is a child being ready, which only they know. So the wave hangs at
+time zero, indefinitely, with no counter running, until the one signal that
+proves the hands are where they need to be arrives: a key.
+
+**Nothing of the storm is on screen while it waits.** A wave's first letter
+spawns at time zero (§8.3), so a field that merely froze the clock would be
+showing it — an unlimited, untimed look at the first target, where every other
+letter of the run gets exactly `QUEUE_MS` to be read in. The same prop that
+puts the panel in the sky is what takes the stones out of it, so the two cannot
+drift apart. What IS drawn is the rest of the field: the HUD at nothing and the
+shield whole, both already where the run will find them, so that pressing a key
+starts a storm rather than rearranging a screen.
+
+What the panel says is the other half of it, and it is the one place this game
+tells a child how to put their hands down. The storm draws no keyboard
+(decision 64), so it names what a real keyboard has instead of a picture — the
+ridges on `F` and `J`. That is the actual technique for finding the home row
+without looking, which is the habit every lesson below is trying to build, and
+a five-year-old can do it in the two seconds they spend reading the line.
+
+"Any key" has two exceptions, and both are the screen's other promises:
+
+- **`Tab`**, which is how the `Quit` in the HUD is reached without a mouse. The
+  gun swallows `Tab` once the run is live (§8.11), which is precisely why being
+  able to reach that button beforehand is worth protecting — a storm that began
+  the instant a child went looking for the exit would be the trap the button
+  exists to prevent.
+- **Anything the layout does not carry** — `F5`, `F12`, a media key. They are
+  not a child putting their hands down, and treating them as one would mean
+  swallowing the reload key on a screen whose whole state is "nothing has
+  happened yet".
+
+`Escape` is not a start key either; it is the way out, exactly as it is
+mid-wave, and it is taken before everything above for the reason §8.11 gives.
+
+**The key that starts a run is spent starting it.** `fire` is not called, no
+wave time has passed, and nothing is on the field to be missed — so the press
+that says "I'm ready" can never also be the first ten points off the score. It
+is answered by the gun's own listener rather than by a second one beside it,
+which is the same one-listener rule `Escape` is taken under: on this screen a
+press answered twice is a press that both starts the wave and misses at it.
+
+A retry gets the beat again, for free: an attempt is a remount (decision 51),
+so the flag starts false — and just after a loss is exactly when a child is
+most likely to have taken a hand off the keys.
+
+The screen a device with no keyboard is left on is now this panel and its way
+out, rather than twelve letters it has no means to shoot. That is not the
+reason the gate exists, but it is a better answer to §8.8 than the one it
+replaced.
+
 ---
 
 ## 9 · Routes and screens
@@ -2241,7 +2333,8 @@ syllabus, and it is the one piece of UI in this epic worth spending real design
 time on.
 
 Component budget: `LessonLadder`, `LessonTile`, `LessonBrief`, `StormBrief`,
-`PassBars`, `Keyboard`, `StormRun`, `StormField`, `StormShield`, `StormOver`.
+`PassBars`, `Keyboard`, `StormRun`, `StormField`, `StormShield`, `StormReady`,
+`StormOver`.
 All under the 300-line cap;
 the ladder is the only one that will come close, and the brief splitting out is
 why it won't. `StormRun` is the route and `StormField` is the screen it draws:
@@ -2358,6 +2451,8 @@ which is what every run saved before this is.
 | 67  | A letter hangs at the top for a second before it falls                                       | A glyph is hardest to read exactly when it is new; standing it still first beats any amount of slowing it down, and it costs the twenty levels nothing                  |
 | 68  | The board's clack is on exactly when the board is                                            | One rule, no fourth setting — and it falls out that the checkpoints, which force the board off, are the runs that go quiet                                              |
 | 69  | A clack has no pitch and does not know if the key was right                                  | It plays eight times a second under `correct` and `wrong`; a fourth opinion on a keystroke, arriving before the other three knew, is a commentary on a child's mistakes |
+| 70  | A shot is matched on the key AND the shift                                                   | `A` and `a` are one key and two letters, so the code alone let a wave of capitals fall to the bare alphabet — and the passage lessons were strict about it all along    |
+| 71  | A storm waits for a key, and shows no letter until it gets one                               | It is the one run entered with the hands in the wrong place, and what is being waited on is a child being ready — which is not an amount of time a counter can spend    |
 
 ---
 

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -505,6 +505,23 @@ try {
       ([id, lesson]) => (location.hash = `#/p/${id}/storm/${lesson}`),
       [player, STORM_LESSON],
     );
+
+    /*
+     * A storm does not begin on mount: it hangs at time zero with an empty sky
+     * and "press any key to start" in it, until a child says they are ready
+     * (§8.13, decision 71). So the entry every section below shares is two
+     * steps, and the wait on the panel is the first half of the proof that the
+     * gate is really there — the second half is that no `.storm__letter`
+     * exists until after the press, which section 13 asserts on a device that
+     * cannot make one.
+     *
+     * The key is spent starting the wave and is never fired at it, so what
+     * follows begins with a clean streak and nothing off the score. `Space` is
+     * a key the board carries and is not one of the two the gate ignores
+     * (`Tab`, and anything off the layout).
+     */
+    await page.waitForSelector(".storm__ready", { timeout: 8000 });
+    await page.keyboard.press("Space");
     await page.waitForSelector(".storm__letter", { timeout: 8000 });
   };
 
@@ -1435,6 +1452,11 @@ try {
   // more session — where a screen that kept its finish guard across the retry
   // would write none, and one that re-fired the old one would write two.
   await page.getByRole("button", { name: /try this wave again/i }).click();
+  // A retry is a remount, so it gets the beat before it falls again (§8.13) —
+  // which is the point of the flag starting false: just after a loss is when a
+  // child is likeliest to have taken a hand off the keys.
+  await page.waitForSelector(".storm__ready", { timeout: 8000 });
+  await page.keyboard.press("Space");
   await page.waitForSelector(".storm__letter", { timeout: 8000 });
   await page
     .waitForFunction(() => document.querySelector(".storm__over") !== null, {
@@ -1764,8 +1786,14 @@ try {
     (lesson) => (location.hash = `${location.hash}/storm/${lesson}`),
     STORM_LESSON,
   );
-  await tablet.waitForSelector(".storm__letter", { timeout: 8000 });
+  await tablet.waitForSelector(".storm__ready", { timeout: 8000 });
   const reachable = await tablet.evaluate(() => ({
+    // What a storm opens on now: the beat before it falls, and no hail at all
+    // until a key starts it (§8.13, decision 71). On this device that is also
+    // the honest ending — a tablet cannot press the key, and the panel it is
+    // left looking at carries the way out rather than twelve letters it has
+    // no way to shoot.
+    ready: document.querySelectorAll(".storm__ready").length,
     stones: document.querySelectorAll(".storm__letter").length,
     quit: document.querySelectorAll(".storm__quit").length,
   }));
@@ -1779,14 +1807,15 @@ try {
   const proved = await ladder();
   check(
     "and one keystroke lets a keyboard in, with nothing reloaded",
-    reachable.stones > 0 &&
+    reachable.ready === 1 &&
+      reachable.stones === 0 &&
       reachable.quit === 1 &&
       proved.touchOnly === true &&
       proved.said === 0 &&
       // What the legend says on a device that can play them, which is the one
       // fact a child needs before pressing a diamond (§8.8).
       proved.legend.includes("Nothing on the ladder waits on one"),
-    `the route opened ${reachable.stones} stone(s) either way; ` +
+    `the route opened the ready panel and ${reachable.stones} stone(s); ` +
       `after one key ${proved.said}/${proved.storms} still name a keyboard`,
   );
   await tabletCtx.close();

--- a/src/engine/keyboard.ts
+++ b/src/engine/keyboard.ts
@@ -190,6 +190,21 @@ export const KEYS: KeyDef[] = KEY_ROWS.flat();
 const BY_CODE = new Map(KEYS.map((k) => [k.code, k]));
 
 /**
+ * The key a `KeyboardEvent.code` names, or `null` for one this board does not
+ * carry — a numpad key, a media key, `F7`, or anything from a layout that is
+ * not US ANSI (§3.4).
+ *
+ * The `null` is the useful half. "Is this code on the board?" is a question two
+ * consumers ask for reasons that have nothing to do with geometry — the clack
+ * plays only for keys the picture draws (§4.8) — and answering it with
+ * `keyX(code) !== null` would be reading a horizontal position to find out
+ * whether a key exists. Same lookup, one name for it.
+ */
+export function keyFor(code: string): KeyDef | null {
+  return BY_CODE.get(code) ?? null;
+}
+
+/**
  * Where a key sits across the board: the middle of it, in key units.
  *
  * The board is 15 units wide, so this is a number from 0 to 15 that scales off
@@ -217,7 +232,7 @@ const BY_CODE = new Map(KEYS.map((k) => [k.code, k]));
  * anything from a layout that is not US ANSI (§3.4).
  */
 export function keyX(code: string): number | null {
-  const key = BY_CODE.get(code);
+  const key = keyFor(code);
   return key ? key.x + (key.width ?? 1) / 2 : null;
 }
 

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -615,6 +615,7 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
   return {
     ch,
     code: stroke.code,
+    shifted: stroke.shift !== null,
     finger: stroke.finger,
     lane: keyX(stroke.code) ?? 0,
     spawnMs,
@@ -898,12 +899,72 @@ describe("firing resolves the lowest letter, and nothing else", () => {
     expect(state.combo).toBe(0);
   });
 
-  it("shoots a capital with the key that types it", () => {
-    // `A` and `a` are one key and two letters (decision 2), so the shift a
-    // child is holding cannot make the shot miss.
-    const state = to(runOf([at("A", 0, 1000)]), 400);
-    expect(state.wave.letters[0].code).toBe("KeyA");
-    expect(fire(state, "KeyA").resolved[0]?.outcome).toBe("shot");
+  describe("a capital is a shift and a letter", () => {
+    /*
+     * Decision 70. `A` and `a` are one key and two letters, and for a while
+     * the storm could only tell you the key — so a wave of capitals fell to
+     * the bare alphabet, and lesson 39 was called "Shift under fire" without
+     * ever asking for a shift. What decides a shot now is the CHARACTER the
+     * stroke produced: `code` for which key, `shifted` for which of its two
+     * legends.
+     */
+
+    /** A capital `A`, alone in the sky and about halfway down. */
+    const capital = () => to(runOf([at("A", 0, 1000)]), 400);
+
+    it("takes the letter's key with a shift held", () => {
+      const state = capital();
+      expect(state.wave.letters[0].code, "the premise: one key").toBe("KeyA");
+      expect(state.wave.letters[0].shifted).toBe(true);
+      expect(fire(state, "KeyA", true).resolved[0]?.outcome).toBe("shot");
+    });
+
+    it("counts the bare letter as a miss", () => {
+      // The bug this replaced: `a` cleared an `A`, and the child was scored
+      // as having typed something they did not type.
+      const state = fire(capital(), "KeyA", false);
+      expect(state.resolved[0], "the letter is still falling").toBeNull();
+      expect(state.misses).toBe(1);
+      expect(state.combo).toBe(0);
+      expect(state.score).toBe(-MISS_POINTS);
+    });
+
+    it("counts a shift held over a lowercase letter as a miss", () => {
+      // The same rule from the other side: shift+`f` is `F`, and `F` is not
+      // what is falling.
+      const state = fire(to(runOf([at("f", 0, 1000)]), 400), "KeyF", true);
+      expect(state.resolved[0]).toBeNull();
+      expect(state.misses).toBe(1);
+    });
+
+    it("holds the same for a shifted mark as for a capital", () => {
+      // Lessons 65 and 69 rain punctuation, where `?` is shift-`/` and the
+      // two share a lane exactly as `A` and `a` do.
+      const marks = to(runOf([at("?", 0, 1000)]), 400);
+      expect(marks.wave.letters[0].code).toBe("Slash");
+      expect(marks.wave.letters[0].shifted).toBe(true);
+      expect(fire(marks, "Slash", false).misses).toBe(1);
+      expect(fire(marks, "Slash", true).resolved[0]?.outcome).toBe("shot");
+    });
+
+    it("leaves an unshifted character alone about the shift", () => {
+      // Every level below lesson 34 rains nothing else, so the default the
+      // reducer takes when a caller says nothing is the one that plays them.
+      const state = to(runOf([at("f", 0, 1000)]), 400);
+      expect(state.wave.letters[0].shifted).toBe(false);
+      expect(fire(state, "KeyF").resolved[0]?.outcome).toBe("shot");
+    });
+
+    it("marks every character a wave can drop by what its stroke needs", () => {
+      // The wave is where this is decided, once, off `strokeFor` — so no
+      // level can rain a letter whose shift the reducer would have to guess
+      // at.
+      for (const [, waveSpec] of SPECS)
+        for (const letter of buildWave(waveSpec, 42).letters)
+          expect(letter.shifted, letter.ch).toBe(
+            strokeFor(letter.ch)?.shift !== null,
+          );
+    });
   });
 
   it("does nothing once the run is over", () => {

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -116,15 +116,41 @@ export type StormLetter = {
   /** The character, as it is drawn: `f`, `A`, `7`, `?`. */
   ch: string;
   /**
-   * `KeyboardEvent.code` of the key that produces it — what a press is
-   * compared against.
+   * `KeyboardEvent.code` of the key that produces it — half of what a press is
+   * compared against, `shifted` being the other half.
    *
    * `code`, not the character (decision 2): a shifted legend and its base
-   * share a key, so `A` and `a` are both fired by `KeyA` and the shift a child
-   * is holding cannot make the shot miss. It is also the code the lane is a
-   * column of, so the thing you press and the place it falls are one fact.
+   * share a key, so `A` and `a` are both struck on `KeyA`, and a code is what
+   * a keyboard reports the same way whatever else is being held down. It is
+   * also the code the lane is a column of, so the thing you press and the
+   * place it falls are one fact.
    */
   code: string;
+  /**
+   * Is this character the SHIFTED legend of its key — `A` rather than `a`, `?`
+   * rather than `/` (decision 70)?
+   *
+   * A shot has to match this as well as the code, and that is the whole of
+   * what makes a capital a capital in this game. Without it `A` and `a` are
+   * one target: a wave of capitals is cleared with the bare letters, lesson 39
+   * is called "Shift under fire" and never asks for a shift, and a child is
+   * credited with typing something they did not type. The passage lessons have
+   * always been strict about it — they judge the character that arrived in a
+   * real `<input>`, so `a` for `A` is simply wrong there — so this is the exam
+   * catching up with the ladder it examines, rather than a new demand.
+   *
+   * **Either shift will do.** `strokeFor` names the one on the opposite hand
+   * because that is the technique worth teaching (§3.3), and the passage's
+   * next-key hint highlights it; but a capital typed with the near shift still
+   * produces the character, and the lessons take it. A storm that marked the
+   * same stroke wrong would be stricter than the course that taught it, on the
+   * one screen with no board to explain itself with (decision 64).
+   *
+   * Read off `strokeFor` once, when the wave is built, like every other fixed
+   * fact about a letter: the reducer never asks the keyboard a question
+   * mid-run.
+   */
+  shifted: boolean;
   /**
    * The finger that types it, which is the shield segment above where it
    * lands (§8.5).
@@ -201,7 +227,10 @@ export type Wave = {
 };
 
 /** A character the board can drop, with everything fixed about it resolved. */
-type Fallable = Pick<StormLetter, "ch" | "code" | "finger" | "lane">;
+type Fallable = Pick<
+  StormLetter,
+  "ch" | "code" | "shifted" | "finger" | "lane"
+>;
 
 /**
  * A character as a thing that could fall, or `null` if it cannot.
@@ -228,7 +257,15 @@ function fallable(ch: string): Fallable | null {
   // still cheaper than asserting the null away, and it cannot hide a bug — a
   // wave short of a character it should have had is what the pool test sees.
   if (lane === null) return null;
-  return { ch, code: stroke.code, finger: stroke.finger, lane };
+  return {
+    ch,
+    code: stroke.code,
+    // `Stroke.shift` names WHICH shift the technique wants; what falls out of
+    // it here is only whether one is wanted at all. See `StormLetter.shifted`.
+    shifted: stroke.shift !== null,
+    finger: stroke.finger,
+    lane,
+  };
 }
 
 /**
@@ -939,6 +976,26 @@ export function tick(state: StormState, dtMs: number): StormState {
 }
 
 /**
+ * Did this press produce this letter's character?
+ *
+ * Both halves, because between them they ARE the character. `code` says which
+ * key was struck, and it is the half that survives whatever is being held down
+ * — `A` and `a` are one key (decision 2), which is why a code and not a
+ * character is what a letter carries. `shifted` says which of that key's two
+ * legends the strike produced, and it is the half that tells them apart: a
+ * capital is a shift and a letter (§3.3), so a storm comparing the code alone
+ * would mark a child right for typing the other one (decision 70).
+ *
+ * A predicate rather than two clauses inside `fire`'s guard, because the guard
+ * has to keep narrowing `index` away from `null` for the lines below it — and
+ * because "was that the right key" is the one question this game is about, so
+ * it is worth having a name.
+ */
+function struck(letter: StormLetter, code: string, shift: boolean): boolean {
+  return letter.code === code && letter.shifted === shift;
+}
+
+/**
  * Fire at the lowest letter on screen. Anything else is a miss.
  *
  * ── Why only the lowest ──────────────────────────────────────────────────────
@@ -972,19 +1029,31 @@ export function tick(state: StormState, dtMs: number): StormState {
  * A shot at an empty field is a miss for the same reason. It is exactly the
  * spray this rule exists to make unprofitable, and a child who could keep
  * their streak through it has found the strategy again by another route. The
- * screen owes them an answer to it that the board can tell the truth with:
- * a stroke that costs points must not light `--lime` for "that was right", so
- * the keyboard flares every key while the gun is live and has no target
- * (`StormField`, decision 43).
+ * screen still owes them an answer, and since there is no board left to say it
+ * on (decision 64) the answer is the one a screen with nothing on it can give:
+ * `sfx.misfire`, the same flat sound every other wrong key makes
+ * (`stormSounds.ts`), plus the `--flare` wash over the score that just fell.
  */
-export function fire(state: StormState, code: string): StormState {
+export function fire(
+  state: StormState,
+  code: string,
+  /**
+   * Was a shift held down as the key went down — `event.shiftKey`, either
+   * hand?
+   *
+   * Defaulted, and the default is the ordinary stroke: no shift, which is what
+   * `a`, `f` and `7` are typed with. It is safe to leave off only because
+   * getting it wrong can make a shot stricter and never looser — a caller that
+   * forgets it can no longer shoot a capital at all, which is a thing a child
+   * would notice on the first wave of lesson 34, where the bug it replaced was
+   * a game that quietly never asked (decision 70).
+   */
+  shift = false,
+): StormState {
   if (state.ending !== null) return state;
 
-  // Compared by `code` and not by the character: a shifted legend and its base
-  // share a key, so `A` and `a` are both `KeyA` and the shift a child is
-  // holding cannot make the shot miss (decision 2).
   const index = targetIndex(state);
-  if (index === null || state.wave.letters[index].code !== code)
+  if (index === null || !struck(state.wave.letters[index], code, shift))
     // A miss: the streak, the score and a mark against the run. Nothing on the
     // field moves — the letter the child should have shot is still falling,
     // which is the other half of the cost.

--- a/src/games/typing/StormBrief.test.tsx
+++ b/src/games/typing/StormBrief.test.tsx
@@ -101,6 +101,24 @@ describe("StormBrief", () => {
     expect(words(storm("L49"))).not.toContain("mostly");
   });
 
+  it("names the shift on every storm that can rain a capital", () => {
+    /*
+     * Decision 70. A capital is shot with a shift held, and it was not always
+     * — so the level a child meets it on has to say so, or it is a rule that
+     * announces itself by taking ten points.
+     *
+     * Asked of the pool and not of `focus`: capitals are unlocked at lesson
+     * 34 and are in every wave's pool from there up (§5.6), so "Pairs" rains
+     * them without being about them and needs the sentence exactly as much.
+     */
+    for (const id of ["L34", "L39", "L45", "L99"])
+      expect(words(storm(id)), id).toContain("A capital needs a shift");
+
+    // And below 34 it never appears, because nothing shifted can fall.
+    for (const id of ["L04", "L13", "L29"])
+      expect(words(storm(id)), id).not.toContain("shift");
+  });
+
   /**
    * §8.8, said in full on the one screen with room for it. The tile carries
    * "worth playing, never required" and this says what that MEANS: the rung

--- a/src/games/typing/StormBrief.tsx
+++ b/src/games/typing/StormBrief.tsx
@@ -2,6 +2,8 @@ import { useId } from "react";
 
 import { Button, Scrim } from "@/components/ui/kit";
 import { plural } from "@/engine/format";
+import { strokeFor } from "@/engine/keyboard";
+import { unlockedAt } from "@/engine/typing/keys";
 import { lessonNumbered } from "@/engine/typing/lessons";
 import type { LadderProgress } from "@/engine/typing/ladder";
 import type { StormLesson } from "@/engine/typing/storms";
@@ -58,6 +60,22 @@ export function StormBrief({
   const locked = tileState(lesson, progress) === "locked";
   const { count, shield, repairAt, focus } = lesson.kind.wave;
 
+  /* Can anything in this storm ask for a shift?
+     Asked of the pool rather than of `focus`, because the two answer different
+     questions. `focus` is what a level MOSTLY rains, and it stops being the
+     whole story the moment capitals are unlocked: from lesson 34 up they are
+     in every wave's pool (§5.6), so "Pairs" and "The long wave" rain them
+     without being about them. A rule that only appeared on the two levels
+     named for it would leave a child losing ten points on lesson 45 with
+     nothing on screen that had ever mentioned it (decision 70).
+
+     `unlockedAt(n)` is the same set `stormWave` draws this level's letters
+     from, so this cannot disagree with what actually falls. Below lesson 34
+     nothing in it is shifted and the sentence never appears. */
+  const shifts = [...unlockedAt(lesson.n)].some(
+    (ch) => strokeFor(ch)?.shift != null,
+  );
+
   /* The rung above this one, which is what "nothing waits on it" is about. No
      two storms are adjacent on the ladder (§5.5), so this is always an ordinary
      lesson; the fallback is written rather than asserted because the ladder is
@@ -81,6 +99,7 @@ export function StormBrief({
         <p className="brief__new">
           Letters fall down the column of the key that types them. Shoot the
           lowest one before it reaches your shield — any other key is a miss.
+          {shifts ? " A capital needs a shift, just like typing one does." : ""}
         </p>
 
         <section className="brief__asks" aria-label="This storm">

--- a/src/games/typing/keyboard/LiveKeyboard.tsx
+++ b/src/games/typing/keyboard/LiveKeyboard.tsx
@@ -1,4 +1,5 @@
 import { Keyboard } from "./Keyboard";
+import { useKeyClack } from "./keySounds";
 import { useKeyEcho } from "./useKeyEcho";
 import type { KeyboardMode } from "@/engine/types";
 
@@ -6,10 +7,11 @@ import type { KeyboardMode } from "@/engine/types";
  * The board as a typist actually meets it: the picture, plus what their hands
  * are doing to it (docs/typing.md §4).
  *
- * Three pieces built apart meet here and nowhere else — `Keyboard` draws
- * (#130), `useKeyEcho` listens (#131), `KeyboardMode` decides how much of it a
- * child wants (#133). It exists as its own component for two reasons, both
- * about what a keystroke is allowed to cost:
+ * Four pieces built apart meet here and nowhere else — `Keyboard` draws
+ * (#130), `useKeyEcho` listens (#131), `useKeyClack` answers out loud (§4.8),
+ * `KeyboardMode` decides how much of it a child wants (#133). It exists as its
+ * own component for two reasons, both about what a keystroke is allowed to
+ * cost:
  *
  *   - **The echo re-renders this and not the passage.** `useKeyEcho` publishes
  *     on every keydown and again when each key's 120ms release fires. Called
@@ -18,9 +20,10 @@ import type { KeyboardMode } from "@/engine/types";
  *     Called here, they re-render sixty spans and stop.
  *   - **"Off" is off, not hidden.** The caller mounts this only when the mode
  *     is not "off" — which is why `mode` excludes it rather than returning
- *     `null` for it. A board that returned `null` after calling the hook would
- *     still hold a window listener and a timer per key for a child who asked
- *     to be rid of it.
+ *     `null` for it. A board that returned `null` after calling the hooks
+ *     would still hold two window listeners and a timer per key for a child
+ *     who asked to be rid of it — and would go on clacking at a child who
+ *     turned the keyboard off, which is the one thing "off" has to mean.
  *
  * Nothing here can take focus. That is not a promise this file keeps by being
  * careful; the board is sixty inert `<span>`s under `pointer-events: none`
@@ -55,6 +58,16 @@ export function LiveKeyboard({
    * the hint would turn every wrong key green.
    */
   const { down, wrong } = useKeyEcho({ expect: next });
+
+  /**
+   * The board's other half of the same answer (§4.8).
+   *
+   * Deliberately not handed `next`: a wrong key clacks exactly like a right
+   * one, because the flash above is already saying which it was and a sound
+   * played on every keystroke is the wrong place to say it twice
+   * (`soundForKey`).
+   */
+  useKeyClack();
 
   return (
     <Keyboard down={down} wrong={wrong} next={mode === "guide" ? next : null} />

--- a/src/games/typing/keyboard/keySounds.test.ts
+++ b/src/games/typing/keyboard/keySounds.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { soundForKey } from "./keySounds";
+
+/**
+ * What the board is allowed to say out loud (docs/typing.md §4.8).
+ *
+ * The rule is one function over one event, so the whole of it is testable
+ * without a mixer or a DOM — the same split `stormSounds.ts` uses, and for the
+ * same reason: the questions worth asking here ("does a held key machine-gun",
+ * "does a wrong key sound wrong") are questions about the rule, and
+ * `playKeySound` is a `switch` with nothing in it to get wrong.
+ *
+ * Three of the four silences below are decisions a well-meaning change would
+ * undo, so they are written as the cases that would have made a noise.
+ */
+
+/** A keydown, as the rule sees one. */
+const press = (code: string, repeat = false) => ({ code, repeat });
+
+describe("soundForKey", () => {
+  it("strikes a typebar for a letter, a digit and a mark", () => {
+    expect(soundForKey(press("KeyF"))).toBe("strike");
+    expect(soundForKey(press("Digit4"))).toBe("strike");
+    expect(soundForKey(press("Semicolon"))).toBe("strike");
+  });
+
+  it("gives the space bar its own, deeper voice", () => {
+    // The key that commits a word, so the beat between words is audible.
+    expect(soundForKey(press("Space"))).toBe("space");
+  });
+
+  it("rings the bell on Return", () => {
+    expect(soundForKey(press("Enter"))).toBe("return");
+  });
+
+  it("sounds the same whether or not the key was the right one", () => {
+    // The rule is not handed an expectation at all, which is the point: the
+    // board already flares the wrong key and the run already plays `wrong` at
+    // the word. This test exists to make deleting that argument visible —
+    // there is nothing in the signature to pass a verdict through.
+    expect(soundForKey(press("KeyD"))).toBe(soundForKey(press("KeyF")));
+  });
+
+  it("stays silent on auto-repeat", () => {
+    // A held key is one stroke. The board relights on every repeat because its
+    // light is a timer that must be re-armed; a clack re-fired every 33ms is a
+    // drone rather than a keyboard.
+    expect(soundForKey(press("KeyF"))).toBe("strike");
+    expect(soundForKey(press("KeyF", true))).toBeNull();
+    expect(soundForKey(press("Space", true))).toBeNull();
+  });
+
+  it("stays silent on the keys that are held rather than struck", () => {
+    // A capital is right-shift and a left-hand letter — one character, and so
+    // one sound, on the letter.
+    expect(soundForKey(press("ShiftRight"))).toBeNull();
+    expect(soundForKey(press("ControlLeft"))).toBeNull();
+    expect(soundForKey(press("MetaLeft"))).toBeNull();
+
+    // CapsLock is not held, is not part of any stroke on this layout, and is
+    // exactly the mis-hit worth pointing out — the echo flares it, so it
+    // clacks like everything else the board draws.
+    expect(soundForKey(press("CapsLock"))).toBe("strike");
+  });
+
+  it("stays silent for a key this board does not draw", () => {
+    // A numpad key, a media key, a function key: the picture shows none of
+    // them, so the clack — which is the picture's voice — has nothing to say.
+    expect(soundForKey(press("Numpad7"))).toBeNull();
+    expect(soundForKey(press("AudioVolumeUp"))).toBeNull();
+    expect(soundForKey(press("F7"))).toBeNull();
+    expect(soundForKey(press(""))).toBeNull();
+  });
+
+  it("clacks for the keys that are not letters but are on the board", () => {
+    // Backspace deliberately sounds like any other key. A typewriter has no
+    // undo, and a quieter correction would be the board passing judgement on
+    // one — which is the thing this set does not do.
+    expect(soundForKey(press("Backspace"))).toBe("strike");
+    expect(soundForKey(press("Tab"))).toBe("strike");
+  });
+});

--- a/src/games/typing/keyboard/keySounds.ts
+++ b/src/games/typing/keyboard/keySounds.ts
@@ -1,0 +1,141 @@
+import { useEffect } from "react";
+
+import { keyFor } from "@/engine/keyboard";
+import { sfx } from "@/services/sound";
+
+import { HELD } from "./useKeyEcho";
+
+/**
+ * What the board sounds like under a child's hands (docs/typing.md §4.8).
+ *
+ * `useKeyEcho` is the board's eyes — which key went down, and whether it was
+ * the wrong one. This is the board's ears, and it is deliberately the simpler
+ * of the two: it looks at one keystroke, in isolation, and says which of three
+ * noises a typewriter would have made. It knows nothing about the passage, the
+ * expectation, the streak or the clock, and that is the point — see
+ * `soundForKey` below.
+ *
+ * ── Why it is a second hook and not a line in `useKeyEcho` ────────────────────
+ * The two are mounted and unmounted together and listen to the same event, so
+ * merging them would work. They are apart for two reasons that outlast the
+ * convenience:
+ *
+ *   - **The echo publishes React state on every keystroke; this publishes
+ *     nothing.** A clack is a side effect with no render behind it, and
+ *     keeping it out of the hook that owns `useState` is what makes that
+ *     obvious rather than something you have to check.
+ *   - **The echo is a pure state machine with a unit suite that runs in Node**
+ *     (`createKeyEcho`). Putting a call to `services/sound` inside its
+ *     listener would put a mixer in the import graph of the one part of the
+ *     board that is testable without a browser.
+ */
+
+/**
+ * One thing a keystroke can sound like.
+ *
+ * Three, and not one per key, because a typewriter only has three voices: the
+ * typebars, the space bar, and the bell-and-carriage on Return. Everything
+ * else on the board — every letter, every digit, `Tab`, `Caps`, `Backspace` —
+ * is a lever that swings and hits the paper, and they sound alike because they
+ * *are* alike.
+ */
+export type KeySound = "strike" | "space" | "return";
+
+/**
+ * What this keystroke sounds like, or `null` for one that makes no sound.
+ *
+ * ── It is not told whether the key was right ─────────────────────────────────
+ * The signature takes the event and nothing else: no expectation, no verdict.
+ * A wrong key clacks exactly like a right one, and that is a decision rather
+ * than an omission. The board already flares the wrong key `--flare` (§4.3),
+ * the passage already goes red behind you, and the run already plays
+ * `sfx.wrong` at the word. A keyboard that scolded a child on the way *down*
+ * would be a fourth opinion about one keystroke, arriving before any of the
+ * other three knew the answer — and it would make the one sound a child hears
+ * constantly into a running commentary on their mistakes.
+ *
+ * So the clack says "that key went down" and nothing more. It is the sound of
+ * a machine working, which is what makes it bearable eight times a second.
+ *
+ * ── Three silences ───────────────────────────────────────────────────────────
+ * Split from the player below so all three are testable without a mixer, in
+ * the same shape `stormSounds.ts` uses for the same reason.
+ */
+export function soundForKey(
+  event: Pick<KeyboardEvent, "code" | "repeat">,
+): KeySound | null {
+  // 1. A held key is one stroke, not thirty a second of it.
+  //
+  // The board relights on auto-repeat, because its light is a timer that has
+  // to be re-armed by something (`HOLD_MS`). The sound has the opposite
+  // failure: a flash re-fired every 33ms reads as a key still held, and a
+  // clack re-fired every 33ms is a drone. Hailstorm made the same call for the
+  // same reason — a held key is not a shot there either (decision 44).
+  if (event.repeat) return null;
+
+  // 2. A modifier is held, not struck.
+  //
+  // The same `HELD` set the echo never flares, so one rule covers both: a
+  // capital is right-shift and a left-hand letter (§3.3), and it should be one
+  // sound, on the letter — not a clack for the reach and a clack for the key.
+  // It also keeps a child switching windows with Cmd-Tab from typing at their
+  // own desktop.
+  if (HELD.has(event.code)) return null;
+
+  // 3. A key the board does not draw makes no sound.
+  //
+  // The clack is the board's voice, so it says exactly what the picture says:
+  // a numpad `7`, a media key or `F7` lights nothing and so clacks nothing. It
+  // is the same rule that keeps a keyboard shortcut on some layout this build
+  // has never heard of from sounding like a letter being typed.
+  const key = keyFor(event.code);
+  if (!key) return null;
+
+  if (key.code === "Space") return "space";
+  if (key.code === "Enter") return "return";
+  return "strike";
+}
+
+/**
+ * Play what a keystroke sounds like.
+ *
+ * `sfx` is silent when the player has sound off and in any environment with no
+ * `AudioContext`, so neither this nor its callers carry a guard of their own.
+ */
+export function playKeySound(
+  event: Pick<KeyboardEvent, "code" | "repeat">,
+): void {
+  switch (soundForKey(event)) {
+    case "strike":
+      sfx.keyStrike();
+      break;
+    case "space":
+      sfx.keySpace();
+      break;
+    case "return":
+      sfx.keyReturn();
+      break;
+  }
+}
+
+/**
+ * The clack, wired to the window.
+ *
+ * On `window` rather than on the field, and in the capture phase, for the two
+ * reasons `useKeyEcho` binds the same way: the board has to stay honest
+ * wherever focus went, and capture runs ahead of every handler that could
+ * `stopPropagation` — `TypeField`'s space handler among them, which
+ * `preventDefault`s the key that commits a word.
+ *
+ * No state, no publish, no return value: this hook never re-renders anything.
+ * It is bound once for the life of the board and removed with it, which is
+ * also the whole of the "only when the keyboard is present" rule — `mode:
+ * "off"` never mounts `LiveKeyboard` at all (§4.8).
+ */
+export function useKeyClack(): void {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => playKeySound(event);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, []);
+}

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -19,9 +19,11 @@ import {
 
 import { StormField } from "./StormField";
 import { StormOver } from "./StormOver";
+import { StormReady } from "./StormReady";
 
 import type { FingerZone, KeyDef } from "@/engine/keyboard";
 import type { StormState, WaveSpec } from "@/engine/typing/storm";
+import type { ComponentProps } from "react";
 
 /**
  * The one claim this screen exists to keep: a letter falls down the column of
@@ -182,8 +184,13 @@ const frameOf = (spec: WaveSpec, atMs: number): StormState =>
  * writes the fall (§8.9); a still frame has no clock, so it is handed an empty
  * ref rather than the component being made to work without one.
  */
-const draw = (state: StormState) =>
-  renderToStaticMarkup(<StormField state={state} skyRef={{ current: null }} />);
+const draw = (
+  state: StormState,
+  over: Partial<ComponentProps<typeof StormField>> = {},
+) =>
+  renderToStaticMarkup(
+    <StormField state={state} skyRef={{ current: null }} {...over} />,
+  );
 
 /** Every falling letter in a rendered field, as `{ ch, lane, fallMs, drop }`. */
 const stones = (state: StormState) =>
@@ -630,6 +637,41 @@ describe("StormField", () => {
     // And one that was shot leaves at the press rather than at its landing —
     // `resolved` is what is drawn from, not the clock alone.
     expect(stones(fire(state, "KeyJ"))).toHaveLength(1);
+  });
+
+  it("draws no letter at all while the wave is waiting to be started", () => {
+    /*
+     * The beat before it falls (§8.13, decision 71). A wave's first letter
+     * spawns at time zero (`buildWave`), so a field that only held the clock
+     * would be showing it — an untimed look at the first target, where every
+     * other letter of the run gets exactly `QUEUE_MS` to be read in. One prop
+     * both puts the panel in the sky and takes the stones out of it, so the
+     * two cannot come apart.
+     */
+    const state = frameOf(only("j", 4, MIN_FALL_MS), 0);
+    expect(
+      stones(state).length,
+      "the premise: there is hail to be hidden",
+    ).toBeGreaterThan(0);
+
+    const waiting = draw(state, { ready: <StormReady /> });
+    expect(waiting).not.toContain("storm__letter");
+    expect(waiting).toContain("storm__ready");
+    expect(waiting).toContain("Press any key to start");
+  });
+
+  it("draws the rest of the field while it waits, so nothing moves on start", () => {
+    // The HUD at nothing and the shield whole, both exactly where the run will
+    // find them: pressing a key has to start a storm, not rearrange a screen.
+    // The way out is in there too, which is the whole of what a device that
+    // cannot press a key is left with (§8.8).
+    const waiting = draw(frameOf(only("j"), 0), {
+      ready: <StormReady />,
+      onQuit: () => {},
+    });
+    expect(waiting).toContain("storm__hud");
+    expect(waiting).toContain("storm__shield");
+    expect(waiting).toContain("storm__quit");
   });
 
   it("puts a stone at the top when it spawns and at the line when it lands", () => {

--- a/src/games/typing/storm/StormField.tsx
+++ b/src/games/typing/storm/StormField.tsx
@@ -108,6 +108,7 @@ export function StormField({
   state,
   skyRef,
   onQuit,
+  ready,
   over,
 }: {
   state: StormState;
@@ -121,6 +122,24 @@ export function StormField({
    * this file would be a second opinion about where that row is.
    */
   onQuit?: () => void;
+  /**
+   * What stands in the sky while the wave is still waiting to be started, or
+   * absent once it is running (§8.13, decision 71).
+   *
+   * **Its presence is what says the run has not begun**, and that is why it is
+   * one prop and not a node beside a boolean. A waiting storm draws no stones:
+   * the first letter of a wave spawns at time zero (`buildWave`), so a field
+   * that only froze the clock would be handing a child a free, untimed look at
+   * the first target — the reading beat every other letter gets (`QUEUE_MS`)
+   * made unlimited for exactly the one that sets the pace. Two props could
+   * disagree about that; one cannot.
+   *
+   * The rest of the field is drawn as it always is — the HUD at nothing, the
+   * shield whole — because that is the picture a child is about to have to
+   * read, and there is nothing to be gained by making them meet it for the
+   * first time on the frame the hail starts.
+   */
+  ready?: React.ReactNode;
   /**
    * What stands under the sky once the run is over (§8.5, STM07).
    *
@@ -150,7 +169,8 @@ export function StormField({
       {state.ending === null && (
         <p className="u-sr">
           Letters fall down the column of the key that types them. Press that
-          key to shoot the lowest one, or press Escape to leave.
+          key to shoot the lowest one — a capital needs a shift, exactly as it
+          would anywhere else — or press Escape to leave.
         </p>
       )}
 
@@ -172,8 +192,14 @@ export function StormField({
             viewport it has nothing left to give (decision 45, `StormHud`). */}
         <StormHud state={state} onQuit={onQuit} />
 
+        {/* Either the wave, or the beat before it — never both. See `ready`:
+            a storm that has not been started has nothing in the sky to read,
+            which is the whole of what "we don't show them the first letter
+            yet" means. */}
+        {ready}
+
         {state.wave.letters.map((letter, index) => {
-          if (!isDrawn(state, index)) return null;
+          if (ready || !isDrawn(state, index)) return null;
 
           return (
             <span

--- a/src/games/typing/storm/StormOver.test.tsx
+++ b/src/games/typing/storm/StormOver.test.tsx
@@ -30,6 +30,7 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
   return {
     ch,
     code: stroke.code,
+    shifted: stroke.shift !== null,
     finger: stroke.finger,
     lane: keyX(stroke.code) ?? 0,
     spawnMs,

--- a/src/games/typing/storm/StormReady.tsx
+++ b/src/games/typing/storm/StormReady.tsx
@@ -1,0 +1,54 @@
+/**
+ * The beat before a storm falls (docs/typing.md §8.13, decision 71).
+ *
+ * ── Why a storm waits, where a race counts ───────────────────────────────────
+ * Every other run on this site opens with the 3·2·1 (`useCountdown`), and the
+ * reason that works there is that a race is entered with the hands already
+ * where they are going to be: a flash card is answered on the number row or
+ * with a tap, and a passage lesson puts the caret in an input a child has
+ * clicked into. A storm is entered from a tile with a mouse, and then asks for
+ * eight fingers on the home row and a reaction time — so a three-second count
+ * is three seconds of a child moving one hand off a trackpad while the first
+ * letter is already being scheduled.
+ *
+ * A clock cannot fix that, because the thing being waited for is not an amount
+ * of time. It is a child being ready, which only they can know. So the storm
+ * waits, indefinitely and with no counter running, for the one signal that
+ * proves the hands are where they need to be: a key.
+ *
+ * ── Nothing is falling yet, and nothing is drawn ─────────────────────────────
+ * The first letter of a wave spawns at time zero (`buildWave`), so a field
+ * that merely held the clock still would be showing it — a free look at the
+ * first target for as long as a child cared to take one, and the reading beat
+ * `QUEUE_MS` gives every OTHER letter turned into an unlimited one for the
+ * first. So the same prop that puts this panel in the sky is what takes the
+ * stones out of it (`StormField`): the letters begin when the storm does.
+ *
+ * ── The bumps ────────────────────────────────────────────────────────────────
+ * The two lines here are the only place on this screen a child is told how to
+ * put their hands down, and the storm is the one screen in the epic with no
+ * keyboard drawn on it (decision 64) — so it names the thing a keyboard has
+ * instead of a picture: the ridges on `F` and `J`. That is the actual
+ * technique for finding the home row without looking, which is the habit every
+ * lesson below is trying to build, and it is a thing a five-year-old can do in
+ * the two seconds they are reading it.
+ *
+ * ── It holds no listener ─────────────────────────────────────────────────────
+ * "Press any key" is answered in `useStormClock`, beside the gun it becomes
+ * (`started`). One window listener on this screen is the rule the whole file
+ * is built on: while a run is live every stroke is a shot, so a second
+ * listener is a press answered twice — and the press that starts a storm is
+ * exactly the one that would otherwise be a miss on the way in.
+ */
+export function StormReady() {
+  return (
+    <div className="storm__ready">
+      <p className="storm__ready-head">Get ready</p>
+      <p className="storm__ready-note">
+        Find the two little bumps — <b>F</b> and <b>J</b> — and rest your
+        fingers on the home row.
+      </p>
+      <p className="storm__ready-go">Press any key to start</p>
+    </div>
+  );
+}

--- a/src/games/typing/storm/StormRun.tsx
+++ b/src/games/typing/storm/StormRun.tsx
@@ -11,6 +11,7 @@ import { QuitSheet, SaveFailed, useRaceFinish } from "@/games/race";
 
 import { StormField } from "./StormField";
 import { StormOver } from "./StormOver";
+import { StormReady } from "./StormReady";
 import { stormConfig, stormTally } from "./stormSession";
 import { useStormClock } from "./useStormClock";
 
@@ -166,6 +167,28 @@ function StormPlay({
   const [quitting, setQuitting] = useState(false);
 
   /**
+   * Has the child started this wave? (§8.13, decision 71.)
+   *
+   * A storm does not begin on mount. It hangs at time zero, with an empty sky
+   * and a panel in it, until a key says go — the reason being that this is the
+   * one game on the site entered with the hands in the wrong place: a tile is
+   * clicked with a mouse, and what the first letter then asks for is eight
+   * fingers on the home row (`StormReady`). The 3·2·1 every race opens with
+   * cannot serve for that, because three seconds is a guess at something only
+   * the child knows.
+   *
+   * False on every attempt, and a retry is a new component (`StormRun`), so
+   * the beat is offered again after a loss — which is exactly when a child is
+   * most likely to have taken a hand off the keys.
+   *
+   * It is `useStormClock`'s to end and this screen's to hold, for the reason
+   * `quitting` is: the key that starts a run has to be taken by the same
+   * listener that would otherwise fire it at a letter, and there is only ever
+   * one of those (`QUIT_KEY`).
+   */
+  const [started, setStarted] = useState(false);
+
+  /**
    * This attempt's wave, and the config the run will be filed under.
    *
    * Built once per mount and never rebuilt: a run's wave is fixed for its
@@ -179,6 +202,10 @@ function StormPlay({
   const config = useMemo(() => stormConfig(lesson.id, wave), [lesson.id, wave]);
   const { state, skyRef } = useStormClock(wave, {
     paused: quitting,
+    started,
+    // The first press is spent starting the wave rather than shot at it — see
+    // `started`, and the gun's own note about why it is taken there.
+    onStart: () => setStarted(true),
     // The keyboard's way to the same sheet the button opens. It is taken
     // inside the gun's own listener because every other key while the run is
     // live is a shot, and a way out that cost ten points would be a trap
@@ -257,6 +284,10 @@ function StormPlay({
         state={state}
         skyRef={skyRef}
         onQuit={() => setQuitting(true)}
+        // Present exactly while the wave is waiting, which is also what takes
+        // the stones out of the sky: nothing is shown of the storm before the
+        // storm starts (`StormField`).
+        ready={started ? undefined : <StormReady />}
         // Drawn where the board was, and only once the run is over — which is
         // `StormField`'s call to make, off the same `ending` the gun dies on.
         over={

--- a/src/games/typing/storm/stormSession.test.ts
+++ b/src/games/typing/storm/stormSession.test.ts
@@ -50,6 +50,7 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
   return {
     ch,
     code: stroke.code,
+    shifted: stroke.shift !== null,
     finger: stroke.finger,
     lane: keyX(stroke.code) ?? 0,
     spawnMs,

--- a/src/games/typing/storm/stormSession.ts
+++ b/src/games/typing/storm/stormSession.ts
@@ -99,9 +99,10 @@ export function stormConfig(lessonId: string, wave: Wave): TypingConfig {
  *     so `troubleFacts` ranks per key and the drill `buildDrill` returns is a
  *     passage of exactly the keys a child keeps losing letters on.
  *   - `given` — the character for a letter that was shot, and `null` for one
- *     that got through, because nothing was pressed at it. `fire` compares
- *     `code` alone (decision 2), so a capital shot without the shift held
- *     still records the character its key was struck for.
+ *     that got through, because nothing was pressed at it. There is no third
+ *     case to worry about: a shot only resolves a letter when it matched both
+ *     the key and the shift (decision 70), so what was typed IS the character,
+ *     and a capital can never be recorded as cleared by the bare letter.
  *   - `ms` — `atMs - spawnMs`: how long the letter was in the air. `atMs` is
  *     the letter's own moment (`LetterOutcome`) — the press for a letter that
  *     was shot and its own `landMs` for one that landed — never the tick that

--- a/src/games/typing/storm/stormSounds.test.ts
+++ b/src/games/typing/storm/stormSounds.test.ts
@@ -26,6 +26,7 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
   return {
     ch,
     code: stroke.code,
+    shifted: stroke.shift !== null,
     finger: stroke.finger,
     lane: keyX(stroke.code) ?? 0,
     spawnMs,

--- a/src/games/typing/storm/useStormClock.test.ts
+++ b/src/games/typing/storm/useStormClock.test.ts
@@ -120,6 +120,7 @@ const letterOf = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
   return {
     ch,
     code: stroke.code,
+    shifted: stroke.shift !== null,
     finger: stroke.finger as ShieldFinger,
     lane: keyX(stroke.code)!,
     spawnMs,

--- a/src/games/typing/storm/useStormClock.ts
+++ b/src/games/typing/storm/useStormClock.ts
@@ -220,6 +220,8 @@ export function useStormClock(
   wave: Wave,
   {
     paused = false,
+    started = true,
+    onStart,
     onQuit,
   }: {
     /**
@@ -239,6 +241,33 @@ export function useStormClock(
      * holds a paused-at timestamp for a resume to get wrong.
      */
     paused?: boolean;
+    /**
+     * Has the child said they are ready? (§8.13, decision 71.)
+     *
+     * A wave does not begin the moment the route mounts. It hangs at zero —
+     * no frames, no wave time, and, because `StormField` draws no stones
+     * before it starts, nothing on screen to read yet — until a key says go.
+     * The screen owns the flag; what is owned here is the key that flips it,
+     * for the same reason `QUIT_KEY` is (below): while the gun is live every
+     * stroke is a shot, so a second window listener sitting beside this one is
+     * a way for one press to be answered twice.
+     *
+     * It defaults to started, which is what a caller with no ready screen —
+     * a test, a story that renders a wave to look at it — should get.
+     *
+     * Distinct from `paused`, and the two are not interchangeable. Pausing is
+     * a run held mid-fall with a sheet over it; this is a run that has not
+     * had its first frame. Both stop the clock, and only this one is waiting
+     * for a key to end it.
+     */
+    started?: boolean;
+    /**
+     * Start the run: what the first key press does while `started` is false.
+     *
+     * Absent on a screen that begins by itself, in which case nothing here
+     * ever asks for it.
+     */
+    onStart?: () => void;
     /**
      * What `QUIT_KEY` does, or nothing where a screen offers no way out.
      *
@@ -265,6 +294,8 @@ export function useStormClock(
    */
   const quitRef = useRef<(() => void) | undefined>(undefined);
   quitRef.current = onQuit;
+  const startRef = useRef<(() => void) | undefined>(undefined);
+  startRef.current = onStart;
 
   useEffect(() => {
     // A run's wave is fixed for its whole life (`StormState.wave`), so this
@@ -297,8 +328,16 @@ export function useStormClock(
      * as the run is live; the rules for what that is worth are `fire`'s, and
      * none of them are here.
      *
-     * Four keydowns are not strokes even while it is, and each is left out
-     * for a reason the board already agrees with:
+     * **A stroke is a code and a shift, and both are handed over**
+     * (decision 70). `event.shiftKey` is the difference between `A` and `a`,
+     * and it is read off the same event as the code rather than tracked across
+     * keydown and keyup: a shift released while the tab was in the background
+     * is a `keyup` this window never saw, and a gun that believed its own
+     * bookkeeping would go on demanding a shift nobody was holding. The
+     * browser's answer is the one on the event, every time.
+     *
+     * Four keydowns are not strokes even while the run is live, and each is left
+     * out for a reason the board already agrees with:
      *
      *   - **`QUIT_KEY`** — the way out (§8.11). It is taken before the trigger
      *     rather than beside it, because a key that reached `fire` would be a
@@ -328,6 +367,23 @@ export function useStormClock(
      * being the engine's table, since this screen draws no board (decision 64). Anything else
      * — F5, F12, the browser's own — is left alone, because a game screen that
      * ate the reload key would be a screen with no way out.
+     *
+     * **Before the run starts, one press does one thing: it starts it**
+     * (`started`). No wave time has passed, no letter is on screen, and `fire`
+     * is not called at all — so the key that says "I'm ready" cannot also be
+     * the first miss of the run. All four guards above hold there too, and two
+     * more keys are left out of "any key":
+     *
+     *   - **`Tab`**, because it is how the way out in the HUD is reached
+     *     without a mouse (`StormHud`). The gun swallows it once the run is
+     *     live, which is exactly why the button is worth being able to reach
+     *     before then — and a game that began the instant a child went looking
+     *     for the exit would be the trap that button exists to prevent.
+     *   - **Anything the layout does not carry** — F5, F12, a media key. Same
+     *     test as the paragraph above, put to a second use: they are not a
+     *     child putting their hands down, and treating them as one would mean
+     *     swallowing the reload key on a screen whose whole state is "nothing
+     *     has happened yet".
      */
     const onKeyDown = (event: KeyboardEvent) => {
       // The gun dies with the run, and the listener has to know it rather than
@@ -348,9 +404,27 @@ export function useStormClock(
         return;
       }
       if (HELD.has(event.code)) return;
-      if (!event.altKey && keyX(event.code) !== null) event.preventDefault();
 
-      const next = fire(live.current, event.code);
+      // Asked once and read by both branches below: is this a key the layout
+      // carries? It is what decides the `preventDefault` (see the block
+      // above), and it is also what "any key" means before the run starts —
+      // F5, F12 and the media keys are not a child saying they are ready, and
+      // a ready screen that swallowed the reload key would be worse than one
+      // that ignored it.
+      const onBoard = keyX(event.code) !== null;
+
+      // The run has not begun: this press begins it, and is spent doing so.
+      // `Tab` is the exception — see the block above.
+      if (!started) {
+        if (!onBoard || event.code === "Tab") return;
+        if (!event.altKey) event.preventDefault();
+        startRef.current?.();
+        return;
+      }
+
+      if (!event.altKey && onBoard) event.preventDefault();
+
+      const next = fire(live.current, event.code, event.shiftKey);
       playStormSounds(live.current, next);
       live.current = next;
       publish(next);
@@ -394,17 +468,23 @@ export function useStormClock(
       if (next.ending === null) frame = requestAnimationFrame(loop);
     };
 
-    frame = requestAnimationFrame(loop);
+    // No frame until a child says go, so a wave that is waiting stays at zero
+    // for as long as it waits — the whole of `started`, since wave time is
+    // what rAF moves and `last` starts over at `null` when the loop is armed.
+    // The listener is bound either way: it is what does the saying.
+    if (started) frame = requestAnimationFrame(loop);
     // Capture, and on the window, exactly as `useKeyEcho` binds: this screen
     // has no focused element for a stroke to land on, and capture runs ahead
     // of anything that might stop propagation on the way up.
     window.addEventListener("keydown", onKeyDown, true);
 
-    // Every way out of a run runs this, and there are three: the route being
-    // left, the run ending, and the pause above. Quitting is now the first of
-    // them by way of the third — the sheet pauses the storm, and confirming it
-    // navigates — which is why `paused` is an input to this effect rather than
-    // something it could have been left to infer.
+    // Every way in or out of a run runs this, and there are four: the route
+    // being left, the run ending, the pause above, and the moment a waiting
+    // wave is started. Quitting is the first of them by way of the third — the
+    // sheet pauses the storm, and confirming it navigates — which is why
+    // `paused` is an input to this effect rather than something it could have
+    // been left to infer, and `started` is one for the same reason: a run
+    // begins by re-arming from the top, with a first frame worth zero.
     //
     // The listener goes with the frame, for a plainer reason than the loop's:
     // one left on the window outlives the screen. It would hold this run's
@@ -416,7 +496,7 @@ export function useStormClock(
       cancelAnimationFrame(frame);
       window.removeEventListener("keydown", onKeyDown, true);
     };
-  }, [wave, paused]);
+  }, [wave, paused, started]);
 
   return { state, skyRef };
 }

--- a/src/services/sound.ts
+++ b/src/services/sound.ts
@@ -349,4 +349,114 @@ export const sfx = {
       }),
     );
   },
+
+  /* ── Typewriter ──────────────────────────────────────────────────────────
+   *
+   * The board's own voice: what a key sounds like going down, played whenever
+   * the keyboard is on screen (docs/typing.md §4.8).
+   *
+   * These are the most frequent sounds on the site by an order of magnitude —
+   * a race plays a handful a minute, a storm one per stroke, and this one plays
+   * eight a second under a child who has got good. Two consequences run through
+   * every number below.
+   *
+   * **They are the quietest things in the kit**, quieter even than the storm's
+   * gun. Anything that could be noticed once is a headache after a passage.
+   *
+   * **They carry no pitch.** Every other sound here means something — the
+   * streak chime climbs, the miss falls, the bell rings. A clack means only
+   * "that key went down", which is a fact and not a verdict, and it has to keep
+   * saying that eight times a second underneath `correct` and `wrong` without
+   * arguing with either. So a strike is three noise bursts and no oscillator:
+   * a typewriter is percussion, and percussion is the one thing that can sit
+   * under a melody without being part of it. It is also why the clack does not
+   * change when a key is wrong — the board already flares `--flare` for that
+   * and the run plays `wrong` at the word, so a keyboard that scolded a child
+   * on the way down would be a third opinion, arriving before either of the
+   * other two knew the answer (`keySounds.ts`).
+   *
+   * `noise` is the right generator for a second reason: its envelope starts at
+   * full gain and decays, where `tone` ramps up over 12ms. Twelve milliseconds
+   * of attack on a forty-millisecond sound is a blip; percussion has no attack
+   * at all, and that difference is the whole distance between a click and a
+   * boop.
+   */
+
+  /**
+   * One key, struck — the sound under every letter, digit and mark.
+   *
+   * Three layers, which are the three things a typewriter actually does when
+   * you press a key: the typebar slaps the platen (high and gone in a frame),
+   * the machine's body answers it (low, a little longer, the wood in the
+   * sound), and the escapement ticks the carriage on one space a beat later.
+   * The tick is what makes the set read as a typewriter rather than as a
+   * mouse click; it is also the quietest of the three, because it is the part
+   * a listener recognises without noticing.
+   */
+  keyStrike: () => {
+    noise({ dur: 0.016, gain: 0.1, sweepFrom: 5200, sweepTo: 2400 });
+    noise({ dur: 0.05, gain: 0.075, sweepFrom: 700, sweepTo: 190 });
+    noise({
+      dur: 0.012,
+      delay: 0.024,
+      gain: 0.05,
+      sweepFrom: 7000,
+      sweepTo: 5200,
+    });
+  },
+
+  /**
+   * The space bar, which is a bigger lever and sounds like one.
+   *
+   * The same three layers, moved down and lengthened. This is not decoration:
+   * space is the key that commits a word (`TypingTrack`), so it is the one
+   * stroke in a passage that is also a beat, and a child hearing the run tick
+   * over word by word is hearing something true about where they are. Making
+   * it deeper rather than louder is what keeps that from becoming a metronome
+   * they type to.
+   */
+  keySpace: () => {
+    noise({ dur: 0.022, gain: 0.11, sweepFrom: 2600, sweepTo: 1100 });
+    noise({ dur: 0.08, gain: 0.09, sweepFrom: 420, sweepTo: 120 });
+    noise({
+      dur: 0.012,
+      delay: 0.03,
+      gain: 0.05,
+      sweepFrom: 7000,
+      sweepTo: 5200,
+    });
+  },
+
+  /**
+   * Return: the bell, and the carriage going back.
+   *
+   * The one sound in this block that is allowed a pitch, because a bell is a
+   * bell — two sine partials a fifth and a bit apart, which is what stops it
+   * reading as a beep. On the real machine the bell rings a few characters
+   * BEFORE the margin, as a warning, and the carriage is thrown afterwards by
+   * hand; putting both on one key merges a warning and an action that a child
+   * has never had to tell apart. What they get is the sound everybody means by
+   * "typewriter", on the key that ends the passage.
+   *
+   * Under the bell, the return itself: a rising sweep as the carriage flies
+   * left, and a low knock as it hits the stop. Rising, because nothing else in
+   * the kit does — `misfire` goes up and then down and is the only near
+   * neighbour, and it lives on a screen that has no keyboard on it.
+   *
+   * It is quiet for its length, and deliberately quieter than `finish`: Enter
+   * commits the last word of a passage, so this and the fanfare land together
+   * and the bell must not be the thing that wins.
+   */
+  keyReturn: () => {
+    tone({ freq: 2093, dur: 0.4, wave: "sine", gain: 0.13 });
+    tone({ freq: 3136, dur: 0.26, wave: "sine", gain: 0.06 });
+    noise({
+      dur: 0.18,
+      delay: 0.05,
+      gain: 0.08,
+      sweepFrom: 900,
+      sweepTo: 2800,
+    });
+    noise({ dur: 0.07, delay: 0.22, gain: 0.09, sweepFrom: 800, sweepTo: 160 });
+  },
 };

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -2603,6 +2603,88 @@ label.segmented__btn {
   border-color: color-mix(in oklab, var(--accent) 45%, transparent);
 }
 
+/* ── Hailstorm: the beat before it falls ─────────────────────────────────
+   What stands in an empty sky while a wave waits to be started
+   (docs/typing.md §8.13, decision 71).
+
+   It is laid over the sky rather than given a track of its own, for the same
+   reason the HUD is: `.storm` has one track that gives and one that never
+   does, and a row taken here is a row taken out of the fall. Absolutely
+   positioned inside the sky, it costs the field nothing and vanishes without
+   moving a single thing — the shield below it and the numbers above it are
+   already exactly where the run will find them, so pressing a key starts a
+   storm rather than rearranging a screen.
+
+   Everything is in `--key` units like the rest of this field, so the panel
+   scales with the board it is about to be played on, and every colour is the
+   world's: `--chalk` for the line a child has to read, `--chalk-dim` for the
+   two that explain it. None of the telemetry five appear — nothing here is
+   right, wrong, a record or a ghost, and a "Get ready" in `--go` would be a
+   button that isn't one.                                                   */
+
+.storm__ready {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: calc(var(--key) * 0.3);
+  padding: calc(var(--key) * 0.5);
+
+  /* The shield is `min(0.34 × --key, 20cqh)` at the bottom of this same box
+     (below), so the panel is nudged up by about that much to sit centred in
+     the sky a child is actually looking at rather than in the box the shield
+     shares. */
+  padding-bottom: calc(var(--key) * 1.2);
+
+  text-align: center;
+  text-wrap: balance;
+}
+
+/* The one line that has to be read from across the room. Mono and bold like a
+   hailstone, because it stands exactly where the hailstones are about to. */
+.storm__ready-head {
+  font-family: var(--font-mono);
+  font-size: calc(var(--key) * 0.62);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: var(--chalk);
+}
+
+/* How to put the hands down. The prose face, not the mono one: it is a
+   sentence to read once, and the F and the J inside it are the only thing in
+   here that wants picking out. */
+.storm__ready-note {
+  max-width: calc(var(--key) * 11);
+  font-size: calc(var(--key) * 0.3);
+  line-height: 1.45;
+  color: var(--chalk-dim);
+}
+
+.storm__ready-note b {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  color: var(--chalk);
+}
+
+/* The instruction, drawn like the way out in the HUD — the same small mono
+   caps, because it is the same kind of thing: a key to press, said quietly
+   under the sentence that matters. It breathes rather than blinking; a pulse
+   on a screen whose next act is falling hail would be motion spent on the one
+   moment nothing is moving (§8.10). */
+.storm__ready-go {
+  margin-top: calc(var(--key) * 0.2);
+  font-family: var(--font-mono);
+  font-size: calc(var(--key) * 0.32);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--chalk-dim);
+  padding: 0.45em 1em;
+  border-radius: calc(var(--key) * 0.18);
+  border: 1px solid var(--hairline);
+}
+
 /* ── Hailstorm: the shield ───────────────────────────────────────────────
    The eight segments the letters land on, one per finger (docs/typing.md
    §8.5, decisions 21 and 41).


### PR DESCRIPTION
Two changes to the typing island.

**[The board clacks](https://github.com/jordanmbush/schoolskills/commit/3b25b44)** (§4.8). The drawn keyboard had eyes and no ears — `useKeyEcho` lit the key that went down and flared the wrong one, and nothing answered a keystroke out loud. `useKeyClack` gives it the other half: three voices, not one per key, because a typewriter has three. A clack has no pitch and does not know whether the key was right (decision 69) — it plays eight times a second under `correct` and `wrong`, and a fourth opinion on a keystroke arriving before the other three knew is a commentary on a child's mistakes. The sound is on exactly when the board is (decision 68), so there is no fourth setting to get wrong.

**[Hailstorm asks for the shift, and waits for the hands](https://github.com/jordanmbush/schoolskills/commit/c6061cd)** (§8.4, §8.13).

- A capital was shot with the bare letter. `fire` compared `KeyboardEvent.code` alone, and `A` and `a` are one key — so lessons 34 ("Capitals") and 39 ("Shift under fire") were waves that never once asked for a shift, and the saved run credited a child with typing a character they hadn't typed. The same hole let `?` fall to a bare `/`. A shot is now matched on the key *and* on which of its two legends the strike produced (decision 70). Either shift counts, because the passage lessons take either.
- A storm began before the hands were on it. It's the one run entered with a mouse that then asks, in its first second, for eight fingers on the home row — and what's being waited on isn't an amount of time, so the 3·2·1 can't serve. The wave now hangs at zero, showing no letter at all, until a key says go (decision 71).

Both landed on `develop` through #201 with CI green. Merge commit, not a squash — squashing diverges the two branches permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)