### PR TITLE
Hold every § to a section that exists (#204)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,20 @@ sits:
 | `src/engine/typing/`, `src/games/typing/`                                                      | `docs/typing.md`     |
 
 A file outside those that still belongs to one subject resolves the same way:
-`src/styles/game.css` and `src/engine/keyboard.ts` are typing's,
-`src/styles/sheet.css` and `src/styles/print.css` are the Print Shop's.
-Anywhere genuinely shared, name the document — `docs/typing.md §8.6` — because
-a bare number in a file with two subjects has no rule to resolve it by.
-`docs/analytics.md` numbers nothing, so it is always cited by name.
-`audit:comments` reports the named references that point at a section which
-doesn't exist; the bare ones are yours to keep right until the guard that
-resolves them lands.
+`src/styles/game.css` and `src/engine/keyboard.ts` are typing's, and
+`src/styles/sheet.css`, `src/styles/print.css`, `src/styles/printshop.css` and
+`src/styles/fonts.css` are the Print Shop's. Shared code that names one
+document and no other — `src/engine/progress.ts`, whose citations are all
+typing's — resolves to that one. Anywhere genuinely shared, name the document —
+`docs/typing.md §8.6` — because a bare number in a file with two subjects has
+no rule to resolve it by. `docs/analytics.md` numbers nothing, so it is always
+cited by name.
+
+`scripts/section-guard.mjs` holds that convention as data and enforces it: the
+build reads every heading in `docs/` and every `§` in `src/`, resolves each one
+and fails on a reference to a section that doesn't exist. So renumbering a
+section is safe — the build names every citation that pointed at the old
+number. Adding a subtree here means adding it there in the same change.
 
 ## Worlds — one game, several biomes
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import { WORLDS } from "./src/engine/worlds";
 import { catalogAudit } from "./src/pages/printables/_search";
 import { pathOf, sitemapGuard } from "./scripts/sitemap-guard.mjs";
 import { searchIndexGuard } from "./scripts/search-index-guard.mjs";
+import { sectionGuard } from "./scripts/section-guard.mjs";
 
 /**
  * Static output, deliberately.
@@ -60,6 +61,12 @@ export default defineConfig({
      * sitemapGuard(WORLDS) makes one line up.
      */
     searchIndexGuard(catalogAudit()),
+    /*
+     * The third of the same kind, over the `§` citations in the comments. It
+     * needs nothing from the build — it reads src/ and docs/ — so it runs at
+     * the start and a wrong citation costs seconds rather than a full build.
+     */
+    sectionGuard(),
   ],
   // Emit `/about/index.html` rather than `/about.html` so CloudFront can serve
   // clean URLs from S3 without a rewrite function.

--- a/scripts/comment-audit.mjs
+++ b/scripts/comment-audit.mjs
@@ -198,13 +198,18 @@ export function sectionsIn(markdown) {
  * `passages/documents.ts` is a copyright statute, and counting it as a pointer
  * into `docs/printables.md` would report a break that isn't one.
  *
+ * A citation may wrap, so `*` and `/` are allowed between the doc and the `§`
+ * — `(docs/typing.md\n * §5.4)` names its doc as plainly as the unwrapped form
+ * does. Read as bare, it would be handed to `section-guard.mjs` to be resolved
+ * by where the file sits, when it already said where it points.
+ *
  * @param {string} source
  * @returns {{ doc: string | null, section: string }[]}
  */
 export function sectionRefs(source) {
   const refs = [];
   for (const m of source.matchAll(
-    /(?:(\d+\s+U\.S\.C\.\s*)|docs\/([a-z]+)\.md\s*)?§\s*([0-9]+(?:\.[0-9]+)*)/g,
+    /(?:(\d+\s+U\.S\.C\.\s*)|docs\/([a-z]+)\.md[\s*/]*)?§\s*([0-9]+(?:\.[0-9]+)*)/g,
   )) {
     if (m[1]) continue;
     refs.push({ doc: m[2] ?? null, section: m[3] });
@@ -213,17 +218,33 @@ export function sectionRefs(source) {
 }
 
 /**
- * Files under `root` matching `extensions`, skipping the corpus directories.
+ * Every file under `root` matching `extensions`.
+ *
+ * @param {string} root
+ * @param {string[]} extensions
+ * @returns {string[]}
+ */
+export function allFiles(root, extensions) {
+  return readdirSync(root, { recursive: true, encoding: "utf8" })
+    .map((entry) => path.join(root, entry))
+    .filter((file) => extensions.includes(path.extname(file)));
+}
+
+/**
+ * The same, minus the corpus directories — the file set this audit measures.
+ *
+ * `section-guard.mjs` reads `allFiles` instead, deliberately: a citation in
+ * `passages/scripture.ts` is as breakable as any other, and only the ratios
+ * are meaningless there.
  *
  * @param {string} root
  * @param {string[]} extensions
  * @returns {string[]}
  */
 export function sourceFiles(root, extensions) {
-  return readdirSync(root, { recursive: true, encoding: "utf8" })
-    .map((entry) => path.join(root, entry))
-    .filter((file) => extensions.includes(path.extname(file)))
-    .filter((file) => !file.split(path.sep).some((part) => CORPUS.has(part)));
+  return allFiles(root, extensions).filter(
+    (file) => !file.split(path.sep).some((part) => CORPUS.has(part)),
+  );
 }
 
 /**

--- a/scripts/comment-audit.test.mjs
+++ b/scripts/comment-audit.test.mjs
@@ -121,6 +121,14 @@ describe("resolving § references", () => {
     ]);
   });
 
+  it("reads a citation that wrapped onto the next line", () => {
+    // Still named. Read as bare, it would be resolved by where the file sits
+    // when it already said where it points.
+    expect(sectionRefs("the record book (docs/typing.md\n * §5.4)")).toEqual([
+      { doc: "typing", section: "5.4" },
+    ]);
+  });
+
   it("reads a bare reference without guessing a doc", () => {
     expect(sectionRefs("the invariant in §5.3")).toEqual([
       { doc: null, section: "5.3" },

--- a/scripts/section-guard.mjs
+++ b/scripts/section-guard.mjs
@@ -1,0 +1,208 @@
+// @ts-check
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { allFiles, sectionRefs, sectionsIn } from "./comment-audit.mjs";
+
+/**
+ * The build-time check that every `§` in the source still points at a section
+ * that exists.
+ *
+ * The comments here cite `docs/` more than a thousand times, and all but a
+ * hundred of those citations are a bare number — `(§8.6)` — resolved by an
+ * agreement about where the file sits rather than by anything written in the
+ * reference itself. That is the cheapest form to write and the most fragile
+ * one to keep: renumbering a heading in `docs/typing.md` silently repoints
+ * every citation under `src/games/typing/`, and nothing about the code stops
+ * working, so nothing tells you.
+ *
+ * So the agreement is written down twice — once in prose, in CLAUDE.md, and
+ * once as `HOMES` below — and the build reads both ends: the headings each doc
+ * defines, and every reference the source makes into them. A build that cites
+ * a section nobody wrote fails rather than shipping a pointer to nowhere.
+ *
+ * The same shape as `sitemap-guard.mjs` and `search-index-guard.mjs`, for the
+ * same reason: a disagreement between two files that are meant to say the same
+ * thing is invisible to a test of either one.
+ *
+ * The parser is `comment-audit.mjs`'s, so the two can't read a citation
+ * differently. They cast different nets: the audit measures commentary in code
+ * and reads neither the stylesheets nor the passage corpus, which is why its
+ * total is the smaller one.
+ */
+
+/**
+ * The document a bare `§` belongs to, by where the file sits.
+ *
+ * This is the table in CLAUDE.md ("The three documents, and what a bare `§`
+ * means") as data, and the two have to agree — a subtree added here without a
+ * row there leaves the convention unwritten again, which is the thing this
+ * guard exists to stop.
+ *
+ * `docs/analytics.md` numbers nothing and so owns no subtree: it is always
+ * cited by name.
+ */
+const HOMES = {
+  printables: [
+    "src/engine/sheets",
+    "src/components/sheet",
+    "src/games/printshop",
+    "src/pages/printables",
+    "src/styles/sheet.css",
+    "src/styles/print.css",
+    "src/styles/printshop.css",
+    "src/styles/fonts.css",
+  ],
+  typing: [
+    "src/engine/typing",
+    "src/games/typing",
+    "src/engine/keyboard.ts",
+    "src/styles/game.css",
+  ],
+};
+
+/**
+ * @param {string} file A path relative to the repo root.
+ * @returns {string | null} The doc that owns it, or null where none does.
+ */
+export function docFor(file) {
+  const here = file.split(path.sep).join("/");
+  for (const [doc, homes] of Object.entries(HOMES)) {
+    const owned = homes.some(
+      (home) => here === home || here.startsWith(`${home}/`),
+    );
+    if (owned) return doc;
+  }
+  return null;
+}
+
+/**
+ * What a bare `§` in one file means, which is `docFor` plus one fallback: a
+ * file no subtree owns but which cites exactly one document is that
+ * document's for as long as that stays true. `engine/progress.ts` is the
+ * case — shared code, eleven bare references, every named one of them typing's.
+ *
+ * A file that cites two documents, or none, gets null and its bare references
+ * fail. That is the rule CLAUDE.md already states — anywhere genuinely shared,
+ * name the document — with a build behind it.
+ *
+ * @param {string} file
+ * @param {{ doc: string | null, section: string }[]} refs
+ * @returns {string | null}
+ */
+function homeOf(file, refs) {
+  const named = new Set(refs.map((ref) => ref.doc).filter(Boolean));
+  return docFor(file) ?? (named.size === 1 ? [...named][0] : null);
+}
+
+/**
+ * Every reference that doesn't land, as lines a human can act on. An empty
+ * array is the passing case.
+ *
+ * Each line names the file, the reference and the document it was resolved
+ * against, because with a bare citation the resolution is the half a reader
+ * can't see: "§5.4 doesn't exist" is not actionable until you know which of
+ * the three documents was asked.
+ *
+ * @param {Map<string, string>} sources Path → contents, under `src/`.
+ * @param {Map<string, string>} docs Path → contents, under `docs/`.
+ * @returns {string[]}
+ */
+export function auditSections(sources, docs) {
+  const defined = new Map(
+    [...docs].map(([file, text]) => [
+      path.basename(file, ".md"),
+      sectionsIn(text),
+    ]),
+  );
+  if ([...defined.values()].every((sections) => sections.size === 0)) {
+    return [
+      "No numbered headings were found in docs/ at all, so every reference below would resolve against nothing. Either the headings stopped being numbered or this guard is reading the wrong directory.",
+    ];
+  }
+
+  const problems = [];
+  let checked = 0;
+
+  for (const [file, source] of sources) {
+    const refs = sectionRefs(source);
+    const home = homeOf(file, refs);
+    for (const ref of refs) {
+      checked++;
+      const doc = ref.doc ?? home;
+      if (!doc) {
+        problems.push(
+          `${file} §${ref.section} — bare, and nothing resolves it: no document owns this file, and its other citations don't name exactly one. Write docs/<name>.md §${ref.section}.`,
+        );
+        continue;
+      }
+      if (!defined.get(doc)?.has(ref.section)) {
+        const how = ref.doc ? "named" : "resolved by where the file sits";
+        problems.push(
+          `${file} §${ref.section} — docs/${doc}.md has no such section (${how}).`,
+        );
+      }
+    }
+  }
+
+  if (checked === 0) {
+    return [
+      "No § references were found under src/ at all. The source carries over a thousand, so this guard is looking in the wrong place — a check that finds nothing passes forever.",
+    ];
+  }
+
+  return problems.sort();
+}
+
+/**
+ * Wired into `astro.config.mjs` at `astro:build:start` rather than
+ * `astro:build:done`, unlike the other two guards: they read what the build
+ * wrote and this one reads what it was built from, so there is no reason to
+ * spend a full build before saying a citation is wrong.
+ *
+ * Paths are relative to the working directory, as `npm run audit:comments`
+ * reads the same tree. A build run from somewhere else finds no files, which
+ * is why finding none is a failure above rather than a pass.
+ *
+ * @returns {import("astro").AstroIntegration}
+ */
+export function sectionGuard() {
+  return {
+    name: "section-guard",
+    hooks: {
+      "astro:build:start": ({ logger }) => {
+        const read = (
+          /** @type {string} */ root,
+          /** @type {string[]} */ extensions,
+        ) =>
+          new Map(
+            allFiles(root, extensions).map((file) => [
+              file,
+              readFileSync(file, "utf8"),
+            ]),
+          );
+
+        const sources = read("src", [".ts", ".tsx", ".astro", ".css"]);
+        const problems = auditSections(sources, read("docs", [".md"]));
+        if (problems.length > 0) {
+          throw new Error(
+            [
+              "Comments cite sections of docs/ that don't exist:",
+              ...problems.map((line) => `  · ${line}`),
+              "",
+              'A bare § resolves by where the file sits — see CLAUDE.md, "The three documents, and what a bare § means", and HOMES in scripts/section-guard.mjs.',
+            ].join("\n"),
+          );
+        }
+
+        const checked = [...sources.values()].reduce(
+          (count, source) => count + sectionRefs(source).length,
+          0,
+        );
+        logger.info(
+          `§ references checked — ${checked} of them, every one a section that exists`,
+        );
+      },
+    },
+  };
+}

--- a/scripts/section-guard.test.mjs
+++ b/scripts/section-guard.test.mjs
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { auditSections, docFor } from "./section-guard.mjs";
+
+/**
+ * A guard that always passes is indistinguishable from a guard that works,
+ * right up until the day it was supposed to fire. So this suite makes it fire,
+ * once per way a citation and the document it points into can come apart.
+ *
+ * The build-time half reads the tree that actually shipped; this half proves
+ * that what it reads it also judges correctly — and, for the bare references
+ * that are most of them, that it resolves them the way CLAUDE.md says it does.
+ */
+
+const DOCS = new Map([
+  ["docs/typing.md", "## 5 · The ladder\n\n### 5.4 · Ghost identity\n"],
+  ["docs/printables.md", "## 7 · Answer keys\n\n## 14 · The builder\n"],
+]);
+
+const source = (/** @type {string} */ text) => new Map([["src/a.ts", text]]);
+
+describe("which document a bare § means", () => {
+  it("resolves a subtree", () => {
+    expect(docFor("src/engine/sheets/maths/money.ts")).toBe("printables");
+    expect(docFor("src/games/typing/storm/StormHud.tsx")).toBe("typing");
+  });
+
+  it("resolves the stylesheets that belong to one subject", () => {
+    // Not a subtree: src/styles/ holds both subjects' sheets side by side.
+    expect(docFor("src/styles/game.css")).toBe("typing");
+    expect(docFor("src/styles/print.css")).toBe("printables");
+  });
+
+  it("claims nothing for shared code", () => {
+    expect(docFor("src/engine/records.ts")).toBeNull();
+  });
+});
+
+describe("auditing the citations against docs/", () => {
+  it("passes a reference that lands, named or bare", () => {
+    const sources = new Map([
+      ["src/engine/typing/ladder.ts", "// the rung it files under (§5.4)"],
+      ["src/engine/records.ts", "// see docs/printables.md §14"],
+    ]);
+    expect(auditSections(sources, DOCS)).toEqual([]);
+  });
+
+  it("fails a bare reference to a section nobody wrote", () => {
+    const sources = new Map([
+      ["src/engine/typing/ladder.ts", "// the rung it files under (§5.9)"],
+    ]);
+    const problems = auditSections(sources, DOCS);
+    expect(problems).toHaveLength(1);
+    // The file, the reference, and the doc it was resolved against — with a
+    // bare citation the last of those is the half a reader cannot see.
+    expect(problems[0]).toContain("src/engine/typing/ladder.ts");
+    expect(problems[0]).toContain("§5.9");
+    expect(problems[0]).toContain("docs/typing.md");
+  });
+
+  it("fails a named reference to a section nobody wrote", () => {
+    const problems = auditSections(source("// see docs/typing.md §9.9"), DOCS);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("§9.9");
+  });
+
+  it("resolves a shared file by the one document it cites", () => {
+    // `engine/progress.ts` is the real case: no subtree owns it, eleven of its
+    // references are bare, and every named one of them is typing's.
+    const sources = new Map([
+      ["src/engine/progress.ts", "// docs/typing.md §5 says, and so (§5.4)"],
+    ]);
+    expect(auditSections(sources, DOCS)).toEqual([]);
+  });
+
+  it("fails a bare reference in a file with two subjects", () => {
+    // The rule CLAUDE.md already states — anywhere genuinely shared, name the
+    // document — with a build behind it. §14 exists, in the other doc.
+    const sources = new Map([
+      [
+        "src/engine/decks/index.ts",
+        "// docs/typing.md §5.4 and docs/printables.md §7, then (§14)",
+      ],
+    ]);
+    const problems = auditSections(sources, DOCS);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("nothing resolves it");
+  });
+
+  it("ignores a legal citation", () => {
+    // `17 U.S.C. §105` is in passages/documents.ts, under the sheets subtree.
+    // Resolving it would fail the build over a section of printables.md that
+    // was never meant to exist.
+    const sources = new Map([
+      [
+        "src/engine/sheets/passages/documents.ts",
+        "// Federal works carry no copyright (17 U.S.C. §105); §7 keys them.",
+      ],
+    ]);
+    expect(auditSections(sources, DOCS)).toEqual([]);
+  });
+
+  it("says so rather than passing when docs/ numbers nothing", () => {
+    // How a two-ended check rots: headings that stopped being numbered leave
+    // every citation resolving against an empty set, and a strict guard would
+    // report a thousand breaks. Neither answer is "fine".
+    const docs = new Map([["docs/typing.md", "## The ladder\n"]]);
+    const problems = auditSections(source("// see docs/typing.md §5.4"), docs);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("No numbered headings");
+  });
+
+  it("says so rather than passing when there is nothing to check", () => {
+    // The other way: a moved source directory finds no files, and an empty
+    // loop reports no problems forever.
+    expect(auditSections(new Map(), DOCS)[0]).toContain(
+      "No § references were found",
+    );
+  });
+});

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -133,7 +133,8 @@ export default function Progress() {
   const owner = WORLDS.find((w) => w.id === spec.world);
   /**
    * The same facts as a worksheet, or null where this build has no sheet for
-   * them — a typing passage is not a page of problems (§14).
+   * them — a typing passage is not a page of problems (docs/printables.md
+   * §14).
    */
   const printable = practiceSheet(
     mode,

--- a/src/engine/decks/biblelists.test.ts
+++ b/src/engine/decks/biblelists.test.ts
@@ -360,7 +360,7 @@ describe("every Bible list, on every sheet style", () => {
         // A page of nothing is the failure mode a long list would hide: a
         // capacity that came out at zero still builds, and still prints.
         expect(sheet.header.score?.outOf).toBeGreaterThan(0);
-        // `(config, seed)` and nothing else (§7).
+        // `(config, seed)` and nothing else (docs/printables.md §7).
         expect(buildSheet(config, 7)).toEqual(sheet);
       });
     }

--- a/src/engine/decks/configkey.test.ts
+++ b/src/engine/decks/configkey.test.ts
@@ -157,9 +157,9 @@ const FROZEN: Frozen[] = [
   ],
   // The ladder's two run shapes. Both key on the LESSON and on the length the
   // rung declares — never on the words a passage came out with, and never on
-  // how much of a wave was survived (§5.4, §8.7). The lesson below carries
-  // both of the fields that have to stay inert: the passage it generated, and
-  // the board the child chose to type it under.
+  // how much of a wave was survived (docs/typing.md §5.4, §8.7). The lesson
+  // below carries both of the fields that have to stay inert: the passage it
+  // generated, and the board the child chose to type it under.
   [
     "typing, a lesson from the ladder",
     {

--- a/src/engine/decks/typing.ts
+++ b/src/engine/decks/typing.ts
@@ -359,11 +359,11 @@ export function passageFor(config: TypingConfig, seed: number): string[] {
    * Both arrive in the same field, because both are a config that carries its
    * own words (docs/typing.md §5.3) — but they are not the same kind of thing.
    * The ladder generates a lesson's text in order and at length, sentences and
-   * their full stops included (§5.1), so dealing it out again would shuffle the
-   * stops into the middle of it. A parent's five tricky words are the opposite:
-   * there is no order to keep and the bag is short, so it is drawn from until
-   * the run is long enough. The lesson id is what tells the two apart, exactly
-   * as it does in `typingConfigKey` below.
+   * their full stops included (docs/typing.md §5.1), so dealing it out again
+   * would shuffle the stops into the middle of it. A parent's five tricky words
+   * are the opposite: there is no order to keep and the bag is short, so it is
+   * drawn from until the run is long enough. The lesson id is what tells the
+   * two apart, exactly as it does in `typingConfigKey` below.
    */
   if (config.lessonId && config.words?.length)
     return config.words.slice(0, config.wordCount);

--- a/src/games/flashcards/RaceResults.tsx
+++ b/src/games/flashcards/RaceResults.tsx
@@ -137,9 +137,9 @@ export default function RaceResults() {
   const selfGhost = { session, profile: outcome.profileAfter, isSelf: true };
   const practiceFirst = missedFacts.length > 0;
   /**
-   * The same facts as a worksheet (§14) — the one thing no other worksheet
-   * site can print, offered at the moment it is most obviously wanted. Null
-   * for a deck this build has no sheet family for.
+   * The same facts as a worksheet (docs/printables.md §14) — the one thing no
+   * other worksheet site can print, offered at the moment it is most obviously
+   * wanted. Null for a deck this build has no sheet family for.
    */
   const printable = practiceFirst
     ? practiceSheet(session.mode, missedFacts)


### PR DESCRIPTION
## What

Adds `scripts/section-guard.mjs`, a build-time guard that holds every `§`
cross-reference in `src/` to a heading that actually exists in `docs/`.

Closes #204.

## Why

Source carries **1,258 `§` citations** into `docs/`, and all but about a
hundred are a bare number — `§8.6` — resolved only by an unwritten agreement
about where the citing file sits. Renumbering a heading silently repoints
every one of them. Nothing breaks, so nothing tells you. The repo already had
this exact pattern twice over (`sitemap-guard.mjs`, `search-index-guard.mjs`);
this is the third.

## What changed

- **`scripts/section-guard.mjs`** reads both ends at `astro:build:start` —
  every heading `docs/` defines, every `§` `src/` makes — and fails the build
  on a reference to a section nobody wrote. It runs *before* the build rather
  than after, unlike the other two guards, because it reads what the build is
  made from rather than what it emitted. A wrong citation costs seconds, not a
  full build.
- **The bare-reference convention is now data**, as `HOMES` in that file: the
  subtrees and stylesheets each document owns, plus one rule for shared code —
  a file no document owns that cites exactly one document is that document's.
  A file citing two, or none, must name its document. CLAUDE.md already said
  that; now there's a build behind it (DEBT02).
- **The failure message names the file, the reference and the document it was
  resolved against** — with a bare citation, the resolution is the half a
  reader cannot see.
- **One parser, not two.** The guard reuses `comment-audit.mjs`'s
  `sectionRefs`/`sectionsIn` rather than writing a second one, so the audit and
  the guard cannot read a citation differently. `sectionRefs` learns to read a
  citation that wrapped onto the next line, and a new `allFiles` lets the guard
  check the passage corpus that the audit's ratios deliberately skip.
- **`17 U.S.C. §105` is still a statute, not a pointer** — the legal citation
  in `engine/sheets/passages/documents.ts` does not trip the guard.
- **Six citations in five shared files now name their document.** These are the
  ones no rule could resolve — and one of them (`Progress.tsx §14`) was
  pointing at the wrong document, which is the first thing the guard found.

## Tests

`scripts/section-guard.test.mjs` sits alongside `sitemap-guard.test.mjs` and
`search-index-guard.test.mjs`, and fires the guard once per way a citation and
its document can come apart — including the two ways a two-ended check quietly
rots into a no-op: docs that stopped numbering, and a source directory that
matches nothing.

## Validation

- `npm run type-check` — clean
- `npm run lint` — clean
- `npm run test:unit` — 2225 tests, 107 files, all passing
- `npm run build` — static, and the guard reports
  `§ references checked — 1258 of them, every one a section that exists`
- `npm run test:smoke` — all checks passed, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
