### PR TITLE
Describe the site that exists, printer and all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,36 @@ undocumented. Ratio alone is a smell rather than a verdict: run
 `npm run audit:comments` to find the files worth reading, then apply the test
 above one comment at a time.
 
+### The three documents, and what a bare `§` means
+
+Rationale that outgrew a comment lives in `docs/`, written once:
+
+- **`docs/typing.md`** — Frost Keys. The keyboard as a model, the board on
+  screen, the hundred-lesson ladder, what passing is, badges, and Hailstorm.
+- **`docs/printables.md`** — The Print Shop. Paper in real inches, the rulings,
+  tracing without a tracing font, answer keys and seeds, the catalog routes and
+  the sitemap landmine, Scripture, phonics, and the builder.
+- **`docs/analytics.md`** — counting visits with no analytics service: the
+  CloudFront logs, the rollup, Athena, and the 90-day ceiling.
+
+Most citations name no document — `(§8.6)` — and resolve by where the file
+sits:
+
+| Subtree                                                                                        | Document             |
+| ---------------------------------------------------------------------------------------------- | -------------------- |
+| `src/engine/sheets/`, `src/components/sheet/`, `src/games/printshop/`, `src/pages/printables/` | `docs/printables.md` |
+| `src/engine/typing/`, `src/games/typing/`                                                      | `docs/typing.md`     |
+
+A file outside those that still belongs to one subject resolves the same way:
+`src/styles/game.css` and `src/engine/keyboard.ts` are typing's,
+`src/styles/sheet.css` and `src/styles/print.css` are the Print Shop's.
+Anywhere genuinely shared, name the document — `docs/typing.md §8.6` — because
+a bare number in a file with two subjects has no rule to resolve it by.
+`docs/analytics.md` numbers nothing, so it is always cited by name.
+`audit:comments` reports the named references that point at a section which
+doesn't exist; the bare ones are yours to keep right until the guard that
+resolves them lands.
+
 ## Worlds — one game, several biomes
 
 The site presents itself as a single game with a map and a world per subject.
@@ -107,6 +137,7 @@ That is a real structure, not a metaphor in the copy:
 | `grid`   | `/flash-cards`, `/multiplication/*` | times tables (space)       |
 | `jungle` | `/spelling/play`, `/spelling`       | spelling and sight words   |
 | `ice`    | `/typing`                           | touch typing (glacier)     |
+| `paper`  | `/printables/*`                     | worksheets (a press room)  |
 | `line`   | `/privacy`, `/terms`, `/about`      | the pause menu             |
 | `empty`  | `/404`                              | literally nothing          |
 
@@ -129,13 +160,31 @@ Three rules:
   engine never interprets the value — to it a world id is an opaque string.
   `useWorld()` in `src/components/state/` is what writes it from the client.
 - **World blocks are scoped to `[data-world]`, not `:root[data-world]`.** That is
-  what lets the overworld map render three worlds at once: each card carries
+  what lets the overworld map render every world at once: each card carries
   `data-world` and is built out of that world's own tokens.
 
-Content pages use `src/layouts/Content.astro` (masthead + footer). The two games
-use `Base.astro` directly, so **site chrome can never appear over a race** —
-there is no prop to set wrong. The way out of an island is the map icon in its
-top bar.
+Content pages use `src/layouts/Content.astro` (masthead + footer). The two
+racing islands — flash cards at `/flash-cards` and `/spelling/play`, typing at
+`/typing` — use `Base.astro` directly, so **site chrome can never appear over a
+race** and there is no prop to set wrong. The way out of one is the map icon in
+its top bar.
+
+The third island is the sheet builder at `/printables/make`, and it keeps
+`Content.astro` on purpose: `print.css` hides the masthead, the footer and
+everything marked `.no-print`, so the builder can have the site around it while
+choosing and lose it at the moment a sheet goes to paper.
+
+**`href` is the front door; `island` is the app.** Both live on `WorldInfo`,
+and only `island` decides what search engines are kept away from — it carries
+`noindex` via `Base.astro`, and `astro.config.mjs` filters the sitemap on that
+field. For the three game worlds the two are the same route, because the game
+_is_ the front door. The Print Shop is why the field had to exist: its `href` is
+`/printables`, a catalog of prerendered worksheets and the largest crawlable
+surface on the site, while its `island` is the builder, which must stay out of
+the sitemap. Filtering on `href` instead would have deleted the whole catalog
+with nothing failing, so `scripts/sitemap-guard.mjs` reads the registry back
+against the sitemap that actually shipped and fails the build instead
+(docs/printables.md §8).
 
 ## Validation
 
@@ -216,3 +265,54 @@ the only copy there is. Adding a store is a `DB_VERSION` bump with an
 without the engine knowing storage exists. Every write goes through
 `HubContext.saveDeck` — a service call that bypasses it lands in IndexedDB and
 stays invisible until the next reload.
+
+## Adding a sheet
+
+The Print Shop is the paper half of the site and the larger half of the code:
+`src/engine/sheets/` builds worksheets, `src/components/sheet/` draws them,
+`src/pages/printables/` publishes them and `src/games/printshop/` is the bench
+a parent tunes one on. Everything below is the short version of
+`docs/printables.md`.
+
+**A `Sheet` is plain data** (`src/engine/sheets/types.ts`): paper size, body
+type size, a header, a list of blocks and a footer. `src/components/sheet/`
+renders one as real elements in real inches — not a canvas, not a PDF, not an
+image — and takes a `Sheet` and nothing else. No context, no service, no
+storage. That is what lets one renderer run at build time on a catalog page and
+at runtime in the builder, and why a catalog page ships zero JavaScript: a
+component with nothing to hydrate needs no `client:*` directive.
+
+**A `SheetSpec` is `DeckSpec` for paper** (`src/engine/sheets/spec.ts`). Paper,
+rulings, capacity, the header and the footer generalise; what a problem is,
+what its answer is, and how to describe the sheet in one line do not, so a
+family states those: `build(config, seed)`, `key(sheet)` and `describe(config)`.
+`key` is not optional on any family — an answer key is the most expected feature
+of a worksheet and the most commonly botched one.
+
+**`src/engine/sheets/index.ts` is the front door, and the registry _is_ the
+narrowing.** A spec is keyed by the same string its config carries as `kind`, so
+looking one up is the only place the `SheetConfig` union is narrowed — there is
+no `if (isLined)` chain to keep in step. Adding a family is a `kind` in
+`types.ts` plus an entry in that table. `sheetSpec(kind)` never throws for the
+same reason `deckSpec(mode)` doesn't: a config bookmarked in March must still
+open in June, so an unknown kind gets `UNKNOWN_SHEET`, which prints a page
+saying so. `buildSheet` is deterministic in `(config, seed)`, and three
+features fall out of that one property — the answer key is the same build with
+the answers switched on, "another like this one" is `seed + 1`, and a shared URL
+reproduces a sheet exactly because the seed is in it.
+
+**The catalog pages are curated, not permuted.** Every page under
+`/printables` is prerendered from an underscored data module in
+`src/pages/printables/` — `_catalog.ts` for paper, `_maths.ts` for the
+worksheets, one per shelf, with `_shelves.ts` naming the shelves so the grade
+hubs can cut across them. Underscored means Astro leaves them out of the routing
+table; each names the handful of sheets a parent actually searches for, and
+`getStaticPaths` turns them into pages. The page **is** the sheet: prose that
+answers the query, the paper itself as HTML under it, and ⌘P produces something
+usable with nothing to click. Generating a page per permutation of a config
+would be a doorway farm, which is what the builder exists for instead.
+
+Saved sheets go through `src/services/sheets.ts`, the only writer of the
+`sheets` store. Unlike custom decks, nothing is mirrored back into the engine —
+a sheet's name and description are computable from the config it already
+carries.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@ Learning games for kids that feel like games, at
 [schoolskills.app](https://schoolskills.app). Static site, no accounts, no
 sign-up — a player's progress lives in their own browser and never leaves it.
 
-First game: **Times Trial**, a gamified multiplication flash-card racer with
-ghost racing and a per-card clock.
+One game with a map and a world per subject:
+
+- **The Grid** (`/flash-cards`) — times tables and the other three operations as
+  timed cards, with a per-card clock and a ghost of your own best run.
+- **Word Jungle** (`/spelling/play`) — the Dolch sight words, read aloud and
+  typed from memory. This week's spellings paste in as a deck like any other.
+- **Frost Keys** (`/typing`) — touch typing, from eight keys under eight fingers
+  up to real punctuation.
+- **The Print Shop** (`/printables`) — worksheets to print, with answer keys.
+  The one stop on the map that is for the grown-up rather than the child.
 
 ## Running it
 
@@ -30,17 +38,31 @@ npm run test:unit
 
 ```
 src/engine/       decks, scoring, records — pure logic, framework-free
+src/engine/sheets/      worksheet families: paper, problems, answer keys
 src/services/     profiles, sessions, persistence
 src/services/storage/   the only code allowed to touch IndexedDB
 src/components/   feature components
 src/components/ui/      the primitive kit: domain-free, prop-driven
-src/games/        one directory per game
+src/components/sheet/   the sheet renderer — real inches, no JavaScript shipped
+src/games/        one directory per mounted app
 src/pages/        Astro routes — real prerendered HTML
 src/layouts/      the page shell (SEO metadata contract lives here)
 ```
 
 The layer boundaries are enforced by `eslint.config.mjs`, not by convention.
 Read `CLAUDE.md` before adding a module.
+
+## The long-form docs
+
+`CLAUDE.md` is the spec — the constraints, the layers and the shape of things.
+Where a subsystem needed more than that, it has a document of its own, and
+comments cite it by section rather than repeating it:
+
+| Doc                  | Covers                                                                                                                     |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `docs/typing.md`     | Frost Keys: the keyboard model, the on-screen board, the hundred-lesson ladder, passing and badges, and the Hailstorm game |
+| `docs/printables.md` | The Print Shop: paper in real inches, the rulings, tracing, answer keys and seeds, the catalog routes, and the builder     |
+| `docs/analytics.md`  | Counting visits without an analytics service: CloudFront logs, the rollup, Athena, and the 90-day ceiling                  |
 
 ## Where progress is stored
 
@@ -60,14 +82,15 @@ Two consequences worth knowing:
 
 ## Scripts
 
-| Script               | What it does                                                            |
-| -------------------- | ----------------------------------------------------------------------- |
-| `npm run dev`        | Astro dev server                                                        |
-| `npm run type-check` | `astro check` + `tsc`                                                   |
-| `npm run lint`       | The architecture boundaries                                             |
-| `npm run test:unit`  | Includes the lint-boundary suite                                        |
-| `npm run test:smoke` | Drives the built site in a real browser (needs `npm run preview` first) |
-| `npm run build`      | Static output to `dist/`                                                |
+| Script                   | What it does                                                            |
+| ------------------------ | ----------------------------------------------------------------------- |
+| `npm run dev`            | Astro dev server                                                        |
+| `npm run type-check`     | `astro check` + `tsc`                                                   |
+| `npm run lint`           | The architecture boundaries                                             |
+| `npm run test:unit`      | Includes the lint-boundary suite                                        |
+| `npm run test:smoke`     | Drives the built site in a real browser (needs `npm run preview` first) |
+| `npm run build`          | Static output to `dist/`                                                |
+| `npm run audit:comments` | Comment-to-code ratio per file, and broken `§` doc references           |
 
 `scripts/` holds the one-off operational tools: `setup-github-oidc.sh`,
 `setup-branch-protection.sh`, `post-deploy-smoke.sh`, `generate-icons.mjs`, and


### PR DESCRIPTION
Closes #203.

## Why

CLAUDE.md was written when there were two games and no paper. The Print Shop is roughly **50k of the 75k code lines in `src`** — `engine/sheets/`, `pages/printables/`, `components/sheet/` and `games/printshop/` — and appeared in neither top-level document. The worlds table listed six worlds where `engine/worlds.ts` has seven, and README still opened with "First game: **Times Trial**".

A spec that is two-thirds out of date is worse than no spec: it sends a reader confidently to the wrong place.

## What changed

**CLAUDE.md**

- The worlds table gains `paper`, so it now matches `engine/worlds.ts` exactly.
- New **"Adding a sheet"** section at the same altitude as "Adding a game": what a `Sheet` is, what a `SheetSpec` is, how the registry in `engine/sheets/index.ts` narrows the config union, and where the catalog pages come from.
- The "two games use `Base.astro`" claim becomes **three islands**, and the `href` vs `island` distinction is written down — it is why the catalog is indexed and the builder is not.
- The bare-`§` reference convention is stated: which source subtree resolves to which document, and when a reference has to name one. (DEBT03 enforces it.)

**README.md**

- The "First game" line is replaced with the four worlds.
- The Layout block includes `src/engine/sheets/` and `src/components/sheet/`.
- The Scripts table was missing `npm run audit:comments` — added.

**Both files** now name `docs/typing.md`, `docs/printables.md` and `docs/analytics.md`, and say what each covers.

## Out of scope

Rewriting `docs/*.md` content. This is about the top-level spec pointing at reality.

## Validation

Documentation only — no source files touched. `type-check`, `lint`, `test:unit` (2213 passing), `build` (200 pages, still static) and the browser smoke test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)