### PR TITLE
Say what a comment is for, so density follows a rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,11 +40,61 @@ Two rules people trip over:
   the youngest player is five. If the kit lacks a primitive, add it to the kit.
 
 Components cap at **300 lines**, counted with `skipComments` and
-`skipBlankLines`. The comment density in this codebase is deliberate and valued:
-**never delete an explanatory comment to pass the cap** — split the module, or
-move the doc block onto the thing it now describes. Files over the cap sit in
-`maxLinesAllowlist` against the story that retires them; delete the entry in the
-same PR that splits the file.
+`skipBlankLines`. The cap measures how much a module _does_, so documenting it
+well never counts against it — and padding it with commentary never buys room,
+because whether a comment belongs is settled by the standard below, not by this
+rule. Over the cap, split the module or move the doc block onto the thing it now
+describes. There is no allowlist to add a file to; an exemption means editing
+the rule.
+
+## Comments
+
+Almost every line here was written by an agent, and an agent works from the
+context it is handed. Too little and it guesses; too much and the one line it
+needed is buried in prose restating the code around it. So comments are
+scrutinised rather than accumulated, and each has to pass the same test:
+
+**Does it say something the code cannot?** An invariant, a constraint, an
+alternative that was tried and rejected, or a consequence a reader would not see
+coming. If it does, it can be as long as it needs to be. If it doesn't, the fix
+isn't a shorter comment — it's no comment.
+
+Three questions before writing one:
+
+- **Would a rename do this instead?** A comment that exists to explain what a
+  name means is a naming bug. Change the name and delete the comment.
+- **Could a reader work this out from the code, its neighbours and its
+  callers?** If so, let them.
+- **Are these plain words?** Reaching for the precise technical term reads as
+  authority and lands as fog.
+
+Four habits to delete on sight — the ones this codebase actually grew:
+
+- **Restating the code.** `// bump the streak` over `streak + 1`.
+- **Narrating history.** "There WAS an allowlist here…" A comment says what is
+  true now; git holds what used to be true.
+- **Repeating `docs/`.** Design rationale lives in `docs/`, written once. A
+  module comment may summarise the decision it implements and cite the section
+  (`docs/typing.md §8.6`), but copying the reasoning across gives one fact two
+  owners, and two owners drift.
+- **Ornate phrasing.** The plain word beats the exact one. From
+  `BackupPanel.tsx`:
+
+  > **Before:** Ids are preserved on both sides, so re-importing the same file
+  > is idempotent rather than duplicating every run.
+  >
+  > **After:** Ids are preserved on both sides, so importing the same file twice
+  > adds nothing the second time.
+
+Never trade clarity for brevity, though: a short comment that loses the point is
+worse than the long one it replaced.
+
+**The standard cuts both ways.** A 245-line component carrying three comment
+lines fails it as surely as a page of narration does — whatever makes that file
+long, an ordering that matters or a browser quirk worked around, is going
+undocumented. Ratio alone is a smell rather than a verdict: run
+`npm run audit:comments` to find the files worth reading, then apply the test
+above one comment at a time.
 
 ## Worlds — one game, several biomes
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,11 +54,12 @@ import prettier from "eslint-config-prettier/flat";
 // No view-layer module may exceed 300 lines. The real test is whether a reader
 // can tell what a component does at a glance; the number is the proxy.
 //
-// Counted with `skipComments` + `skipBlankLines` DELIBERATELY. This codebase is
-// comment-dense on purpose and that density is valued — a raw line count would
-// quietly pressure people to strip documentation to pass the rule. Never delete
-// an explanatory comment to hit the number; relocate the doc block onto the
-// module it now describes.
+// Counted with `skipComments` + `skipBlankLines` DELIBERATELY: the cap is about
+// how much a module DOES, so documenting it well must never count against it.
+// Nor is it a reason to keep a comment — whether one belongs is decided by the
+// standard in CLAUDE.md ("Comments"), which this rule says nothing about.
+// Over the number, split the module or move the doc block onto the thing it now
+// describes.
 const MAX_COMPONENT_LINES = 300;
 
 // Storage is an implementation detail of the service layer — the direct
@@ -460,11 +461,8 @@ export default defineConfig([
   // tone — and hit targets are not cosmetic here, the youngest player is five.
   {
     files: ["**/*.tsx"],
-    // No exceptions. There WAS an allowlist here — 55 hand-rolled controls
-    // across 8 files, inherited from the local-only app where no kit existed.
-    // It was drained to zero by the KIT01–KIT04 stories and then deleted, so
-    // adding a file back means editing this rule rather than appending to a
-    // list, which is the point.
+    // The kit is the only exception, and there is no allowlist beside it to
+    // add a file to: an exemption means editing this rule, which is the point.
     ignores: ["src/components/ui/**"],
     rules: {
       "no-restricted-syntax": [
@@ -492,10 +490,7 @@ export default defineConfig([
   // is coverage, not scannability.
   {
     files: ["src/components/**/*.{ts,tsx}", "src/games/**/*.{ts,tsx}"],
-    // Tests only. There WAS an allowlist here too — RaceTrack (655), RaceSetup
-    // (473), Progress (392) and RaceResults (351), inherited from the
-    // local-only app where nothing enforced a cap. All four were split along
-    // their seams by the KIT03/KIT04 stories and the list was deleted.
+    // Tests only, and no allowlist beside it: a module over the cap is split.
     ignores: ["**/*.test.{ts,tsx}"],
     rules: {
       "max-lines": [


### PR DESCRIPTION
Closes #217.

## Why

`CLAUDE.md` said **"never delete an explanatory comment to pass the cap."** That
rule is what produced the imbalance the audit found — 32,173 comment lines
against 75,586 code lines in `src` (42.6%), with no principle deciding where the
density landed. `engine/combo.ts` carries 27 comment lines over 4 lines of code;
`components/PlayerEditor.tsx` carries 3 over 245. And because the old rule made
every comment permanent, it blocked the paydown stories (DEBT05–DEBT08) before
they could start.

This replaces a rule about what you may not remove with a standard for what a
comment is **for**.

## What changed

**`CLAUDE.md` — a new "Comments" section.** The test a comment must pass: it
says something the code cannot — an invariant, a constraint, a rejected
alternative, or a non-obvious consequence. If it does, it can be as long as it
needs to be; if it doesn't, the fix is no comment rather than a shorter one.

Around that test:

- **Try renaming first.** A comment that exists to explain what a name means is
  a naming bug — change the name and delete the comment.
- **Four anti-patterns named**, each one this codebase actually grew: restating
  the code, narrating history ("There WAS an allowlist here…"), repeating
  `docs/` prose, and ornate phrasing where plain words work. Design rationale
  lives in `docs/`, written once; a module comment may summarise the decision
  and cite the section, but copying the reasoning across gives one fact two
  owners.
- **Plain language over precise-but-technical**, with a before/after taken from
  `BackupPanel.tsx` ("idempotent rather than duplicating every run" → "importing
  the same file twice adds nothing the second time") — and an explicit guard
  that clarity is never traded for brevity.
- **It cuts both ways.** A 245-line component with three comment lines fails the
  standard as surely as a page of narration does. Ratio is a smell, not a
  verdict: `npm run audit:comments` finds the files worth reading, then the test
  is applied one comment at a time.

**`eslint.config.mjs` — `MAX_COMPONENT_LINES` updated to match.**
`skipComments` + `skipBlankLines` stays, and the reason is restated: the cap
measures how much a module *does*, so documenting it well must never count
against it. But it is no longer a reason to *keep* a comment — that question
belongs to the standard, which this rule says nothing about. Two comments in the
same file that narrated retired allowlists were rewritten to say what is true
now, applying the standard to itself.

## Validation

`type-check`, `lint`, `test:unit` (2,213 passing), `build` (200 static pages)
and the browser smoke test all pass. Documentation-only change — no runtime
behaviour touched.
