### PR TITLE
Let one document own the typing rationale, and cut the copy out of the code

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -232,6 +232,12 @@ One field rather than `showKeyboard` + `showHint`, because three of the four
 boolean combinations are meaningful and the fourth ("hint on, board hidden")
 is nonsense. A union cannot express the nonsense.
 
+The middle mode is what makes the union worth having. "Keys" is the rung a
+child climbs before turning the board off entirely, and it is where most of the
+learning happens — so it must not be the thing you reach by unchecking half a
+pair. The control is a `SegmentedControl` for the same reason: a switch can
+only say on or off.
+
 ### 4.2 · Where the setting lives, and who wins
 
 The player's own preference is a field on `Profile`, alongside `soundOn`:
@@ -559,6 +565,14 @@ are otherwise found by a seven-year-old:
   characters. Below that it isn't a lesson about them; above it, it is a memory
   test rather than typing.
 
+The second has one exception, and it is a fact about the ladder rather than a
+concession by the generator: at lesson 1 the unlocked alphabet is `f`, `j` and
+the space bar, so there is no review to be had and the whole drill is the two
+new keys — which is exactly what §5.5 asks for there. So the test states the
+band in derived terms: a lesson **with review available** is 15–35% new. A
+re-ordered ladder that left lesson 40 with nothing to review would then be
+named by the test rather than quietly excused by it.
+
 ### 5.3 · The lexicon, and the 222 KB lesson
 
 Filtering "words using only `f j d k s l`" needs a corpus. The Dolch lists in
@@ -651,6 +665,23 @@ Three things about that order are deliberate:
 - **Comma and full stop come in with the bottom row**, because that is where
   they physically are. It costs nothing and it means real sentences are
   available at the end of block 3 rather than needing their own lesson.
+
+Two rows in that table are not what they look like:
+
+- **Block 4 introduces capitals, not shifts.** A shift is not a character, and
+  the unit of this curriculum is a character — so what lessons 31 and 32 hand
+  over is the set of capitals each shift _reaches_. The right shift is held by
+  the right pinky and capitalises the left hand's letters; the left shift the
+  right hand's. Two lessons, twenty-six characters, and the opposite-hand rule
+  (§3.3) taught as the only way either of them works. `keys.ts` reads the
+  shifts back out of those two rows, and there is nowhere else they are
+  written down.
+- **Block 7 re-introduces two characters the ladder already unlocked.** `;`
+  arrived at lesson 5 as a home key and `/` at lesson 25 as a bottom-row reach,
+  and both come back here in their punctuation role. The unlocked alphabet is a
+  union, so saying it twice changes nothing about what a child may type; what
+  it does is put the character back under the new-key gate (§6.4), which is the
+  point. Knowing where `;` is and knowing what it is for are two lessons.
 
 ### 5.6 · The hundred
 
@@ -943,17 +974,21 @@ keys, then speed.
 
 ### 6.2 · Accuracy is nearly flat, and high
 
-**95%** for a lesson, **97%** for a checkpoint, all the way up. It does not
-scale with the material, and it does not scale with age.
+**95%** for a lesson, **97%** for a checkpoint. It does not scale with the
+material, and it does not scale with age.
 
 The temptation is to make it easy at the start, because the child is five.
 That gets it backwards: lesson 1 has _two keys_, and 95% of a two-key drill is
 easier than 95% of anything that comes later. The bar being constant is what
 makes it teach — it says accuracy is not the thing that varies, speed is.
 
-The one exception is lesson 97, which asks for 99% at a deliberately modest
-pace. It exists so that "slow down and get it right" is a thing the ladder has
-asked for explicitly at least once.
+**It bends late, and the table in §5.6 is the authority.** From block 8 the bar
+is 96% rather than 95% — for the endurance lessons, for checkpoint 90, and for
+block 10's prose (91–96) — because holding a rate over a hundred words is a
+different thing from holding it over thirty. Lesson 97 bends the other way,
+asking 99% at a deliberately modest pace, so that "slow down and get it right"
+is a thing the ladder has asked for explicitly at least once. An accuracy
+column "corrected" back to a flat 95/97 would be wrong from block 8 to the end.
 
 ### 6.3 · Speed scales, and dips
 
@@ -982,6 +1017,16 @@ every seed (§5.2), so the gate can never be unpassable through bad luck.
 
 This is the criterion that turns a hundred typing tests into a hundred
 lessons, and it is the one no other course on the internet has.
+
+**Twelve wherever twelve fits.** That is every lesson arriving two keys at a
+time: 24 strikes in a 24-word lesson is a fifth of the characters, comfortably
+inside §5.2's band. Four lessons hand over more than a pair at once — 31, 32,
+67 and 68 — and three of them cannot also ask twelve of each. Lesson 31's
+fifteen capitals would want 180 strikes in 150 characters, so there the demand
+is divided between the new keys rather than being made unreachable. Lesson 68's
+four keys still fit twelve apiece inside its 175, which is why the ceiling is a
+`min` against the room rather than a rule about how many keys arrived. Two is
+the floor: below it the gate cannot tell a typist from a lucky guess.
 
 **Per-key stats come from the cards, not from keystrokes.** A `CardResult`
 carries `answer` and `given`, so a word typed right contributes a hit to each
@@ -1387,6 +1432,14 @@ moment it is new, and this is the moment it is not moving. Reading the letter
 and racing it down become two things instead of one, and a child who has
 already identified an `i` does not need it to be legible on the way past.
 
+A second is a judgement rather than a measurement, and what anchors it is that
+it is the same order as the fastest fall on the ladder (900ms, at lessons 4, 9
+and 13). Round, long enough to read an unfamiliar glyph without hurrying, and
+short enough that a level with a 300ms gap still has a queue rather than a
+crowd. What the beat is **not** is a head start on the schedule: the letters
+still arrive at the same intervals, so a child who reads fast simply gets to
+spend it, and one who does not still has the whole fall.
+
 Four things about it, and the first is the one that matters most:
 
 - **A queued letter is shootable.** `isAirborne` says it is on the field,
@@ -1484,6 +1537,14 @@ Whether a shift was down is read off `event.shiftKey` on the keydown itself,
 never tracked across keydown and keyup. A shift released while the tab was in
 the background is a `keyup` this window never saw, and a gun trusting its own
 bookkeeping would go on demanding a shift nobody was holding.
+
+**The brief has to say so.** A rule that announces itself by taking ten points
+is not a rule a child was taught, so every storm whose wave can rain a capital
+carries "A capital needs a shift" on the screen before it starts. The
+obligation is read off the wave's **pool** rather than its `focus`: capitals
+are in every pool from lesson 34 up (§5.6), so a level like Pairs rains them
+without being about them, and a brief keyed to what the level is _for_ would
+miss exactly those.
 
 ### 8.5 · The shield is your fingers
 

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -983,11 +983,14 @@ easier than 95% of anything that comes later. The bar being constant is what
 makes it teach — it says accuracy is not the thing that varies, speed is.
 
 **It bends late, and the table in §5.6 is the authority.** From block 8 the bar
-is 96% rather than 95% — for the endurance lessons, for checkpoint 90, and for
-block 10's prose (91–96) — because holding a rate over a hundred words is a
-different thing from holding it over thirty. Lesson 97 bends the other way,
-asking 99% at a deliberately modest pace, so that "slow down and get it right"
-is a thing the ladder has asked for explicitly at least once. An accuracy
+is 96% rather than 95% — for the endurance lessons and for block 10's prose
+(91–96) — because holding a rate over a hundred words is a different thing from
+holding it over thirty. Checkpoint 90 reaches the same 96% from the other side:
+a checkpoint asks 97%, and this one trades a point away because thirty-five
+words a minute is the whole subject of block 9, and that point is the price of
+asking for it. Lesson 97 bends the other way, asking 99% at a deliberately
+modest pace, so that "slow down and get it right" is a thing the ladder has
+asked for explicitly at least once. An accuracy
 column "corrected" back to a flat 95/97 would be wrong from block 8 to the end.
 
 ### 6.3 · Speed scales, and dips

--- a/src/engine/keyboard.ts
+++ b/src/engine/keyboard.ts
@@ -1,40 +1,20 @@
 /**
  * The physical keyboard, as data.
  *
- * A *picture* of a keyboard belongs in the view. The keyboard itself does not,
- * because three of its four consumers are not pictures (docs/typing.md §3.1):
+ * In the engine and not the view because three of its four consumers are not
+ * pictures — the curriculum, the generator's `reachable()`, and Hailstorm's
+ * lanes (§3.1, decision 1). Only the fourth draws it, and putting the layout
+ * there would make the other three import upwards.
  *
- *   - The **curriculum** needs to know that `e` is the left middle finger on
- *     the top row, so "introduce one key per hand" is a rule the lesson list
- *     can be checked against rather than a claim in a comment.
- *   - The **generator** needs `reachable()` — is every character of this word
- *     producible from the keys unlocked so far? That is the invariant which
- *     makes a hundred lessons safe to re-order (§5.2), and it is a pure
- *     function over this table.
- *   - **Hailstorm** needs a key's horizontal position, because that is the lane
- *     its letter falls down (§8.2): `f` falls onto `f`, and `y` falls between
- *     `g` and `h` because that is where `y` is. The game is not themed around a
- *     keyboard, it is teaching the layout geometrically the whole time.
- *
- * Only the fourth consumer draws it. Put the layout in the view and the other
- * three have to import upwards, which the lint boundary correctly forbids.
- *
- * ── US ANSI QWERTY, and nothing else ─────────────────────────────────────────
- * The site is `en` and typing marks punctuation exactly, so a UK board — where
- * `"` is shift-`2` and `@` is shift-`'` — would fail a punctuation lesson for a
- * child who is doing everything right. That is a real limitation and it is
- * written down here rather than discovered later. It is also a cheap one to
- * lift: the layout is data behind one function, so a second board is a second
- * table plus a profile field, and `strokeFor` is the only caller that would
- * have to learn about it (§3.4).
+ * US ANSI QWERTY and nothing else: a real limit, written down rather than
+ * discovered, and a cheap one to lift (§3.4, decision 26).
  */
 
 /**
  * Which finger presses a key, in touch-typing's standard assignment.
  *
- * `thumb` is one finger rather than two because either thumb will do for the
- * keys it covers — the space bar and the two Alts — and nothing downstream
- * needs to know which.
+ * `thumb` is one finger rather than two: either thumb will do for the space bar
+ * and the two Alts, and nothing downstream needs to know which.
  */
 export type Finger =
   | "l-pinky"
@@ -51,20 +31,17 @@ export type KeyDef = {
   /**
    * `KeyboardEvent.code`. "KeyF", "Semicolon", "Digit4", "Space".
    *
-   * `code`, not `key`. `KeyboardEvent.key` reports the character that was
-   * produced, which is the wrong question for "light up the key that was
-   * pressed": shift+`4` produces `$` and there is no `$` key to light. `code`
-   * is the physical switch, which is exactly what the picture draws and
-   * exactly what the falling-letter lane is a column of.
+   * `code`, not `key`: shift+`4` produces `$` and there is no `$` key to light
+   * (§3.2).
    */
   code: string;
   /**
    * Unshifted and shifted legends: ["a","A"], ["4","$"], ["/","?"].
    *
    * A key that produces no character carries a word — "Tab", "Shift", "Bksp" —
-   * never a glyph like "⌫". `strokeFor` indexes the legends that are a single
-   * character, so a word legend is what keeps a modifier out of the answer to
-   * "which key types this?" without needing a second field to exclude it.
+   * never a glyph like "⌫". `strokeFor` indexes only the single-character
+   * legends, so a word legend is what keeps a modifier out of "which key types
+   * this?" without a second field to exclude it.
    */
   cap: [string, string];
   /** 0 = number row, 1 = top, 2 = home, 3 = bottom, 4 = space. */
@@ -81,10 +58,8 @@ export type KeyDef = {
 /**
  * One row's worth of keys, left to right.
  *
- * `x` is written down rather than accumulated because the row stagger is not
- * derivable from anything — it is a fact about the plastic. Row 1 starts a
- * third of a unit in, row 2 a little further, row 3 further still. Storing it
- * costs one number per key and leaves no arithmetic for anybody to trust.
+ * `x` is written down rather than accumulated: the row stagger is a fact about
+ * the plastic and is derivable from nothing (§3.2).
  */
 const key = (
   code: string,
@@ -99,10 +74,8 @@ const key = (
  * The board, as rows — 15 key units wide, which is what the view scales off a
  * single `--key` custom property and what Hailstorm measures its lanes in.
  *
- * Fingers are the standard assignment: the index fingers take two columns
- * each (`4 5 r t f g v b` on the left, `6 7 y u h j n m` on the right) and the
- * pinkies take everything outboard of `q a z` and `p ; /`. That is the thing
- * being taught, so it is written once here rather than inferred from `x`.
+ * The finger assignment is touch-typing's standard one, and it is the thing
+ * being taught: written per key here rather than inferred from `x`.
  */
 export const KEY_ROWS: KeyDef[][] = [
   // Row 0 — the number row.
@@ -194,42 +167,26 @@ const BY_CODE = new Map(KEYS.map((k) => [k.code, k]));
  * carry — a numpad key, a media key, `F7`, or anything from a layout that is
  * not US ANSI (§3.4).
  *
- * The `null` is the useful half. "Is this code on the board?" is a question two
- * consumers ask for reasons that have nothing to do with geometry — the clack
- * plays only for keys the picture draws (§4.8) — and answering it with
- * `keyX(code) !== null` would be reading a horizontal position to find out
- * whether a key exists. Same lookup, one name for it.
+ * The `null` is the useful half. "Is this code on the board?" is asked for
+ * reasons that have nothing to do with geometry — the clack plays only for keys
+ * the picture draws (§4.8) — and `keyX(code) !== null` would answer it by
+ * reading a horizontal position. Same lookup, one name for it.
  */
 export function keyFor(code: string): KeyDef | null {
   return BY_CODE.get(code) ?? null;
 }
 
 /**
- * Where a key sits across the board: the middle of it, in key units.
+ * Where a key sits across the board: the middle of it, in key units, or `null`
+ * for a code this board does not carry (§3.4).
  *
  * The board is 15 units wide, so this is a number from 0 to 15 that scales off
- * the same single `--key` custom property the picture of the keyboard does —
- * which is the point. Hailstorm's lanes are this function (docs/typing.md §8.2,
- * decision 19): a letter falls down the column of the key that produces it, so
- * `keyX("KeyF")` is where `f` falls and `keyX("KeyY")` lands between `g` and
- * `h` because that is where `y` is.
- *
- * The field and the drawn board cannot disagree about where a key is because
- * both read the same `KEY_ROWS` table and both measure in key units off that
- * one `--key`. It is one *table*, not one function: `keyX` is the field's
- * convenience for the centre of a key's slot, while the board wants a left
- * edge and a width and takes `KeyDef.x` / `KeyDef.width` straight from the
- * same rows without calling this. A lane half a unit out would be a spatial
- * hint that teaches the wrong thing, and the shared table is what rules that
- * out. The keycap drawn inside a slot is inset by `--key-gap`, so a slot's
- * centre and a cap's centre are 0.045 units apart — §8.2 has that number.
+ * the same single `--key` the picture does. Hailstorm's lanes are this function
+ * (§3.2, §8.2, decision 19).
  *
  * The **middle** rather than the left edge, because a falling glyph is centred
  * on its column and the wide keys are where the difference shows: the space bar
  * is 6.25 units, so its edge and its middle are three keys apart.
- *
- * `null` for a code this board does not carry — a numpad key, a media key, or
- * anything from a layout that is not US ANSI (§3.4).
  */
 export function keyX(code: string): number | null {
   const key = keyFor(code);
@@ -256,35 +213,16 @@ export type FingerZone = {
 };
 
 /**
- * How much of the board each finger is responsible for, in key units.
+ * How much of the board each finger is responsible for, in key units: each
+ * finger's home-row span, which is a choice between four staggered rows rather
+ * than a derivation (§8.5, decision 41). Hailstorm's shield is these eight.
  *
- * The second thing Hailstorm needs from this table, after the lane: its shield
- * is eight segments across the bottom of the field, one per finger, and each
- * one has to sit over the keys whose misses break it (docs/typing.md §8.5).
- * Here rather than in the component that draws it for the same reason `keyX`
- * is here — it is a fact about the plastic, and a second opinion about which
- * keys the right ring finger covers would put the hole over the wrong hand.
+ * Here rather than in the component that draws that shield, for the same reason
+ * `keyX` is here — a second opinion about which keys the right ring finger
+ * covers would put the hole over the wrong hand.
  *
- * ── The home row is the zone ────────────────────────────────────────────────
- * The eight spans are the home row's keys grouped by finger, and that is a
- * choice between four rows rather than a derivation. Every row divides into
- * eight runs — no row hands a key back to a finger it has already passed — but
- * the four rows do not agree about WHERE the divisions fall, because the rows
- * are staggered. The left pinky gives way to the left ring at 2 on the number
- * row, at 2.5 on the top row, at 2.75 on the home row and at 3.25 on the
- * bottom row. A vertical seam can honour one of those four, so the question
- * is which row's seams the shield is drawn on.
- *
- * The home row, because it is the row the hands are literally on: `a s d f`
- * and `j k l ;` is where a touch typist's fingers rest and what every reach
- * returns to, so "your right ring finger" and "the column over `l`" are the
- * same statement to the child being told it. The other rows are then off by
- * the stagger and no more — a key never sits further than a quarter unit
- * outside its own finger's zone, which is `keyboard.test.ts`'s to pin.
- *
- * The thumbs have no zone. Nothing falls on the space bar (§8.3), so the eight
- * here are exactly the eight the shield is divided into, and the home row
- * carries no thumb key for the cast below to have to exclude.
+ * The thumbs have no zone: nothing falls on the space bar (§8.3), and the home
+ * row carries no thumb key for the cast below to have to exclude.
  */
 export const FINGER_ZONES: Readonly<
   Record<Exclude<Finger, "thumb">, FingerZone>
@@ -309,30 +247,22 @@ export const FINGER_ZONES: Readonly<
 })();
 
 /**
- * What to call a finger out loud, for the one screen that has to name one.
- *
- * Hailstorm's shield is eight finger zones, and when a letter gets through a
- * hole the run ends with the screen saying which finger let it in
- * (docs/typing.md §8.5). "Your right ring finger" is the entire value of that
- * feedback: it is a thing a child can look down at, and `r-ring` is not.
+ * What to call a finger out loud, for the one screen that has to name one:
+ * Hailstorm's ending says which finger let a letter through (§8.5).
  *
  * Here rather than in the component that renders the sentence, for the same
  * reason `FINGER_ZONES` is here — the id and the name are one fact about the
- * hands, and a second opinion about which finger `r-ring` is would put the
- * blame on the wrong one. It is also why the words are plain and lowercase:
- * they are a fragment a sentence is built around ("Your ___ let two through"),
- * not a label, so the caller supplies the capital.
+ * hands. Lowercase and plain because each is a fragment a sentence is built
+ * around ("Your ___ let two through"), so the caller supplies the capital.
  *
  * **Little finger, not pinky**, and index rather than pointing: the rest of
  * this site is written in British English, and these are the words a UK
  * five-year-old is taught to name their own hand with.
  *
- * No thumb, deliberately. The thumb is the one entry in `Finger` that is not a
- * finger of one hand — it covers the space bar and both Alts, so there is no
- * "left" or "right" to say — and nothing that names a finger to a child ever
- * needs it: the shield has no thumb segment, because nothing falls on the
- * space bar (§8.5). Excluding it here means the eight zones and the eight
- * names are the same eight, checked by the compiler rather than by a reader.
+ * No thumb. It is the one entry in `Finger` that is not a finger of one hand,
+ * so there is no "left" or "right" to say, and the shield has no thumb segment
+ * (§8.5) — which leaves the eight zones and the eight names the same eight,
+ * checked by the compiler rather than by a reader.
  */
 export const FINGER_NAMES: Readonly<Record<Exclude<Finger, "thumb">, string>> =
   {
@@ -356,13 +286,8 @@ export type Stroke = {
 };
 
 /**
- * The shift on the other hand from this finger.
- *
- * Typing `A` with the left pinky on shift and the left pinky on `a` is
- * impossible; the technique is right-shift plus left-`a`, and teaching it is
- * the single most-skipped thing in typing courses aimed at children. So the
- * hint highlights the shift a child can actually reach, which means knowing
- * which hand the letter is on.
+ * The shift on the other hand from this finger — the technique the hint teaches
+ * rather than merely locating the key (§3.3).
  *
  * `thumb` falls to the same branch as the right hand and never reaches it: no
  * thumb key carries a single-character *shifted* legend — the space bar's two
@@ -399,10 +324,8 @@ for (const k of KEYS) {
 /**
  * How to type one character, or `null` if this layout cannot produce it.
  *
- * That null is load-bearing rather than defensive: it is what `reachable()` is
- * built out of, and it is what would have caught the curly quotation marks
- * that `decks/typing.ts` had to hand-exclude from the Scripture pool — a verse
- * containing one is unpassable rather than hard, because typing marks exactly.
+ * That null is load-bearing rather than defensive: `reachable()` is built out
+ * of it (§3.3).
  */
 export function strokeFor(ch: string): Stroke | null {
   return STROKES.get(ch) ?? null;
@@ -414,14 +337,11 @@ export function strokeFor(ch: string): Stroke | null {
  * `keys` is the unlocked *alphabet* — the characters those keys produce, which
  * is the form a lesson declares (`Lesson.introduces`) and the form the ladder
  * accumulates. A capital is its own entry because shift is its own lesson:
- * unlocking `a` does not hand a child `A`, and a generator that assumed it
- * would write a word nobody at that lesson can type.
+ * unlocking `a` does not hand a child `A`.
  *
  * Both halves matter. The `keys` check is the curriculum's — don't use a key
  * they haven't met. The `strokeFor` check is the layout's — don't use a
- * character this board cannot produce at all, which is how prose pulled from
- * the passage library gets its curly quotes and dashes caught before a child
- * meets them.
+ * character this board cannot produce at all (§5.2).
  */
 export function reachable(text: string, keys: ReadonlySet<string>): boolean {
   for (const ch of text) {

--- a/src/engine/typing/generate.test.ts
+++ b/src/engine/typing/generate.test.ts
@@ -7,39 +7,21 @@ import type { Lesson } from "./lessons";
 import { WORDS } from "./lexicon";
 
 /**
- * The three invariants that make a hundred generated lessons safe
- * (docs/typing.md §5.2, §12).
- *
- * This is the test the three stories before it were for. The hundred specs
- * gave it something to walk, `unlockedAt` gave it the question to ask of every
- * character, and the corpus gave the generator something to answer with — and
- * what it buys is the ladder being *editable*: move a lesson, re-order a
- * block, hand a key over two lessons earlier, and the text follows or this
- * file says which lesson it stopped following at.
- *
- *   1. **Reachability.** Every character of every lesson, at every seed, is
- *      producible on the board and unlocked by that lesson.
- *   2. **The new key shows up enough.** Every introduced character occurs at
- *      least `pass.keyStrikes` times, at every seed, so the new-key gate
- *      (§6.4) can never be unpassable through bad luck.
- *   3. **A lesson is mostly review.** New keys are 15–35% of the characters:
- *      below that it is not a lesson about them, above it a memory test.
+ * The three invariants that make a hundred generated lessons safe (§5.2, §12):
+ * reachability, `pass.keyStrikes` met at every seed, and new keys at 15–35% of
+ * the characters.
  *
  * Each is asserted over all hundred lessons crossed with a spread of seeds,
  * because a generator is a distribution and one seed is an anecdote. Failures
  * are collected rather than thrown at the first one: "lessons 61, 63 and 67
- * are short of strikes" is a finding about the ladder, where "lesson 61 is"
- * is a bug report you have to fix three times.
+ * are short of strikes" is a finding about the ladder, where "lesson 61 is" is
+ * a bug report you have to fix three times.
  *
- * ── The one lesson invariant 3 cannot cover, and why that is not a licence ───
- * At lesson 1 the unlocked alphabet is `f`, `j` and the space bar. There is no
- * review to be had, so a lesson that is 15–35% new keys is not merely
- * undesirable there, it is arithmetically impossible — and §5.5 asks for
- * exactly what the ladder does instead: "three lessons of `fff jjj fjf` is
- * standard and correct". So the band is asserted wherever the ladder has
- * anything to review and a *stronger* claim — every character is a new key —
- * where it has not. Both halves are derived from `unlockedAt`, never from a
- * list of excused lesson numbers, which is what keeps the exception honest: a
+ * At lesson 1 the unlocked alphabet is `f`, `j` and the space bar, so the
+ * 15–35% band is arithmetically impossible there. The band is asserted
+ * wherever the ladder has anything to review, and a stronger claim — every
+ * character is a new key — where it has not. Both halves are derived from
+ * `unlockedAt` rather than from a list of excused lesson numbers, so a
  * re-ordered ladder that leaves lesson 40 with nothing to review is reported
  * by the same line rather than covered by it.
  */
@@ -49,11 +31,9 @@ const MIN_NEW_SHARE = 0.15;
 const MAX_NEW_SHARE = 0.35;
 
 /**
- * Enough seeds that a rare draw is not a lucky pass.
- *
- * Sixteen crossed with a hundred lessons is sixteen hundred generations, which
- * runs in under a second because the corpus is filtered once per lesson. The
- * seeds are spread rather than 0–15: `mulberry32` is well-behaved over
+ * Enough seeds that a rare draw is not a lucky pass. Sixteen crossed with a
+ * hundred lessons runs in under a second, because the corpus is filtered once
+ * per lesson. Spread rather than 0–15: `mulberry32` is well-behaved over
  * neighbouring seeds, but the numbers a run actually uses come from
  * `randomSeed()` and look nothing like a counter.
  */
@@ -63,12 +43,10 @@ const SEEDS = [
 ];
 
 /**
- * Every lesson that has text — the storms have a wave instead (§8.3).
- *
- * Read off the *kind* and not off `wordCount`, which stopped being able to
- * answer this the day the twenty waves landed: a storm level's `wordCount` is
- * its wave's `count` (§5.6), so "has a length" is now true of all hundred and
- * "has words" is true of eighty.
+ * Every lesson that has text — the storms have a wave instead (§8.3). Read off
+ * the *kind* and not off `wordCount`: a storm level's `wordCount` is its
+ * wave's `count` (§5.6), so "has a length" is true of all hundred and "has
+ * words" of eighty.
  */
 const WITH_TEXT = LESSONS.filter((lesson) => lesson.kind.type !== "storm");
 
@@ -93,9 +71,6 @@ const countOf = (text: string, chars: readonly string[]) => {
 
 describe("the reachability invariant", () => {
   /**
-   * The one §5.2 calls "the test that makes the ladder editable", and the only
-   * one whose failure a child would meet as a key they have never been shown.
-   *
    * `canType` is asked per character rather than per word so the report names
    * the character: "L27 needs 'q'" is a curriculum bug you can act on.
    */
@@ -113,14 +88,10 @@ describe("the reachability invariant", () => {
   });
 
   /**
-   * Reachability is about characters; this is about the words they make.
-   *
    * A lesson asks for `wordCount` words because that is what its wpm bar is
-   * computed against (§6.3): a lesson that quietly ran nine words short would
-   * report a speed nobody typed. Storm levels are the exception, and their
-   * `wordCount` means something else entirely — the letters in the wave — so
-   * they are asked the question they do have an answer to instead, three tests
-   * down: a storm generates no text at all.
+   * computed against (§6.3): one that quietly ran nine words short would
+   * report a speed nobody typed. Storms are excluded here and asked the
+   * question they do have an answer to — no text at all — three tests down.
    */
   it("produces exactly the number of words the lesson asks for", () => {
     const offenders: string[] = [];
@@ -140,10 +111,9 @@ describe("the reachability invariant", () => {
 
 describe("the new-key invariant", () => {
   /**
-   * The gate in §6.4 waits for `keyStrikes` strikes of each new character
-   * before it will judge that key at all. If the text does not contain that
-   * many, the lesson cannot be passed however well it is typed — and the child
-   * has no way of knowing why, because everything they typed was right.
+   * §6.4's gate will not judge a key until `keyStrikes` strikes of it. Text
+   * short of that is a lesson that cannot be passed however well it is typed,
+   * with nothing on screen to say why.
    */
   it("strikes every new key at least as often as its gate demands", () => {
     const offenders: string[] = [];
@@ -164,13 +134,6 @@ describe("the new-key invariant", () => {
     expect(offenders).toEqual([]);
   });
 
-  /**
-   * §5.2's band, everywhere the ladder has review to give.
-   *
-   * The floor and the ceiling fail differently and both matter: under 15% the
-   * lesson is not about the keys it claims to introduce, and over 35% it has
-   * stopped being typing practice and become a memory test of two keys.
-   */
   it("keeps the new keys between 15% and 35% of the characters", () => {
     const offenders: string[] = [];
     for (const lesson of INTRODUCING) {
@@ -188,13 +151,9 @@ describe("the new-key invariant", () => {
   });
 
   /**
-   * The other side of that exception, asserted rather than assumed.
-   *
-   * Lesson 1 is the whole of it today: `f`, `j` and the space bar, so every
-   * character that is not a space is a new key by necessity. Writing it down
-   * as its own expectation is what stops "the ladder had nothing to review" —
-   * true and unavoidable at lesson 1 — from becoming a silent excuse the day
-   * somebody moves a lesson into a place where it is neither.
+   * The exception the header describes, asserted rather than assumed: pinning
+   * the list to `L01` is what stops "nothing to review" becoming a silent
+   * excuse the day somebody moves a lesson.
    */
   it("spends a lesson with nothing to review entirely on its new keys", () => {
     const nothingToReview = INTRODUCING.filter(
@@ -215,8 +174,6 @@ describe("the new-key invariant", () => {
 
 describe("generate", () => {
   /**
-   * Deterministic in `(lesson, seed)`, like every other deck on this site.
-   *
    * Not a nicety: a lesson is re-rendered on every mount of the results screen
    * and re-read out of the record book months later, and a run whose text
    * changed underneath it would show a child a passage they never typed.
@@ -227,9 +184,6 @@ describe("generate", () => {
   });
 
   /**
-   * …and a different one for a different seed, or the ladder is a hundred
-   * fixed passages a child could learn by heart.
-   *
    * Counted across the ladder rather than asserted per lesson: lesson 8 draws
    * from ten words and lesson 1 from two keys, so a handful of collisions is
    * the pool being small rather than the seed being ignored.
@@ -254,8 +208,8 @@ describe("a lesson's kind decides its text", () => {
 
   /**
    * A drill is groups of one length, so the lesson is as long in characters as
-   * `strikesFor` assumed when it sized the gate (five to a word, the space
-   * included). It is also what a drill looks like on the page.
+   * `strikesFor` assumed when it sized the gate — five to a word, the space
+   * included.
    */
   it("keys · lays the new keys into even letter groups", () => {
     for (const lesson of LESSONS.filter((l) => l.kind.type === "keys"))
@@ -365,14 +319,10 @@ describe("a bag is exhausted before it repeats", () => {
   });
 
   /**
-   * And where the pool is smaller than the lesson it is emptied before it is
-   * refilled, which is the only reason a tiny bag is usable at all.
-   *
-   * Lesson 8 is the smallest on the ladder: `ll`, `ss` and `dd` at nine
-   * unlocked letters is ten words in the whole corpus, one of them for `ss`.
-   * Its twenty-five slots therefore *have* to repeat — repetition is what a
-   * pairs lesson is — and what the bag rule buys is that every one of the ten
-   * is met before any of them comes round a third time.
+   * Lesson 8 is the smallest pool on the ladder: `ll`, `ss` and `dd` at nine
+   * unlocked letters is ten words in the whole corpus. Its twenty-five slots
+   * therefore have to repeat, and what the bag rule buys is that every one of
+   * the ten is met before any comes round a third time.
    */
   it("empties a small pool before drawing from it again", () => {
     const lesson = LESSONS.find((l) => l.n === 8) as Lesson;

--- a/src/engine/typing/generate.ts
+++ b/src/engine/typing/generate.ts
@@ -18,56 +18,35 @@ import {
  *
  * `generate(lesson, seed)` is the whole of this module's surface, and it is
  * deterministic in the pair: the same lesson and the same seed produce the
- * same words in the same order, on any device, for ever. That is the rule
- * every other deck on this site already follows — a ghost is only a race if
- * both runs saw the same cards — and here it is also what makes a saved run
- * legible: `Session.mode` says `typing:L07` and the seed says which lesson 7.
+ * same words in the same order, on any device, for ever. A ghost is only a
+ * race if both runs saw the same cards, and determinism is also what makes a
+ * saved run legible: `Session.mode` says `typing:L07`, and the seed says which
+ * lesson 7 it was.
  *
- * ── Why a strategy per kind, rather than one shuffle ─────────────────────────
- * A single "pick words the child can type" would satisfy the reachability
- * invariant and teach almost nothing. What a lesson is *for* is written on it,
- * and the eight kinds want eight different things:
+ * **Every character produced satisfies `canType(ch, n)`** (§5.2): a lesson may
+ * only use keys the ladder has already taught. Each pool is filtered rather
+ * than trusted, which is what lets the ladder be re-ordered by editing one
+ * array — and it is the promise an editor adding a pool here would otherwise
+ * break in silence, in front of a five-year-old.
  *
- *   - **keys** meets a new key, so it is letter groups in a drill rhythm,
- *     weighted to the new keys and padded out with the ones already learnt.
- *   - **words** wants real words, commonest first, because a child who can
- *     type `the` fluently can type a third of English.
- *   - **bigrams** wants words chosen *because* they carry the focus pairs, so
- *     one hand shape comes round again and again inside ordinary spelling.
- *   - **sentences** and **passage** want English, split on spaces and never on
- *     meaning: that is where the space bar and the full stop get learnt.
- *   - **numbers** and **mixed** want figures that mean something — an age, a
- *     date, a score, a price — because random digits teach the row and nothing
- *     else.
- *   - **sprint** wants the short, common words, at pace.
+ * Two more `generate.test.ts` holds: each introduced character occurs at least
+ * `pass.keyStrikes` times at every seed, and new keys are 15–35% of the
+ * characters. The second has one exception, and it is a fact about the ladder
+ * rather than a concession by the generator: at lesson 1 the alphabet is `f`,
+ * `j` and the space bar, so there is no review to be had and `keyDrill` spends
+ * the whole lesson on the new keys. The test states that in derived terms — a
+ * lesson with review available is 15–35% new — so a re-ordered ladder that
+ * leaves lesson 40 with nothing to review is named by the test rather than
+ * quietly excused by it.
  *
- * ── The three invariants this module exists to satisfy ───────────────────────
- * §5.2, and `generate.test.ts` is where they are actually asserted:
+ * A strategy per kind rather than one shuffle, because "pick words the child
+ * can type" would satisfy reachability and teach almost nothing: what a lesson
+ * is *for* is written on it, and each strategy below says what it makes of it.
  *
- *   1. **Reachability.** Every character produced satisfies `canType(ch, n)`.
- *      Every pool is filtered through it rather than trusted, which is what
- *      lets the ladder be re-ordered by editing one array.
- *   2. **The new key shows up enough.** Each introduced character occurs at
- *      least `pass.keyStrikes` times, at every seed, or the new-key gate
- *      (§6.4) is unpassable through no fault of the child's.
- *   3. **A lesson is mostly review.** New keys are 15–35% of the characters.
- *
- * The third has one exception, and it is a fact about the ladder rather than a
- * concession by the generator: at lesson 1 the unlocked alphabet is `f`, `j`
- * and the space bar, so there is no review to be had and the drill is all new
- * keys. §5.5 asks for exactly that ("three lessons of `fff jjj fjf` is
- * standard and correct"). `keyDrill` therefore spends the whole lesson on the
- * new keys when nothing else is unlocked, and the test states the exception in
- * the same derived terms — a lesson with review available is 15–35% new — so a
- * re-ordered ladder that leaves lesson 40 with nothing to review is named by
- * the test rather than quietly excused by it.
- *
- * ── Why this file may import the corpus ──────────────────────────────────────
  * `local/no-corpus-in-decks` bans `lexicon.ts` and this module from every
  * engine file the deck layer can reach, and exempts these two. The way a run
  * gets its words is `TypingConfig.words`: the ladder screen, inside the typing
- * island, calls `generate` and hands the result to the deck. Nothing under
- * `decks/` ever imports this (§5.3, and the 222 KB it cost the last time).
+ * island, calls `generate` and hands the result to the deck (§5.3).
  */
 
 // ── The shape of a drill ─────────────────────────────────────────────────────
@@ -75,37 +54,32 @@ import {
 /**
  * Characters in a drill group: `ffjj`, `QWER`, `4545`.
  *
- * Four, as §5.1 prints, and the reason is arithmetic rather than taste.
- * `strikesFor` in `lessons.ts` sizes the new-key gate against `wordCount × 5`
- * characters — the words-per-minute convention, five keys to a word, the space
- * included. Groups of three would make a lesson a fifth shorter than the gate
- * assumes, and lesson 67 (six new symbols, ten strikes apiece) would need 60
- * of its 139 characters to be new: 43%, well over §5.2's ceiling, with the
- * generator doing nothing wrong. Four plus a space is five, so the two halves
- * of the ladder agree about how long a lesson is.
+ * Four rather than three, so that a group plus the space after it is the five
+ * characters `wordCount` is counted in — the same figure `strikesFor` sizes
+ * the new-key gate against. At three the two halves of the ladder would
+ * disagree about how long a lesson is, and lesson 67 would be over §5.2's
+ * ceiling with the generator doing nothing wrong (§5.1).
  */
 const GROUP = 4;
 
 /**
  * How much of a drill the new keys should be — the middle of §5.2's 15–35%.
  *
- * A target rather than a limit. Where the gate asks for more than this (a
- * lesson handing over six keys at twelve strikes each), the gate wins and the
- * lesson runs denser: a lesson nobody can pass is a worse failure than a
- * lesson that leans hard on its new keys, and the band test is what says so
- * out loud if the two ever stop being reconcilable.
+ * A target rather than a limit. Where the gate asks for more than this — a
+ * lesson handing over six keys at twelve strikes each — the gate wins and the
+ * lesson runs denser: a lesson nobody can pass is the worse failure, and the
+ * band test says so out loud if the two ever stop being reconcilable.
  */
 const TARGET_NEW_SHARE = 0.25;
 
 /**
  * Up to this many new keys get an opening group of their own: `ffff jjjj`.
  *
- * A run of one key is how a key is met, and it is the first thing every typing
- * course prints. It stops being useful when a lesson hands over eleven or
- * fifteen keys at once — block 4's two shift lessons — where fifteen groups of
- * `QQQQ` would be half the lesson and would spend the entire new-key budget
- * before the drill got to using them. Those lessons take four distinct new
- * keys per group instead, which is `QWER TASD` and reads as the drill it is.
+ * A run of one key is how a key is met. It stops being useful when a lesson
+ * hands over eleven or fifteen at once — block 4's two shift lessons — where
+ * fifteen groups of `QQQQ` would be half the lesson and would spend the whole
+ * new-key budget before the drill got to using them. Those lessons take four
+ * distinct new keys per group instead: `QWER TASD`.
  */
 const RUN_KEYS_MAX = 4;
 
@@ -124,12 +98,11 @@ const FREQ_BIAS = 2;
 /**
  * The window a `words` lesson draws inside, in words per word asked for.
  *
- * The coarse half of the same weighting. A lesson of thirty-five words reaching
- * into two thousand would meet its fifteen-hundredth-commonest word about as
- * often as anything else worth practising, and "practise the words you will
- * actually write" is the point of a frequency-ordered corpus. The tail is not
- * wasted: it is what the bigram lessons filter and what keeps the early
- * alphabets from emptying.
+ * The coarse half of the same weighting. A lesson of thirty-five words
+ * reaching into two thousand would meet its fifteen-hundredth-commonest word
+ * about as often as anything worth practising. The tail is not wasted: it is
+ * what the bigram lessons filter, and what keeps the early alphabets from
+ * emptying.
  */
 const WINDOW_PER_WORD = 6;
 
@@ -148,17 +121,14 @@ const MIN_BAG = 12;
  * The lessons whose subject is a particular pool, by number.
  *
  * `LessonKind` carries a payload for exactly one thing — `bigrams.focus` —
- * because a title is otherwise spec enough for the generator. The eleven below
- * are the exceptions §5.6 names in words: "The twenty-five" is the twenty-five,
- * "Hands that take turns" is the alternating list, "Names, and the word I" is
- * the names. The corpus was built with those lessons written on it
- * (`lexicon.ts` says so in every one of their doc blocks), so the table that
- * connects them lives here, beside the only module that reads it, rather than
- * as a second payload on a type the deck layer imports.
+ * because a title is otherwise spec enough. The eleven below are the lessons
+ * §5.6 names a pool in words: "The twenty-five", "Hands that take turns",
+ * "Names, and the word I". The table connecting them lives here, beside the
+ * only module that reads it, rather than as a second payload on a type the
+ * deck layer imports.
  *
- * Keyed by `n` for the same reason `BIGRAMS` in `lessons.ts` is: a row of §5.6
- * carries its number with it, and a lesson that is genuinely re-numbered has
- * changed which lesson it is.
+ * Keyed by `n` for the same reason `BIGRAMS` in `lessons.ts` is: a lesson that
+ * is genuinely re-numbered has changed which lesson it is.
  */
 type Source = (lesson: Lesson, rand: () => number) => readonly string[];
 
@@ -197,11 +167,9 @@ const POOLS = new Map<number, Source>([
 // ── Bags ─────────────────────────────────────────────────────────────────────
 
 /**
- * A bag that is emptied before it is refilled — the rule the other decks
- * follow, so a short lesson never asks for one word four times while another
- * never comes up at all.
- *
- * Refilling reshuffles, so a pool smaller than the lesson repeats in a
+ * A bag emptied before it is refilled — the rule the other decks follow, so a
+ * short lesson never asks for one word four times while another never comes up
+ * at all. Refilling reshuffles, so a pool smaller than the lesson repeats in a
  * different order each time round rather than looping.
  */
 function bag<T>(items: readonly T[], rand: () => number): () => T {
@@ -220,9 +188,9 @@ function bag<T>(items: readonly T[], rand: () => number): () => T {
  * The same rule, with the draw weighted towards the front of the pool.
  *
  * Frequency weighting and bag exhaustion pull against each other — the first
- * wants `the` often, the second wants it once — so the compromise is drawing
- * *without replacement* from a biased index: every word is gone until the bag
- * is empty, and which one goes first is decided by how common it is.
+ * wants `the` often, the second wants it once — so this draws *without
+ * replacement* from a biased index: every word is gone until the bag is empty,
+ * and which goes first is decided by how common it is.
  */
 function frequencyBag(
   pool: readonly string[],
@@ -240,10 +208,9 @@ function frequencyBag(
 /**
  * Lowercase the characters this lesson has not been given, and only those.
  *
- * The sentence pool holds English as it is printed — a capital at the front, a
- * name in the middle — because it has to still be English at lesson 40. Lesson
- * 30 asks for sentences a whole block before either shift is taught, and
- * folding the case for it is this module's job (`lexicon.ts` says as much):
+ * The sentence pool holds English as it is printed, because it has to still be
+ * English at lesson 40. Lesson 30 asks for sentences a whole block before
+ * either shift is taught, and folding the case for it is this module's job:
  * the unlocked alphabet is in hand here and is not in the corpus.
  *
  * Conditional on the character rather than on the lesson, so the fold is a
@@ -264,7 +231,7 @@ function fold(text: string, n: number): string {
  * The reachability test generates every lesson at many seeds, and each
  * generation would otherwise walk two thousand words character by character.
  * The ladder and the corpus are both fixed at module load, so the answer is
- * too; a `WeakMap` keyed by the pool means a caller can hand over a slice
+ * too; the `WeakMap` is keyed by the pool so a caller can hand over a slice
  * without leaking it for the life of the process.
  */
 const FILTERED = new WeakMap<
@@ -306,14 +273,10 @@ const readable = (pool: readonly string[], n: number) =>
 /**
  * `ffff jjjj fjfj fdfd dkdk` — a new key, met and then used.
  *
- * Three sorts of group, in the proportions §5.2's band asks for:
- *
- *   - **new**, four characters of the keys that arrived today. One run per key
- *     opens the lesson, and the rest are woven so a pair alternates.
- *   - **mixed**, two new and two already learnt, which is the actual exercise:
- *     the finger has to come back to the new key from somewhere.
- *   - **review**, four characters of two older keys, which is what the other
- *     two thirds of the lesson are made of.
+ * Three sorts of group, in the proportions §5.2's band asks for: **new** (four
+ * of today's keys), **mixed** (two new and two already learnt, which is the
+ * actual exercise — the finger has to come back to the new key from
+ * somewhere), and **review** (four characters of two older keys).
  *
  * The new characters come off a round-robin over the day's keys, so a lesson
  * introducing fifteen capitals spreads them evenly rather than spending its
@@ -402,10 +365,9 @@ function drawWords(
 /**
  * Real words, commonest first, that this lesson's alphabet can spell.
  *
- * The pool is the lesson's own if §5.6 gave it one, and the corpus otherwise,
+ * The pool is the lesson's own if §5.6 gave it one and the corpus otherwise,
  * narrowed to a window whose size follows the lesson's length. Both halves are
- * frequency weighting: which words are in the bag, and which of them is drawn
- * first.
+ * frequency weighting: which words are in the bag, and which is drawn first.
  */
 function wordRun(lesson: Lesson, rand: () => number): string[] | null {
   const source = POOLS.get(lesson.n);
@@ -419,11 +381,11 @@ function wordRun(lesson: Lesson, rand: () => number): string[] | null {
 /**
  * Words chosen *because* they contain the focus sequences.
  *
- * Round-robin over the sequences rather than one pooled bag, so `th`, `he`,
- * `er` and `re` each get a quarter of the lesson however many words the corpus
- * offers for them. Lesson 8 is the case that shapes this: at nine letters
- * unlocked, `ss` has exactly one word in the whole corpus, and a pooled draw
- * would spend the lesson on `ll` and never drill the pair a child is there for.
+ * Round-robin over the sequences rather than one pooled bag, so each gets an
+ * equal share of the lesson however many words the corpus offers for it.
+ * Lesson 8 is the case that shapes this: at nine letters unlocked, `ss` has
+ * exactly one word in the whole corpus, and a pooled draw would spend the
+ * lesson on `ll` and never drill the pair a child is there for.
  */
 function bigramRun(
   lesson: Lesson,
@@ -490,8 +452,8 @@ function punctuated(lesson: Lesson): readonly string[] {
  * Never split on meaning: a sentence goes in entire, so the capital at the
  * front and the stop at the end land where a child expects them. The only cut
  * is the last one, where the lesson reaches its length mid-sentence — the same
- * trade `decks/typing.ts` makes, and for the same reason: a passage that stops
- * mid-sentence is better than one that starts mid-sentence.
+ * trade `decks/typing.ts` makes, because a passage that stops mid-sentence is
+ * better than one that starts mid-sentence.
  */
 function proseRun(
   lesson: Lesson,
@@ -512,12 +474,11 @@ function proseRun(
  * The figures a lesson can be built out of, and what each one costs.
  *
  * Ages, dates, scores and prices (§5.6, lesson 57) rather than digits at
- * random: a date has a shape, and typing `14/6/2019` teaches the number row
- * *and* the reach to the slash in the order a child will actually need them.
- * `needs` is the punctuation the shape cannot be written without, checked
- * against the unlocked alphabet before the shape is offered — which is why a
- * score is absent until the hyphen arrives at lesson 63 rather than being
- * quietly rewritten as two separate numbers.
+ * random: a date has a shape, and `14/6/2019` teaches the number row *and* the
+ * reach to the slash. `needs` is the punctuation the shape cannot be written
+ * without, checked against the unlocked alphabet before the shape is offered —
+ * which is why a score is absent until the hyphen arrives at lesson 63 rather
+ * than being quietly rewritten as two separate numbers.
  */
 const FIGURES: { needs: string; make: (rand: () => number) => string }[] = [
   /** An age. */

--- a/src/engine/typing/keys.test.ts
+++ b/src/engine/typing/keys.test.ts
@@ -7,14 +7,10 @@ import { KEYS, strokeFor } from "../keyboard";
 
 /**
  * The unlocked alphabet, asserted as a set of characters rather than a size
- * (docs/typing.md §5.1, §5.2).
- *
- * A count is the wrong assertion here: "thirty-one characters at lesson 30" is
- * satisfied by thirty-one *wrong* characters, and the failure this module
- * exists to prevent is one specific key being in a set it has no business
- * being in. So every expectation below is spelled out, and the ones that
- * cannot be — the hundredth lesson's — are computed from the ladder itself so
- * that re-ordering it re-derives the answer instead of breaking the test.
+ * (§5.1, §5.2). A count is satisfied by thirty-one *wrong* characters, and the
+ * failure this module exists to prevent is one specific key being in a set it
+ * has no business being in. The hundredth lesson's expectation is computed
+ * from the ladder, so re-ordering it re-derives the answer.
  */
 
 /** A set of characters as one sorted string, so a diff prints readably. */
@@ -45,10 +41,9 @@ const capitalsIn = (set: ReadonlySet<string>) =>
 
 describe("unlockedAt", () => {
   /**
-   * Block 1 is the eight home keys plus the inside reach, and `;` is one of
-   * the eight — the right pinky rests on it (§5.6, lesson 5 · Both pinkies).
-   * Lessons 7–10 introduce nothing, so the alphabet block 1 ends on is the
-   * alphabet lesson 6 left behind.
+   * `;` is one of the eight home keys — the right pinky rests on it. Lessons
+   * 7–10 introduce nothing, so the alphabet block 1 ends on is the one lesson
+   * 6 left behind (§5.6).
    */
   it("is exactly the home row and the space bar at the end of block 1", () => {
     expect(chars(unlockedAt(10))).toBe(sorted("asdfghjkl; "));
@@ -56,11 +51,9 @@ describe("unlockedAt", () => {
   });
 
   /**
-   * Block 3 finishes the alphabet, and it brings the comma and the full stop
-   * with it because that is physically where they are (§5.5) — plus the slash,
-   * which came in at lesson 25 alongside `z` as the last bottom-row corner.
-   * `;` and `/` both come back in block 7 in their punctuation role; the union
-   * does not care, which is the point of that note in the table.
+   * The comma, the full stop and the slash are in a letters-only expectation
+   * because they sit on the bottom row and arrive with it (§5.5). `;` and `/`
+   * come back in block 7 as punctuation; a union does not double-count.
    */
   it("is every letter, and no capital, at the end of block 3", () => {
     expect(chars(unlockedAt(30))).toBe(
@@ -70,10 +63,9 @@ describe("unlockedAt", () => {
   });
 
   /**
-   * The whole ladder, against the ladder's own `introduces`. This is the
-   * assertion that says nothing is silently dropped anywhere in the hundred:
-   * every shifted character block 7 teaches has its base key and its shift
-   * behind it, or it would be missing here.
+   * Nothing is silently dropped anywhere in the hundred: every shifted
+   * character block 7 teaches has its base key and its shift behind it, or it
+   * would be missing here.
    */
   it("covers everything the hundred lessons introduce", () => {
     expect(chars(unlockedAt(100))).toBe(chars(EVER_INTRODUCED));
@@ -81,23 +73,16 @@ describe("unlockedAt", () => {
   });
 
   /**
-   * And covers nothing else. The ten legends on the board that no lesson ever
-   * teaches: the backquote key, both bracket keys, and the four shifted
-   * characters — `^ < > |` — whose base keys the ladder does teach. A closure
-   * over unlocked *keys* rather than a union of introduced *characters* would
-   * hand all four of those over for free, `<` and `>` from lesson 31.
+   * The ten legends no lesson ever teaches: the backquote, both brackets, and
+   * the four shifted characters — `^ < > |` — whose base keys the ladder does
+   * teach. A closure over unlocked *keys* rather than a union of introduced
+   * *characters* would hand all four over for free, `<` and `>` from lesson 31.
    */
   it("never hands over a character no lesson taught", () => {
     const untaught = [...EVERYTHING].filter((ch) => !unlockedAt(100).has(ch));
     expect(sorted(untaught.join(""))).toBe(sorted("`~[]{}|^<>"));
   });
 
-  /**
-   * The union, stated one lesson at a time. Every step of the ladder adds
-   * exactly what that lesson introduces and takes nothing away — which is what
-   * "computed, never written down" has to mean if moving a lesson is to move
-   * its alphabet with it.
-   */
   it("grows by exactly what each lesson introduces, and never shrinks", () => {
     for (let n = 1; n <= 100; n++) {
       const expected = new Set([...unlockedAt(n - 1), ...introducedBy(n)]);
@@ -106,9 +91,9 @@ describe("unlockedAt", () => {
   });
 
   /**
-   * Total, like `deckSpec(mode)`: a session saved against a ladder that has
-   * since been re-tuned still has to open its record book, and the number in
-   * its mode string may not be on the ladder any more — or may not parse.
+   * Total, like `deckSpec(mode)`: a session saved against a ladder since
+   * re-tuned still has to open its record book, and the number in its mode
+   * string may not be on the ladder any more — or may not parse.
    */
   it("clamps a lesson number that is not on the ladder", () => {
     expect(chars(unlockedAt(0))).toBe(" ");
@@ -117,8 +102,6 @@ describe("unlockedAt", () => {
     expect(chars(unlockedAt(101))).toBe(chars(unlockedAt(100)));
     expect(chars(unlockedAt(1e6))).toBe(chars(unlockedAt(100)));
     expect(chars(unlockedAt(10.9))).toBe(chars(unlockedAt(10)));
-    // Off the end is off the end however far off it is, which is what the doc
-    // block says and what `NaN` — a mode string that did not parse — is not.
     expect(chars(unlockedAt(Number.POSITIVE_INFINITY))).toBe(
       chars(unlockedAt(100)),
     );
@@ -128,10 +111,9 @@ describe("unlockedAt", () => {
 
 describe("the shift rule", () => {
   /**
-   * The subtle one. Every letter is unlocked at lesson 26 and every capital
-   * needs one of them, so a rule that only checked the letter would hand a
-   * child the whole of block 4 four lessons early — and with it the one
-   * technique the block exists to teach.
+   * Every letter is unlocked at lesson 26 and every capital needs one of them,
+   * so a rule that only checked the letter would hand a child the whole of
+   * block 4 four lessons early.
    */
   it("gives no capital before block 4, however old the letter is", () => {
     for (let n = 0; n <= 30; n++)
@@ -141,10 +123,8 @@ describe("the shift rule", () => {
   });
 
   /**
-   * And gives them one shift at a time. Lesson 31 is the right shift, which
-   * reaches the left hand's letters and only those; `M` is a left-shift
-   * capital and waits for lesson 32. Two lessons, twenty-six characters, and
-   * the opposite-hand rule as the only way either of them works.
+   * Lesson 31 is the right shift, which reaches the left hand's letters and
+   * only those; `M` is a left-shift capital and waits for lesson 32.
    */
   it("arrives one shift at a time, in the hand each shift reaches", () => {
     expect(sorted(capitalsIn(unlockedAt(31)).join(""))).toBe(
@@ -158,11 +138,9 @@ describe("the shift rule", () => {
   });
 
   /**
-   * Both halves, over the whole ladder: nothing needing a shift is unlocked
-   * without its base key, and nothing needing a shift is unlocked before a
-   * capital has taught that shift. Block 7's `!` and `?` are the ones this
-   * covers that block 4's capitals do not — they arrive assuming the child
-   * already knows to hold shift, and this is the assertion that they do.
+   * Block 7's `!` and `?` are what this covers that block 4's capitals do not:
+   * they arrive assuming the child already knows to hold shift, and this is
+   * the assertion that they do.
    */
   it("needs both the base key and a shift, everywhere on the ladder", () => {
     for (let n = 0; n <= 100; n++) {
@@ -217,11 +195,8 @@ describe("canType", () => {
   });
 
   /**
-   * The story's whole point, stated as one loop: no lesson asks for a key it
-   * has not taught. The generator's own reachability test (§5.2) is this
-   * assertion over the words it produces; this is it over the keys the lesson
-   * declares, which is the half that can be checked before the generator
-   * exists.
+   * The generator's own reachability test (§5.2) is this assertion over the
+   * words it produces; this is it over the keys the lesson declares.
    */
   it("can type the new keys of every lesson, at that lesson", () => {
     for (const lesson of LESSONS)
@@ -236,9 +211,9 @@ describe("canType", () => {
  *
  * Today's hundred never introduce a shifted character before its base key or
  * before block 4 has taught a shift, so every assertion above still passes
- * with the rule deleted — the union alone satisfies them. That is exactly why
- * these two are here: the rule is for the ladder somebody re-orders, and a
- * rule with no test is a rule the next reader deletes as dead weight.
+ * with the rule deleted — the union alone satisfies them. These two are for
+ * the ladder somebody re-orders, and a rule with no test is a rule the next
+ * reader deletes as dead weight.
  */
 describe("a ladder that introduces a key too early", () => {
   const lesson = (n: number, introduces: string): Lesson => ({

--- a/src/engine/typing/keys.ts
+++ b/src/engine/typing/keys.ts
@@ -6,25 +6,19 @@ import { LESSONS } from "./lessons";
  * What a child may be asked to type at lesson n (docs/typing.md §5.1, §5.2).
  *
  * The **unlocked alphabet** at lesson n is the union of `introduces` over
- * lessons 1…n, plus space. It is *computed here, never written down*, which is
- * the whole point: a per-block alphabet spelled out in a table is a second
- * source of truth that a re-ordered ladder walks away from silently, and the
- * failure it produces is a lesson asking a five-year-old for a key nobody has
- * shown them. Move a lesson and its alphabet moves with it, because there is
- * nowhere else for the alphabet to be.
+ * lessons 1…n, plus space, and it is *computed here, never written down*: a
+ * per-block alphabet spelled out in a table is a second source of truth that a
+ * re-ordered ladder walks away from silently, and what that produces is a
+ * lesson asking a five-year-old for a key nobody has shown them. Move a lesson
+ * and its alphabet moves with it, because there is nowhere else for it to be.
+ * It is what the reachability invariant is checked against (§5.2), and why the
+ * layout is in the engine rather than the view (§3.1).
  *
- * This is the module the reachability test (§5.2) is built out of — "every
- * character of every word a lesson can generate is producible from the keys
- * unlocked at that lesson" — and it is why the layout had to be in the engine
- * rather than the view (§3.1): the curriculum, not the picture, is what asks
- * the keyboard questions.
- *
- * ── The two halves of a shifted character ────────────────────────────────────
- * `A` is not `a`. `strokeFor("A")` names KeyA *and* ShiftRight, so a character
- * is only unlocked once both keys are — which is why the capitals are not
- * available at lesson 30 even though every letter is. A naive union would hand
- * them over the moment the letters arrived and block 4 would have nothing left
- * to teach.
+ * A shifted character needs both of its keys: `strokeFor("A")` names KeyA
+ * *and* ShiftRight (§3.3), so `A` is locked until both have been taught. That
+ * is why the capitals are still out of reach at lesson 30, where every letter
+ * has arrived and neither shift has — a naive union would hand them over and
+ * leave block 4 with nothing to teach.
  */
 
 /** The one character no lesson introduces, because words are made of them. */
@@ -52,18 +46,16 @@ const LETTER = /^[a-z]$/;
  *
  * A shift is not a character, so it can never appear in `introduces` — and yet
  * it plainly has to be unlocked by something, or `A` is either free from
- * lesson 1 or unreachable forever. What unlocks it is block 4's capitals
- * (§5.5): "A shift is not a character, so what these two lessons introduce is
- * the set of capitals each one *reaches*", and each teaches only the shift it
- * is actually held with — lesson 31's fifteen left-hand capitals are all
- * right-shift, so ShiftLeft is still locked when lesson 31 ends.
+ * lesson 1 or unreachable forever. Block 4 unlocks it by introducing the
+ * capitals each shift reaches (§5.5), so each of its two lessons teaches only
+ * the shift it is actually held with: ShiftLeft is still locked when lesson
+ * 31's fifteen right-shift capitals end.
  *
  * Every *other* shifted character on the board — `!`, `?`, `:`, `"` — arrives
- * in block 7, thirty lessons later, and arrives assuming the child already
- * knows to hold shift. So a capital is what teaches a shift and punctuation is
- * not, which is what gives the rule below its teeth: a punctuation lesson
- * dragged up in front of block 4 loses its keys instead of quietly teaching a
- * technique nobody has been shown.
+ * in block 7 assuming the child already knows to hold shift. So a capital
+ * teaches a shift and punctuation does not, which is what gives the rule below
+ * its teeth: a punctuation lesson dragged up in front of block 4 loses its
+ * keys instead of quietly teaching a technique nobody has been shown.
  */
 function shiftTaughtBy(ch: string): ShiftCode | null {
   const stroke = strokeFor(ch);
@@ -83,12 +75,12 @@ function shiftTaughtBy(ch: string): ShiftCode | null {
  *     pools, Hailstorm's waves) and it should not carry a character no
  *     keyboard can type.
  *   - **No shift has been taught yet.** The capitals at lesson 30.
- *   - **Its base key has not arrived.** `_` before `-`, `?` before `/`. Today's
- *     ladder never does this — the test at lesson 100 asserts the whole union
- *     survives — and the reason to drop rather than to trust is that dropping
- *     is the safe direction: a lesson that loses its own new keys fails §5.2's
- *     reachability test loudly, where handing a child an untaught key fails
- *     silently, in front of them.
+ *   - **Its base key has not arrived.** `_` before `-`, `?` before `/`.
+ *
+ * Today's ladder never hits the last two — the test at lesson 100 asserts the
+ * whole union survives — and dropping is the safe direction anyway: a lesson
+ * that loses its own new keys fails §5.2's reachability test loudly, where
+ * handing a child an untaught key fails silently, in front of them.
  */
 function strikeable(
   unlocked: ReadonlySet<string>,
@@ -115,8 +107,7 @@ function strikeable(
  * Built once, walking the lessons in order of `n` rather than array order —
  * `n` is the number in `Session.mode` and the array is a table someone will
  * one day re-order in place, so "lessons 1…n" means what it says. Index 0 is
- * the alphabet before the ladder starts, which is the space bar and nothing
- * else.
+ * the alphabet before the ladder starts: the space bar and nothing else.
  *
  * A hundred sets of a hundred characters is a few thousand strings held for
  * the life of the process, and the alternative is rebuilding the union on
@@ -148,19 +139,17 @@ const ALPHABETS: readonly ReadonlySet<string>[] = (() => {
 /**
  * The characters a child has met by the end of lesson `n`, plus space.
  *
- * Total, and never throws: a lesson number off the end of the ladder is the
- * whole alphabet and one before the start is the space bar, for the same
- * reason `deckSpec(mode)` never throws — a saved session outlives the ladder
- * it was run on, and a record book from two re-tunings ago still has to open.
- * `Infinity` is off the end like any other overshoot, and `-Infinity` is
- * before the start; only `NaN` is turned away, because it is not a lesson
- * number that missed but a `Number("L7x")` that failed, and the safe answer to
- * a question nobody asked is nothing at all rather than an alphabet somebody
- * was never given.
+ * Total, and never throws: a number off the end of the ladder is the whole
+ * alphabet and one before the start is the space bar, for the same reason
+ * `deckSpec(mode)` never throws — a saved session outlives the ladder it was
+ * run on. `NaN` is the one input sent to the start rather than the end,
+ * because it is not a lesson number that overshot but a `Number("L7x")` that
+ * failed, and the safe answer to a question nobody asked is the space bar
+ * rather than an alphabet somebody was never given.
  *
- * The set is shared, not copied. It is `ReadonlySet` because every caller
- * reads it; one that mutates it would be editing the curriculum for everybody
- * else in the tab.
+ * The set is shared, not copied. `ReadonlySet` because every caller reads it;
+ * one that mutated it would be editing the curriculum for everybody else in
+ * the tab.
  */
 export function unlockedAt(n: number): ReadonlySet<string> {
   const last = ALPHABETS.length - 1;

--- a/src/engine/typing/ladder.test.ts
+++ b/src/engine/typing/ladder.test.ts
@@ -9,14 +9,7 @@ import { LESSONS } from "./lessons";
 import type { Lesson } from "./lessons";
 
 /**
- * What deriving progress has to prove (docs/typing.md §6.5, §6.6, §8.8).
- *
- * Four of these are the reason the module exists rather than a stored
- * `passedLessons` set, and each of them is a bug a stored one would have:
- * unlocking on `max` survives the day the oldest sessions are pruned; a storm
- * level never holds a child up; a checkpoint passed out of order carries them
- * to it; and re-tuning a lesson's criteria clears the runs that were one wpm
- * short without anything being written back.
+ * What deriving progress has to prove (§6.5, §6.6, §8.8).
  *
  * The runs below are built against the shipped ladder on purpose — unlike
  * `verdict.test.ts`, which dictates its own criteria because what it tests is
@@ -43,12 +36,9 @@ const card = (answer: string, given: string | null): CardResult => ({
 let saved = 0;
 
 /**
- * A run of `lesson`, filed exactly as the island files one: `typing:L44` for
- * its mode, its cards, counters that follow them, and its own copy of how long
- * the passage — or the wave — was.
- *
- * `durationMs` is worked back from the words per minute asked for, so a test
- * can sit a run exactly on a lesson's speed bar or exactly one under it.
+ * A run of `lesson`, filed exactly as the island files one. `durationMs` is
+ * worked back from the words per minute asked for, so a test can sit a run
+ * exactly on a lesson's speed bar or exactly one under it.
  */
 function run(
   of: Lesson,
@@ -110,11 +100,9 @@ const diedInTheStorm = (of: Lesson) =>
   );
 
 /**
- * Re-tune a lesson's speed bar for the length of one test, and put it back.
- *
- * Standing in for the deploy that lowers lesson 41 from 18 wpm to 17 after a
- * hundred children have found it too fast. Nothing else about the world
- * changes — least of all the sessions, which is the point.
+ * Re-tune a lesson's speed bar for the length of one test, and put it back:
+ * the deploy that lowers lesson 41 from 18 wpm to 17. Nothing else changes —
+ * least of all the sessions, which is the point.
  */
 function retuned(n: number, wpm: number, body: () => void) {
   const pass = lesson(n).pass;
@@ -137,10 +125,8 @@ describe("a child who has done nothing", () => {
   });
 
   /**
-   * The ladder is the hundred and nothing else is on it. A typing *level*, a
-   * parent's drill and a spelling race all sit in the same record book — and
-   * `typing:home-row` is one `typing:` prefix away from a lesson, which is the
-   * mistake worth pinning.
+   * Everything shares one record book, and `typing:home-row` is one `typing:`
+   * prefix away from a lesson — which is the mistake worth pinning.
    */
   it("is not advanced by runs that are not lessons", () => {
     const notALesson = (mode: string): Session => ({
@@ -157,15 +143,10 @@ describe("a child who has done nothing", () => {
   });
 
   /**
-   * A drill is filed under the mode it came from, and is not that lesson.
-   *
-   * `buildDrill(keys, "typing:L41")` builds ten to forty words of trouble
-   * keys with a `wordCount` of its own and **no `lessonId`** — the practice
-   * deck a child takes from lesson 41's results, or from the finger a storm
-   * broke (§8.5). Filed by mode alone it would clear the lesson it was offered
-   * from without the lesson ever being run: the ladder would fill in behind a
-   * child who only ever practised. `progress.ts` already reads its badges off
-   * `config.lessonId` for the same reason; this is that rule, one module over.
+   * A drill carries the mode it was offered from and **no `lessonId`** (§8.5).
+   * Filed by mode alone it would clear the lesson without the lesson ever
+   * being run — the ladder filling in behind a child who only ever practised.
+   * `progress.ts` reads its badges off `config.lessonId` for the same reason.
    */
   it("is not advanced by a drill filed under a lesson's mode", () => {
     const drill = {
@@ -201,14 +182,10 @@ describe("unlocking", () => {
   });
 
   /**
-   * §6.6, and the whole of the placement test. A nine-year-old who already
-   * types opens checkpoint 30, passes it, and starts at 31 — with no session
-   * for a single lesson below it.
-   *
-   * Note what `cleared` does *not* say: 1–29 are not in it, because nothing
-   * was ever run at them and this set is proof rather than permission. They
-   * are behind the child all the same, because `best` is what the ladder locks
-   * against and `best` is a maximum.
+   * §6.6's placement test. Note what `cleared` does *not* say: 1–29 are not in
+   * it, because nothing was ever run at them and this set is proof rather than
+   * permission. They are behind the child all the same, because `best` is what
+   * the ladder locks against and `best` is a maximum.
    */
   it("carries a child to the checkpoint they passed", () => {
     const progress = ladderProgress([passing(lesson(30))]);
@@ -236,10 +213,9 @@ describe("unlocking", () => {
   });
 
   /**
-   * §6.6's reason for `max` over `count`. `MAX_SESSIONS_PER_PROFILE` prunes
+   * §6.6's reason for `max` over `count`: `MAX_SESSIONS_PER_PROFILE` prunes
    * the *oldest* runs, so the first thing a child 2000 runs in loses is the
-   * proof that they ever passed lesson 1 — and a tally would answer "you have
-   * cleared three lessons, go and do lesson 4".
+   * proof that they ever passed lesson 1.
    */
   it("does not re-lock anything when the oldest session is pruned", () => {
     const runs = [
@@ -261,11 +237,6 @@ describe("unlocking", () => {
 });
 
 describe("Hailstorm never gates the ladder", () => {
-  /**
-   * §8.8 and decision 24. A tablet has no keys to press, so a child who can do
-   * the whole course cannot play the game — and a reward that blocks you is
-   * not a reward.
-   */
   it("opens lesson 46 when 44 is cleared, whatever happened at 45", () => {
     const failed = ladderProgress([
       passing(lesson(44)),
@@ -281,13 +252,8 @@ describe("Hailstorm never gates the ladder", () => {
   });
 
   /**
-   * All twenty, and not only the one §8.8 uses as its example.
-   *
-   * The rule is a property of the ladder rather than of lesson 45: every storm
-   * sits between two lessons, and clearing the one below it has to open the
-   * one above it — at rung 4, where a child has met four keys, and at rung 99,
-   * where the only thing above is the Ice Exam. A table re-cut so that two
-   * storms sat side by side would break this and nothing else.
+   * All twenty, not only the one §8.8 uses as its example: a table re-cut so
+   * that two storms sat side by side would break this and nothing else.
    */
   it("is stepped over at every one of the twenty rungs", () => {
     const storms = LESSONS.filter((l) => l.kind.type === "storm");
@@ -304,9 +270,8 @@ describe("Hailstorm never gates the ladder", () => {
 
   /**
    * A storm level is a `Session` like any other (§8.7), so surviving one is a
-   * pass like any other. It is worth nothing extra and costs nothing to
-   * honour: reaching lesson 45 needed 44, and keeping the storm's proof is one
-   * more run that can hold a child's place after the older ones are pruned.
+   * pass like any other — one more run that can hold a child's place after the
+   * older ones are pruned.
    */
   it("still clears a wave that was survived", () => {
     const progress = ladderProgress([passing(lesson(45))]);
@@ -318,10 +283,9 @@ describe("Hailstorm never gates the ladder", () => {
 
 describe("criteria that change", () => {
   /**
-   * §6.5's second claim, which is the one a stored flag cannot make: tune
-   * lesson 41's speed bar down and every child who was one wpm short is
-   * through — with no backfill, no migration and nothing written back to a
-   * record book that holds the only copy there is.
+   * §6.5's second claim: tune lesson 41's speed bar down and every child who
+   * was one wpm short is through, with nothing written back to a record book
+   * that holds the only copy there is.
    */
   it("clears a run that was one wpm short, without touching it", () => {
     const asked = lesson(41).pass;

--- a/src/engine/typing/ladder.ts
+++ b/src/engine/typing/ladder.ts
@@ -7,20 +7,12 @@ import { verdictFor, type Run } from "./verdict";
 /**
  * How far up the ladder a child has got (docs/typing.md §6.5, §6.6).
  *
- * Everything here is **derived from the sessions the hub has already loaded**.
- * There is no `passedLessons` field, no new object store and no `DB_VERSION`
- * bump behind it, and three things fall out of that which are worth more than
- * the memo below costs (decision 14):
- *
- *   - **No migration, ever.** Not for this, and not when the criteria change.
- *   - **It self-heals.** Tune lesson 40's wpm down and every child who was one
- *     wpm short is through, with no backfill and nothing to re-run.
- *   - **It cannot disagree with the record book.** A stored flag and a session
- *     list are two sources of truth for one fact, and they drift the first
- *     time a save half-fails.
+ * Everything here is **derived from the sessions the hub has already loaded**:
+ * no `passedLessons` field, no new object store and no `DB_VERSION` bump, for
+ * the three reasons §6.5 gives (decision 14).
  *
  * This is the same kind of function as `records.ts`'s `factStats` and
- * `tableProgress`: sessions in, an answer about a child in, nothing written
+ * `tableProgress`: sessions in, an answer about a child out, nothing written
  * down. Which sessions belong to which child is the caller's to say — hand it
  * `sessionsFor(sessions, profile.id)`, exactly as the progress screens do.
  */
@@ -29,14 +21,12 @@ import { verdictFor, type Run } from "./verdict";
  * What the ladder needs of a run, which is less than a whole `Session`.
  *
  * `verdictFor`'s `Run` — what the child did — plus the string the run is filed
- * under, which is what says *which* lesson they did it on. Nothing here wants
- * an id or a `finishedAt`, and asking for them would cost something real: the
- * badge evaluator (`engine/progress.ts`) asks this about the run that has just
- * finished, before the session service has written it and given it either
- * field. A ladder that insisted would have made that caller cast, and a cast
- * is a promise nobody checks.
- *
- * Every other caller hands over real `Session`s, which are `LadderRun`s.
+ * under, which is what says *which* lesson they did it on. Asking for an id or
+ * a `finishedAt` on top would cost something real: the badge evaluator
+ * (`engine/progress.ts`) asks this about the run that has just finished,
+ * before the session service has written it and given it either field. A
+ * ladder that insisted would have made that caller cast, and a cast is a
+ * promise nobody checks.
  */
 export type LadderRun = Run & Pick<Session, "mode">;
 
@@ -50,26 +40,13 @@ export type LadderProgress = {
    * standing in the way (§8.8) and capped at the top of the ladder. On a
    * profile with no runs at all it is 1.
    *
-   * **It is not the whole unlock rule.** A screen that opens a tile on
+   * **It is not the whole unlock rule**, and a screen that opens a tile on
    * `n <= next` alone is wrong in the direction that locks a child out. A
-   * lesson is openable when *either* of these holds (§6.6):
-   *
-   *   - **`n <= next`** — everything up to and including the pointer, the
-   *     storm levels it stepped over included. The pointer is carried over
-   *     them rather than made to jump, so a storm stays playable: skippable
-   *     is not the same as skipped, and no storm level ever gates the lesson
-   *     after it (decision 24).
-   *   - **the lesson is a checkpoint** (`lesson.checkpoint`, every tenth —
-   *     10, 20 … 100). **All ten are always open**, at every value of `next`,
-   *     including on a profile that has never run anything (decision 16).
-   *     That is the placement test: a nine-year-old who already types opens
-   *     checkpoint 40, passes it, and starts at 41 — rather than being sent
-   *     to `fff jjj` for a week. Gate the checkpoints on `next` and that
-   *     express lane is gone, with nothing on screen looking broken.
-   *
-   * Nothing else gates, and a failed attempt costs nothing (§6.6), so opening
-   * a checkpoint early is free — which is what makes "just try one" the
-   * whole of the levelling advice.
+   * lesson is openable when *either* `n <= next` — the storm levels the
+   * pointer stepped over included — *or* it is a checkpoint: all ten are open
+   * at every value of `next`, on a profile that has never run anything
+   * included, which is what makes the placement test work (§6.6, decisions 16
+   * and 24). Nothing else gates, and a failed attempt costs nothing.
    */
   next: number;
 };
@@ -78,11 +55,11 @@ export type LadderProgress = {
  * The ladder by the string a saved run is filed under, which is what a session
  * carries: `Session.mode` is `typing:L07` for a lesson (§5.4).
  *
- * Keyed on the whole mode rather than on the id inside it so that the two
+ * Keyed on the whole mode rather than on the id inside it, so the two
  * namespaces behind the `typing:` prefix cannot answer for each other. A run
  * of the `home-row` level is not lesson 7 and misses this map, which is the
- * right answer rather than a case to handle: the ladder is the hundred, and a
- * level, a drill or a spelling race is simply not on it.
+ * right answer rather than a case to handle: a free-play level, a drill or a
+ * spelling race is simply not on the ladder.
  */
 const BY_MODE = new Map(
   LESSONS.map((lesson) => [typingMode(lesson.id), lesson]),
@@ -92,18 +69,12 @@ const BY_MODE = new Map(
 const LAST = LESSONS.reduce((top, lesson) => Math.max(top, lesson.n), 0);
 
 /**
- * The first lesson above `best` that can actually hold a child up (§8.8).
+ * The first lesson above `best` that can actually hold a child up.
  *
  * A Hailstorm level never gates: lesson 46 opens when 44 is cleared, whatever
- * happened at 45. Two reasons and either alone is sufficient (decision 24) —
- * **a tablet has no keys to press**, so a child on an iPad who can do the whole
- * course cannot play the game and would be locked out at lesson 4; and **a
- * reward that blocks you is not a reward**, which is the opposite of what the
- * storm levels were put on the ladder for.
- *
- * So the pointer is carried over them. It is carried rather than made to jump:
- * everything at or below `next` is open, so a storm it steps over stays
- * playable — skippable is not the same as skipped.
+ * happened at 45 (§8.8, decision 24). The pointer is carried over them rather
+ * than made to jump, so everything at or below `next` is open and a storm it
+ * steps over stays playable — skippable is not the same as skipped.
  */
 function carriedOverStorms(best: number): number {
   let next = best + 1;
@@ -117,44 +88,31 @@ function derive(sessions: readonly LadderRun[]): LadderProgress {
   for (const session of sessions) {
     const lesson = BY_MODE.get(session.mode);
     // `verdictFor` walks every card of the run, and there is nothing to learn
-    // from a second pass at a lesson already cleared — so what the `cleared`
-    // guard buys is that repeat passes are free, however many times a child
-    // replays a lesson they have beaten. Runs of a lesson *not* yet cleared
-    // each still pay a verdict, retries included, until one of them clears it.
+    // from a second pass at a lesson already cleared — so replaying a beaten
+    // lesson is free, however many times. Runs of a lesson *not* yet cleared
+    // each still pay a verdict, retries included, until one clears it.
     if (!lesson || cleared.has(lesson.n)) continue;
     // ── A lesson is cleared by a run that says it IS that lesson ───────────
     // The mode is not enough on its own. `buildDrill` files a practice deck
     // under the mode it came from, so the drill a child takes from lesson 41's
     // results — or from the finger a storm broke (§8.5) — is also
-    // `typing:L41`: ten to forty words of trouble keys, with its own
-    // `wordCount`, that would otherwise clear the lesson it was offered from
-    // without the lesson ever being run. `lessonId` is the discriminator §5.4
-    // put on the config for exactly this, and `progress.ts` already reads the
-    // badges off it rather than off the mode; this is the same rule, one
-    // module over. A run from before the ladder existed carries no `lessonId`
-    // and no lesson mode either, so nothing already saved changes.
+    // `typing:L41`: ten to forty words of trouble keys that would otherwise
+    // clear the lesson it was offered from without the lesson ever being run.
+    // `lessonId` is the discriminator §5.4 put on the config for exactly this,
+    // and `progress.ts` reads the badges off it for the same reason. A run
+    // from before the ladder existed carries neither, so nothing already saved
+    // changes.
     if (session.config?.kind !== "typing") continue;
     if (session.config.lessonId !== lesson.id) continue;
-    // A `Session` is a `Run`: what passes a lesson is what the child did, not
-    // which profile did it or when.
     if (verdictFor(session, lesson).passed) cleared.add(lesson.n);
   }
 
   // ── Unlock is `max(cleared) + 1`, not `count(cleared)` (§6.6) ─────────────
-  // Counting would be brittle in a way that only shows up years in:
-  // `MAX_SESSIONS_PER_PROFILE` prunes the *oldest* sessions, so a child 2000
-  // runs in loses the proof that they ever passed lesson 1 and would be sent
-  // back to `fff jjj` by a tally. Taking the maximum means losing old proof
-  // costs nothing as long as one later run survives.
-  //
-  // It is also the whole of the placement test. **Any checkpoint may be
-  // attempted at any time** (decision 16), and passing one sets `best` to its
-  // number, which clears everything below it by this same line — a
-  // nine-year-old who already types opens checkpoint 40, passes it and starts
-  // at 41. That is a skip-ahead, a placement test and the ordering rule in one
-  // sentence, and it is one sentence precisely because nothing here treats a
-  // checkpoint specially. Nor does the loop above ask whether a lesson was
-  // unlocked when it was run: failing costs nothing, so trying one is free.
+  // Counting would be brittle in a way that only shows up years in, because
+  // `MAX_SESSIONS_PER_PROFILE` prunes the *oldest* sessions. Taking the
+  // maximum is also what makes the placement test a line rather than a case,
+  // since passing checkpoint 40 clears 1–39 with it. Nor does the loop above
+  // ask whether a lesson was unlocked when it was run: trying one is free.
   let best = 0;
   for (const n of cleared) best = Math.max(best, n);
 
@@ -169,9 +127,9 @@ function derive(sessions: readonly LadderRun[]): LadderProgress {
  * from — weakly, so a profile switch or a reload drops it with the sessions
  * themselves. The array is the whole key: the ladder and its criteria are
  * fixed at module load, so the same sessions can only ever mean the same
- * progress in one build. Callers slicing per profile should hold that slice
- * still (a `useMemo`, as the progress screens already do), or every render
- * hands over a fresh array and pays for the pass again.
+ * progress in one build. **Callers slicing per profile must hold that slice
+ * still** (a `useMemo`, as the progress screens do), or every render hands
+ * over a fresh array and pays for the pass again.
  */
 const MEMO = new WeakMap<readonly LadderRun[], LadderProgress>();
 

--- a/src/engine/typing/lessons.test.ts
+++ b/src/engine/typing/lessons.test.ts
@@ -5,13 +5,8 @@ import type { Lesson } from "./lessons";
 import { strokeFor } from "../keyboard";
 
 /**
- * The cheap tests that catch the embarrassing failures (docs/typing.md §12).
- *
- * The expensive ones — reachability, and "the new key shows up often enough" —
- * belong to the generator and cannot be written until it exists. What can be
- * written now is everything the table itself claims: that it is a hundred
- * lessons, numbered once each, with the checkpoints where the blocks say they
- * are and the keyboard off when it has to be.
+ * What the table itself claims (§12). Reachability and "the new key shows up
+ * often enough" belong to the generator, and live in `generate.test.ts`.
  */
 
 const byN = new Map(LESSONS.map((l) => [l.n, l]));
@@ -45,10 +40,9 @@ describe("the shape of the ladder", () => {
   });
 
   /**
-   * The id is what goes into `Session.mode` as `typing:L07`, so it outlives
-   * every re-tuning of the lesson it names. Pinning the format here is pinning
-   * a promise to runs already saved: change it and a record book two years old
-   * stops being able to say what it is looking at.
+   * The id is what goes into `Session.mode` as `typing:L07`, so pinning the
+   * format is pinning a promise to runs already saved: change it and a record
+   * book two years old stops being able to say what it is looking at.
    */
   it("writes the id as L + the number, two digits", () => {
     expect(lesson(1).id).toBe("L01");
@@ -58,10 +52,9 @@ describe("the shape of the ladder", () => {
   });
 
   /**
-   * The other half of that promise: the id has to resolve back. A screen asks
-   * "is this run a lesson?" with a config in hand and gets the lesson or
-   * nothing — never a throw, because a saved run outlives the ladder it was
-   * played on and every one of these three cases reaches a live screen.
+   * The id has to resolve back, and never throw: a saved run outlives the
+   * ladder it was played on, and every one of these three cases reaches a live
+   * screen.
    */
   it("resolves an id back to its lesson, and anything else to null", () => {
     expect(lessonById("L07")).toBe(lesson(7));
@@ -97,10 +90,9 @@ describe("checkpoints", () => {
   });
 
   /**
-   * A checkpoint that can be passed while reading the answer off the screen
-   * measures nothing (§4.2), and a checkpoint is the placement test — passing
-   * number 40 clears 1–39 with it (§6.6). So the board is off and the player's
-   * own toggle cannot turn it back on.
+   * A checkpoint is the placement test, so it cannot be passed with the answer
+   * on screen (§4.2, §6.6) — hence the board off *and* the player's toggle
+   * locked.
    */
   it("hides the keyboard, and does not let the player show it", () => {
     for (const l of LESSONS.filter((l) => l.checkpoint)) {
@@ -163,12 +155,9 @@ describe("the keys, and the order they arrive in", () => {
   });
 
   /**
-   * Mirrored pairs, one per hand, through the three letter blocks (§5.5).
-   *
-   * `f`/`j` are the index home keys and `d`/`k`, `s`/`l`, `a`/`;` walk outward
-   * together — the same finger on each hand, every time. It keeps the hands
-   * balanced and it teaches the symmetry, which is what makes the bottom row
-   * guessable by the time a child reaches it.
+   * Mirrored pairs, one per hand, through the three letter blocks (§5.5):
+   * `f`/`j`, then `d`/`k`, `s`/`l`, `a`/`;` walking outward — the same finger
+   * on each hand, every time.
    */
   it("hands the letters over one finger at a time, both hands at once", () => {
     const letterBlocks = LESSONS.filter(
@@ -187,11 +176,10 @@ describe("the keys, and the order they arrive in", () => {
   });
 
   /**
-   * The number row is the deliberate exception, and this is the rule it
-   * follows instead: each pair straddles the centre of the board, so the two
-   * digits always sum to nine. `4 5` are both the left index's and `9 0` are
-   * the right ring and pinky — the standard assignment, not a slip, which is
-   * why the mirrored-hand test above stops at block 3.
+   * The number row is the exception to the pair above, which is why that one
+   * stops at block 3: each pair straddles the centre of the board and so sums
+   * to nine. `4 5` are both the left index's, `9 0` the right ring and pinky —
+   * the standard assignment, not a slip.
    */
   it("walks the number row outward from the middle of the board", () => {
     const digits = LESSONS.filter((l) => l.block === 6 && l.introduces.length);
@@ -220,11 +208,9 @@ describe("the pass criteria", () => {
   });
 
   /**
-   * The gate that turns a hundred typing tests into a hundred lessons (§6.4):
-   * `z` is 3% of the text, so 95% and 12 wpm can both be met while getting it
-   * wrong every single time it appears. It only has to be askable — a lesson
-   * that wanted twelve strikes of each of fifteen new capitals would want a
-   * hundred and eighty of them in a hundred and fifty characters.
+   * §6.4's gate, and the ceiling on it: twelve strikes of each of fifteen new
+   * capitals would want a hundred and eighty of them in a hundred and fifty
+   * characters, which is what the last assertion sizes.
    */
   it("asks for enough of each new key to judge it, and no more than fits", () => {
     for (const l of LESSONS) {
@@ -247,16 +233,11 @@ describe("the pass criteria", () => {
 
 describe("the speed bar", () => {
   /**
-   * Read the wpm column down the page and it does NOT climb smoothly — it
-   * drops every time a key arrives and climbs back over the review lessons
-   * after it. Lesson 50 asks 25 and lesson 51 asks 16 (§6.3, decision 11).
-   *
-   * So the non-decreasing claim is about BLOCKS, and only the blocks that
-   * introduce nothing: 5, 8, 9 and 10 are forty lessons of pure practice, and
-   * speed is the only thing left for them to be about. Reading it per lesson
-   * would be false even inside those blocks — 44 is harder material than 43
-   * and 97 is the accuracy run — and a test that asserted it would be a test
-   * that has to be deleted the first time someone reads the doc.
+   * The wpm column does not climb smoothly — it drops every time a key arrives
+   * and climbs back over the review lessons after it (§6.3, decision 11). So
+   * the non-decreasing claim is about BLOCKS, and only the four that introduce
+   * nothing; per lesson it would be false even inside those, since 44 is
+   * harder material than 43 and 97 is the accuracy run.
    */
   const checkpointWpm = (block: number) => wpmOf(lesson(block * 10)) ?? 0;
 
@@ -288,10 +269,8 @@ describe("the speed bar", () => {
   });
 
   /**
-   * The dip, pinned so nobody smooths it out. A lesson that introduces keys
-   * targets about 80% of its block's running figure: you have just got slower
-   * and you should have, and a ladder that pretended otherwise would punish
-   * the exact moment it should encourage.
+   * The dip, pinned so nobody smooths it out: a lesson that introduces keys
+   * targets about 80% of its block's running figure.
    */
   it("drops below the block's own figure whenever keys arrive", () => {
     for (const l of LESSONS.filter((l) => l.introduces.length > 0)) {

--- a/src/engine/typing/lessons.ts
+++ b/src/engine/typing/lessons.ts
@@ -4,33 +4,16 @@ import type { WaveSpec } from "./storm";
 /**
  * The hundred lessons of Frost Keys, as data (docs/typing.md §5).
  *
- * A lesson declares what it is *for* — which keys it puts under the fingers,
- * how long it runs, how much of the keyboard is on screen and what passing it
- * means — and the words are generated from that rather than written out. A
- * hundred hand-written pools would be a hundred chances to use a letter the
- * child hasn't met yet; a hundred specs is one array, and re-ordering the
- * ladder is editing it (§5.1).
+ * A lesson declares what it is *for* and its text is generated from that
+ * (§5.1). The unlocked alphabet at lesson n is computed from `introduces`
+ * rather than written down here — that is `keys.ts`'s job — which is what lets
+ * a lesson carry its words with it when it moves.
  *
- * The **unlocked alphabet** at lesson n is the union of `introduces` over
- * lessons 1…n, plus space. It is computed rather than written down — that is
- * `engine/typing/keys.ts`'s job — which is what lets a lesson carry its words
- * with it when it moves.
- *
- * ── Why there is no text in this file ───────────────────────────────────────
- * `engine/decks/typing.ts` imports this module to label a saved run:
- * `deckSpec("typing:L07")` has to name lesson 7 in a record book two years
- * from now, long after the ladder has been re-tuned. And `decks/index.ts` is
- * the front door for every island on the site — flash cards, spelling, the
- * record book, the print shop — so a module in its graph is shipped to all of
- * them, whole.
- *
- * The last time that was got wrong, an import of the passage library from
- * `decks/typing.ts` took the shared chunk from 46 KB to 222 KB, which is why
- * thirty-three verses are written out by hand in that file today. This is the
- * same trap one file over. So: titles, key sets and pass criteria, and not one
- * word a child ever types. The corpus lives in `engine/typing/lexicon.ts` and
- * the generator in `generate.ts`, and neither may ever become reachable from
- * here (§5.3, decision 7).
+ * This is the one module in `engine/typing/` the deck layer may import, so
+ * that `deckSpec("typing:L07")` can name lesson 7 in a record book years from
+ * now. It therefore holds titles, key sets and pass criteria and not one word
+ * a child ever types: neither `lexicon.ts` nor `generate.ts` may ever become
+ * reachable from here (§5.3, decision 7).
  */
 
 /**
@@ -59,15 +42,12 @@ export type LessonKind =
   /** Short and fast — the speed bar moved up and the length cut down. */
   | { type: "sprint" }
   /**
-   * A Hailstorm level, and the storm it is (§8, §5.6's storm table).
+   * A Hailstorm level, and the storm it is (§8, §5.7).
    *
    * The wave is a `WaveSpec` **minus its keys** (`StormShape` below, decision
-   * 56), which is the whole of how "a storm can never ask for a key the ladder
-   * has not taught" is kept: there is nowhere in the table to write one down.
-   * `storms.ts` composes the real spec by drawing the pool from
-   * `unlockedAt(n)` — the same computed alphabet every lesson's words come
-   * from (§5.2) — so moving a storm up the ladder moves what falls in it, and
-   * a level cannot be given a key by hand.
+   * 56): there is nowhere in the table to write a character down, so
+   * `storms.ts` can only draw the pool from `unlockedAt(n)` and a storm can
+   * never rain a key the ladder has not taught.
    */
   | { type: "storm"; wave: StormShape };
 
@@ -75,13 +55,10 @@ export type LessonKind =
  * Which class of character a storm level is *about*, or absent for one that is
  * about everything.
  *
- * §8.3 leaves repeats in `spec.keys` meaning "this falls more often", and this
- * is the curriculum's half of that: "Hailstorm · Digits" has to rain digits
- * and not one digit in six. The classes are named rather than written out as
- * characters for the same reason `introduces` is per lesson — the pool is
- * always a filter over what the ladder has taught by then, so a focus can only
- * ever weight keys a child already has. `storms.ts` decides what each name
- * matches.
+ * A named class rather than the characters themselves, because the pool is
+ * always a filter over what the ladder has taught by then — so a focus can
+ * only ever weight keys a child already has. `storms.ts` decides what each
+ * name matches, and §5.7 what the weighting comes to.
  */
 export type StormFocus = "capitals" | "digits" | "marks";
 
@@ -98,26 +75,15 @@ export type StormFocus = "capitals" | "digits" | "marks";
  */
 export type StormShape = Omit<WaveSpec, "keys"> & {
   /**
-   * The seed this level's weather comes from (decision 58).
-   *
-   * A Hailstorm level is a *level*, so it is the same storm every time it is
-   * opened — the twenty waves that ship are the twenty a child meets, and the
-   * twenty the no-strobe rule is measured on (§8.10). "Try this wave again"
-   * already meant the same letters in the same lanes; this is the same promise
-   * across two visits instead of two attempts.
+   * The seed this level's weather comes from (decision 58): the same storm
+   * every time it is opened, not merely the same on a retry.
    */
   seed: number;
   /** The characters this level rains, over the ones it merely includes. */
   focus?: StormFocus;
 };
 
-/**
- * What passing looks like, in three bars rather than one score (§6.1).
- *
- * Three because a single number tells a seven-year-old that they failed and
- * not what to do. "Fast enough, not accurate enough" and "you have `x` but not
- * `z`" are instructions; a blended net-WPM is not.
- */
+/** What passing looks like, in three bars rather than one score (§6.1). */
 export type PassCriteria =
   | {
       kind: "lesson";
@@ -129,10 +95,8 @@ export type PassCriteria =
        * Each newly-introduced key, at least this fraction correct…
        *
        * Inert on a lesson that introduces nothing — the verdict's `keys` array
-       * is one bar per introduced character, so on a review or a checkpoint it
-       * is empty and these two are never read. They are still filled in, so
-       * that a lesson which grows an `introduces` later is gated the moment it
-       * does.
+       * is empty there and these two are never read. Filled in anyway, so a
+       * lesson that grows an `introduces` later is gated the moment it does.
        */
       keyAccuracy: number;
       /** …over at least this many strikes. The generator guarantees enough. */
@@ -183,13 +147,10 @@ const CHARS_PER_WORD = 5;
 const MAX_NEW_KEY_SHARE = 0.35;
 
 /**
- * The accuracy bar on a Hailstorm level.
- *
- * §5.6 prints — in that column because the column belongs to a passage and a
- * storm is not one: what it measures is single-key reaction, so its bar is the
- * new-key gate's figure rather than a passage's 95%. It is also the one bar on
- * the ladder that opens no door — a storm level can never gate a lesson (§8.8,
- * decision 24) — so this is a line on a results screen and nothing more.
+ * The accuracy bar on a Hailstorm level: the new-key gate's figure rather than
+ * a passage's 95%, because what a storm measures is single-key reaction
+ * (§5.6). It is also the one bar on the ladder that opens no door (§8.8,
+ * decision 24), so it is a line on a results screen and nothing more.
  */
 const STORM_ACCURACY = NEW_KEY_ACCURACY;
 
@@ -197,15 +158,13 @@ const STORM_ACCURACY = NEW_KEY_ACCURACY;
  * How many strikes of each new character the gate waits for.
  *
  * Twelve (§6.4) wherever twelve fits, which is every lesson that arrives two
- * keys at a time: 24 strikes in a 24-word lesson is a fifth of the characters,
- * comfortably inside §5.2's band. Four lessons hand over more than a pair at
- * once — 31, 32, 67 and 68 — and three of them cannot also ask twelve of each:
- * lesson 31 introduces fifteen capitals, and 15 × 12 is 180 strikes in 150
- * characters, so there the demand is divided between them instead of being made
- * unreachable. Lesson 68's four keys still fit twelve apiece inside its 175,
- * which is why the ceiling is a `min` against the room rather than a rule about
- * how many keys arrived. Two is the floor: below it the gate cannot tell a
- * typist from a lucky guess.
+ * keys at a time. Four hand over more at once — 31, 32, 67 and 68 — and three
+ * of those cannot also ask twelve of each: lesson 31's fifteen capitals would
+ * want 180 strikes in 150 characters, so there the demand is divided between
+ * them instead of being made unreachable. Lesson 68's four keys still fit
+ * twelve apiece inside its 175, which is why the ceiling is a `min` against
+ * the room rather than a rule about how many keys arrived. Two is the floor:
+ * below it the gate cannot tell a typist from a lucky guess.
  */
 function strikesFor(introduces: string[], wordCount: number): number {
   if (introduces.length === 0) return NEW_KEY_STRIKES;
@@ -217,19 +176,16 @@ function strikesFor(introduces: string[], wordCount: number): number {
 }
 
 /**
- * What each `bigrams` lesson drills.
+ * What each `bigrams` lesson drills. Four of the six are their own title in
+ * §5.6; the other two are named by description there, and "the hard pairs" is
+ * not a spec:
  *
- * Four of the six are named by their own title in §5.6 and are transcribed
- * from it. The other two are named by description, and are written down here
- * because a spec that says "the hard pairs" is not a spec:
- *
- *   - **8 · Pairs that repeat** is the doubled letters, and at lesson 8 the
- *     alphabet is still `a s d f g h j k l ;` — so `ll`, `ss` and `dd` are all
- *     of them there are (all, hall, glass, add).
- *   - **44 · The hard pairs** is the *same-finger* bigrams, which is what makes
+ *   - **8 · Pairs that repeat** — the doubled letters, and at lesson 8 the
+ *     alphabet is still `a s d f g h j k l ;`, so `ll`, `ss` and `dd` are all
+ *     of them there are.
+ *   - **44 · The hard pairs** — the *same-finger* bigrams, which is what makes
  *     a pair hard rather than which letters it uses: `ed` is both the left
- *     middle finger, `ju` both the right index. They are the sequences a fast
- *     typist still slows down on, which is exactly what a fluency block is for.
+ *     middle finger, `ju` both the right index.
  */
 const BIGRAMS: Record<number, string[]> = {
   8: ["ll", "ss", "dd"],
@@ -255,11 +211,10 @@ type Keyboard = KeyboardMode | `${KeyboardMode}!`;
  * One row of §5.6, in the doc's own column order: number, title, new keys,
  * kind, keyboard, words, wpm, accuracy.
  *
- * A tuple rather than an object because this is read as a table. A hundred
+ * A tuple rather than an object because this is read as a table: a hundred
  * rows of `{ n: 7, title: "…", wordCount: 25 }` is the same data with ten
  * times the punctuation, and a column that has drifted out of line is
- * invisible in it. Keeping the shape of the doc is what lets the two be
- * checked against each other by eye.
+ * invisible in it.
  *
  * `n` is data rather than the array index on purpose: it is half of the id
  * that goes into `Session.mode` and outlives any re-ordering, so "1–100 with
@@ -283,10 +238,10 @@ type LessonRow = readonly [
  * column is the wave's `count`, which `toLesson` reads out of `STORM_WAVES`.
  *
  * The wave is a table of its own rather than six more columns here, exactly as
- * §5.6 prints it: a storm's numbers are read against *each other* — a `gap`
+ * the doc splits it: a storm's numbers are read against *each other* — a `gap`
  * means nothing except beside the `fall` it does or does not clear — where a
  * lesson's columns are read down the page against the same column on the rows
- * above. Two tables, each shaped like the thing it is.
+ * above.
  */
 type StormRow = readonly [
   n: number,
@@ -299,33 +254,22 @@ type StormRow = readonly [
 type Row = LessonRow | StormRow;
 
 /**
- * The hundred, transcribed from docs/typing.md §5.6.
- *
- * Three things to know before editing it:
+ * The hundred, transcribed from docs/typing.md §5.6. Three things an editor
+ * needs before touching a column:
  *
  *   - **The wpm column drops every time keys arrive** and climbs back over the
- *     review lessons after it. Lesson 50 asks 25 and lesson 51 asks 16. That is
- *     §6.3 and decision 11 written into the data: you have just got slower and
- *     you should have, and a ladder that pretended otherwise would punish the
- *     exact moment it should encourage. Do not smooth it out.
+ *     review lessons after it (§6.3, decision 11). Do not smooth it out.
  *   - **Keys arrive in mirrored pairs, one per hand** through the three letter
- *     blocks — `f`/`j` are the index home keys and `d`/`k`, `s`/`l`, `a`/`;`
- *     walk outward together, which is what makes the bottom row guessable by
- *     the time you reach it (§5.5). The number row is the deliberate exception:
- *     it walks outward from the centre of the *board* instead, so `4 5` are
- *     both the left index's and `9 0` are the right ring and pinky. That is
- *     the standard finger assignment, not a slip.
+ *     blocks (§5.5). The number row is the deliberate exception: it walks
+ *     outward from the centre of the *board* instead, so `4 5` are both the
+ *     left index's and `9 0` are the right ring and pinky. That is the
+ *     standard finger assignment, not a slip.
  *   - **The tenth of every block is a checkpoint**, always `off` and always
- *     locked: a checkpoint that can be passed while reading the answer off the
- *     screen measures nothing (§4.2). Lesson 1 is locked the other way, to
- *     `guide`, because a child who has never seen a keyboard cannot be asked
- *     to guess.
+ *     locked (§4.2). Lesson 1 is locked the other way, to `guide`, because a
+ *     child who has never seen a keyboard cannot be asked to guess.
  */
 const ROWS: readonly Row[] = [
   // ── Block 1 · Home row ─────────────────────────────────────────────────────
-  // No English word can be spelled in `f j d k s l`, so words cannot start
-  // until lesson 7 — and that is why lesson 4 is a storm level. The first
-  // thing that is *fun* arrives before the first thing that is a word (§5.5).
   [1, "Two keys", "fj", "keys", "guide!", 20, 8, 95],
   [2, "Four keys", "dk", "keys", "guide!", 20, 8, 95],
   [3, "Six keys", "sl", "keys", "guide!", 24, 9, 95],
@@ -350,10 +294,6 @@ const ROWS: readonly Row[] = [
   [20, "Checkpoint · Two rows", "", "words", "off!", 35, 15, 97],
 
   // ── Block 3 · Reaching down ────────────────────────────────────────────────
-  // The comma and the full stop come in with the bottom row because that is
-  // where they physically are. It costs nothing, and it means real sentences
-  // are available at the end of this block rather than needing a lesson of
-  // their own (§5.5).
   [21, "Down to v and m", "vm", "keys", "guide!", 26, 11, 95],
   [22, "c, and the comma", "c,", "keys", "guide!", 26, 11, 95],
   [23, "Hailstorm · Down low", "", "storm", "guide"],
@@ -367,10 +307,9 @@ const ROWS: readonly Row[] = [
 
   // ── Block 4 · Capitals ─────────────────────────────────────────────────────
   // A shift is not a character, so what these two lessons introduce is the set
-  // of capitals each one *reaches*: the right shift is held by the right pinky
-  // and capitalises the left hand's letters, and the left shift the right
-  // hand's. Two lessons, twenty-six characters, and the opposite-hand rule
-  // taught as the only way either of them works.
+  // of capitals each one *reaches* — the right shift capitalises the left
+  // hand's letters and the left shift the right hand's. `keys.ts` reads the
+  // shifts back out of these two rows; there is nowhere else they are written.
   [31, "The right shift", "QWERTASDFGZXCVB", "keys", "guide!", 30, 13, 95],
   [32, "The left shift", "YUIOPHJKLNM", "keys", "guide!", 30, 13, 95],
   [33, "Names, and the word I", "", "words", "guide", 35, 15, 95],
@@ -383,10 +322,9 @@ const ROWS: readonly Row[] = [
   [40, "Checkpoint · Real sentences", "", "sentences", "off!", 45, 20, 97],
 
   // ── Block 5 · Fluency ──────────────────────────────────────────────────────
-  // Nothing new arrives here, so speed is the lesson and the bar climbs
-  // fastest (§6.3). It does not climb *monotonically*: 44 and 47 ask for less
-  // than the lesson before them because harder material is the point of them,
-  // not because the column slipped.
+  // The bar climbs fastest here (§6.3) but not *monotonically*: 44 and 47 ask
+  // for less than the lesson before them because harder material is the point
+  // of them, not because the column slipped.
   [41, "The twenty-five", "", "words", "keys", 40, 18, 95],
   [42, "th · he · in · er", "", "bigrams", "keys", 40, 19, 95],
   [43, "an · re · on · at · en", "", "bigrams", "keys", 40, 20, 95],
@@ -399,8 +337,6 @@ const ROWS: readonly Row[] = [
   [50, "Checkpoint · Fluent", "", "passage", "off!", 60, 25, 97],
 
   // ── Block 6 · Numbers ──────────────────────────────────────────────────────
-  // 50 asks 25 wpm and 51 asks 16. The number row is a fresh reach for every
-  // finger and the bar drops to meet it, all the way back to block 3's pace.
   [51, "Four and five", "45", "keys", "guide!", 30, 16, 95],
   [52, "Three and six", "36", "keys", "guide!", 30, 16, 95],
   [53, "Hailstorm · Digits", "", "storm", "guide"],
@@ -413,12 +349,10 @@ const ROWS: readonly Row[] = [
   [60, "Checkpoint · Numbers", "", "mixed", "off!", 50, 22, 97],
 
   // ── Block 7 · Punctuation ──────────────────────────────────────────────────
-  // Two rows re-introduce a character the ladder already unlocked: `;` arrived
-  // at lesson 5 as a home key and `/` at lesson 25 as a bottom-row reach, and
-  // both come back here in their punctuation role. The unlocked alphabet is a
-  // union, so saying it twice changes nothing about what a child may type; what
-  // it does is put the character back under the new-key gate, which is the
-  // point — knowing where `;` is and knowing what it is for are two lessons.
+  // Two rows re-introduce a character the ladder already unlocked — `;` from
+  // lesson 5, `/` from lesson 25 — in their punctuation role. The unlocked
+  // alphabet is a union, so saying it twice changes nothing about what a child
+  // may type; what it does is put the character back under the new-key gate.
   [61, "Asking and shouting", "?!", "keys", "guide!", 35, 18, 95],
   [62, "Speech marks", '"', "keys", "guide!", 35, 18, 95],
   [63, "Hyphen and underscore", "-_", "keys", "guide!", 35, 19, 95],
@@ -431,12 +365,11 @@ const ROWS: readonly Row[] = [
   [70, "Checkpoint · Punctuated", "", "passage", "off!", 55, 24, 97],
 
   // ── Block 8 · Endurance ────────────────────────────────────────────────────
-  // Length is the variable. The accuracy bar moves to 96% for the block — the
-  // first of several places §6.2's flat 95/97 line bends: holding a rate over
-  // a hundred words is a different thing from holding it over thirty. Block
-  // 9's checkpoint (90) bends the same way, so does block 10's prose (91–96),
-  // and lesson 97 bends the other way at 99%. An accuracy column "corrected"
-  // back to a flat 95/97 would be wrong from here to the end of the ladder.
+  // The accuracy bar moves to 96% here — the first of several places §6.2's
+  // flat 95/97 line bends. Block 9's checkpoint (90) bends the same way, so
+  // does block 10's prose (91–96), and lesson 97 bends the other way at 99%.
+  // An accuracy column "corrected" back to a flat 95/97 would be wrong from
+  // here to the end of the ladder.
   [71, "Sixty words", "", "passage", "off", 60, 22, 96],
   [72, "A whole paragraph", "", "passage", "off", 70, 23, 96],
   [73, "Hailstorm · The long wave", "", "storm", "off"],
@@ -449,9 +382,6 @@ const ROWS: readonly Row[] = [
   [80, "Checkpoint · A hundred words", "", "passage", "off!", 100, 28, 97],
 
   // ── Block 9 · Speed ────────────────────────────────────────────────────────
-  // Its checkpoint asks 96% rather than 97%: thirty-five words a minute is the
-  // whole subject of the block, and the point it trades away is the price of
-  // asking for it.
   [81, "Sprint · Common words", "", "sprint", "off", 30, 28, 95],
   [82, "Sprint · Alternating hands", "", "sprint", "off", 30, 30, 95],
   [83, "Hailstorm · Hard rain", "", "storm", "off"],
@@ -464,9 +394,6 @@ const ROWS: readonly Row[] = [
   [90, "Checkpoint · Thirty-five", "", "passage", "off!", 80, 35, 96],
 
   // ── Block 10 · Everything ──────────────────────────────────────────────────
-  // Lesson 97 is the one lesson that asks for 99%, at a deliberately modest
-  // pace, so that "slow down and get it right" is something the ladder has
-  // said out loud at least once (§6.2).
   [91, "Mixed prose", "", "passage", "off", 90, 30, 96],
   [92, "Prose with numbers", "", "mixed", "off", 90, 30, 96],
   [93, "Hailstorm · Everything falls", "", "storm", "off"],
@@ -480,14 +407,13 @@ const ROWS: readonly Row[] = [
 ];
 
 /**
- * One storm, as §5.6's storm table writes it: the six numbers that make a
- * level, its seed, and the class of character it is about.
+ * One storm, as §5.7's table writes it: the six numbers that make a level, its
+ * seed, and the class of character it is about.
  *
- * Positional for the same reason `LessonRow` is — this is read as a table, and
- * a column out of line is invisible in twenty objects of seven fields. The
- * ranges are flat pairs because that is how they are read: `gap` against
- * `fall` is the whole difficulty shape (§8.3), and the eye compares two
- * columns down the page rather than two brackets across a row.
+ * Positional for the same reason `LessonRow` is. The ranges are flat pairs
+ * because that is how they are read: `gap` against `fall` is the whole
+ * difficulty shape (§8.3), and the eye compares two columns down the page
+ * rather than two brackets across a row.
  */
 type StormWaveRow = readonly [
   n: number,
@@ -503,33 +429,14 @@ type StormWaveRow = readonly [
 ];
 
 /**
- * The twenty storms (docs/typing.md §5.6's storm table, §8.3).
+ * The twenty storms (§5.7, §8.3), which is where the shape of every column is
+ * argued: where `gap` clears `fall`, where the ladder eases, where the repairs
+ * stop, and why no row may ask for a fall under `MIN_FALL_MS`. It does not
+ * climb smoothly and must not be smoothed.
  *
- * Four things about the shape of it, and none of them is arbitrary:
- *
- *   - **`gap` clears `fall` at the top of the ladder and overlaps below it.**
- *     Lessons 4, 9 and 13 never put two letters on screen — pure reaction —
- *     and from 19 on they stack, which is reading ahead. Both halves are
- *     asserted off the *built* schedule in `storms.test.ts`, because
- *     `MIN_FALL_MS` can raise a fall and turn a spacing promise into an
- *     overlap (§8.10, decision 52).
- *   - **It does not climb smoothly, and must not be smoothed.** Lesson 53's
- *     storm eases where the number row has just arrived, exactly as the wpm
- *     column does (§6.3, decision 11); lesson 73 is long where 79 is dense.
- *     What climbs is each *quarter* of the twenty, which is what the test
- *     holds it to.
- *   - **The repairs stop at 79 and never come back.** "No repairs" is that
- *     level's name and the block's turn: below it the weakest zone mends every
- *     `repairAt` clean hits, above it what breaks stays broken.
- *   - **No row asks for a fall under `MIN_FALL_MS`.** The floor is a backstop
- *     and not a knob (decision 52); a row that went under it would come out of
- *     `fallRange` as a metronome at 800ms and quietly not be what it says.
- *
- * The seed is the level's own number, or the first above it whose wave keeps
- * the level's promises — no zone tinting more than twice a second (§8.10), six
- * of the eight fingers used, and no finger taking more than a third of the
- * letters. Six of the twenty needed the bump; `storms.test.ts` re-derives all
- * twenty rather than trusting the column (decision 58).
+ * The doc's table is the one being checked and this is what it is checked
+ * against: `storms.test.ts` reads §5.7 off disk and compares it cell by cell,
+ * and re-derives every seed rather than trusting the column (decision 58).
  */
 const STORM_WAVES: readonly StormWaveRow[] = [
   //  n  len       gap        fall  shield repair seed  focus
@@ -560,11 +467,11 @@ const STORM_WAVES: readonly StormWaveRow[] = [
  *
  * `satisfies StormShape` and not only the `Map`'s type argument, because the
  * two are not the same check: excess properties do not survive a `.map` into a
- * `new Map<number, StormShape>`, so a `keys` written here would have
- * type-checked clean and then been discarded in silence by `waveSpecFor`'s
- * spread. `satisfies` fires excess-property checking on the literal itself,
- * which is what makes "a storm cannot name its own keys" (decision 56) a thing
- * the compiler refuses rather than a thing the spread order rescues.
+ * `new Map<number, StormShape>`, so a `keys` written here would type-check
+ * clean and then be discarded in silence by `waveSpecFor`'s spread.
+ * `satisfies` fires excess-property checking on the literal itself, which is
+ * what makes "a storm cannot name its own keys" (decision 56) something the
+ * compiler refuses rather than something the spread order rescues.
  */
 const WAVE_BY_N = new Map<number, StormShape>(
   STORM_WAVES.map(([n, count, gapFrom, gapTo, fallFrom, fallTo, ...rest]) => {
@@ -587,8 +494,8 @@ const WAVE_BY_N = new Map<number, StormShape>(
 // ── Table → lessons ──────────────────────────────────────────────────────────
 
 /**
- * "L07", and "L100". Two digits because that is what §5.1 writes down and what
- * `Session.mode` has to keep saying forever; the hundredth simply runs over.
+ * "L07", and "L100". Two digits because that is what `Session.mode` has to
+ * keep saying forever (§5.1); the hundredth simply runs over.
  */
 const idFor = (n: number) => `L${String(n).padStart(2, "0")}`;
 
@@ -629,14 +536,12 @@ function toLesson(row: Row): Lesson {
     title,
     introduces,
     keyboard: MODE_OF[keyboard],
-    // A storm level is `keyboard: "guide"` without the lock as often as not,
-    // so this stays undefined rather than false: `keyboardLocked?: true` is
-    // the shape §4.2 asks for and an absent flag is the ordinary case.
+    // Undefined rather than false: `keyboardLocked?: true` is the shape §4.2
+    // asks for, and an unlocked row is the ordinary case.
     ...(locked ? { keyboardLocked: true } : {}),
-    // The tenth of every block, by §5.5's definition of a block. Derived
-    // rather than written on the row, for the same reason `block` is: a
-    // checkpoint is a *position* in the ladder, and a row that could disagree
-    // with its own position is a row that will.
+    // Derived rather than written on the row, for the same reason `block` is:
+    // a checkpoint is a *position* in the ladder, and a row that could
+    // disagree with its own position is a row that will.
     ...(n % 10 === 0 ? { checkpoint: true as const } : {}),
   };
 
@@ -655,10 +560,8 @@ function toLesson(row: Row): Lesson {
       // **A storm level's length is its wave's `count`** (§8.3), and this is
       // the one place the two are joined. Three things read it back and all
       // three would be wrong against any other number: `survived` in
-      // `verdict.ts` is `cards.length >= wordCount`, the `unbroken` badge is
-      // guarded on the wave having a length (decision 29), and `lessonKey` —
-      // the string a run is filed under — is `typing|L39|28`, which is what
-      // makes a storm and its lesson share one bucket (§5.4, §8.7).
+      // `verdict.ts`, the `unbroken` badge (decision 29), and the key a run is
+      // filed under — `typing|L39|28` (§5.4, §8.7).
       wordCount: wave.count,
       pass: { kind: "storm", survive: true, accuracy: STORM_ACCURACY },
     };
@@ -700,9 +603,7 @@ const BY_ID = new Map(LESSONS.map((lesson) => [lesson.id, lesson]));
  * for a free-play config, which simply has no `lessonId`, and an id from a
  * build that has since re-cut the ladder is a run that must still open rather
  * than a case to throw on. It is the same promise `deckSpec` makes one layer
- * up — a saved run outlives the ladder it was played on (CLAUDE.md) — and it
- * is what lets a screen ask "is this a lesson?" and get the lesson back in the
- * same breath.
+ * up — a saved run outlives the ladder it was played on (CLAUDE.md).
  */
 export const lessonById = (id?: string | null): Lesson | null =>
   (id ? BY_ID.get(id) : undefined) ?? null;
@@ -729,14 +630,9 @@ export const lessonNumbered = (n: number): Lesson | null =>
  * the engine, beside the rows it reads — because two layers need the same
  * answer to two different questions. The island asks it to draw the board and
  * to grey out the control (`keyboardFor`, `keyboardLock`); the engine asks it
- * to award `eyes-up` (§6.7), and the engine may not import from `src/games/`.
- *
- * That badge is why the distinction is a function at all rather than a line
- * inside the island's resolver. Every checkpoint forces the board `off`,
- * because a checkpoint passed while reading the answer off the screen measures
- * nothing — so a badge for "passed with the keyboard hidden" that asked only
- * what was on screen would land on exactly the ten runs where being eyes-up
- * was compulsory, which is the inverse of what it is for.
+ * to award `eyes-up` (§6.7, decision 28), and the engine may not import from
+ * `src/games/`. That badge is why the distinction is a function at all rather
+ * than a line inside the island's resolver.
  *
  * A lock over `keyboard: null` is not a lock, and hands back `null` here: a
  * lesson that names no mode is insisting on nothing.

--- a/src/engine/typing/lexicon.test.ts
+++ b/src/engine/typing/lexicon.test.ts
@@ -20,17 +20,12 @@ import { strokeFor } from "../keyboard";
 /**
  * The corpus, checked against the board it will be typed on.
  *
- * One assertion here matters more than the rest: **every character of every
- * word, sentence and passage has a `strokeFor`**. Typing marks exactly, so a
- * curly quotation mark, an accent or an em dash that reached this file by way
- * of a copy-paste is not a typo — it is a lesson a child cannot pass, however
- * well they type it, and they will be the one who finds it. `decks/typing.ts`
- * had to hand-exclude exactly that from the Scripture pool; here it is a test
- * instead of a reading rule.
- *
- * The rest of the suite is about the ladder actually being able to use what is
- * here — a bigram lesson with no words in it, or a first words lesson whose
- * alphabet leaves an empty bag, fails silently in front of a five-year-old.
+ * One assertion matters more than the rest: every character of every word,
+ * sentence and passage has a `strokeFor`. A curly quotation mark or an accent
+ * that arrived by copy-paste is not a typo but a lesson a child cannot pass,
+ * and they will be the one who finds it. The rest of the suite is about the
+ * ladder being able to use what is here — a bigram lesson with no words in it
+ * fails silently in front of a five-year-old.
  */
 
 /** Every string this file offers, in one place, so nothing escapes the check. */
@@ -112,17 +107,15 @@ describe("WORDS", () => {
   });
 
   /**
-   * Letters and the apostrophe, and capitals only where English insists on
-   * them: `I`, and the days and months. Anything else with a capital in it is
-   * a proper noun that has wandered in from `NAMES` or the sentence pool,
-   * where names belong.
+   * Capitals only where English insists on them: `I`, and the days and months.
+   * Anything else with a capital in it is a proper noun that has wandered in
+   * from `NAMES` or the sentence pool, where names belong.
    *
    * The permitted set is enumerated rather than described by a shape. A regex
-   * ending in `[A-Z][a-z]+` — which is what this test used to carry — admits
-   * "London", "Ravi" and "England" while claiming to admit only the calendar,
-   * and it also cannot see the failure in the other direction: eleven of the
-   * twelve months, with the missing one noticed by whichever child types the
-   * year out.
+   * ending in `[A-Z][a-z]+` admits "London", "Ravi" and "England" while
+   * claiming to admit only the calendar, and it cannot see the failure in the
+   * other direction either: eleven of the twelve months, with the missing one
+   * noticed by whichever child types the year out.
    */
   it("is lowercase but for I, the days and the months", () => {
     const days = [
@@ -199,12 +192,9 @@ describe("the focus sets", () => {
   });
 
   /**
-   * The cross-check that keeps the ladder and the corpus in step: every
-   * sequence a bigram lesson names is one of the sets here, and the corpus can
-   * offer at least one word containing it *at that lesson's alphabet*. Both
-   * halves are needed — a focus nobody stocked and a focus whose only words
-   * use a letter the child has not met fail identically, as a lesson that
-   * cannot be generated.
+   * Both halves are needed: a focus nobody stocked and a focus whose only
+   * words use a letter the child has not met fail identically, as a lesson
+   * that cannot be generated.
    */
   it.each(FOCUSES)("stocks lesson $n's $focus", ({ n, focus }) => {
     const known = new Set([...BIGRAMS, ...DOUBLES, ...HARD_PAIRS, ...TRIGRAMS]);
@@ -249,11 +239,9 @@ describe("the hand sets", () => {
 });
 
 /**
- * Lesson 33, "Names, and the word I", is a **words** lesson — it hands over a
- * list, not prose — and its entire subject is the one thing `WORDS` is
- * deliberately empty of. Without a pool of its own it is a lesson about names
- * with no name in anything it can reach, which is what these cases are here to
- * stop coming back.
+ * Lesson 33, "Names, and the word I", is a **words** lesson whose entire
+ * subject is the one thing `WORDS` is deliberately empty of. Without a pool of
+ * its own it is a lesson about names with no name in anything it can reach.
  */
 describe("NAMES", () => {
   const LESSON_33 = LESSONS.find((lesson) => lesson.n === 33);
@@ -269,10 +257,9 @@ describe("NAMES", () => {
   });
 
   /**
-   * The apostrophe does not arrive until lesson 35 and the shifts land at 31
-   * and 32, so lesson 33 is the first place a capital is typeable at all. A
-   * name here that needed a key the child has not met would fail exactly as a
-   * word does (§5.2) — as a lesson that cannot be generated.
+   * The shifts land at 31 and 32 and the apostrophe not until 35, so lesson 33
+   * is the first place a capital is typeable at all — and a name needing a key
+   * the child has not met is a lesson that cannot be generated (§5.2).
    */
   it("is typeable at the lesson that asks for it", () => {
     for (const name of NAMES) expect(canType(name, 33)).toBe(true);
@@ -318,14 +305,10 @@ describe("SENTENCES", () => {
 
 describe("PASSAGES", () => {
   /**
-   * Counted against the ladder, not against a constant. The window this used to
-   * assert — fifty to a hundred and sixty — was one no lesson had asked for
-   * since the ladder was written, and a pool that topped out at ninety-six
-   * passed it while lessons 80, 94, 96 and 100 (a hundred, a hundred, a hundred
-   * and twenty, a hundred and fifty) had nothing they could be generated from.
-   * A number in a test is a claim about the curriculum, and this is the same
-   * mistake the FOCUSES cases above exist to avoid: drive the case off LESSONS
-   * and the assertion cannot drift away from what the ladder wants.
+   * Counted against the ladder, not against a constant: a number in a test is
+   * a claim about the curriculum, and a fixed window goes green while lessons
+   * 80, 94, 96 and 100 have nothing they can be generated from. Driving the
+   * case off LESSONS is what the FOCUSES cases above do, for the same reason.
    */
   it.each(PASSAGE_LESSONS)(
     "is long enough for lesson $n, $title ($wordCount words)",
@@ -336,10 +319,8 @@ describe("PASSAGES", () => {
   );
 
   /**
-   * And the exam is not a pool of one. Lesson 100 is the longest ask on the
-   * ladder, so a single passage clearing it would mean every child's Ice Exam
-   * is the same text, every attempt — which §5.4 does not require and nobody
-   * would enjoy.
+   * The exam is not a pool of one: a single passage clearing lesson 100 would
+   * mean every child's Ice Exam is the same text, every attempt.
    */
   it("gives the longest lesson on the ladder a choice", () => {
     const longest = Math.max(...PASSAGE_LESSONS.map((l) => l.wordCount));
@@ -377,13 +358,11 @@ describe("PASSAGES", () => {
 });
 
 /**
- * The bundle rule, from the corpus's side.
- *
  * `eslint.config.mjs` bans the import and `eslint.config.test.mjs` proves the
- * ban fires; this is the other half — that nothing here needs the deck layer
- * either, so the wall has no reason to be climbed from this direction. A
- * corpus that imported `decks/wordlists.ts` for its sight words would put the
- * two modules in one graph again, from the end nobody is watching.
+ * ban fires; this is the other half — nothing here needs the deck layer, so
+ * the wall has no reason to be climbed from this direction. A corpus that
+ * imported `decks/wordlists.ts` for its sight words would put the two modules
+ * in one graph again, from the end nobody is watching.
  */
 describe("the layer it must not reach into", () => {
   it("imports nothing from the deck layer", async () => {

--- a/src/engine/typing/lexicon.ts
+++ b/src/engine/typing/lexicon.ts
@@ -1,43 +1,27 @@
 /**
  * The words Frost Keys builds its lessons out of (docs/typing.md §5.3).
  *
- * Filtering "words a child can type with only `f j d k s l`" needs something
- * to filter. The Dolch lists in `decks/wordlists.ts` are a few hundred words —
- * enough to be a spelling syllabus, nowhere near enough to survive that filter
- * — so this is a few thousand instead, commonest first, so that a lesson
+ * A few thousand common English words, commonest first, so that a lesson
  * asking for "the twenty-five" or "the hundred" (§5.6, lessons 41 and 48) is a
- * `slice` rather than a second list to keep in step with this one.
+ * `slice` rather than a second list to keep in step with this one. §5.3 says
+ * why it is this rather than the Dolch lists in `decks/wordlists.ts`.
  *
  * Nothing here decides anything. The generator picks, the ladder filters, and
  * `keys.ts` says what a child has met; this file is the bag they all reach
  * into. That is why it exports data and no functions — a helper here would be
  * a place for the curriculum to leak into the corpus.
  *
- * ── This file must never be reachable from `decks/index.ts` ──────────────────
- * `decks/index.ts` is the front door for every island on the site — flash
- * cards, spelling, the record book, the print shop — and a module in its graph
- * is shipped to all of them, whole. The last time that was got wrong, an import
- * of the passage library from `decks/typing.ts` took the shared chunk from
- * 46 KB to 222 KB, which is why thirty-three verses are written out by hand in
- * that file today. This is the same trap one file over, and it is a bigger one:
- * the corpus is the largest thing in the epic.
- *
- * A comment would not have stopped it the first time, so the ban is a lint
- * rule — `local/no-corpus-in-decks` in `eslint.config.mjs`, naming this
- * paragraph as its reason. It covers `src/engine/**` rather than
- * `src/engine/decks/**`, because reachability is transitive and `lessons.ts`
- * next door is importable from the deck layer: banning only the decks
- * directory would leave `import { WORDS } from "./lexicon"` one file over as a
- * legal way to ship this to every island. Only this file, `generate.ts` and
- * their tests are exempt.
- *
- * The way past it is already in the type. `TypingConfig.words` carries a run's
- * own text, so the ladder screen — inside the typing island, where the corpus
- * belongs — generates a passage and hands it over in the config, and the deck
- * layer builds cards out of `config.words` exactly as it does for a
- * parent-authored drill. `lessons.ts` stays importable from `decks/` because
- * it holds titles and pass criteria and not one word a child ever types; this
- * file is the half that must stay on the other side of the wall.
+ * **This file must never be reachable from `decks/index.ts`**, which would
+ * ship the corpus to every island on the site (§5.3, decision 7). A comment
+ * would not have stopped it the first time, so the ban is a lint rule:
+ * `local/no-corpus-in-decks` in `eslint.config.mjs`. It covers `src/engine/**`
+ * rather than `src/engine/decks/**`, because reachability is transitive and
+ * `lessons.ts` next door is importable from the deck layer — banning only the
+ * decks directory would leave `import { WORDS } from "./lexicon"` one file
+ * over as a legal way to ship this to all of them. Only this file,
+ * `generate.ts` and their tests are exempt. The way past the wall is
+ * `TypingConfig.words`: the ladder screen generates a passage inside the
+ * typing island and hands it to the deck layer in the config.
  *
  * ── Where the words came from ───────────────────────────────────────────────
  * Written for this repository. No corpus file was copied in, so there is no
@@ -54,13 +38,12 @@
  * `decks/wordlists.ts` for the early bands and on what a primary reader
  * actually meets for the rest.
  *
- * The sentences and passages are original prose written for this file. That is
- * deliberate rather than lazy: real prose arrives with curly quotation marks,
- * en dashes and accents, none of which a US ANSI board can produce, and typing
- * marks exactly — a passage carrying one is unpassable rather than hard. The
- * ladder's Scripture is not duplicated here either; `decks/typing.ts` holds
- * thirty-three verses for the free-play levels and the reason it holds them is
- * the paragraph above.
+ * The sentences and passages are original prose written for this file, which
+ * is deliberate rather than lazy: real prose arrives with curly quotation
+ * marks, en dashes and accents, none of which a US ANSI board can produce, and
+ * typing marks exactly — a passage carrying one is unpassable rather than
+ * hard. Scripture is not duplicated here either; `decks/typing.ts` holds
+ * thirty-three verses for the free-play levels, for the reason above.
  *
  * ── House rules for adding a word ───────────────────────────────────────────
  *   - **Typeable on the board.** Every character must have a `strokeFor`

--- a/src/engine/typing/storm.test.ts
+++ b/src/engine/typing/storm.test.ts
@@ -28,20 +28,12 @@ import {
 import type { Shield, StormLetter, StormState, Wave, WaveSpec } from "./storm";
 
 /**
- * The wave's properties, proved rather than sampled (docs/typing.md §8.3).
+ * The wave's properties, proved rather than sampled (§8.3).
  *
- * Every interesting claim this module makes is universally quantified — "the
- * same seed is the same storm", "every character is one the child can type",
- * "an early level never puts two letters on screen" — so each is asserted over
- * a spread of seeds crossed with a spread of specs, not over one hand-picked
- * wave. A generator is a distribution and one seed is an anecdote.
- *
- * Two of them are also load-bearing beyond this file. The first is the story:
- * a child who just lost retries and meets the storm that beat them, which is
- * only true while `(spec, seed)` decides everything. The second is the one that
- * gives the early levels their shape — `gap` above `fall` means pure reaction —
- * and it is arithmetic, so the boundary case is tested at the boundary and one
- * millisecond the other side of it.
+ * Every interesting claim this module makes is universally quantified, so each
+ * is asserted over a spread of seeds crossed with a spread of specs rather
+ * than over one hand-picked wave. A generator is a distribution and one seed
+ * is an anecdote.
  */
 
 /**
@@ -131,16 +123,13 @@ const SPECS: [name: string, spec: WaveSpec][] = [
 ];
 
 /**
- * The specs whose `gap` clears their `fall` — the levels that are pure
- * reaction — and the ones whose ranges overlap.
- *
- * Both read `fallRange(spec)` and never `spec.fall`, which is what
- * `fallRange`'s own docstring asks for: `MIN_FALL_MS` can only ever RAISE a
- * fall, so a spec that declared "one letter at a time" with falls under the
- * floor gets letters that overlap — and a classifier reading the declaration
- * would put it in the group whose assertion is that they never do. Today's
- * fixtures are all above the floor, so the two readings agree; the pair at the
- * bottom of this file is what keeps that a fact rather than an assumption.
+ * The specs whose `gap` clears their `fall` — the pure reaction levels — and
+ * the ones whose ranges overlap. Both read `fallRange(spec)` and never
+ * `spec.fall`: the floor can only raise a fall, so a spec declaring "one
+ * letter at a time" with falls under it gets overlap, and a classifier reading
+ * the declaration would put it in the group whose assertion is that they never
+ * do. Today's fixtures all clear the floor; the pair at the bottom of this
+ * file is what keeps the distinction a fact rather than an assumption.
  */
 const REACTION = SPECS.filter(([, s]) => s.gap[0] >= fallRange(s)[1]);
 const STACKING = SPECS.filter(([, s]) => s.gap[1] < fallRange(s)[0]);
@@ -151,16 +140,13 @@ const STACKING = SPECS.filter(([, s]) => s.gap[1] < fallRange(s)[0]);
  * The count only ever goes up when a letter starts to drop, so asking
  * `isFalling` at every drop instant finds the maximum without a sweep. Reading
  * the half-open interval out of the engine rather than restating it here is
- * what makes the boundary pair at the bottom of this file — `gap` exactly
- * `fall`, and one millisecond the other side — a test of the rule the reducer
- * actually fires and damages by, instead of a test of a second copy of it that
- * happens to live in the test file.
+ * what makes the boundary pair below — `gap` exactly `fall`, and one
+ * millisecond the other side — a test of the rule the reducer fires by rather
+ * than of a second copy living in this file.
  *
- * Falling and not merely on the field, because that is what `gap >= fall`
- * buys: every letter waits the same beat at the top before it moves
- * (`QUEUE_MS`), so a reaction level has one letter coming down with the next
- * one queued above it. `maxOnField` below is the other count, and the pair of
- * them is what says the queue is a queue.
+ * Falling and not merely on the field: a letter hanging at the top
+ * (`QUEUE_MS`) is a queue rather than a second thing to track, which is what
+ * `maxOnField` beside it says.
  */
 const maxFalling = (wave: Wave): number =>
   Math.max(
@@ -194,8 +180,8 @@ describe("a wave is deterministic in (spec, seed)", () => {
   });
 
   it("meets the storm that beat you when you retry it", () => {
-    // The story, spelled out: a retry has nothing but the wave in hand, and
-    // rebuilding from what the wave carries has to produce the wave back.
+    // A retry has nothing but the wave in hand, so rebuilding from what the
+    // wave carries has to produce the wave back.
     for (const [name, s] of SPECS)
       for (const seed of SEEDS) {
         const wave = buildWave(s, seed);
@@ -217,10 +203,9 @@ describe("a wave is deterministic in (spec, seed)", () => {
   });
 
   it("reads no randomness of its own", () => {
-    // `Math.random()` anywhere in here would make a wave unrepeatable while
-    // every other assertion in this file still passed — the two calls would
-    // simply differ from each other, and only a child pressing "again" would
-    // ever find out. So the global is taken away for the length of one build.
+    // `Math.random()` in here would make a wave unrepeatable while every other
+    // assertion in this file still passed — the two calls would simply differ,
+    // and only a child pressing "again" would find out.
     const real = Math.random;
     Math.random = () => {
       throw new Error("buildWave must draw only from mulberry32(seed)");
@@ -265,9 +250,8 @@ describe("every letter in a wave is one the child can shoot", () => {
 
   it("never drops anything onto a thumb", () => {
     // The shield has eight segments, one per finger, and none for the thumbs
-    // (§8.5) — so a falling space would have nothing above it to damage. The
-    // unlocked alphabet always contains one, which is why this is a filter and
-    // not a note in the docs.
+    // (§8.5). The unlocked alphabet always carries a space, which is why this
+    // is a filter and not a note in the docs.
     const alphabet = SPECS.find(([name]) => name === "everything falls")![1];
     expect(
       alphabet.keys,
@@ -300,9 +284,8 @@ describe("every letter in a wave is one the child can shoot", () => {
   });
 
   it("is an empty storm rather than a throw when nothing can fall", () => {
-    // The engine's habit: a mode that no longer makes sense still opens
-    // (`deckSpec` never throws). A wave with nothing in it is a screen that
-    // ends; a throw is a game loop that dies holding a child's run.
+    // A wave with nothing in it is a screen that ends rather than a game loop
+    // that dies holding a child's run — `deckSpec`'s habit, one layer down.
     const wave = buildWave(spec({ keys: [" ", "“"], count: 20 }), 3);
     expect(wave.letters).toEqual([]);
     expect(wave.durationMs).toBe(0);
@@ -360,16 +343,11 @@ describe("gap and fall are sampled per letter", () => {
   });
 
   it("can draw either end of a range", () => {
-    // A range of three, so every value in it must turn up across the sweep.
-    // This is the assertion an exclusive bound fails: a generator that never
-    // reached `max` would make every level fractionally easier than written,
-    // and nothing else here would notice.
-    //
-    // The fall range sits just above `MIN_FALL_MS` rather than at any three
-    // numbers, because the floor would flatten a range under it (below) — and
-    // a range flattened to a constant is exactly what this assertion is here
-    // to catch. Sitting one millisecond above the floor also says the floor
-    // does not disturb a range that clears it.
+    // A range of three, so every value must turn up across the sweep — the
+    // assertion an exclusive bound fails, and nothing else here would notice a
+    // generator that never reached `max`. The fall range sits just above
+    // `MIN_FALL_MS` because the floor would flatten a range under it into the
+    // constant this assertion exists to catch.
     const s = spec({
       keys: HOME,
       count: 40,
@@ -393,12 +371,7 @@ describe("gap and fall are sampled per letter", () => {
 });
 
 describe("no letter is ever a blur", () => {
-  /*
-   * The cap at the top of the ladder (§8.10, decision 52). "Whiteout" is meant
-   * to be hard because there are many letters, not because one of them cannot
-   * be read — and the only place that can be guaranteed is the generator,
-   * because the twenty specs are a table and a table is edited a row at a time.
-   */
+  /* The cap at the top of the ladder (§8.10, decision 52). */
 
   it("floors every fall a too-fast spec asks for", () => {
     const blur = spec({ count: 40, gap: [200, 300], fall: [40, 200] });
@@ -437,9 +410,8 @@ describe("no letter is ever a blur", () => {
   });
 
   it("raises a range rather than flattening it", () => {
-    // Clamping each sample would pile every letter of a too-fast spec onto the
-    // floor exactly; clamping the range keeps the draw a draw. Only the half
-    // of the range under the floor moves.
+    // Clamping each sample would pile a too-fast spec's letters onto the floor
+    // exactly; clamping the range keeps the draw a draw (§8.10).
     const half = spec({ count: 40, fall: [MIN_FALL_MS - 400, 2000] });
     expect(fallRange(half)).toEqual([MIN_FALL_MS, 2000]);
 
@@ -507,17 +479,10 @@ describe("the schedule the wave hands the reducer", () => {
 
 describe("when gap clears fall, one letter falls at a time", () => {
   /*
-   * The invariant the early levels are made of (§8.3), and it is arithmetic
-   * rather than luck. Letter i is on the field over `[spawn_i, spawn_i +
-   * fall_i)` and letter i+1 spawns at `spawn_i + gap_{i+1}`, so the two share
-   * the screen exactly when `gap_{i+1} < fall_i`. If every gap the spec can
-   * draw is at least every fall it can draw, that is never true — and because
-   * spawn times only increase, no later letter can overlap letter i either.
-   *
-   * The boundary goes to safety: `gap` exactly equal to `fall` still leaves one
-   * letter on screen, because a letter occupies `[spawnMs, landMs)` — it is
-   * gone the instant it lands, and landing is the tick that turns it into
-   * shield damage. So the guarantee is `gap[0] >= fall[1]`, not `>`.
+   * The guarantee is `gap[0] >= fall[1]`, and `>=` rather than `>` because a
+   * letter occupies `[spawnMs, landMs)` — at exactly equal, one lands on the
+   * millisecond the next starts to drop (§8.3). The pair below tests the
+   * boundary and one millisecond the other side of it.
    */
 
   it("puts nothing beside a letter on the reaction levels", () => {
@@ -536,20 +501,16 @@ describe("when gap clears fall, one letter falls at a time", () => {
   });
 
   it("holds when a gap is exactly a fall", () => {
-    // The boundary itself. The outgoing letter lands on the same millisecond
-    // the next one spawns, which is a handover and not an overlap.
     const s = spec({ count: 30, gap: [900, 900], fall: [900, 900] });
     for (const seed of SEEDS)
       expect(maxFalling(buildWave(s, seed)), `@ ${seed}`).toBe(1);
   });
 
   it("is not a reaction level just because the row says so", () => {
-    // The floor raises a fall and can therefore turn a spacing promise into an
-    // overlap (§8.10, `fallRange`): this spec's own numbers read as one letter
-    // at a time — 700ms between spawns against a 500ms fall — and the wave it
-    // builds puts two on screen, because every letter falls for 800ms. Which
-    // is the right way for it to go; the alternative is a level keeping its
-    // promise by dropping letters nobody could read.
+    // The floor raises a fall and can turn a spacing promise into an overlap
+    // (§8.10): this spec's own numbers read as one letter at a time — 700ms
+    // between spawns against a 500ms fall — and the wave it builds puts two on
+    // screen, because every letter falls for 800ms.
     //
     // It is here because the classification above is otherwise only ever asked
     // of specs written above the floor, where the two readings agree and a
@@ -622,8 +583,7 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
     // No queue: a hand-placed letter falls the instant it appears, so every
     // absolute moment below is the one the test wrote down. The beat a real
     // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it is tested
-    // where it is added rather than folded into the arithmetic of every
-    // reducer test that only cares about what a landing costs.
+    // where it is added.
     dropMs: spawnMs,
     fallMs,
     landMs: spawnMs + fallMs,
@@ -646,7 +606,7 @@ const to = (state: StormState, ms: number) => tick(state, ms - state.timeMs);
 const evenShield = (points: number): Shield =>
   Object.fromEntries(SHIELD_FINGERS.map((f) => [f, points])) as Shield;
 
-/** Which letters got through, by index — the shape STM07's death screen counts. */
+/** Which letters got through, by index — the shape the death screen counts. */
 const landed = (state: StormState) =>
   state.resolved.flatMap((outcome, index) =>
     outcome?.outcome === "landed" ? [index] : [],
@@ -654,19 +614,14 @@ const landed = (state: StormState) =>
 
 describe("a letter hangs before it falls", () => {
   /*
-   * The queue (§8.3, decision 67). A letter appears, stands perfectly still
-   * for `QUEUE_MS` while a child reads it, and only then starts to drop.
-   *
-   * Everything here is about what that beat must NOT disturb, because the
-   * whole reason it can be a single constant is that it disturbs nothing: it
-   * is added to every letter of every level, so it shifts the schedule and
-   * warps no part of it.
+   * The queue (§8.3, decision 67). Everything here is about what that beat
+   * must NOT disturb: it is added to every letter of every level, so it shifts
+   * the schedule and warps no part of it.
    */
 
   it("is drawn and shootable from the moment it appears", () => {
-    // The point of the beat is that a child can read the letter — and a game
-    // that showed them one and then charged ten points for pressing it would
-    // be punishing them for doing exactly that (`QUEUE_MS`).
+    // A queued letter is shootable: showing a child a letter and then charging
+    // ten points for pressing it would punish them for reading it (§8.3).
     const wave = buildWave(spec({ count: 1, keys: ["f"] }), 3);
     const [letter] = wave.letters;
     const half = letter.spawnMs + QUEUE_MS / 2;
@@ -705,8 +660,7 @@ describe("a letter hangs before it falls", () => {
   it("gives two letters hanging side by side to the earlier spawn", () => {
     // Floored, they tie at the top of the sky, and a tie goes to the index
     // like every other dead heat (decision 33). Unfloored they would be ranked
-    // by how long each had left divided by how long its own fall is, which is
-    // a number nothing on screen shows a child.
+    // by a number nothing on screen shows a child.
     const slow = {
       ...at("f", 0, 4000),
       dropMs: QUEUE_MS,
@@ -735,9 +689,7 @@ describe("a letter hangs before it falls", () => {
         const where = `${name} @ ${seed}`;
 
         // Spawns are untouched — the queue is time added to a letter's life,
-        // not a head start on the wave. The first letter is still the instant
-        // the wave begins, and every gap after it is still a draw from the
-        // level's own range.
+        // not a head start on the wave.
         expect(wave.letters[0].spawnMs, where).toBe(0);
         for (const gap of gapsOf(wave)) {
           expect(gap, where).toBeGreaterThanOrEqual(s.gap[0]);
@@ -760,8 +712,7 @@ describe("a letter hangs before it falls", () => {
   it("costs a level nothing it did not already have on the field", () => {
     // A reaction level shows one letter falling with the next queued above it
     // — two on the field, never three. A third would mean the beat had grown
-    // past the gaps these levels are spaced at, which is the shape of the
-    // failure a bigger `QUEUE_MS` would have.
+    // past the gaps these levels are spaced at.
     for (const [name, s] of REACTION)
       for (const seed of SEEDS) {
         const wave = buildWave(s, seed);
@@ -775,10 +726,8 @@ describe("where a letter is at time t", () => {
   const letter = at("f", 1000, 500);
 
   it("is on the field over [spawn, land), and not one millisecond either side", () => {
-    // Decision 30, as a boundary rather than as prose. The instant it lands is
-    // the tick that turns it into shield damage, so it cannot still be
-    // shootable there — a letter that was both would be a free hit that also
-    // took a hit point off.
+    // Decision 30 as a boundary: a letter that was both airborne and landed
+    // would be a free hit that also took a hit point off.
     expect(isAirborne(letter, 999)).toBe(false);
     expect(isAirborne(letter, 1000)).toBe(true);
     expect(isAirborne(letter, 1499)).toBe(true);
@@ -805,10 +754,10 @@ describe("where a letter is at time t", () => {
 
 describe("the lowest letter is the target", () => {
   it("is the greatest fall progress, not the earliest landing", () => {
-    // The disagreement STM01 wrote down, built to order: a slow letter spawned
-    // first is more than halfway down while a fast one spawned later has
-    // barely started — and yet the fast one lands first. `landMs` order would
-    // aim the gun at the letter that is visibly nearer the top of the screen.
+    // A slow letter spawned first is more than halfway down while a fast one
+    // spawned later has barely started — and yet the fast one lands first.
+    // `landMs` order would aim the gun at the letter that is visibly nearer
+    // the top of the screen.
     const slow = at("f", 0, 5000); // lands at 5000
     const fast = at("j", 3000, 1000); // lands at 4000
     const state = to(runOf([slow, fast], { shield: 3 }), 3100);
@@ -834,8 +783,7 @@ describe("the lowest letter is the target", () => {
 
   it("gives an exact tie to the earlier spawn", () => {
     // Two letters at the same height are the same shot to a child, so the tie
-    // goes to the letter's identity — the index — and a replay of the same
-    // wave resolves the dead heat the same way every time.
+    // goes to the letter's identity — the index (decision 33).
     const state = to(runOf([at("f", 0, 1000), at("j", 0, 1000)]), 400);
     expect(targetIndex(state)).toBe(0);
   });
@@ -871,9 +819,8 @@ describe("firing resolves the lowest letter, and nothing else", () => {
   });
 
   it("counts the second-lowest letter as a miss", () => {
-    // The rule the whole game is balanced on. `KeyJ` is a real letter on a
-    // real lane and it is the wrong shot, because it is not the one about to
-    // cost a shield point.
+    // `KeyJ` is a real letter on a real lane and it is still the wrong shot,
+    // because it is not the one about to cost a shield point.
     const before = two();
     const state = fire(before, "KeyJ");
 
@@ -901,12 +848,8 @@ describe("firing resolves the lowest letter, and nothing else", () => {
 
   describe("a capital is a shift and a letter", () => {
     /*
-     * Decision 70. `A` and `a` are one key and two letters, and for a while
-     * the storm could only tell you the key — so a wave of capitals fell to
-     * the bare alphabet, and lesson 39 was called "Shift under fire" without
-     * ever asking for a shift. What decides a shot now is the CHARACTER the
-     * stroke produced: `code` for which key, `shifted` for which of its two
-     * legends.
+     * Decision 70. What decides a shot is the CHARACTER the stroke produced:
+     * `code` for which key, `shifted` for which of its two legends.
      */
 
     /** A capital `A`, alone in the sky and about halfway down. */
@@ -920,8 +863,8 @@ describe("firing resolves the lowest letter, and nothing else", () => {
     });
 
     it("counts the bare letter as a miss", () => {
-      // The bug this replaced: `a` cleared an `A`, and the child was scored
-      // as having typed something they did not type.
+      // `a` clearing an `A` would score a child as having typed something
+      // they did not type.
       const state = fire(capital(), "KeyA", false);
       expect(state.resolved[0], "the letter is still falling").toBeNull();
       expect(state.misses).toBe(1);
@@ -977,10 +920,8 @@ describe("firing resolves the lowest letter, and nothing else", () => {
 
 /* ═══ Score, combo and XP (§8.6) ═════════════════════════════════════════════
  *
- * Two numbers with opposite rules, which is the whole of this section: the
- * score is the run's and may fall, the XP is the profile's and may not. They
- * are tested together because the only way to get them wrong is to let one
- * become the other.
+ * Tested together because the only way to get the two rules wrong is to let
+ * one number become the other.
  */
 
 /**
@@ -1060,9 +1001,7 @@ describe("a wrong key costs", () => {
 
   it("charges the same for a shot at an empty sky", () => {
     // Spraying between letters is the same strategy by another route (§8.4),
-    // so it costs the same. The screen says so with the `--flare` wash over the
-    // score, which is every miss's signal now that the storm draws no board to
-    // turn red (decision 64).
+    // so it costs the same.
     const empty = runOf([at("f", 1000, 500)]);
     expect(targetIndex(empty), "the premise: nothing is falling").toBeNull();
 
@@ -1071,9 +1010,8 @@ describe("a wrong key costs", () => {
   });
 
   it("lets the score go negative, because it is the run's own", () => {
-    // A five-year-old who hammers the board bottoms out below zero and can
-    // see it. Nothing about that reaches the profile: `stormXp` is floored,
-    // and it is floored at the other end of the run rather than here.
+    // Nothing about a negative score reaches the profile: `stormXp` is
+    // floored, and floored at the other end of the run rather than here.
     const sprayed = fire(fire(fire(volley(), "KeyZ"), "KeyQ"), "KeyP");
     expect(sprayed.score).toBe(-30);
     expect(sprayed.misses).toBe(3);
@@ -1097,20 +1035,13 @@ describe("a wrong key costs", () => {
   });
 });
 
-/* ── The miss flash, and the one cadence a wave cannot shape (decision 57) ──
+/* ── The miss flash (§8.10, decision 57) ────────────────────────────────────
  *
- * §8.10's "no strobe, ever, in any mode" is kept two different ways, because
- * the two things that light have two different clocks. A shield zone tints
- * when a letter LANDS, so its rate is a property of the schedule and each of
- * the twenty levels is held to two a second at its own seed (`storms.test.ts`).
- * The score's `--flare` wash fires when a child presses a WRONG KEY, and no
- * spec can shape a hand: auto-repeat is already not a shot (decision 44), but
- * eight or ten deliberate presses a second is a seven-year-old having a bad
- * time and not a bug to defend against.
- *
- * So the wash carries its own floor, here in the reducer where the clock is.
- * What a miss costs is unchanged and unconditional; what is rate-limited is
- * only the moment the HUD mounts a fresh element from (`StormHud`).
+ * A zone tints when a letter LANDS, so its rate belongs to the schedule and is
+ * held per level in `storms.test.ts`. The wash fires on a WRONG KEY, which no
+ * spec can shape — so it carries its own floor here in the reducer, where the
+ * clock is. What a miss costs is unchanged and unconditional; only the moment
+ * the HUD mounts a fresh element from is rate-limited.
  */
 describe("the miss flash cannot be strobed by a fast hand", () => {
   /** A run with a letter in the air, so a wrong key is a miss and not a stroke
@@ -1153,20 +1084,15 @@ describe("the miss flash cannot be strobed by a fast hand", () => {
   });
 
   it("stays at two flashes in any one second, whatever the hand does", () => {
-    // **Two, not three.** WCAG 2.3.1's line is *more than three* flashes in
-    // any one second, and a gap of `g` permits `ceil(1000 / g)` starts inside
-    // one — so 340ms would have sat exactly on the line with nothing to spare,
-    // and 500 buys the second flash back. That is the same headroom the twenty
-    // waves' zone tints ship with (§8.10), on the same screen, for the same
-    // five-year-old. Counted the way `storms.test.ts` counts a zone's: starts
-    // inside a sliding second, anchored at each start, which is where every
-    // window's maximum sits.
+    // Two, not three: WCAG 2.3.1's line is *more than three* in any one
+    // second, and a gap of `g` permits `ceil(1000 / g)` starts inside one — so
+    // 340ms would have sat exactly on the line (§8.10). Counted the way
+    // `storms.test.ts` counts a zone's: starts inside a sliding second,
+    // anchored at each start.
     //
     // Swept rather than hammered at one rate, because the worst case is not
-    // the fastest hand. A hand landing just inside the gap is the one that
-    // reached three, and no amount of pressing faster finds it — so the sweep
-    // walks the cadences either side of the constant as well as the ones a
-    // child can actually produce.
+    // the fastest hand — a hand landing just inside the gap is the one that
+    // reached three, and no amount of pressing faster finds it.
     const PRESSES = 60;
     // A letter that outlasts the whole sweep, so every press is a miss inside
     // a live run rather than a key at a run that has already ended.
@@ -1213,11 +1139,10 @@ describe("score can fall; XP cannot", () => {
    * about a run, and the run is what this file builds.
    */
   it("pays each hit exactly what `cardXp` pays a card", () => {
-    // Reused unchanged, which is what makes a Hailstorm level and a
-    // flash-card race pay out on the same scale. Restating the curve here
-    // would only pin a copy of it, so the assertion is against `cardXp`
-    // itself, on the arguments §8.7 says a hit hands it: how long the letter
-    // was in the air, and the streak it was shot on.
+    // Reused unchanged, which is what makes a Hailstorm level and a flash-card
+    // race pay out on the same scale. Restating the curve here would only pin
+    // a copy of it, so the assertion is against `cardXp` itself, on the
+    // arguments a hit hands it (§8.7).
     const state = fire(fire(volley(), "KeyF"), "KeyF");
     const shots = [
       { ms: 200 - 0, combo: 1 },
@@ -1232,10 +1157,8 @@ describe("score can fall; XP cannot", () => {
   });
 
   it("pays nothing for a letter that landed, and never less than nothing", () => {
-    // The floor is what §8.6 turns on: XP is cumulative across years and four
-    // games, so a run a child played badly may pay nothing and must never take
-    // anything away. Here the score is deep in the red and the XP is zero,
-    // which is the pair the whole rule exists to keep apart.
+    // The score is deep in the red here and the XP is zero, which is the pair
+    // the rule exists to keep apart (§8.6).
     const beaten = to(
       fire(fire(runOf([at("f", 0, 200)], { shield: 3 }), "KeyZ"), "KeyQ"),
       500,
@@ -1278,9 +1201,9 @@ describe("what lands takes the shield apart", () => {
   });
 
   it("lets the next letter through once a zone is exhausted", () => {
-    // The acceptance criterion, in three moments: a zone at zero is a hole and
-    // the run continues; the letter that lands in the hole is what ends it;
-    // and the finger it names is the finger that typed it.
+    // Three moments: a zone at zero is a hole and the run continues; the
+    // letter that lands in the hole is what ends it; and the finger it names
+    // is the finger that typed it.
     const letters = [at("f", 0, 100), at("f", 200, 100)];
     const state = runOf(letters, { shield: 1 });
 
@@ -1573,10 +1496,9 @@ describe("the rules are pure, and they do not mutate what they are given", () =>
   it("reads no clock, no DOM and no randomness", () => {
     // The engine's lint boundary bans *imports* of React and the services
     // layer, but nothing in it catches a bare `document` or a
-    // `requestAnimationFrame` — so the boundary cannot prove this and a test
-    // has to. Each global is made hostile for the length of one run: a reducer
-    // that so much as reads one throws here, in a millisecond, rather than
-    // three stories from now inside a game loop at 60fps.
+    // `requestAnimationFrame` — so a test has to. Each global is made hostile
+    // for the length of one run, so a reducer that so much as reads one throws
+    // here rather than inside a game loop at 60fps.
     const boom = () => {
       throw new Error("the storm reducer must be pure");
     };
@@ -1683,12 +1605,10 @@ describe("the rules are pure, and they do not mutate what they are given", () =>
   });
 });
 
-/* ═══ What a run came to (§8.5, STM07) ═══════════════════════════════════════
+/* ═══ What a run came to (§8.5) ══════════════════════════════════════════════
  *
- * The ending screen is a rendering of these four answers and nothing else, so
- * this is where "your right ring finger let three through" is decided to be
- * true. Every one of them is a question about a run that has stopped, which is
- * a state a test can write down and a browser can only be waited for.
+ * Every one of these is a question about a run that has stopped — a state a
+ * test can write down and a browser can only be waited for.
  */
 
 describe("the per-zone tally the ending is named from", () => {
@@ -1722,14 +1642,12 @@ describe("the per-zone tally the ending is named from", () => {
   it("counts `resolved`, and never the clock", () => {
     /*
      * The case `tick` leaves behind, and the reason this is a tally over
-     * outcomes rather than a filter on `hasLanded`.
-     *
-     * The run ends at 300ms on `l-index`, and the clock stops THERE rather
-     * than at the end of the tick. A letter from a higher index landing on
-     * that same millisecond is left unresolved — but `hasLanded(letter, 300)`
-     * reads true of it, because 300 is exactly its `landMs`. A screen that
-     * counted the clock would report a letter through a zone the storm never
-     * reached, on the one screen where the number is the whole point.
+     * outcomes rather than a filter on `hasLanded`. The run ends at 300ms on
+     * `l-index` and the clock stops THERE rather than at the end of the tick,
+     * so a letter from a higher index landing on that same millisecond is left
+     * unresolved — while `hasLanded(letter, 300)` reads true of it. A screen
+     * counting the clock would report a letter through a zone the storm never
+     * reached.
      */
     const letters = [at("f", 0, 100), at("f", 100, 200), at("j", 0, 300)];
     const dead = tick(runOf(letters, { shield: 1 }), 60_000);
@@ -1808,8 +1726,8 @@ describe("the report the ending screen reads", () => {
   });
 
   it("names the finger that let it through, and how many it let through", () => {
-    // The acceptance criterion, in one assertion: "your left index finger let
-    // three through" is these two fields and nothing else.
+    // "Your left index finger let three through" is these two fields and
+    // nothing else.
     const letters = [
       at("f", 0, 100),
       at("j", 100, 100),

--- a/src/engine/typing/storm.ts
+++ b/src/engine/typing/storm.ts
@@ -1,43 +1,22 @@
 /**
  * Hailstorm's rules, both halves: the wave — what falls, where, and when
- * (docs/typing.md §8.3) — and the reducer that plays it (§8.4, §8.5).
+ * (§8.3) — and the reducer that plays it (§8.4, §8.5).
  *
- * They are one module because they are one set of rules and the seam between
- * them is a lie waiting to happen: the reducer's damage lands on the shield
- * segment the wave already chose for a letter, and its "lowest letter" is the
- * half-open interval the wave's schedule is written in. Two files would be two
- * places to state each of those, and the second copy is always the one that
- * drifts.
+ * One module because the two halves share the facts that would drift if split:
+ * the reducer's damage lands on the shield segment the wave chose, and its
+ * "lowest letter" is the interval the wave's schedule is written in.
  *
- * A wave is generated **whole, up front, from a seed**, exactly as every deck
- * on this site is. That is not a stylistic echo — it is the story this module
- * exists for. A child who has just lost wants to retry *the storm that beat
- * them*, and a game that rolled its next letter as it went could only ever
- * offer them a different one. Beating a wave you have met before means you got
- * better; beating a fresh one means you got luckier, and a five-year-old can
- * tell the difference even when they cannot say it.
+ * Two constraints on anything added here:
  *
- * The second thing it buys is this file being testable at all. Spawn schedule,
- * lanes and fall speeds are plain arithmetic over plain data here, so "is there
- * ever more than one letter on screen at this level" is a question a unit test
- * asks in a millisecond rather than a thing somebody watches for and hopes.
- *
- * ── Model, and it has to stay model ──────────────────────────────────────────
- * No React, no rAF, no DOM, no clock (§8.9). The loop calls this; the tests
- * call it too. The only reason the loop is allowed to be dumb — write a
- * transform, do nothing else — is that everything it would otherwise have to
- * decide was decided here, before the first frame.
- *
- * ── And it has to stay small ─────────────────────────────────────────────────
- * `lessons.ts` is importable from the deck layer, and each of the twenty storm
- * lessons names a `WaveSpec` — as a **type**, which is erased, so this module
- * and the keyboard layout behind it stay out of the chunk `decks/index.ts`
- * ships to every island on the site (§5.3, decision 7). That is a build away
- * from being untrue: one value import from `lessons.ts` and the layout is in
- * every island's bundle. So it must never grow a table either. There is
- * nothing here but the spec, the RNG, the keyboard and the rules: the
- * characters a wave draws from arrive as `spec.keys`, from a caller that
- * already knows them (`storms.ts`, decision 56).
+ *   - **It stays model.** No React, no rAF, no DOM, no clock (§8.9). The loop
+ *     calls this; so do the tests.
+ *   - **It stays out of the chunk every island downloads.** `lessons.ts` is
+ *     importable from the deck layer and names `WaveSpec` as a *type*, which
+ *     is erased, so this module and the keyboard layout behind it never reach
+ *     that chunk (§5.3, §8.6). One value import from `lessons.ts` undoes it.
+ *     So there is no table here either: the characters a wave draws from
+ *     arrive as `spec.keys`, from a caller that already has them (`storms.ts`,
+ *     decision 56).
  */
 import { comboMultiplier } from "@/engine/combo";
 import { keyX, strokeFor } from "@/engine/keyboard";
@@ -45,50 +24,34 @@ import type { Finger } from "@/engine/keyboard";
 import { between, mulberry32 } from "@/engine/random";
 
 /**
- * The eight fingers the shield is divided into — every finger but the thumbs.
+ * The eight fingers the shield is divided into — every finger but the thumbs
+ * (§8.5).
  *
- * The shield spans the bottom of the field in one segment per finger (§8.5),
- * and thumbs are excluded because nothing falls on the space bar. Stating that
- * as a type rather than as a convention is what makes it one rule instead of
- * two: the pool filter below drops any character typed with a thumb, so a wave
- * can never carry a letter with no segment above it — which is the case the
- * reducer would otherwise have to invent an answer for at the worst moment.
+ * A type rather than a convention, so it stays one rule: `fallable` drops any
+ * character a thumb types, and a wave therefore can never carry a letter with
+ * no segment above it for the reducer to damage.
  */
 export type ShieldFinger = Exclude<Finger, "thumb">;
 
 /**
  * One level of Hailstorm, as declared by the lesson that hosts it.
  *
- * `gap` and `fall` are **ranges rather than numbers**, and that is what "the
- * storm is sometimes random within the level" means: each letter draws its own
- * spawn delay and its own fall time. The relationship between the two ranges is
- * the level's whole difficulty shape:
- *
- *   - `gap` at or above `fall` → a letter lands before the next one starts to
- *     drop, so there is never more than one FALLING and the game is pure
- *     reaction. That is what the early levels are (see `buildWave` for the
- *     arithmetic). There may still be one queued above it — every letter waits
- *     a beat before it moves (`QUEUE_MS`) — which is the next one waiting its
- *     turn rather than a second thing to track.
- *   - `gap` below `fall` → two or three coming down at once, and the child has
- *     to work bottom-up. Which is reading ahead, which is the thing that makes
- *     a fast typist.
+ * `gap` and `fall` are ranges rather than numbers, and the relation between
+ * the two is the level's whole difficulty shape (§8.3). `buildWave` holds the
+ * arithmetic behind "never more than one letter falling".
  */
 export type WaveSpec = {
   /**
-   * Which characters can fall — for the twenty levels, everything unlocked by
-   * that lesson, with the level's focus weighted up inside it (§5.7).
+   * Which characters can fall — for the twenty levels, everything the lesson
+   * has unlocked, with the level's focus weighted up inside it (§5.7).
    *
-   * Order and repeats are the caller's to use: a character listed twice falls
-   * about twice as often, which is how a level built around six new symbols
-   * weights them above the forty a child already has. Anything this board
-   * cannot produce, and anything typed with a thumb, is dropped rather than
-   * refused — see `buildWave`.
+   * Repeats are the weighting: a character listed twice falls about twice as
+   * often. Anything this board cannot produce, and anything a thumb types, is
+   * dropped rather than refused — see `fallable`.
    *
-   * A level cannot write this field down: the shape the ladder holds is a
-   * `WaveSpec` minus this one key, and `storms.ts` is the only place the two
-   * are joined (decision 56). That is what makes "a storm can never ask for a
-   * key the ladder has not taught" structural rather than a promise.
+   * A level cannot write this field down: the ladder holds a `WaveSpec` minus
+   * this one key, and `storms.ts` is the only place the two are joined (§5.7,
+   * decision 56).
    */
   keys: string[];
   /** How many letters in the wave. */
@@ -104,101 +67,61 @@ export type WaveSpec = {
 };
 
 /**
- * One falling letter, decided before the wave starts.
- *
- * Everything a frame, a hit or a death needs to know about it is here, so that
- * the reducer never has to ask the keyboard a question mid-run and the renderer
- * never has to do arithmetic: `lane` is where to draw it, `spawnMs`/`fallMs`
- * are where it is at time _t_, `code` is what shoots it and `finger` is the
- * shield segment it breaks if nothing does.
+ * One falling letter, decided before the wave starts — everything fixed about
+ * it resolved against the keyboard once, up front (§8.3).
  */
 export type StormLetter = {
   /** The character, as it is drawn: `f`, `A`, `7`, `?`. */
   ch: string;
   /**
    * `KeyboardEvent.code` of the key that produces it — half of what a press is
-   * compared against, `shifted` being the other half.
+   * compared against, `shifted` being the other half (§8.4, decision 2).
    *
-   * `code`, not the character (decision 2): a shifted legend and its base
-   * share a key, so `A` and `a` are both struck on `KeyA`, and a code is what
-   * a keyboard reports the same way whatever else is being held down. It is
-   * also the code the lane is a column of, so the thing you press and the
+   * It is also the code `lane` is a column of, so the thing you press and the
    * place it falls are one fact.
    */
   code: string;
   /**
    * Is this character the SHIFTED legend of its key — `A` rather than `a`, `?`
-   * rather than `/` (decision 70)?
+   * rather than `/`?
    *
-   * A shot has to match this as well as the code, and that is the whole of
-   * what makes a capital a capital in this game. Without it `A` and `a` are
-   * one target: a wave of capitals is cleared with the bare letters, lesson 39
-   * is called "Shift under fire" and never asks for a shift, and a child is
-   * credited with typing something they did not type. The passage lessons have
-   * always been strict about it — they judge the character that arrived in a
-   * real `<input>`, so `a` for `A` is simply wrong there — so this is the exam
-   * catching up with the ladder it examines, rather than a new demand.
-   *
-   * **Either shift will do.** `strokeFor` names the one on the opposite hand
-   * because that is the technique worth teaching (§3.3), and the passage's
-   * next-key hint highlights it; but a capital typed with the near shift still
-   * produces the character, and the lessons take it. A storm that marked the
-   * same stroke wrong would be stricter than the course that taught it, on the
-   * one screen with no board to explain itself with (decision 64).
-   *
-   * Read off `strokeFor` once, when the wave is built, like every other fixed
-   * fact about a letter: the reducer never asks the keyboard a question
-   * mid-run.
+   * A shot has to match this as well as the code, and **either** shift
+   * produces it (§8.4, decision 70).
    */
   shifted: boolean;
   /**
    * The finger that types it, which is the shield segment above where it
    * lands (§8.5).
    *
-   * Carried rather than looked up so that the reducer, the death screen and
-   * the drill it offers all read the same value. A hole under the right ring
-   * finger is the best thing this game tells a child about their own hands,
-   * and it must not be able to disagree with where the letter actually fell.
+   * Carried rather than looked up, so the reducer, the death screen and the
+   * drill it offers cannot disagree about where the letter fell.
    */
   finger: ShieldFinger;
   /**
-   * The column it falls down: the middle of its key, in key units from the
-   * left edge of the board (§8.2, decision 19).
+   * The column it falls down: the middle of its key, in key units, measured
+   * from the board's left edge (§8.2, decision 19).
    *
    * The board is 15 units wide, so this is a number from 0 to 15 that the
    * field scales by the same `--key` custom property the drawn keyboard uses.
-   * `f` falls onto `f`; `y` falls between `g` and `h`, because that is where
-   * `y` is.
    */
   lane: number;
   /** ms from the start of the wave to this letter appearing at the top. */
   spawnMs: number;
   /**
-   * `spawnMs + QUEUE_MS` — when it stops hanging and starts to fall.
-   *
-   * A letter is **on the field, and shootable, from `spawnMs`**; it does not
-   * move until this. See `QUEUE_MS` for why there is a difference at all.
+   * `spawnMs + QUEUE_MS` — when it stops hanging and starts to fall. A letter
+   * is on the field, and shootable, from `spawnMs` (§8.3).
    */
   dropMs: number;
   /** ms it takes to cross the field, drawn from `spec.fall`. */
   fallMs: number;
   /**
-   * `dropMs + fallMs` — when it reaches the shield.
+   * `dropMs + fallMs` — when it reaches the shield. A letter occupies the
+   * field on the **half-open** interval `[spawnMs, landMs)` (§8.3).
    *
-   * A letter occupies the field on the **half-open** interval
-   * `[spawnMs, landMs)`: it is there the instant it spawns and gone the instant
-   * it lands, because landing is the tick that resolves it into damage. That
-   * convention is what makes `gap === fall` the safe side of the boundary in
-   * `buildWave`'s no-overlap guarantee, so it is written down here rather than
-   * left for the reducer to pick again.
-   *
-   * Derived, and stored anyway, because it is read on every tick. One warning
-   * belongs with it: the *lowest* letter on screen is the one with the greatest
-   * `(t - dropMs) / fallMs`, which is not the same order as `landMs` once two
-   * letters fall at different speeds. Two orderings that look interchangeable
-   * and part company exactly where it matters are worth a sentence — and, now
-   * that something depends on the difference, a function: `targetIndex` aims by
-   * `progressAt` and never by this field.
+   * Derived, and stored anyway, because it is read on every tick. Do not order
+   * by it to find the lowest letter: letters fall at different speeds, so that
+   * is not the same order as `progressAt`, which is what `targetIndex` aims
+   * by (§8.4).
    */
   landMs: number;
 };
@@ -208,11 +131,10 @@ export type StormLetter = {
  *
  * Both are carried on it so that everything downstream takes one argument: the
  * reducer needs `shield` and `repairAt`, the results screen needs `count`, and
- * the retry button needs the seed — which is this story's whole point.
+ * the retry button needs the seed.
  *
- * `letters` is in spawn order, and **the index is the letter's identity** —
- * for the reducer's "which are in the air", and for a React key. The wave is
- * built once and never grows, so nothing can shift under either of them.
+ * `letters` is in spawn order and **a letter's index is its identity** — for
+ * the reducer's "which are in the air", and for a React key (§8.3).
  */
 export type Wave = {
   spec: WaveSpec;
@@ -235,17 +157,12 @@ type Fallable = Pick<
 /**
  * A character as a thing that could fall, or `null` if it cannot.
  *
- * Everything here is read off `engine/keyboard.ts` and nothing is restated:
- * the layout knows which key produces a character, which finger presses it and
- * where that key sits. Two characters get dropped, for different reasons:
- *
- *   - **This board cannot produce it.** A curly quote, an em dash, a letter
- *     from another layout. Same null `strokeFor` that `reachable()` is built
- *     out of (§5.2) — a wave that dropped one would be unshootable.
- *   - **A thumb types it.** The space bar, and nothing else that types a
- *     character. The shield has no thumb segment (§8.5), so a falling space
- *     would have nothing above it to damage. Spaces matter here because the
- *     unlocked alphabet a caller passes as `spec.keys` always contains one.
+ * Everything here is read off `engine/keyboard.ts` and nothing is restated.
+ * Two kinds of character are dropped rather than refused: one this board
+ * cannot produce (the same null `strokeFor` that `reachable()` is built out
+ * of, §5.2), and one a thumb types — the shield has no thumb segment, and the
+ * unlocked alphabet a caller passes as `spec.keys` always carries a space
+ * (§8.3).
  */
 function fallable(ch: string): Fallable | null {
   const stroke = strokeFor(ch);
@@ -261,7 +178,7 @@ function fallable(ch: string): Fallable | null {
     ch,
     code: stroke.code,
     // `Stroke.shift` names WHICH shift the technique wants; what falls out of
-    // it here is only whether one is wanted at all. See `StormLetter.shifted`.
+    // it here is only whether one is wanted at all.
     shifted: stroke.shift !== null,
     finger: stroke.finger,
     lane,
@@ -271,101 +188,28 @@ function fallable(ch: string): Fallable | null {
 /**
  * The fastest a letter may ever cross the sky, in ms (§8.10, decision 52).
  *
- * **"Whiteout" is hard because there are many letters, not because one is a
- * blur.** That is a promise about the top of the ladder, and the only place it
- * can be kept is here: twenty `WaveSpec`s are a table somebody writes, and a
- * table is exactly the kind of thing a difficulty pass tightens one row at a
- * time until a level nobody can read ships. A floor in the generator cannot be
- * forgotten by a row.
- *
- * 800ms is a judgement and worth being honest about that — it is not a
- * measured reaction time. What it is anchored to is the ladder's own shapes:
- * the fastest fall any of the twenty declares is 900ms (lessons 4, 9 and 13,
- * §5.7), so the floor sits just under the fastest the ladder ever *means* to
- * be and no row is touched by it. Under it a letter stops being a thing to read, find and press and
- * becomes a streak going past — which is the failure §8.10 names, and the one
- * a five-year-old cannot tell from the game being broken.
- *
- * It is a backstop, not a difficulty knob: it bites only on a spec that asked
- * for something faster than the ladder ever intends, and a wave built entirely
- * above it is untouched.
+ * A backstop in the generator rather than a floor written into the twenty
+ * levels, so no row of that table can forget it. It bites only on a spec that
+ * asked for something faster than the ladder ever intends.
  *
  * **There is deliberately no `MIN_GAP_MS` beside it, and the symmetry is a
- * trap.** The thing a gap floor looks like it would buy is §8.10's "no strobe,
- * ever" — a zone tinting over and over. But a zone tints when two letters
- * *land* on one finger, and `fall` is a range too, so letters spawned a second
- * apart land together: `storm.test.ts`'s "capitals", at `gap` 600–1000ms,
- * already lands two on one zone 14ms apart. Measured on its "everything
- * falls", the lesson-93 shape: flooring its
- * `gap` at 350ms takes one zone from four tint starts a second to three, and
- * flooring it at 800ms — which would make the top of the ladder one letter at
- * a time — still leaves three. The floor would cost the density knob the top
- * of the ladder is built out of and buy almost no safety, so the rule the
- * twenty levels keep is a count per zone per second and not a floor here:
- * `storms.test.ts` builds each of the twenty at the seed it ships with and
- * asserts no zone starts more than **two** tints inside any one second, under
- * WCAG 2.3.1's line of more than three (§8.10). The other half of that rule is
- * `MIN_TINT_GAP_MS` below, for the flash no wave can shape (decision 57).
+ * trap.** A gap floor would cost the density the top of the ladder is built
+ * out of and buy almost no safety; what the twenty levels keep instead is a
+ * per-zone cap on tints per second (§8.10). The other half of that rule is
+ * `MIN_TINT_GAP_MS` below, for the flash no wave can shape.
  */
 export const MIN_FALL_MS = 800;
 
 /**
  * How long a letter hangs at the top of the sky before it starts to fall
- * (decision 67).
+ * (§8.3, decision 67).
  *
- * ── The problem it solves ────────────────────────────────────────────────────
- * A letter has to be **read** before it can be aimed at, and until this it had
- * to be read while moving. That is the hardest possible moment to do it: the
- * display smears a moving glyph across whatever it crosses in one frame, and
- * the letters a child confuses — `i` and `l`, `1` and `l`, `O` and `0` — are
- * exactly the ones told apart by a detail that survives least. Capping the
- * fall speed (§8.2, decision 65) makes the smear smaller; this removes it for
- * the one moment it matters most, which is the moment a letter is new.
+ * A queued letter is on the field, and shootable, the whole time it hangs
+ * there.
  *
- * So a letter appears, hangs perfectly still for this long, and only then
- * falls. What a child does in that beat is the actual skill the mode teaches:
- * read the character, and find the key.
- *
- * ── It is time added, and it has to be ───────────────────────────────────────
- * The obvious cheaper version is to hold a letter inside its own fall time —
- * hang for a beat, then cover the same distance in what is left. That is
- * strictly worse than doing nothing: the same sky in less time is a FASTER
- * drop, which is the problem it was meant to fix, at its most urgent point.
- * There is no version of this that does not add time to the letter's life.
- *
- * ── Shootable the whole time ─────────────────────────────────────────────────
- * A queued letter is on the field: `isAirborne` says so, `targetIndex` will
- * aim at it, and `fire` will take it. That is not a detail. A game that showed
- * a child a letter and then charged them ten points for pressing it too early
- * would be punishing them for doing the thing the queue exists to let them do.
- * What the queue is NOT is a head start on the schedule — the letters still
- * arrive at the same intervals, so a child who reads fast simply gets to spend
- * the beat, and one who does not still has the whole fall.
- *
- * ── What it does not disturb ─────────────────────────────────────────────────
- * The value is the same for every letter of every level, so it shifts the
- * whole schedule and warps none of it. Three things fall out of that, and each
- * is a thing that would otherwise have needed re-tuning:
- *
- *   - **The twenty levels keep their shapes.** `gap` against `fall` is the
- *     difficulty (`WaveSpec`), both are untouched, and the seeds are drawn in
- *     the same order from the same generator — so every level rains the same
- *     letters in the same lanes at the same speeds it did before.
- *   - **"One at a time" survives, as a claim about falling.** Levels 4, 9 and
- *     13 promise pure reaction, and what that has always meant is that no two
- *     letters are coming DOWN at once — which `gap[0] >= fall[1]` still buys
- *     exactly, because every fall is shifted by the same amount. A letter
- *     queued above a falling one is the next one waiting its turn, which is
- *     what makes it a queue.
- *   - **A run's own times mean what they did.** `CardResult.ms` is
- *     `atMs - spawnMs` (§8.7) — time from a child first *seeing* the letter,
- *     which is what it always was. A fast player's card is the same number it
- *     would have been; only a slow one has longer to be slow in.
- *
- * A second is a judgement, not a measurement, and it is the same order as the
- * fastest fall on the ladder (900ms, lessons 4, 9 and 13). Round, long enough
- * to read an unfamiliar glyph without hurrying, and short enough that a level
- * with a 300ms gap still has a queue rather than a crowd.
+ * A second is a judgement and not a measurement. Round, long enough to read an
+ * unfamiliar glyph without hurrying, and short enough that a level with a
+ * 300ms gap still has a queue rather than a crowd.
  */
 export const QUEUE_MS = 1000;
 
@@ -373,17 +217,10 @@ export const QUEUE_MS = 1000;
  * The fall times a spec can actually produce — its own range, floored at
  * `MIN_FALL_MS`.
  *
- * Exported because two questions are asked of it and neither should re-derive
- * the clamp: `buildWave` samples from it, and anything asking whether a level
- * is "one letter at a time" has to read the schedule the wave was built with
- * rather than the one it was written with. `gap[0] >= fall[1]` is that
- * property (see `buildWave`), and a fall the floor has raised is a fall that
- * can overlap where the declaration said it would not.
- *
- * The range is clamped rather than each sample, so the draw stays uniform over
- * what a letter can be. Flooring the sample instead would pile every letter of
- * a too-fast spec onto the floor exactly, which is a metronome wearing a
- * range's clothes.
+ * Exported so that nothing re-derives the clamp. Anything asking whether a
+ * level is "one letter at a time" has to read the schedule the wave was built
+ * with rather than the one it was declared with, because a floor can only
+ * raise a fall (§8.10).
  */
 export function fallRange(spec: WaveSpec): [number, number] {
   return [
@@ -396,43 +233,23 @@ export function fallRange(spec: WaveSpec): [number, number] {
  * The whole wave, from a seed.
  *
  * Deterministic in `(spec, seed)` and in nothing else: no clock is read and
- * `Math.random` is never called, here or below. The **draw order** — the gap in
- * front of a letter, then which letter, then how fast it falls — is therefore
- * part of what a seed means. Reordering those three lines re-rolls every storm,
- * which is free today and is not free the moment a level's seed is written down
- * beside a saved run (STM08).
+ * `Math.random` is never called, here or below. The **draw order** — the gap
+ * in front of a letter, then which letter, then how fast it falls — is
+ * therefore part of what a seed means. Reordering those three lines re-rolls
+ * every storm, including the twenty seeds that ship (§5.7).
  *
- * ── Why `gap ≥ fall` means one letter falling at a time ──────────────────────
- * Letter _i_ is coming down over `[drop_i, drop_i + fall_i)` and letter _i+1_
- * drops at `drop_i + gap_{i+1}` — the queue shifts both by the same
- * `QUEUE_MS`, so it cancels out of this entirely — and the two are therefore
- * falling together exactly when `gap_{i+1} < fall_i`. If every gap a spec can
- * draw is at least every fall it can draw — `gap[0] ≥ fall[1]` — that is never
- * true, and since spawn times only increase, no *later* letter can overlap
- * letter _i_ either. So the early levels' "never more than one falling" is a
- * property of the spec, not a hope about the draw.
- *
- * The boundary goes to safety: `gap` exactly equal to `fall` still leaves one
- * letter coming down, because the interval is half-open — the outgoing letter
- * lands on the same millisecond the next one starts to drop, and landing is
- * the tick that takes it off the field.
- *
- * That arithmetic is read against `fallRange(spec)` and not against
- * `spec.fall`: the fall a letter gets is floored at `MIN_FALL_MS`, and a floor
- * can only ever raise a fall — so a spec that declared "one at a time" with
- * falls under the floor gets letters that overlap. Which is the right way for
- * that to go: the alternative is a level that keeps its spacing promise by
- * dropping letters nobody could read.
+ * "Never more than one letter falling" is a property of the spec rather than a
+ * hope about the draw: `gap[0] >= fall[1]` buys it exactly, and the boundary
+ * goes to safety because the interval is half-open (§8.3). That arithmetic is
+ * read against `fallRange(spec)` and never against `spec.fall` (§8.10).
  */
 export function buildWave(spec: WaveSpec, seed: number): Wave {
   const rand = mulberry32(seed);
   const fall = fallRange(spec);
 
-  // Filtered once, up front. An empty pool — a spec naming only characters
-  // this board cannot type — yields an empty wave rather than an exception:
-  // the engine's habit is that a mode which no longer makes sense still opens
-  // (`deckSpec` never throws), and a storm with nothing in it is a screen that
-  // ends, where a throw is a game loop that dies holding a child's run.
+  // Filtered once, up front. An empty pool builds an empty wave rather than
+  // throwing — the engine's habit that a mode which no longer makes sense
+  // still opens (§8.3).
   const pool = spec.keys
     .map(fallable)
     .filter((entry): entry is Fallable => entry !== null);
@@ -441,14 +258,13 @@ export function buildWave(spec: WaveSpec, seed: number): Wave {
   let spawnMs = 0;
   for (let i = 0; i < spec.count && pool.length > 0; i++) {
     // The gap is the time since the previous spawn, so the first letter has
-    // none — the wave starts with it. Not sampled-and-discarded for i = 0,
-    // because a draw nobody uses is still part of what the seed means.
+    // none. Not sampled-and-discarded for i = 0, because a draw nobody uses is
+    // still part of what the seed means.
     if (i > 0) spawnMs += between(spec.gap[0], spec.gap[1], rand);
     const from = pool[between(0, pool.length - 1, rand)];
     const fallMs = between(fall[0], fall[1], rand);
-    // Every letter waits the same beat before it moves (`QUEUE_MS`), so this
-    // shifts the whole schedule and warps none of it — and draws nothing from
-    // `rand`, which is what keeps every level's weather exactly what it was.
+    // Every letter waits the same beat, so this shifts the whole schedule and
+    // warps none of it — and draws nothing from `rand`.
     const dropMs = spawnMs + QUEUE_MS;
     letters.push({ ...from, spawnMs, dropMs, fallMs, landMs: dropMs + fallMs });
   }
@@ -463,35 +279,19 @@ export function buildWave(spec: WaveSpec, seed: number): Wave {
 
 /* ═══ The reducer: the wave, played (§8.4, §8.5, §8.9) ═══════════════════════
  *
- * Everything below is a pure function of the state it is handed. No clock, no
- * `Math.random`, no DOM, no React — the loop reads a real clock, calls `tick`
- * with the delta and writes transforms; the tests call the same two functions
- * with numbers. "Did that letter get through" is therefore a question that can
- * be asked without a browser, which is the only reason the shield's rules are
- * testable at all.
+ * Everything below is a pure function of the state it is handed. The loop
+ * reads a real clock and calls `tick` with the delta; the tests call the same
+ * functions with numbers.
  */
 
 /**
  * Is this letter on the field at `timeMs` — queued or falling?
  *
- * A letter occupies the **half-open** interval `[spawnMs, landMs)`: there the
- * instant it spawns, gone the instant it lands, because landing is the tick
- * that turns it into shield damage (decision 30).
- *
- * That convention is exported as a pair of predicates rather than written out
- * where it is needed, because it is one `<` against one `<=` and more than one
- * thing reads it: `targetIndex` decides what can be shot with `isAirborne`,
- * `tick` decides what damages the shield with `hasLanded`, and the field draws
- * whatever `isAirborne` says is there (STM03). Spelled out at each of those,
- * it would be three chances to pick the wrong side of a millisecond — and the
- * wrong side of a millisecond is a letter that is both shootable and already
- * spent.
- *
- * **Airborne, and not yet falling, is a real state** (`QUEUE_MS`): a letter
- * hangs at the top of the sky for a beat before it moves. It is on the field
- * throughout — drawn, aimed at and shootable — because a queue a child may not
- * shoot into is a letter the game shows them and then charges them ten points
- * for pressing.
+ * The half-open interval `[spawnMs, landMs)` (§8.3, decision 30), exported as
+ * a predicate rather than spelled out at each of its three readers —
+ * `targetIndex`, `tick` and the field — where it would be three chances to
+ * pick the wrong side of a millisecond, and the wrong side is a letter that is
+ * both shootable and already spent.
  *
  * `hasLanded` is deliberately not `!isAirborne`: a letter that has not spawned
  * yet is neither on the field nor landed, and the reducer must not charge the
@@ -504,15 +304,11 @@ export function isAirborne(letter: StormLetter, timeMs: number): boolean {
 /**
  * Is this letter actually coming down at `timeMs`, rather than waiting to?
  *
- * The narrower half of `isAirborne`, and what "one letter at a time" is a
- * claim about: the early levels promise pure reaction, and what that has
- * always meant is that no two letters are FALLING at once (`buildWave`). A
- * letter queued above a falling one is the next one waiting its turn.
- *
  * Nothing in the reducer reads it — the rules care about what is on the field
- * and what has landed, and neither of those is this. It is here because the
- * property it names is one the twenty levels are held to, and a test that
- * restated the interval would be a second opinion about `QUEUE_MS`.
+ * and what has landed, and neither of those is this. It is here because "one
+ * letter at a time" is a claim about falling that the twenty levels are held
+ * to, and a test restating the interval would be a second opinion about
+ * `QUEUE_MS` (§8.3).
  */
 export function isFalling(letter: StormLetter, timeMs: number): boolean {
   return letter.dropMs <= timeMs && timeMs < letter.landMs;
@@ -526,20 +322,13 @@ export function hasLanded(letter: StormLetter, timeMs: number): boolean {
 /**
  * How far down the field a letter is at `timeMs`: 0 at the top, 1 at the shield.
  *
- * One function rather than an expression repeated wherever it is wanted,
- * because two of its readers must agree exactly: the renderer writes it into a
- * `translateY` (STM03) and `targetIndex` takes the maximum of it to decide
- * what the gun is aimed at. A child aims by looking, so the letter the game
- * thinks is lowest has to be the letter that is drawn lowest.
+ * One function rather than an expression repeated, because two readers must
+ * agree exactly: the renderer writes it into a `translateY`, and `targetIndex`
+ * takes the maximum of it. A child aims by looking, so the letter the game
+ * thinks is lowest has to be the one drawn lowest.
  *
- * **Floored at zero, which is what a queued letter is** (`QUEUE_MS`). Both
- * readers need that and for the same reason. The renderer would otherwise
- * carry a queued stone UP out of the sky, since `--drop` is multiplied by the
- * travel and a negative one is a negative offset. And `targetIndex` would rank
- * two letters hanging side by side at the top — visibly at the same height —
- * by how long each has left before it drops divided by how long its fall is,
- * which is a number nothing on screen shows. Floored, they tie, and a tie goes
- * to the earlier spawn like every other dead heat (decision 33).
+ * **Floored at zero**: a queued letter has made no progress, and both readers
+ * need it to read that way (§8.3).
  *
  * `fallMs` cannot be 0 while a letter is falling — `drop <= t < drop + fall`
  * has no solutions at `fall = 0` — so the division is safe everywhere the
@@ -553,12 +342,9 @@ export function progressAt(letter: StormLetter, timeMs: number): number {
 /**
  * The eight shield segments, in board order — left pinky to right pinky.
  *
- * An order rather than a set, because two things need it to be the *same*
- * order: the shield is drawn as eight segments across the bottom of the field
- * (STM03), and a repair has to break a tie between equally weak zones somehow.
- * Using the order the child is looking at means the tie-break is at least a
- * thing they could watch happen, rather than whatever order a `Record`'s keys
- * came out in.
+ * An order rather than a set, because a repair has to break a tie between
+ * equally weak zones somehow, and this is the order the shield is drawn in
+ * (§8.5). The tie-break is then at least a thing a child could watch happen.
  */
 export const SHIELD_FINGERS: readonly ShieldFinger[] = [
   "l-pinky",
@@ -577,21 +363,15 @@ export type Shield = Readonly<Record<ShieldFinger, number>>;
 /**
  * What became of one letter, and when.
  *
- * `atMs` is wave time — the instant of the press for a letter that was shot,
- * and the letter's own `landMs` for one that got through. Its own landing and
- * not the tick that noticed it, because a tick can arrive several landings
- * late (see `tick`), and STM08 turns this into a `CardResult.ms` of
- * `atMs - spawnMs` (§8.7). A card that timed a backgrounded tab instead of a
- * fall would put a nonsense number in a child's record book for ever.
+ * `atMs` is wave time: the press for a letter that was shot, and the letter's
+ * own `landMs` for one that got through — its own landing and not the tick
+ * that noticed it, because a tick can arrive several landings late (see
+ * `tick`), and a card timing a backgrounded tab would put a nonsense number in
+ * a child's record book for ever (§8.7).
  *
- * `combo` is the streak the shot left the run on — the number the HUD draws
- * its multiplier from the instant after it — and 0 for a letter that got
- * through, since a landing is what breaks a streak. It is recorded rather than recovered
- * because it cannot be recovered: a wrong key breaks the combo and resolves no
- * letter, so nothing in `resolved` remembers that it happened, and a run's XP
- * counted back off this array without it would pay a child for a streak they
- * did not keep. `stormXp` folds exactly this pair — `atMs - spawnMs` and
- * `combo` — through `cardXp` when the run is over (§8.6).
+ * `combo` is the streak the shot left the run on, and 0 for a letter that got
+ * through. Recorded because it cannot be recovered: a wrong key breaks the
+ * combo and resolves no letter, so nothing in `resolved` remembers it.
  */
 export type LetterOutcome = {
   outcome: "shot" | "landed";
@@ -602,12 +382,10 @@ export type LetterOutcome = {
 /**
  * How a run finished, or `null` while it is still going.
  *
- * `breached` carries the finger rather than leaving it to be looked up later.
- * Naming the finger that failed is the best thing this game tells a child
- * (§8.5), and it must be the finger the letter actually fell on — so it is
- * copied from the letter at the moment it got through, not re-derived from a
- * shield that by then reads the same at several zones. `index` is the letter
- * that ended it: what the death screen can show, and where its drill starts.
+ * `breached` carries the finger taken from the letter as it got through, never
+ * re-derived afterwards from a shield that by then reads the same at several
+ * zones (§8.5). `index` is the letter that ended it: what the death screen can
+ * show, and where its drill starts.
  */
 export type StormEnding =
   | { kind: "cleared" }
@@ -617,27 +395,17 @@ export type StormEnding =
  * A run, mid-storm.
  *
  * Everything here is a fact that cannot be recovered from the wave and the
- * clock, and nothing here is a fact that can. There is no list of letters on
- * screen, no cached lowest letter and no per-finger tally of what got through:
- * the first two are `isAirborne` and `targetIndex` over a schedule that was
- * decided before the run started, and the third is a `filter` over `resolved`
- * that the death screen can do for itself. A second copy of any of them would
- * be a second thing to keep in step sixty times a second, and the copy is
- * always the one that ends up lying.
+ * clock, and nothing here is a fact that can. No list of letters on screen, no
+ * cached lowest letter, no per-finger tally of what got through — each of
+ * those already falls out of a schedule decided before the run started, and a
+ * second copy is a second thing to keep in step sixty times a second.
  *
  * `resolved` is parallel to `wave.letters` and indexed by the letter's
  * identity (§8.3). Indexed rather than appended to, because resolution is
  * **not** in spawn order: shoot the middle one of three and the array gets a
- * hole in it. That indexing is also what makes the run a `Session` with no
- * bookkeeping: card _i_ is built from letter _i_ and outcome _i_ together, so
- * `prompt`, `answer` and `factId` are the letter's character and `ms` is
- * `atMs - spawnMs` (§8.7, `stormSession.ts`). It is a card **per resolved
- * letter**, not per index — a run that ended early leaves holes in here, and
- * they are the letters that never happened.
- *
- * Two stories read this and neither wanted a different shape: STM07 takes the
- * finger off `ending` and counts `resolved` by finger for "let three through",
- * and STM08 walks it in order for the cards.
+ * hole in it. It is a card **per resolved letter**, not per index — a run that
+ * ended early leaves holes in here, and they are the letters that never
+ * happened (§8.7, `stormSession.ts`).
  */
 export type StormState = {
   /** The storm being played. Decided before the run; never changes during it. */
@@ -654,16 +422,10 @@ export type StormState = {
   /**
    * Consecutive hits, unbroken by a miss or by a letter getting through.
    *
-   * It is state and not a view's counter because a rule reads it: every
-   * `repairAt` of them puts a point back into the weakest zone (§8.5), which
-   * is the game's only comeback path and pays out for exactly the behaviour it
-   * exists to build. A letter that landed breaks the streak as surely as a
-   * wrong key does — the streak means "are you keeping up", and a letter you
-   * let through is the definition of not keeping up.
-   *
-   * The score multiplier hangs on this same number, through the same
-   * `comboMultiplier` a race pays its cards at — so a child sees ONE streak,
-   * and the ×1.6 in the HUD is the ×1.6 their XP is worth (§8.6).
+   * State and not a view's counter because two rules read it: every `repairAt`
+   * of them puts a point back into the weakest zone (§8.5), and the score
+   * multiplier hangs on the same number — so the ×1.6 in the HUD is the ×1.6
+   * the XP is worth (§8.6).
    */
   readonly combo: number;
   /**
@@ -673,29 +435,21 @@ export type StormState = {
    * points and resolves no letter, so `resolved` has no record of it, and the
    * multiplier a hit was paid at is history the moment the streak moves on.
    *
-   * It is not XP and it never becomes XP. `stormXp` is computed once at the
-   * end, from the hits alone and floored at zero, precisely so that this
-   * number is free to fall (see `progress.ts`).
+   * It is not XP and it never becomes XP (§8.6).
    */
   readonly score: number;
   /**
    * Wrong keys — shots that hit nothing, including shots at an empty sky.
    *
-   * A count and not a list, because what reads it wants a number: the HUD
-   * mounts one `--flare` flash per miss off it, and a counter that only goes
-   * up cannot restart an animation (§8.10, decision 42).
+   * A count and not a list, because what reads it wants a number.
    *
-   * **It is the run's own number and does not reach the record book.** STM08
-   * weighed giving a saved session an `incorrect` that counted wrong keys as
-   * well as letters that got through, and did not: a card is a letter's
-   * outcome, a wrong key resolves no letter, and two things downstream read
-   * "nothing marked wrong" as "nothing got through" — `survived`, which is
-   * `cards.length >= wordCount`, and the `unbroken` badge (§8.7, decision 48).
-   * What a miss cost is still saved, in the streak it broke: `bestStreak` is
-   * `bestCombo`, and the combo a wrong key ended is one the maximum never saw.
+   * **It is the run's own number and does not reach the record book.** A card
+   * is a letter's outcome, so a saved session's `incorrect` counts what got
+   * through and nothing else (§8.7, decision 48). What a miss cost is saved in
+   * the streak it broke.
    *
-   * It is the count and **not** what the HUD's flash is mounted from — see
-   * `missTintAt` below, which is the half of this that a hand can strobe.
+   * It is **not** what the HUD's flash is mounted from — see `missTintAt`
+   * below, which is the half of this that a hand can strobe.
    */
   readonly misses: number;
   /**
@@ -703,21 +457,9 @@ export type StormState = {
    * the first one. **A new value is a new flash, and an unchanged one is the
    * same element left alone** (§8.10, decision 42).
    *
-   * The count above cannot do that job, and this is the one cadence on this
-   * screen no `WaveSpec` can shape (decision 57). A wave's tint rate is read
-   * off its own schedule and held to two a second by each of the twenty levels
-   * (`storms.ts`); a miss happens when a child presses a wrong key, so its rate
-   * is the rate a hand can move at. Auto-repeat is already not a shot
-   * (decision 44), which takes 30Hz off the table, but a child mashing at
-   * eight or ten a second is not a bug and must not produce eight or ten
-   * flashes — "no strobe, ever, in any mode" (§8.10) is a promise about the
-   * screen and not about the wave.
-   *
-   * So the flash is rate-limited where the rule lives rather than in the view:
-   * a miss inside `MIN_TINT_GAP_MS` of the last flash still costs the points
-   * and still breaks the streak, and simply does not re-light a wash that is
-   * already lit. The reducer is the only thing here holding a clock, which is
-   * why this is a field and not a `useRef` in the HUD.
+   * The HUD keys its wash off this rather than off `misses`, which is what
+   * lets a miss be charged in full while the flash it would have lit is held
+   * back — see `MIN_TINT_GAP_MS` for why that throttle is in the reducer.
    */
   readonly missTintAt: number | null;
   /** How the run finished, or `null` while it is live. */
@@ -728,16 +470,9 @@ export type StormState = {
  * What a clean hit is worth before the combo multiplier, and what a wrong key
  * costs (§8.6).
  *
- * Equal, and that is the whole of the balance: **one wrong key undoes one
- * plain hit**, which is a sentence a five-year-old can hold on to. A hit on a
- * long streak is worth two of them (×2 at ten in a row), so keeping a run
- * clean pays for itself twice over — once in the multiplier, and once in the
- * misses it did not make.
- *
- * A letter that gets through costs neither. It has already cost a shield
- * point, which is the thing that ends runs, and charging for it twice would
- * make the number that goes down mean two different failures at once
- * (decision 46).
+ * Equal, and that is the whole of the balance: one wrong key undoes one plain
+ * hit. A letter that gets through costs neither, having already cost a shield
+ * point (decision 46).
  */
 export const HIT_POINTS = 10;
 export const MISS_POINTS = 10;
@@ -746,27 +481,27 @@ export const MISS_POINTS = 10;
  * The least time between two starts of the score's miss wash, in wave ms
  * (§8.10, decision 57).
  *
- * **WCAG 2.3.1's line is more than three flashes in any one second**, and 500ms
- * holds the wash to **two starts inside any second** — the same number the
- * twenty waves' zone tints ship at (§8.10), so the two things that light on
- * this screen have the same full flash a second of headroom under the line.
+ * WCAG 2.3.1 draws its line at more than three flashes inside one second, and
+ * 500ms holds the wash to two starts a second — the same headroom the twenty
+ * waves' zone tints ship with. The smaller round values do not, and the
+ * arithmetic is in §8.10.
  *
- * The arithmetic is worth writing down, because the obvious value is wrong.
- * A gap of `g` permits `ceil(1000 / g)` starts inside a second: 340ms permits
- * **three** — 0, 340 and 680 — which is exactly the standard's ceiling with
- * nothing to spare, and this is the one screen on the site where the youngest
- * player is hammering keys *because they are losing*. 500 is the largest round
- * number that buys the second flash back. Measured by driving `fire` 60 times
- * at cadences from 10ms to 750ms: every one of the 60 charged, and no second
- * ever contains more than two starts.
+ * **The throttle is here in the reducer and not in the HUD**, because the
+ * reducer is the only thing on this screen holding a clock. A wave's tint rate
+ * can be read off its schedule in advance; a miss happens when a child presses
+ * a wrong key, so its rate is the rate a hand can move at, and only something
+ * watching the live run can bound it. In the view this would be a `useRef`
+ * keeping a second clock that then has to agree with this one. A miss inside
+ * the gap still costs the points and still breaks the streak — it simply does
+ * not re-light a wash that is already lit.
  *
- * It is also deliberately longer than the 150ms the tint is drawn for, so what
- * a fast hand gets is a wash that lights, fades and then is allowed to light
- * again, never a wash that blinks off and on inside its own animation.
+ * Longer than the wash is drawn for, too, so a fast hand gets a wash that
+ * lights, fades and is then allowed to light again, never one that blinks off
+ * and on inside its own animation.
  *
- * Wave time and not wall-clock time, so the quit sheet's pause (§8.11) cannot
- * spend it: a run resumed after a minute behind the sheet is exactly where it
- * was, which is what "the sheet costs the run zero" means everywhere else.
+ * **Wave time, not wall-clock time**, so the quit sheet's pause cannot spend
+ * it: a run resumed after a minute behind the sheet is exactly where it was
+ * (§8.11).
  */
 export const MIN_TINT_GAP_MS = 500;
 
@@ -776,9 +511,7 @@ export const MIN_TINT_GAP_MS = 500;
  * Cleared is "every letter resolved" rather than "the clock passed
  * `durationMs`", because shooting the last letter ends the wave there and
  * then; the alternative leaves a child watching an empty field for the second
- * and a half that letter would have taken to fall. The two agree wherever it
- * matters — a letter is only ever resolved by being shot or by landing, and
- * nothing can land after `durationMs`.
+ * and a half that letter would have taken to fall.
  */
 const settled = (state: StormState): StormState =>
   state.ending !== null || state.resolved.some((outcome) => outcome === null)
@@ -789,13 +522,10 @@ const settled = (state: StormState): StormState =>
  * A run at time zero: full shield, nothing resolved, no streak.
  *
  * The wave is carried, not copied. The retry button, the results screen and
- * the reducer are all meant to be looking at the same storm, and a state that
- * owned its own copy of the schedule would be a second place for it to be
- * wrong.
+ * the reducer are all meant to be looking at the same storm.
  *
- * An empty wave is born `cleared` — the same habit as `buildWave` not throwing
- * (§8.3). A storm with nothing in it is a screen that ends, where a loop
- * waiting on a letter that will never spawn is a run a child cannot leave.
+ * An empty wave is born `cleared`, so a loop can never be left waiting on a
+ * letter that will never spawn (§8.3).
  */
 export function startStorm(wave: Wave): StormState {
   const shield = Object.fromEntries(
@@ -817,23 +547,10 @@ export function startStorm(wave: Wave): StormState {
 
 /**
  * The lowest letter on the field, as an index into `wave.letters` — or `null`
- * if nothing is falling.
+ * if nothing is on it.
  *
- * **Lowest is the greatest `progressAt`, and not the earliest `landMs`.** The
- * two orderings look interchangeable and are not: every letter draws its own
- * fall time, so a fast letter spawned second genuinely overtakes a slow one
- * spawned first, and from the crossing until the landing the two orderings
- * disagree about which is nearer the shield. Aiming by `landMs` would point
- * the gun at a letter that is visibly higher up the screen — and the child is
- * looking at the field, not at the schedule.
- *
- * On an exact tie — two letters at the same height, which is the single
- * instant their lines cross — the lower index wins, which is the earlier
- * spawn. Neither is fairer to a child who cannot see a difference between
- * them, so the tie goes to the thing that is already a letter's identity
- * (§8.3): the same wave replayed resolves the same dead heat the same way. A
- * replay that diverged on a rounding difference would be a worse bug than
- * either answer to the tie.
+ * **Lowest is the greatest `progressAt`, and not the earliest `landMs`**, and
+ * on an exact tie the lower index wins, which is the earlier spawn (§8.4).
  *
  * It does not read `state.ending`. A run that ended mid-wave still has letters
  * in the air, so this still names one; `fire` asks only after its own guard,
@@ -861,26 +578,18 @@ export function targetIndex(state: StormState): number | null {
 }
 
 /**
- * The shield after a hit, with `repairAt` applied.
- *
- * The weakest zone rather than the last one damaged, because a hole is what
- * ends a run: the segment at zero is simultaneously the one about to kill you
- * and the one a single point is worth most in. "Weakest" picks it with no
- * special case for holes at all.
+ * The shield after a hit, with `repairAt` applied — into the weakest zone,
+ * never the last one damaged (§8.5).
  *
  * Two edges, both deliberate:
  *
- *   - **`repairAt: 0` disables repairs**, as `WaveSpec` declares — said out
- *     loud rather than left to `combo % 0` being `NaN`. The arithmetic does
- *     fall the right way on its own, which is the problem: the rule the spec
- *     writes down would be an accident of IEEE, and the same expression hands
- *     a *negative* `repairAt` a repair every other hit.
- *   - **No zone ever exceeds `spec.shield`.** A wave whose repairs outran its
- *     damage would hand a strong player a shield deeper than the level ever
- *     wrote down, and the eight-of-`shield` a run starts with is exactly what
- *     "the shield came through untouched" is reported against. At the cap the
- *     repair is spent rather than banked — banking it would be a hit point
- *     arriving at a moment nothing on screen explains.
+ *   - **`repairAt: 0` disables repairs**, as `WaveSpec` declares — checked
+ *     rather than left to `combo % 0` being `NaN`. That the arithmetic falls
+ *     the right way on its own is the problem, not the reassurance: the same
+ *     expression hands a *negative* `repairAt` a repair every other hit.
+ *   - **No zone ever exceeds `spec.shield`** (§8.5). At the cap the repair is
+ *     spent rather than banked — banking it would be a hit point arriving at a
+ *     moment nothing on screen explains.
  */
 function repaired(shield: Shield, spec: WaveSpec, combo: number): Shield {
   if (spec.repairAt <= 0 || combo % spec.repairAt !== 0) return shield;
@@ -900,25 +609,14 @@ function repaired(shield: Shield, spec: WaveSpec, combo: number): Shield {
 /**
  * Advance the clock, and resolve everything that reached the shield on the way.
  *
- * ── A tick may be arbitrarily long ───────────────────────────────────────────
- * `dtMs` is whatever the loop hands over, and a backgrounded tab hands over
- * seconds: `requestAnimationFrame` stops, the child comes back, and a dozen
- * letters are due at once. Every landing inside the interval is resolved, in
- * the order it happened — including letters that spawned *and* landed inside
- * the same tick and were never airborne at any instant anybody sampled.
- * Dropping those would leave the shield quietly disagreeing with the storm
- * that damaged it, and the disagreement would be invisible: the letters are
- * gone from the screen either way.
+ * `dtMs` is whatever the loop hands over, and **every** landing inside the
+ * interval is resolved in the order it happened, including ones that spawned
+ * and landed inside a single tick (§8.9). Clamping a long delta is the loop's
+ * decision to make deliberately, and so is keeping a non-finite one out: a
+ * `NaN` delta poisons `timeMs` for the rest of the run and ends nothing.
  *
- * Whether a child should be *held responsible* for a tab they were not looking
- * at is a different question, and it belongs to the clock (STM03): clamping
- * the delta, or pausing on `visibilitychange`, is a decision the loop can only
- * make deliberately because the rules underneath it are honest about the whole
- * interval they were given. Two things that loop cannot lean on: a `NaN` delta
- * poisons `timeMs` for the rest of the run and ends nothing — no delta between
- * two real clock readings is one, and clamping is STM03's — and neither a tick
- * with no landing nor a missed `fire` returns the object it was handed, so
- * identity is not a "nothing changed" signal.
+ * A returned state is always a new object, even from a tick with no landing,
+ * so `===` is not a "nothing changed" signal (§8.9, decision 40).
  */
 export function tick(state: StormState, dtMs: number): StormState {
   if (state.ending !== null) return state;
@@ -950,20 +648,18 @@ export function tick(state: StormState, dtMs: number): StormState {
 
   for (const { letter, index } of landings) {
     // Combo 0 on the outcome as well as on the run: a letter that got through
-    // was shot on no streak at all, and `stormXp` pays nothing for it either
-    // way — it looks only at what was shot.
+    // was shot on no streak at all.
     resolved[index] = { outcome: "landed", atMs: letter.landMs, combo: 0 };
     combo = 0;
 
     if (shield[letter.finger] <= 0) {
-      // The zone above it is a hole, so there is nothing left to take the hit
-      // and the storm is through. The clock stops at that landing rather than
-      // at the end of the tick: the rest of this interval never happened, and
-      // the letters still due inside it stay unresolved rather than being
-      // charged to a shield the child no longer had. That includes a letter
-      // tying this exact `landMs` from a higher index, which `hasLanded` now
-      // reads true of — so "got through" (STM07) counts `resolved`, never
-      // `hasLanded`.
+      // The zone above it is a hole, so there is nothing left to take the hit.
+      // The clock stops at that landing rather than at the end of the tick:
+      // the rest of this interval never happened, and the letters still due
+      // inside it stay unresolved rather than being charged to a shield the
+      // child no longer had. That includes a letter tying this exact `landMs`
+      // from a higher index, which `hasLanded` now reads true of — so "got
+      // through" counts `resolved`, never `hasLanded`.
       ending = { kind: "breached", finger: letter.finger, index };
       clock = letter.landMs;
       break;
@@ -978,61 +674,25 @@ export function tick(state: StormState, dtMs: number): StormState {
 /**
  * Did this press produce this letter's character?
  *
- * Both halves, because between them they ARE the character. `code` says which
- * key was struck, and it is the half that survives whatever is being held down
- * — `A` and `a` are one key (decision 2), which is why a code and not a
- * character is what a letter carries. `shifted` says which of that key's two
- * legends the strike produced, and it is the half that tells them apart: a
- * capital is a shift and a letter (§3.3), so a storm comparing the code alone
- * would mark a child right for typing the other one (decision 70).
+ * Both halves, because between them they ARE the character: `code` is the half
+ * that survives whatever else is being held down, and `shifted` is the half
+ * that tells the key's two legends apart (§8.4, decisions 2 and 70).
  *
  * A predicate rather than two clauses inside `fire`'s guard, because the guard
- * has to keep narrowing `index` away from `null` for the lines below it — and
- * because "was that the right key" is the one question this game is about, so
- * it is worth having a name.
+ * has to keep narrowing `index` away from `null` for the lines below it.
  */
 function struck(letter: StormLetter, code: string, shift: boolean): boolean {
   return letter.code === code && letter.shifted === shift;
 }
 
 /**
- * Fire at the lowest letter on screen. Anything else is a miss.
+ * Fire at the lowest letter on screen. Anything else is a miss, a shot at an
+ * empty field included (§8.4).
  *
- * ── Why only the lowest ──────────────────────────────────────────────────────
- * The alternative is not "let the second letter count too"; it is a game with
- * no wrong answer in it. If any letter on screen can be shot by its own key,
- * the winning strategy is to hammer every key the wave draws from and let the
- * matches happen — and the child doing that is practising nothing at all while
- * the score congratulates them for it. Firing has to be able to be *wrong*
- * before hitting can mean anything, and the only sense of "wrong" a
- * falling-letter game can defend is out of order: the bottom letter is the one
- * nearest the shield *on screen*, which is the one a child can see is most
- * urgent and can aim at without knowing anything the field is not showing
- * them.
- *
- * Nearest is not soonest. Letters fall at different speeds, so the letter due
- * to land first may be a different one, visibly higher up the screen, from the
- * moment two paths cross until one of them lands (decision 32, and
- * `targetIndex`). The rule follows the field and not the schedule on purpose:
- * a target picked by `landMs` would refuse the letter the child is watching
- * drop and demand one they have no way to know was closer in time.
- *
- * That is also what makes the difference between one letter in the air and
- * three a difference in kind. With one, target and only letter are the same
- * thing and the game is pure reaction. With three, taking the bottom one first
- * is an act of prioritising under time pressure — reading ahead, which is the
- * thing that separates a typist from a hunter — and it is a skill precisely
- * because getting the order wrong costs something: the streak, and with it the
- * multiplier every later hit would have been paid at, plus `MISS_POINTS` off
- * the score there and then.
- *
- * A shot at an empty field is a miss for the same reason. It is exactly the
- * spray this rule exists to make unprofitable, and a child who could keep
- * their streak through it has found the strategy again by another route. The
- * screen still owes them an answer, and since there is no board left to say it
- * on (decision 64) the answer is the one a screen with nothing on it can give:
- * `sfx.misfire`, the same flat sound every other wrong key makes
- * (`stormSounds.ts`), plus the `--flare` wash over the score that just fell.
+ * The rule follows the field and not the schedule: nearest is not soonest,
+ * because letters fall at different speeds (decision 32, and `targetIndex`). A
+ * target picked by `landMs` would refuse the letter the child is watching drop
+ * and demand one they had no way to know was closer in time.
  */
 export function fire(
   state: StormState,
@@ -1041,12 +701,10 @@ export function fire(
    * Was a shift held down as the key went down — `event.shiftKey`, either
    * hand?
    *
-   * Defaulted, and the default is the ordinary stroke: no shift, which is what
-   * `a`, `f` and `7` are typed with. It is safe to leave off only because
-   * getting it wrong can make a shot stricter and never looser — a caller that
-   * forgets it can no longer shoot a capital at all, which is a thing a child
-   * would notice on the first wave of lesson 34, where the bug it replaced was
-   * a game that quietly never asked (decision 70).
+   * Defaulted, and the default is the ordinary stroke: no shift. It is safe to
+   * leave off only because getting it wrong can make a shot stricter and never
+   * looser — a caller that forgets it can no longer shoot a capital at all
+   * (§8.4, decision 70).
    */
   shift = false,
 ): StormState {
@@ -1056,12 +714,8 @@ export function fire(
   if (index === null || !struck(state.wave.letters[index], code, shift))
     // A miss: the streak, the score and a mark against the run. Nothing on the
     // field moves — the letter the child should have shot is still falling,
-    // which is the other half of the cost.
-    //
-    // The flash is the one part of that a fast hand could turn into a strobe,
-    // so it is the one part with a clock on it: the wash starts again only
-    // once `MIN_TINT_GAP_MS` of wave time has passed, and every other cost of
-    // a miss is charged in full whether it lights or not (decision 57).
+    // which is the other half of the cost. Only the flash is rate-limited; the
+    // points, the streak and the mark are taken either way (§8.10).
     return {
       ...state,
       combo: 0,
@@ -1083,10 +737,9 @@ export function fire(
     resolved,
     combo,
     // Paid at the multiplier the hit LANDS on, not the one before it: the
-    // fifth hit in a row is worth ×1.5, and it is the number the HUD is
-    // already showing by the time a child looks at it. Same convention as
-    // `cardXp(ms, streakAfter)`, which is what pays the same hit in XP —
-    // one streak, one multiplier, two currencies (§8.6).
+    // fifth hit in a row is worth ×1.5, which is the number the HUD is already
+    // showing by the time a child looks at it. Same convention as
+    // `cardXp(ms, streakAfter)`, which pays the same hit in XP (§8.6).
     score: state.score + Math.round(HIT_POINTS * comboMultiplier(combo)),
     shield: repaired(state.shield, state.wave.spec, combo),
   });
@@ -1094,13 +747,10 @@ export function fire(
 
 /* ═══ What a run came to (§8.5, §8.7) ════════════════════════════════════════
  *
- * The screen a child meets when the storm stops asks a handful of questions
- * the reducer can already answer, and one it cannot. Which finger let it
- * through, how many that finger let through, what that finger's keys are, how
- * much armour is left and how long the best streak ran are all `state` — so
- * they are decided here, and the screen puts them on a page. What is NOT here
- * is XP: `stormXp` lives in `progress.ts`, which reaches `decks/index.ts`, and
- * this module is one type-only hop from the deck layer (see the file header).
+ * The questions the ending screen asks, answered here so that the screen holds
+ * no rules. XP is the one it cannot ask for: `stormXp` sits in `progress.ts`,
+ * on the far side of the deck layer this module stays clear of (§8.5, and the
+ * file header).
  */
 
 /** What one zone has been through: the two things worth drawing an event for. */
@@ -1114,30 +764,18 @@ export type ZoneTally = {
 /**
  * The eight zones' histories, from the run itself.
  *
- * `hit` is a filter over `resolved` — the tally `StormState` deliberately does
- * not keep, because a second copy of it is a second thing to hold in step
- * sixty times a second.
- *
- * **`resolved`, and never `hasLanded`.** After a breach the clock stops at the
- * fatal `landMs` rather than at the end of the tick that found it, so a letter
- * from a higher index tying that exact millisecond is left unresolved while
- * `hasLanded(letter, state.timeMs)` reads true of it. Counting the clock
- * instead of the outcomes would over-report what got through, on the one
- * screen where that number is the whole point (`tick`, and STM07's ending).
+ * **Counted off `resolved`, and never off `hasLanded`.** A breach stops the
+ * clock at the fatal `landMs`, which leaves a letter tying that millisecond
+ * from a higher index unresolved while the clock already reads it as landed —
+ * so asking the clock over-reports the number this screen is about (§8.5, and
+ * `tick`).
  *
  * `mend` is arithmetic over the same: a zone's hit points are
- * `spec.shield - absorbed + repairs` by construction, so solving for repairs
- * needs nothing that is not already on screen. **Absorbed, not landed**: the
- * letter that ends a run lands on a zone that is already at nothing and takes
- * no point off it (`tick` breaks before the decrement), so counting it would
- * read as a phantom repair on the frame a child dies. It still tints — it is
- * the loudest thing that ever gets through — which is why the two counters are
- * separate rather than one.
- *
- * Here beside the reducer rather than in the shield that draws it, because it
- * is the same arithmetic the ending screen names a finger with: "your right
- * ring finger let three through" is `hit` on one zone, and two files working
- * it out separately is two chances to count a landing differently.
+ * `spec.shield - absorbed + repairs` by construction. **Absorbed, not
+ * landed** — the letter that ends a run falls on a zone already at nothing and
+ * takes no point off it (`tick` breaks before the decrement), so counting it
+ * would read as a phantom repair on the frame a child dies. It still tints,
+ * which is why the two counters are separate.
  */
 export function zoneTally(state: StormState): Record<ShieldFinger, ZoneTally> {
   const full = state.wave.spec.shield;
@@ -1172,19 +810,11 @@ export function zoneTally(state: StormState): Record<ShieldFinger, ZoneTally> {
  * The characters this wave could drop on one finger — the drill a hole earns.
  *
  * `spec.keys` and not the whole board, which is the difference between a drill
- * and a punishment. A zone covers four rows of keys, and a child who has just
- * died at lesson 13 has met exactly one of the right ring finger's — `l`.
- * Handing them `o`, `.`, `9` and `(` as well, because the plastic says those
- * are that finger's, would be a practice deck of keys nobody has taught them.
- * The wave's own pool is exactly "what this level draws from", so the drill is
- * the keys they were being asked for and missed.
- *
- * It can never come back empty for a finger that has just breached: the letter
- * that got through came out of this same pool wearing this same finger.
+ * and a punishment (§8.5). It is never empty after a breach: whatever got
+ * through was drawn from this same pool wearing this same finger.
  *
  * Filtered through `fallable`, so this and the wave agree by construction
- * about which finger types what — including the two kinds of character a wave
- * drops silently: the ones this board cannot produce, and the thumb's.
+ * about which finger types what, and drop the same characters.
  */
 export function zoneKeys(wave: Wave, finger: ShieldFinger): string[] {
   // The `Set` is the de-duplication and the order in one: it keeps first-seen
@@ -1198,15 +828,13 @@ export function zoneKeys(wave: Wave, finger: ShieldFinger): string[] {
 /**
  * The longest streak the run ever reached.
  *
- * Recovered from `resolved` rather than kept on the run, for the reason
- * everything else about a finished storm is: `LetterOutcome.combo` is the
- * streak each hit landed on and a streak only ever climbs by one, so the
- * largest of them IS the longest run of clean hits. A `bestCombo` field on
- * `StormState` would be a second number to move on every hit and a second
- * thing to get wrong in `fire`.
+ * Recovered from `resolved` rather than kept on the run: `LetterOutcome.combo`
+ * is the streak each hit landed on and a streak only ever climbs by one, so
+ * the largest of them IS the longest run of clean hits (§8.5). A field for it
+ * would be a second number to move on every hit.
  *
- * Zero for a run that never hit anything, which is the same zero a run that
- * never started has — and the right answer to both.
+ * Zero for a run that never hit anything, which is also what a run that never
+ * started answers — and the right answer to both.
  */
 export function bestCombo(state: StormState): number {
   return state.resolved.reduce<number>(
@@ -1217,17 +845,11 @@ export function bestCombo(state: StormState): number {
 }
 
 /**
- * Everything the ending screen says, decided (§8.5, STM07).
+ * Everything the ending screen says, decided (§8.5).
  *
  * `null` while the run is live, so a screen cannot draw an ending that has not
  * happened: the one call answers "is it over" and "what happened" together,
  * where two would let a caller ask the second without the first.
- *
- * The screen holds no rules at all, and this is the list of them it would
- * otherwise have had to hold: which finger failed, how many it let through,
- * which keys to practise, and how much of the shield came through. Same
- * division as the loop and `tick` — the picture is the view's, the arithmetic
- * is the model's (§8.9).
  */
 export type StormReport = {
   /** How the run finished. Never `null` — there is no report without one. */
@@ -1254,7 +876,7 @@ export type StormReport = {
    *
    * Not `shieldFull - shieldLeft`: a zone that was hit and then repaired is
    * back to full, and a run that was hit and mended is not a run that was
-   * never hit. Zero is what "the shield came through untouched" is (§8.5).
+   * never hit. Zero is the untouched run (§8.5).
    */
   readonly through: number;
   /** The longest run of clean hits. See `bestCombo`. */

--- a/src/engine/typing/storms.test.ts
+++ b/src/engine/typing/storms.test.ts
@@ -26,44 +26,23 @@ import {
 } from "./storms";
 
 /**
- * The twenty Hailstorm levels (docs/typing.md §5.6, §8.1, §8.3, §8.10).
+ * The twenty Hailstorm levels (§5.6, §8.1, §8.3, §8.10).
  *
- * Three kinds of claim live here and they are worth separating before reading
- * any of them:
- *
- *   - **Reachability**, which is the one a child would meet. A storm may only
- *     rain keys the ladder has taught by its own rung — the same invariant
- *     §5.2 holds the generated passages to, asked of the waves.
- *   - **Safety**, which nobody would ever meet as a bug report. §8.10's "no
- *     strobe, ever, in any mode" is a promise about how often one shield zone
- *     can light up, and #155 established by measurement that no floor on `gap`
- *     buys it — two letters spawned a second apart can land together, because
- *     `fall` is a range too. So the rule is a **count of tint starts per zone
- *     per second, read off the built schedule**, and this is where the twenty
- *     specs meet it.
- *   - **Shape**, which is what makes twenty levels a ladder rather than twenty
- *     copies: one letter at a time at the bottom, five or more in the air at
- *     the top, repairs that stop, and a shield that thins.
+ * Three kinds of claim live here: **reachability**, that a storm only rains
+ * keys the ladder has taught by its own rung; **safety**, which is a count of
+ * tint starts per zone per second read off the *built* schedule rather than
+ * off a spec's ranges; and **shape**, which is what makes twenty levels a
+ * ladder rather than twenty copies.
  */
 
 /**
- * A sample of the space a spec can draw from, and honestly no more than that.
- *
- * The same spread `storm.test.ts` and `generate.test.ts` use. What it is for
- * differs by claim, and the difference is worth stating once here rather than
- * being inferred at each assertion below:
- *
- *   - **Reachability** really is universal over seeds — a wave can only ever
- *     draw from `stormPool`, whatever the roll — so asking it at sixteen is
- *     asking it of the generator, and a seventeenth would only be slower.
- *   - **The tint rate is not.** A `WaveSpec` is a pair of *ranges*, so it is a
- *     built wave and not a spec that is safe or unsafe, and sixteen seeds are
- *     sixteen measurements rather than a bound. Swept far more widely, four of
- *     the twenty specs (83, 89, 93, 99) do reach four or five starts a second
- *     at seeds nobody is ever served. What makes the shipped twenty safe is
- *     that a level's seed is derived to keep the rule and frozen (decision 58,
- *     re-derived in "each level's seed" below), not that the specs cannot roll
- *     a bad wave.
+ * The same spread `storm.test.ts` and `generate.test.ts` use, and what it
+ * proves differs by claim. Reachability really is universal over seeds — a
+ * wave can only ever draw from `stormPool`, whatever the roll. The tint rate
+ * is not: a `WaveSpec` is a pair of *ranges*, so sixteen seeds are sixteen
+ * measurements rather than a bound (§8.10). What makes the shipped twenty safe
+ * is that a level's seed is derived to keep the rule and frozen (decision 58,
+ * re-derived in "each level's seed" below).
  */
 const SEEDS = [
   0, 1, 2, 7, 42, 99, 128, 1000, 4242, 65535, 123456, 999983, 2147483647,
@@ -93,15 +72,10 @@ const SAMPLED: [name: string, spec: WaveSpec, wave: Wave][] =
 /**
  * When each zone lights up, in ms: one entry per letter that lands on it.
  *
- * Read off the **built schedule** and not off the spec, which is the whole
- * point (§8.10, `fallRange`). A zone tints when a letter *lands* on the finger
- * above it, and a landing is `spawnMs + fallMs` — two draws, not one — so a
- * question about how often a zone lights can only be answered after the wave
- * exists.
- *
- * Every letter counts, because a run in which nothing is shot is the worst
- * case and the one a child who cannot keep up is actually having. A letter
- * that IS shot never lands and never tints.
+ * A landing is `spawnMs + fallMs` — two draws, not one — so this can only be
+ * read off the built schedule (§8.10). Every letter counts, because a run in
+ * which nothing is shot is the worst case and the one a child who cannot keep
+ * up is actually having; a letter that IS shot never lands and never tints.
  */
 function tintsByZone(wave: Wave): Map<ShieldFinger, number[]> {
   const zones = new Map<ShieldFinger, number[]>();
@@ -119,13 +93,9 @@ function tintsByZone(wave: Wave): Map<ShieldFinger, number[]> {
  *
  * A sliding window anchored at each landing, which is where every window's
  * maximum sits: moving the window's start off a landing can only drop letters
- * from the front.
- *
- * Deliberately an over-count. §8.10 measured the tint's own curve — 40% of
- * peak gone by 20ms, 90% by 50ms — so two landings within ~20ms of each other
- * re-peak one lit tint and are one visible episode rather than two flashes.
- * Counting them separately errs towards the strobe, which is the direction to
- * be wrong in.
+ * from the front. Deliberately an over-count — two landings within ~20ms are
+ * one visible episode (§8.10), and counting them separately errs towards the
+ * strobe.
  */
 function peakTintRate(wave: Wave, windowMs = 1000): number {
   let peak = 0;
@@ -164,13 +134,9 @@ function peakZonesLit(wave: Wave, windowMs = 150): number {
  * The count only ever rises when a letter starts to drop, so asking
  * `isFalling` at every drop instant finds the maximum without sweeping the
  * clock — and it asks the engine's own half-open interval rather than
- * restating it (§8.3).
- *
- * Falling and not merely drawn, because that is the claim the early levels
- * make. Every letter hangs at the top for the same beat before it moves
- * (`QUEUE_MS`), so a reaction level shows one letter coming down with the next
- * queued above it — which is a queue, not a second thing to track. `maxOnField`
- * is the other count, and the pair of them is what says so.
+ * restating it (§8.3). Falling and not merely drawn: a letter hanging at the
+ * top (`QUEUE_MS`) is a queue rather than a second thing to track, which is
+ * what `maxOnField` beside it says.
  */
 const maxFalling = (wave: Wave): number =>
   Math.max(
@@ -207,18 +173,12 @@ const mean = (values: number[]) =>
 
 describe("the twenty levels", () => {
   /**
-   * **§5.7 is checked, not trusted.**
-   *
-   * "The design doc and the shipped specs agree" is an acceptance criterion of
-   * this story and it is the kind that rots in a week — twenty rows of numbers
-   * in prose, beside twenty rows of numbers in code, with nothing between them
-   * but somebody's diligence. So the doc's own table is read off disk and
-   * compared column by column, exactly as `StormField.test.tsx` reads
-   * `game.css` rather than restating its arithmetic.
-   *
-   * The doc is the source being checked and not the other way round: if these
-   * ever part company, one of them is wrong and this says which two cells to
-   * look at.
+   * §5.7 is checked, not trusted: twenty rows of numbers in prose beside
+   * twenty rows in code, with nothing between them but somebody's diligence.
+   * The doc's table is read off disk and compared column by column, the same
+   * way `StormField.test.tsx` reads `game.css` rather than restating its
+   * arithmetic. Neither side is the authority — if they part company, one of
+   * them is wrong and this says which two cells to look at.
    */
   it("matches §5.7's table in docs/typing.md, column by column", () => {
     const doc = readFileSync("docs/typing.md", "utf8");
@@ -293,15 +253,10 @@ describe("the twenty levels", () => {
 
 describe("a storm can only rain what the ladder has taught", () => {
   /**
-   * **The acceptance criterion, and the same guarantee §5.2 gives the
-   * passages.** A child at lesson 13 has met fifteen characters, and a wave
-   * that dropped a `9` on them would be asking for a key nobody has shown them
-   * — unshootable, and unfair in the one mode where a letter you cannot find
-   * costs you a shield point.
-   *
-   * It is checked over the pool rather than over a built wave because the pool
-   * is the stronger statement: a wave is a sample of it, and a seed that
-   * happened not to draw the bad key would hide the fault until a re-tune.
+   * The same guarantee §5.2 gives the passages. Checked over the pool rather
+   * than over a built wave because the pool is the stronger statement: a wave
+   * is a sample of it, and a seed that happened not to draw the bad key would
+   * hide the fault until a re-tune.
    */
   it("draws every key from `unlockedAt(n)`", () => {
     for (const lesson of STORM_LESSONS) {
@@ -360,29 +315,19 @@ describe("a storm can only rain what the ladder has taught", () => {
 
 describe("no zone can strobe", () => {
   /**
-   * **WCAG 2.3.1's own line: more than three flashes in any one second.**
-   *
-   * The unit is one shield zone, because that is the thing that lights: a
-   * `.storm__hit` tint is mounted per landing on one segment (§8.10, decision
-   * 42), and eight segments taking one letter each in a second is eight small
-   * patches lighting in turn rather than a flash. A zone taking four is the
-   * failure.
-   *
-   * Three is the standard's line and not a preference — but it is asserted
-   * here over a *sample* of sixteen seeds per spec, which is a measurement and
-   * not a property of the specs (see `SEEDS`). The claim that carries a child
-   * is the next one down: `SHIPPED` is held to two, at the seed each level
-   * freezes, and "each level's seed" re-derives that seed from the rule rather
-   * than reading it off the table.
+   * WCAG 2.3.1's line: more than three flashes in any one second. The unit is
+   * one shield zone, because that is the thing that lights (§8.10, decision
+   * 42) — eight segments taking one letter each is eight small patches
+   * lighting in turn, and a zone taking four is the failure. Asserted here
+   * over a sample of sixteen seeds per spec rather than as a property of them
+   * (see `SEEDS`).
    */
   const MAX_TINTS_PER_ZONE_PER_SECOND = 3;
 
   /**
-   * And what the shipped twenty are actually at.
-   *
-   * The seed on each row is derived to keep it (decision 58, re-derived
-   * below), so this is not a hope about a draw: it is the wave that is served,
-   * and the one claim here that is a guarantee rather than a sample.
+   * What the shipped twenty are actually at. The seed on each row is derived
+   * to keep it (decision 58, re-derived below), so this is the wave that is
+   * served — a guarantee rather than a sample.
    */
   const SHIPPED_MAX = 2;
 
@@ -535,19 +480,13 @@ describe("the ladder's difficulty climbs", () => {
 
 describe("each level's seed", () => {
   /**
-   * **The twenty seeds are derived, not chosen** (decision 58).
-   *
-   * A level is the same weather every time it is opened, so twenty numbers sit
-   * in the table — and twenty unexplained numbers would be twenty things
-   * nobody could ever safely edit. So the rule is written here and the table
-   * is checked against it: **the level's own number, or the first seed above
-   * it whose wave keeps the level's promises.** Fourteen of the twenty are the
-   * lesson number itself; the other six are within six of it.
-   *
-   * The promises are the three things this file has already asserted about
-   * every shipped wave, which is what makes this a derivation rather than a
-   * second opinion: the tint rate under two, at least six of the eight fingers
-   * used, and no zone taking more than a third of the letters.
+   * The twenty seeds are derived, not chosen (decision 58): the level's own
+   * number, or the first seed above it whose wave keeps the level's promises.
+   * Fourteen of the twenty are the lesson number itself; the other six are
+   * within six of it. The promises are the three things this file has already
+   * asserted about every shipped wave — the tint rate under two, at least six
+   * of the eight fingers used, and no zone taking more than a third of the
+   * letters.
    */
   const keeps = (wave: Wave, spec: WaveSpec) =>
     peakTintRate(wave) <= 2 &&
@@ -577,10 +516,9 @@ describe("each level's seed", () => {
   });
 
   it("is the same storm on every machine and in every session", () => {
-    // Decision 58, said as the thing a child would notice: opening lesson 45
-    // twice is opening the same level twice. `buildWave` is deterministic in
-    // `(spec, seed)` and both halves come off the rung, so this is what makes
-    // "I beat Whiteout" a sentence about a thing rather than about a roll.
+    // `buildWave` is deterministic in `(spec, seed)` and both halves come off
+    // the rung, so opening lesson 45 twice is opening the same level twice
+    // (decision 58).
     for (const [name, lesson, wave] of SHIPPED)
       expect(stormWave(lesson), name).toEqual(wave);
   });

--- a/src/engine/typing/storms.test.ts
+++ b/src/engine/typing/storms.test.ts
@@ -26,7 +26,7 @@ import {
 } from "./storms";
 
 /**
- * The twenty Hailstorm levels (§5.6, §8.1, §8.3, §8.10).
+ * The twenty Hailstorm levels (§5.6, §5.7, §8.1, §8.3, §8.10).
  *
  * Three kinds of claim live here: **reachability**, that a storm only rains
  * keys the ladder has taught by its own rung; **safety**, which is a count of

--- a/src/engine/typing/storms.ts
+++ b/src/engine/typing/storms.ts
@@ -3,33 +3,28 @@ import { LESSONS, type Lesson, type StormFocus } from "./lessons";
 import { buildWave, type Wave, type WaveSpec } from "./storm";
 
 /**
- * The twenty Hailstorm levels, as waves (docs/typing.md §5.6, §8.1, §8.3).
+ * The twenty Hailstorm levels, as waves (docs/typing.md §5.7, §8.1, §8.3).
  *
- * `lessons.ts` writes down what each storm *is* — how many letters, how far
- * apart, how fast, how deep the shield, whether it repairs — and this module
- * is where that becomes a `WaveSpec` the engine can build. The split is not
- * bookkeeping. It is the whole of the acceptance criterion that **a storm can
- * never ask for a key the ladder has not taught** (decision 56): a
- * `StormShape` has no `keys` field and the table `satisfies` it, so there is
- * nowhere to write a character down, and the pool can only ever come from
- * `unlockedAt(n)` — the same computed alphabet every lesson's words are drawn
- * from (§5.2). Move lesson 39's storm to rung 12 and it rains what a child at
- * lesson 12 has met, with nothing to edit.
+ * `lessons.ts` writes down what each storm *is* and this module turns that
+ * into a `WaveSpec` the engine can build. The split is the acceptance
+ * criterion rather than bookkeeping: a `StormShape` has no `keys` field and
+ * the table `satisfies` it, so there is nowhere to write a character down and
+ * the pool can only ever come from `unlockedAt(n)` — **a storm can never ask
+ * for a key the ladder has not taught** (decision 56). Move lesson 39's storm
+ * to rung 12 and it rains what a child at lesson 12 has met, with nothing to
+ * edit.
  *
- * ── Why it is not in `lessons.ts` ────────────────────────────────────────────
- * That module is the one file in `engine/typing/` the deck layer may import
- * (§5.3, decision 7), and `unlockedAt` lives in `keys.ts`, which imports the
- * ladder to build the alphabets from it. A pool computed in `lessons.ts` would
- * therefore be a cycle at module load — the alphabets being built out of a
- * table that is still being built. Here, the direction is one way:
- * `lessons.ts` → `storm.ts` (a type, erased), `storms.ts` → both.
+ * It cannot live in `lessons.ts`. That module is the one file in
+ * `engine/typing/` the deck layer may import (§5.3, decision 7), and
+ * `unlockedAt` lives in `keys.ts`, which imports the ladder to build the
+ * alphabets from it — so a pool computed there would be a cycle at module
+ * load. Here the direction is one way: `lessons.ts` → `storm.ts` (a type,
+ * erased), `storms.ts` → both.
  *
- * ── And why the seed is here too ─────────────────────────────────────────────
- * A Hailstorm level is a **level**: the same weather every time it is opened
- * (decision 58). So the wave a child meets at lesson 45 is a function of the
- * ladder and nothing else — not of the visit, not of the clock — which is what
- * lets the no-strobe rule (§8.10) be measured on the twenty waves that
- * actually ship rather than on a sample of what the generator might roll.
+ * The seed is here for the same reason: a level's weather is a function of the
+ * ladder and nothing else (decision 58), which is what lets the no-strobe rule
+ * (§8.10) be measured on the twenty waves that actually ship rather than on a
+ * sample of what the generator might roll.
  */
 
 /**
@@ -66,12 +61,10 @@ export const STORM_LESSONS: readonly StormLesson[] =
  * Named classes rather than character lists, because the list is always "the
  * ones this child has met" — `unlockedAt(n)` filtered, never a set written
  * down beside it. Lesson 53 is the case that makes the difference: the digits
- * a child has at lesson 53 are `3 4 5 6`, because 54, 55 and 56 are still
- * ahead of them, and a hand-written `0123456789` would rain four keys the
- * ladder has not taught.
+ * a child has by then are `3 4 5 6`, and a hand-written `0123456789` would
+ * rain four keys the ladder has not taught.
  *
- * `marks` is everything that is neither a letter nor a digit nor the space —
- * which is what "punctuation and symbols" is, and is stated as the complement
+ * `marks` is stated as the complement — neither letter nor digit nor space —
  * so that a symbol added to the layout is in it without an edit here.
  */
 const FOCUS: Record<StormFocus, (ch: string) => boolean> = {
@@ -81,21 +74,14 @@ const FOCUS: Record<StormFocus, (ch: string) => boolean> = {
 };
 
 /**
- * How much of a focused level is its focus: **about half**.
+ * How much of a focused level is its focus: **about half** (§5.7).
  *
- * A share rather than a fixed multiplier, and the reason is lesson 53. Four
- * digits have arrived by then — `3 4 5 6` — against a good sixty letters and
- * marks, so "three copies of each digit" would put 17% of "Hailstorm · Digits"
- * on the number row and the level would be a review lesson wearing a title.
- * At lesson 34 the opposite is true: 26 capitals against 30 other characters
- * means the alphabet is already nearly half capitals and a multiplier that
- * ignored that would rain almost nothing else.
- *
- * So the number of copies is solved for rather than chosen: repeat the focus
- * until it is about as much of the pool as everything else put together. It is
- * still a weighting and never a replacement — a storm is practice at
- * everything the child has, and a "Digits" that rained only digits would be a
- * number-row drill with a shield in front of it.
+ * A share rather than a fixed multiplier, because the two ends of the ladder
+ * pull opposite ways. At lesson 53 four digits stand against sixty letters and
+ * marks, so "three copies of each" would put 17% of "Hailstorm · Digits" on
+ * the number row; at lesson 34 the alphabet is already nearly half capitals,
+ * and the same multiplier would rain almost nothing else. So the number of
+ * copies is solved for rather than chosen.
  */
 const FOCUS_SHARE = 0.5;
 
@@ -138,16 +124,15 @@ export function stormPool(lesson: StormLesson): string[] {
  * decides.
  *
  * **The level's shape is spread first and `keys` is written last**, so the
- * pool this module computes is the last word and a level cannot override it —
- * which is the guarantee this module exists for (decision 56). The ordering is
- * the enforcement at runtime; `satisfies StormShape` on the table in
- * `lessons.ts` is what makes writing a stray `keys` there a type error rather
- * than an inert field that this line quietly discards.
+ * pool this module computes is the last word and a level cannot override it
+ * (decision 56). The ordering is the enforcement at runtime; `satisfies
+ * StormShape` on the table in `lessons.ts` is what makes writing a stray
+ * `keys` there a type error rather than an inert field this line discards.
  *
- * `focus` and `seed` ride along into the spec harmlessly. They are inert to
- * `buildWave` (it reads `count`, `gap`, `fall` and `keys`, and carries the rest
- * for the reducer), and having them on the spec means a wave in hand can still
- * say which level it is — which is what a retry rebuilds from (§8.3).
+ * `focus` and `seed` ride along harmlessly — `buildWave` reads `count`, `gap`,
+ * `fall` and `keys` and carries the rest for the reducer — and having them on
+ * the spec means a wave in hand can still say which level it is, which is what
+ * a retry rebuilds from (§8.3).
  */
 export function waveSpecFor(lesson: StormLesson): WaveSpec {
   return { ...lesson.kind.wave, keys: stormPool(lesson) };

--- a/src/engine/typing/verdict.test.ts
+++ b/src/engine/typing/verdict.test.ts
@@ -8,12 +8,7 @@ import { verdictFor } from "./verdict";
 import type { Run } from "./verdict";
 
 /**
- * What the three bars have to prove (docs/typing.md §6.1, §6.4).
- *
- * The interesting tests here are all the same shape: a run that a single
- * blended score would wave through, which one of the three bars has to catch.
- * A child who is fast and accurate and never once gets the letter the lesson
- * was about is the case §6.4 exists for, and it is the first test below.
+ * What the three bars have to prove (§6.1, §6.4).
  *
  * The criteria are built here rather than taken from the ladder, because what
  * is under test is the gate and not lesson 25's tuning — a test that read
@@ -86,12 +81,9 @@ const lessonWith = (over: Partial<Lesson> = {}): Lesson => ({
 });
 
 /**
- * A storm level, dictated like the lesson above it rather than read off the
- * ladder — what is on trial here is the criteria and not the table.
- *
- * `wordCount` is the wave's length (§8.3), which is what `survived` reads back
- * off a run's own config; twelve is a first storm's shape and every case below
- * says which of the twelve a run faced.
+ * A storm level, dictated like the lesson above rather than read off the
+ * ladder. `wordCount` is the wave's length (§8.3), which is what `survived`
+ * reads back off a run's own config.
  */
 const stormWith = (over: Partial<Lesson> = {}): Lesson => ({
   n: 4,
@@ -118,10 +110,9 @@ const stormWith = (over: Partial<Lesson> = {}): Lesson => ({
 
 describe("the new-key gate", () => {
   /**
-   * §6.4, in one test. Forty-two words at 95% and 26 wpm is a pass by every
-   * measure a typing test has — and the child got `z` wrong half the times
-   * they met it, which is the only thing lesson 25 was for. Two wrong words
-   * out of forty-two is 5% of the run and 50% of the letter.
+   * §6.4, in one test: two wrong words out of forty-two is 5% of the run and
+   * 50% of the letter, so the run passes on accuracy and on speed and fails on
+   * the only thing lesson 25 was for.
    */
   it("fails a run that was fast and accurate but fumbled the new key", () => {
     const lesson = lessonWith({
@@ -221,16 +212,13 @@ describe("the new-key gate", () => {
   });
 
   /**
-   * A character never reached is a miss, not an absence: a word abandoned
-   * halfway, or a `given` of null, has to cost the keys it never got to.
-   *
-   * The run therefore mixes one `p` that *was* struck with two that were not,
-   * so what is asserted is the fraction and not just a bar that reads empty.
-   * An implementation that skipped past the end of `given` — counting neither
-   * a strike nor a hit — would leave `p` at 1/1 rather than 1/3, and a bar
+   * The run mixes one `p` that *was* struck with two that were not, so what is
+   * asserted is the fraction and not just a bar that reads empty. An
+   * implementation that skipped past the end of `given` — counting neither a
+   * strike nor a hit — would leave `p` at 1/1 rather than 1/3, and a bar
    * asserted only as `got: 0, ok: false` would go green for both. That is the
-   * lenient direction and it matters: abandoned words containing the new key
-   * would simply stop counting against it.
+   * lenient direction: abandoned words containing the new key would stop
+   * counting against it.
    */
   it("counts a character that was never reached as a miss", () => {
     const lesson = lessonWith({
@@ -257,12 +245,10 @@ describe("the new-key gate", () => {
   });
 
   /**
-   * The documented approximation (§6.4): per-key stats come from the cards, so
-   * what the gate sees is what ended up on the line. A key struck wrong and
-   * backspaced away is invisible here *by construction* — the card records the
-   * word, not the keystrokes — which is the whole trade. What can be asserted
-   * is the rule that makes it true: a word the run marked right is a hit in
-   * every character, whatever `given` happens to read.
+   * §6.4's documented approximation: a key struck wrong and backspaced away is
+   * invisible here, because the card records the word and not the keystrokes.
+   * What can be asserted is the rule that makes it true — a word marked right
+   * is a hit in every character, whatever `given` reads.
    */
   it("counts every character of a word marked right as a hit", () => {
     const lesson = lessonWith({
@@ -311,10 +297,9 @@ describe("accuracy and speed", () => {
   });
 
   /**
-   * Gross wpm, with accuracy beside it rather than folded in (§6.1). The two
-   * runs typed the same number of characters in the same time, so they type at
-   * the same speed; what separates them is the accuracy bar, which is the
-   * distinction a blended net figure would hide.
+   * The two runs typed the same characters in the same time, so they type at
+   * the same speed; what separates them is the accuracy bar, which a blended
+   * net figure would hide (§6.1).
    */
   it("reports speed gross, and accuracy separately", () => {
     const lesson = lessonWith();

--- a/src/engine/typing/verdict.ts
+++ b/src/engine/typing/verdict.ts
@@ -8,17 +8,11 @@ import type { Lesson, PassCriteria } from "./lessons";
  * Did this run pass this lesson, and if not, which part missed
  * (docs/typing.md §6.1, §6.4)?
  *
- * Three bars rather than one score, for a reason that is about a seven-year-old
- * and not about statistics: **a single number tells you that you failed and not
- * what to do**. Three bars, each either full or not, say "you were fast enough
- * and not accurate enough" or "you have `x` but not `z`", which is an
- * instruction a child can act on. A blended "net WPM" — the industry default —
- * hides exactly the distinction a beginner most needs.
- *
- * So this module never returns a percentage and a verdict. It returns the three
- * criteria side by side, each with what was asked and what arrived, and leaves
- * `passed` as the conjunction of them. What draws them is LES09's problem; what
- * they mean is this file's.
+ * Three bars rather than one score (§6.1), so this module never returns a
+ * percentage and a verdict: it returns the three criteria side by side, each
+ * with what was asked and what arrived, and leaves `passed` as the conjunction
+ * of them. What draws them is the results screen's problem; what they mean is
+ * this file's.
  */
 
 /**
@@ -38,9 +32,8 @@ export type KeyBar = Bar & { key: string };
 /**
  * The three bars and their conjunction.
  *
- * The order they are *shown* in is the order they matter — accuracy, then the
- * new keys, then speed (§6.1) — and the order they are written in here is the
- * doc's. A renderer should follow §6.1 rather than the field order.
+ * The order they are *shown* in is not the field order: a renderer follows
+ * §6.1, which is accuracy, then the new keys, then speed.
  */
 export type Verdict = {
   passed: boolean;
@@ -76,15 +69,12 @@ const bar = (got: number, need: number): Bar => ({
 /**
  * Did the wave get all the way through, or did the run end early (§8.7)?
  *
- * A Hailstorm run is a `Session` like any other, and the one thing that is
- * different about it is that it can stop in the middle: dying at letter 18 of
- * 40 saves a session with eighteen cards, `correct`, `incorrect` and
- * `durationMs` all honest, and the `survive` criterion simply not met. So
- * surviving is "you faced every letter the wave had", and the wave's length
- * (§8.3's `count`) is read off the run's own config rather than off today's
- * ladder — the same rule `configKey` follows (§5.4). A wave re-tuned from forty
- * letters to thirty next year must not hand a pass, in hindsight, to a run that
- * died at eighteen.
+ * A Hailstorm run is the one kind of `Session` that can stop in the middle:
+ * dying at letter 18 of 40 saves eighteen cards with `correct`, `incorrect`
+ * and `durationMs` all honest. So surviving is "you faced every letter the
+ * wave had", and the wave's length is read off the run's **own config** rather
+ * than off today's ladder — a wave re-tuned from forty letters to thirty next
+ * year must not hand a pass, in hindsight, to a run that died at eighteen.
  *
  * A run whose config carries no length counts as survived. That is the lenient
  * direction on purpose: a storm level opens no door on the ladder (§8.8), so
@@ -97,36 +87,13 @@ const survived = (run: Run) =>
 /**
  * The new-key gate, one bar per character the lesson introduces (§6.4).
  *
- * This is the criterion that turns a hundred typing tests into a hundred
- * lessons. Accuracy and speed together still miss the thing the lesson was
- * *for*: a lesson that introduces `z` can be passed at 95% and 12 wpm while
- * getting `z` wrong every single time it appears, because `z` is 3% of the
- * text. So every introduced character must be struck correctly at least
- * `keyAccuracy` of the time, over at least `keyStrikes` strikes — and the
- * generator is tested to put that many occurrences in the passage at every
- * seed (§5.2), so the gate can never be unpassable through bad luck.
- *
  * No lesson introduces the space bar — it is unlocked from lesson 1, in
  * `keys.ts` — so the key that commits every word is never one of these bars.
  *
- * ── Per-key stats come from the cards, not from keystrokes ───────────────────
- * A `CardResult` carries `answer` and `given`, so a word typed right
- * contributes a hit to each of its characters and a word typed wrong
- * contributes a miss to each character that differs from the answer.
- *
- * That is a deliberate, documented approximation, and what it forgives is a
+ * The tally comes from the cards rather than from keystrokes, which forgives a
  * **correction**: a key struck wrong and then backspaced away counts as a hit,
- * because what ended up on the line is right. The trade was taken knowingly.
- * Recording raw keystrokes would mean a new field on `Session` — a shared
- * engine type that every game on this site reads and writes — for one game's
- * benefit; and it would mean the gate measures something the child cannot see
- * on the results screen, which lists the words they typed. Being failed on `z`
- * by a `z` that is not in any of them is unexplainable at seven. Measuring what
- * ended up on the line is both simpler and more explicable, and if it ever
- * proves too soft the fix is a `noBackspace` flag on the lesson rather than a
- * schema change.
- *
- * The comparison is positional, which errs the other way: `zip` typed as `zzip`
+ * because what ended up on the line is right. §6.4 argues that trade. The
+ * comparison is positional, which errs the other way: `zip` typed as `zzip`
  * marks every character after the insertion wrong. Both halves are the same
  * bargain — this describes the text, not the fingers.
  */
@@ -178,16 +145,9 @@ function keyBars(
 /**
  * Three bars and a pass, for one run of one lesson.
  *
- * Pure, and stored nowhere. A lesson is passed if a session exists that meets
- * its criteria, which is a filter over sessions the hub has already loaded
- * (§6.5) — so there is no `passedLessons` field, no new object store and no
- * `DB_VERSION` bump behind this. Tune lesson 40's wpm down next year and every
- * child who was one wpm short is through, with no backfill, and with nothing
- * that can disagree with the record book.
- *
- * `deckSpec` never throws on a mode it does not know, and this is the same
- * promise one layer up: a `Lesson` is the only thing that says what passing it
- * means, so a run and the lesson it was played on are all there is to ask.
+ * Pure, and stored nowhere: a lesson is passed if a session exists that meets
+ * its criteria (§6.5). A run and the lesson it was played on are all there is
+ * to ask — nothing here reads a profile, a clock or a store.
  */
 export function verdictFor(run: Run, lesson: Lesson): Verdict {
   // Whole-lesson accuracy, from the run's own counters — `accuracyOf` is the
@@ -201,10 +161,9 @@ export function verdictFor(run: Run, lesson: Lesson): Verdict {
       // Survive plus accuracy, which is all a storm level is marked on.
       passed: accuracy.ok && survived(run),
       accuracy,
-      // A storm has no passage, so it has no words per minute — §5.6 prints —
-      // in that column. Zero against a need of zero says "not a passage"
-      // rather than "typed nothing", the same thing `wordCount: 0` says about
-      // a storm level on the ladder, and `ok` stays true so a bar a storm does
+      // A storm has no passage, so it has no words per minute (§5.6 prints —
+      // in that column). Zero against a need of zero says "not a passage"
+      // rather than "typed nothing", and `ok` stays true so a bar a storm does
       // not have can never fail one.
       wpm: { got: 0, need: 0, ok: true },
       // A storm level introduces nothing, and its criteria carry no
@@ -214,8 +173,7 @@ export function verdictFor(run: Run, lesson: Lesson): Verdict {
 
   // Gross wpm, reused unchanged from the deck family that already counts it:
   // every keystroke counts, right or wrong, and accuracy stands beside it as
-  // its own bar instead of being folded in. A child who types fast and misses
-  // half of it should see both numbers, not one that hides which is which.
+  // its own bar instead of being folded in (§6.1).
   const wpm = bar(wordsPerMinute(run.cards, run.durationMs), lesson.pass.wpm);
   const keys = keyBars(run.cards, lesson.introduces, lesson.pass);
 

--- a/src/games/typing/App.tsx
+++ b/src/games/typing/App.tsx
@@ -15,19 +15,18 @@ import StormRun from "./storm/StormRun";
 /**
  * The typing game, as its own island.
  *
- * A separate island rather than another deck inside the flash-card game,
- * because the interaction really is different: no discrete cards to submit, no
- * choice of input mode, no per-card clock, and a passage that has to stay on
- * screen while you type through it. Everything that ISN'T different is shared
- * — `@/games/race` for the clock, the lane and the finish, `HubProvider` for
- * the profiles.
+ * Separate from the flash-card island because the interaction is different —
+ * no discrete cards to submit, no input mode to choose, a passage that has to
+ * stay on screen (CLAUDE.md). Everything that ISN'T different is shared:
+ * `@/games/race` for the clock, the lane and the finish, `HubProvider` for the
+ * profiles.
  *
  * Same origin, so a player's profile, XP, badges and record book follow them
- * here from `/flash-cards` with nothing to sign into. That is the whole reason
- * games are paths and not subdomains; see CLAUDE.md.
+ * here from `/flash-cards` with nothing to sign into — which is why games are
+ * paths and not subdomains (CLAUDE.md).
  *
  * Routes are flatter than the flash-card island's: there's one game here, so
- * `/p/:id` is the setup screen rather than a hub in front of it.
+ * `/p/:id` is the setup screen rather than a hub in front of it (§9).
  */
 
 function Shell() {
@@ -74,13 +73,12 @@ function Shell() {
         <Route path="/" element={<PlayerSelect />} />
         <Route path="/p/:profileId" element={<TypingSetup />} />
         <Route path="/p/:profileId/go" element={<TypingTrack />} />
-        {/* Hailstorm (docs/typing.md §9). Its own route rather than a mode of
-            `/go`, because it shares none of that screen's machinery — no
-            passage, no input, no ghost — and all of its own. The lesson is in
-            the path because a storm is a rung of the ladder: twenty levels,
-            one route, and the tile a child pressed is what says which. A
-            `lessonId` that names no storm goes back to the ladder rather than
-            opening an empty sky (`StormRun`). */}
+        {/* Hailstorm (§9). Its own route rather than a mode of `/go`, because
+            it shares none of that screen's machinery — no passage, no input,
+            no ghost — and all of its own. The lesson is in the path because a
+            storm is a rung of the ladder; a `lessonId` that names no storm
+            goes back to the ladder rather than opening an empty sky
+            (`StormRun`). */}
         <Route path="/p/:profileId/storm/:lessonId" element={<StormRun />} />
         <Route path="/p/:profileId/results" element={<TypingResults />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/games/typing/LessonBars.test.tsx
+++ b/src/games/typing/LessonBars.test.tsx
@@ -7,8 +7,7 @@ import type { CardResult, TypingConfig } from "@/engine/types";
 import { LessonBars } from "./LessonBars";
 
 /**
- * The bars a lesson is run against, while it is being run
- * (docs/typing.md §7, §6.1).
+ * The bars a lesson is run against, while it is being run (§7, §6.1).
  *
  * What the numbers mean is pinned next door in `verdict.test.ts`, and this
  * file deliberately does not re-test it: these bars come from `verdictFor`
@@ -71,8 +70,7 @@ const render = (lesson = L01, cards: CardResult[] = [], elapsedMs = 60000) =>
 
 describe("LessonBars", () => {
   it("shows accuracy, then the new key, then speed", () => {
-    // §6.1's order, which is the order they matter: a child who is failing
-    // both should be told about the accuracy first.
+    // §6.1's order, which is the order they matter.
     expect(render().map((row) => row.label)).toEqual([
       "Accuracy",
       "New key f",
@@ -102,10 +100,8 @@ describe("LessonBars", () => {
   });
 
   /**
-   * The one that matters at seven. A lesson introduces two keys as a rule and
-   * fifteen at lesson 31, and the gate is every one of them at once (§6.4) —
-   * so the bar worth the room is the key that is holding you up, and naming it
-   * is the instruction.
+   * A lesson can introduce fifteen keys and the gate is every one of them at
+   * once (§6.4), so the one bar worth the room is the key holding you up.
    */
   it("names the key that is holding the run up", () => {
     const drill = [

--- a/src/games/typing/LessonBars.tsx
+++ b/src/games/typing/LessonBars.tsx
@@ -4,15 +4,7 @@ import type { CardResult, RaceConfig } from "@/engine/types";
 import { PassBars } from "./PassBars";
 
 /**
- * What the lesson is asking for, filling as the child does it
- * (docs/typing.md §7, §6.1).
- *
- * This is what a lesson has where a race has the ghost lane. Nothing is
- * chasing you here — what you are chasing is the criteria, and the point of
- * putting them on screen while the run is live is that you can watch yourself
- * meet them. Three bars rather than one number for the reason the whole
- * verdict exists: a single score tells a seven-year-old that they failed and
- * not what to do, where "fast enough, not accurate enough" is an instruction.
+ * What the lesson is asking for, filling as the child does it (§7, §6.1).
  *
  * The bars are the SAME ones the results screen draws — literally `PassBars`,
  * off the same `verdictFor` over the run so far: cards in, elapsed in, three
@@ -24,13 +16,12 @@ import { PassBars } from "./PassBars";
  */
 
 /**
- * The verdict is recomputed every time the clock ticks — about sixteen times a
- * second — so it walks the cards that often. That is a pass over at most
- * `lesson.wordCount` (150 at the top of the ladder) doing character compares,
- * next to a screen that is already re-rendering the passage at that rate. It is
- * measured in microseconds and it buys the one thing worth having: there is no
- * second definition of "how it is going" to disagree with the one that decides
- * whether the lesson was passed.
+ * The verdict is recomputed every clock tick — about sixteen times a second —
+ * so it walks the cards that often: at most `lesson.wordCount` (150 at the top
+ * of the ladder) character compares, beside a screen already re-rendering the
+ * passage at that rate. Microseconds, and it buys the one thing worth having —
+ * no second definition of "how it is going" to disagree with the one that
+ * decides whether the lesson was passed.
  */
 export function LessonBars({
   lesson,

--- a/src/games/typing/LessonBrief.test.tsx
+++ b/src/games/typing/LessonBrief.test.tsx
@@ -9,18 +9,17 @@ import type { CardResult, KeyboardMode } from "@/engine/types";
 import { LessonBrief } from "./LessonBrief";
 
 /**
- * What is written on the door (docs/typing.md §9, §4.2).
+ * What is written on the door (§9, §4.2).
  *
  * Three things are on trial here and only one of them is copy:
  *
  *   - **The keyboard is seeded, not imposed.** An unlocked lesson opens on its
- *     own suggestion with three pills a child may press; a locked one shows the
- *     same three, disabled, with the reason. That distinction is the whole of
- *     #145's folded-in half, and before it `keyboardLocked` marked nothing.
+ *     own suggestion with three pills a child may press; a locked one shows
+ *     the same three, disabled, with the reason.
  *   - **What starts, and what cannot.** A locked lesson has no Start, and
- *     **every checkpoint is startable at any time** — the express lane (§6.6)
- *     runs through this screen now, and a brief that gated on `n <= next` would
- *     take it out with nothing on the ladder looking broken.
+ *     every checkpoint is startable at any time — the express lane (§6.6) runs
+ *     through this screen, and a brief that gated on `n <= next` would take it
+ *     out with nothing on the ladder looking broken.
  *   - **What it says it wants**, which is the three bars, in §6.1's order.
  */
 
@@ -88,9 +87,8 @@ describe("LessonBrief", () => {
   });
 
   /**
-   * The three bars as targets. In §6.1's order, and the new-key row absent
-   * exactly where its bar is — a lesson that introduces nothing is not being
-   * asked a third thing, and a row for it could never be met or missed.
+   * In §6.1's order, and the new-key row absent exactly where its bar is: a
+   * row a lesson could never meet or miss is not a target.
    */
   it("asks for the three bars, in the order they matter", () => {
     const html = render(L01);
@@ -120,8 +118,7 @@ describe("LessonBrief", () => {
 
   it("opens on the lesson's mode, with the choice left open", () => {
     // The lesson suggests `guide`; the child's own setting is `off`. Seeded
-    // from the lesson, and every pill still pressable — which is the half that
-    // was missing: before #145 the lesson's mode was simply imposed.
+    // from the lesson, and every pill still pressable.
     const html = render(L07, { profileKeyboard: "off" });
 
     expect(pills(html).filter((pill) => pill.on)).toEqual([
@@ -143,9 +140,9 @@ describe("LessonBrief", () => {
   });
 
   it("falls through to the player's own setting where a lesson defers", () => {
-    // No lesson in the shipped hundred defers, which is exactly why the chain
-    // read as an override for so long. Free play is the live caller of this
-    // arm; this pins that the arm still exists for a lesson that ever does.
+    // No lesson in the shipped hundred defers, so free play is this arm's only
+    // live caller. Pinned here so the arm survives for a lesson that ever
+    // does.
     const html = render({ ...L07, keyboard: null }, { profileKeyboard: "off" });
 
     expect(pills(html).find((pill) => pill.on)?.value).toBe("off");
@@ -168,9 +165,8 @@ describe("LessonBrief", () => {
   });
 
   /**
-   * Decision 16, through the brief. A nine-year-old who already types opens
-   * checkpoint 40 from a standing start, passes it, and begins at 41 — and
-   * that only works if this screen offers them Start.
+   * Decision 16, through the brief (§6.6): the placement test only works if
+   * this screen offers Start on a checkpoint nothing has unlocked.
    */
   it("starts any checkpoint, on a profile with no runs at all", () => {
     expect(started(render(L10))).toBe(true);

--- a/src/games/typing/LessonBrief.tsx
+++ b/src/games/typing/LessonBrief.tsx
@@ -13,39 +13,21 @@ import { lockNote } from "./lessonNotes";
 import { tileState } from "./LessonTile";
 
 /**
- * What a lesson teaches and what it asks for, before the clock starts
- * (docs/typing.md §9, §4.2).
+ * What a lesson teaches and what it asks for, before the clock starts (§9).
  *
- * A tile is a door and a door is not an explanation. Between them goes this:
- * which keys are new, the three bars that decide the run, your best if you
- * have one, and how much of the keyboard will be on screen. A child who starts
- * without any of that is guessing at the target while being timed, and the
- * three bars are the one thing on the ladder they cannot work out from the map.
+ * A tile is a door and a door is not an explanation. A child who starts without
+ * this is guessing at the target while being timed.
  *
- * ── The keyboard is seeded here, not decided here ──────────────────────────
- * §4.2 resolves the board as `lesson.keyboard ?? profile.keyboard ?? "guide"`.
- * Every one of the hundred lessons names a mode, so read as an override that
- * chain silently beats the setting the child chose — which is the bug #142's
- * review found, and the reason `keyboardLocked` had stopped distinguishing
- * anything. So: the lesson's mode **seeds** this control, an unlocked lesson
- * may be changed before Start, and a locked one shows its pills disabled with
- * the reason on them. `lessonKeyboard.ts` owns both halves of that; this screen
- * is where a child meets them.
+ * The lesson's mode **seeds** this screen's keyboard control rather than
+ * overruling the child's own setting (§4.2); `lessonKeyboard.ts` owns both
+ * halves of that and this screen is where a child meets them. The choice lives
+ * in this component's state, dies with it, and travels to the run in
+ * `config.keyboard` the way the passage travels in `config.words`.
  *
- * The choice lives in this component's state and dies with it. That is the
- * lifetime it should have: it is a decision about *this run*, and writing it
- * back to the profile would let a lesson's own suggestion — which is what the
- * control opens on — overwrite a setting the child made for themselves in free
- * play. It travels to the run in `config.keyboard`, the way the passage
- * travels in `config.words`.
- *
- * ── It asks the ladder whether it may start ───────────────────────────────
- * `tileState`, the same function the tiles are drawn from, so the express lane
- * survives the trip: **every checkpoint is openable at any time** (§6.6), and a
- * brief that gated on `n <= next` would delete the placement test while looking
- * completely reasonable. Asking twice — once to draw the tile, once to offer
- * Start — is deliberate. A screen that can say "locked" must not also be able
- * to start the thing it just called locked.
+ * Start is offered off `tileState`, the same function the tiles are drawn from,
+ * so the express lane survives the trip (§6.6). Asking twice — once to draw the
+ * tile, once to offer Start — is deliberate: a screen that can say "locked"
+ * must not also be able to start the thing it just called locked.
  */
 export function LessonBrief({
   lesson,
@@ -64,7 +46,10 @@ export function LessonBrief({
    * rounds differently would be telling a child two things about one run.
    */
   best: Run | null;
-  /** `Profile.keyboard`, for the arm of §4.2 an unpinned lesson falls through to. */
+  /**
+   * `Profile.keyboard`, for the arm of §4.2 an unpinned lesson falls through
+   * to.
+   */
   profileKeyboard?: KeyboardMode;
   /** The chosen mode is handed over; `undefined` when the lesson pinned it. */
   onStart: (keyboard?: KeyboardMode) => void;
@@ -75,11 +60,10 @@ export function LessonBrief({
   const why = keyboardLock(lesson);
 
   /**
-   * Seeded from the lesson, resolved once, on mount.
-   *
-   * `LessonBrief` is mounted per lesson (`key={lesson.id}` at the call site),
-   * so opening a second brief seeds a second time rather than carrying the
-   * first one's choice onto a lesson that suggests something else.
+   * Seeded from the lesson, resolved once, on mount. `LessonBrief` is mounted
+   * per lesson (`key={lesson.id}` at the call site), so opening a second brief
+   * seeds a second time rather than carrying the first one's choice onto a
+   * lesson that suggests something else.
    */
   const [keyboard, setKeyboard] = useState<KeyboardMode>(() =>
     keyboardFor(lesson, profileKeyboard),
@@ -115,8 +99,7 @@ export function LessonBrief({
         {/* Said where the Start button would be, because "why can't I press
             it" is a question about the button and not about the lesson. The
             second sentence is the express lane (§6.6): this is the one screen
-            where a child is stopped, and "climb" is only half the answer when
-            all ten checkpoints are open behind them. */}
+            where a child is stopped by it. */}
         {locked && (
           <p className="brief__locked">
             {lockNote(lesson)} Or try a checkpoint — every one of those is open
@@ -148,8 +131,8 @@ export function LessonBrief({
  * Drawn as caps rather than listed in the sentence because they are what the
  * child is about to look for: two glyphs, or fifteen at lesson 31, and a
  * comma-separated list of fifteen is a paragraph. A lesson that introduces
- * nothing says so — half the ladder is review, and silence there would read as
- * a missing line rather than as "no new keys today".
+ * nothing says so — silence would read as a missing line rather than as "no new
+ * keys today".
  */
 function NewKeys({ lesson }: { lesson: Lesson }) {
   if (lesson.introduces.length === 0) {
@@ -175,21 +158,16 @@ function NewKeys({ lesson }: { lesson: Lesson }) {
 /**
  * The three bars, as what they want rather than as how you are doing.
  *
- * Same three in §6.1's order — accuracy, the new keys, then speed — so the
- * list a child reads before the run is the list that fills beside them during
- * it (`LessonBars`) and the list they are marked against after it (`PassBars`).
- * Empty bars would be the other way of showing this and a worse one: three
- * troughs at zero over the word "Accuracy" reads as a score, and the score is
- * nought.
- *
- * The new-key row is absent exactly where its bar is — a review lesson and
- * every checkpoint introduce nothing, so there is no third thing being asked.
+ * Same three in §6.1's order, so the list a child reads before the run is the
+ * list that fills beside them during it (`LessonBars`) and the list they are
+ * marked against after it (`PassBars`). Empty bars would be the other way of
+ * showing this and a worse one: three troughs at zero over the word "Accuracy"
+ * reads as a score, and the score is nought.
  */
 function Asks({ lesson }: { lesson: Lesson }) {
-  // A Hailstorm level is marked on surviving a wave rather than on three bars,
-  // and has no passage to ask anything about (§6.1). A storm's tile opens
-  // `StormBrief` instead (decision 60), so this arm is the type-level half of
-  // that rather than a screen a child reaches — and it is what narrows the
+  // A storm is marked on surviving a wave rather than on three bars, and its
+  // tile opens `StormBrief` instead (§8.8) — so this arm is the type-level half
+  // of that rather than a screen a child reaches, and it is what narrows the
   // three bars below to the criteria that have them.
   if (lesson.pass.kind !== "lesson") return null;
   const { accuracy, wpm, keyAccuracy, keyStrikes } = lesson.pass;
@@ -218,10 +196,10 @@ function Asks({ lesson }: { lesson: Lesson }) {
 /**
  * Your best here, in the units the bars above just asked in.
  *
- * Through `verdictFor` rather than through a wpm helper, so the two numbers
- * are the ones this lesson was actually marked on — the accuracy a lesson
- * counts is its own (§6.1), and a brief quoting a different one would be
- * quietly arguing with the results screen that produced it.
+ * Through `verdictFor` rather than through a wpm helper, so the two numbers are
+ * the ones this lesson was actually marked on (§6.1) — a brief quoting a
+ * different accuracy would be quietly arguing with the results screen that
+ * produced it.
  */
 function bestNote(best: Run, lesson: Lesson): string {
   const verdict = verdictFor(best, lesson);

--- a/src/games/typing/LessonLadder.test.tsx
+++ b/src/games/typing/LessonLadder.test.tsx
@@ -8,7 +8,7 @@ import { LessonLadder } from "./LessonLadder";
 import { tileState } from "./LessonTile";
 
 /**
- * The map, and which of its hundred doors are open (docs/typing.md §6.6, §9).
+ * The map, and which of its hundred doors are open (§6.6, §9).
  *
  * What progress *is* is pinned next door in `ladder.test.ts`; what this file
  * is for is the half of the unlock rule that lives on the screen. `next` is a
@@ -71,9 +71,8 @@ describe("tileState", () => {
   });
 
   /**
-   * Decision 16, and the one this whole file exists for. All ten, at `next`
-   * of 1 — a nine-year-old who already types opens checkpoint 40, passes it,
-   * and starts at 41 rather than spending a week on `fff jjj`.
+   * Decision 16, and the one this whole file exists for: all ten, at `next`
+   * of 1 (§6.6).
    */
   it("opens every checkpoint on a brand-new profile", () => {
     expect(CHECKPOINTS).toHaveLength(10);
@@ -89,9 +88,8 @@ describe("tileState", () => {
   });
 
   /**
-   * §8.8: the pointer is carried over a storm rather than made to jump it, so
+   * The pointer is carried over a storm rather than made to jump it (§8.8), so
    * the storm it stepped past stays at or below `next` and stays open.
-   * Skippable is not the same as skipped.
    */
   it("leaves a skipped storm open behind the pointer", () => {
     // Lessons 1–3 cleared; 4 is a storm, so the pointer is carried to 5.
@@ -131,8 +129,8 @@ describe("LessonLadder", () => {
       "Lesson 10, Checkpoint · Home row. Checkpoint — always open, whatever you have passed. Open.",
     );
     // A storm says its own sentence first and then the same state every other
-    // tile says out loud (#156) — here a rung this child has not reached, so
-    // it carries what would open it as well.
+    // tile says out loud — here a rung this child has not reached, so it
+    // carries what would open it as well.
     expect(drawn[8].label).toBe(
       "Lesson 9, Hailstorm · Home row. Hailstorm — worth playing, never required. Locked. Pass lesson 8 to open this one.",
     );
@@ -170,13 +168,8 @@ describe("LessonLadder", () => {
   });
 
   /**
-   * A storm is a rung of the ladder with a shape of its own, and — on a device
-   * with keys — a door that opens (#156). Both halves matter: the diamond is
-   * what says "not the course" without a word, and being enterable is what it
-   * is there for.
-   *
    * The twenty are drawn at the top of the ladder, where every rung is behind
-   * the child, so a shut tile here could only be a storm that had stopped
+   * the child — so a shut tile here could only be a storm that had stopped
    * being playable.
    */
   it("draws the storms as diamonds a child can enter", () => {
@@ -190,10 +183,6 @@ describe("LessonLadder", () => {
   });
 
   /**
-   * And a storm a child has not climbed to yet is locked like any other rung —
-   * with the way out of it on the tile, because "Locked" alone is a state and
-   * not a way out of one (#145).
-   *
    * The rung it names is never the storm's own neighbour: `lockNote` walks
    * down past any storm in the way, so lesson 9's tile asks for lesson 8 and
    * never for a wave a tablet cannot play (§8.8).
@@ -207,14 +196,9 @@ describe("LessonLadder", () => {
   });
 
   /**
-   * The tablet (docs/typing.md §8.8, #155). Hailstorm needs raw `keydown` with
-   * a `code` and there is no software keyboard on screen during it, so a
-   * device with no keys is told which of these tiles is not for it and why —
-   * rather than being given a tile that does nothing when it is pressed.
-   *
-   * Every other rung is unaffected, and that is half the claim: a passage is
-   * typed on the software keyboard like anything else, so a child on an iPad
-   * still has the whole course.
+   * The tablet (§8.8). Every other rung being unaffected is half the claim: a
+   * passage is typed on the software keyboard like anything else, so a child
+   * on an iPad still has the whole course.
    */
   it("says why a storm tile is shut on a device with no keyboard", () => {
     const drawn = tiles(at(99, 100), false);
@@ -235,10 +219,9 @@ describe("LessonLadder", () => {
   });
 
   /**
-   * And the way out of a wrong guess, said once where there is room for it.
-   * Detection is a guess (`useKeyboardPresence`), so the legend has to carry
-   * the instruction that overturns it — a child in a keyboard folio reads
-   * "press any key", presses one, and the ladder redraws with no reload.
+   * Detection is a guess (`useKeyboardPresence`), so the legend carries the
+   * instruction that overturns it: a child in a keyboard folio presses a key
+   * and the ladder redraws with no reload.
    */
   it("offers the keystroke that overturns the guess, in the legend only", () => {
     const shut = renderToStaticMarkup(

--- a/src/games/typing/LessonLadder.tsx
+++ b/src/games/typing/LessonLadder.tsx
@@ -3,35 +3,22 @@ import { LESSONS, type Lesson } from "@/engine/typing/lessons";
 import { STORM_NOTE, LessonTile } from "./LessonTile";
 
 /**
- * The hundred lessons, as the ice world's own overworld (docs/typing.md §9).
+ * The hundred lessons, as the ice world's own overworld — ten rows of ten, the
+ * blocks named down the side (§9).
  *
- * Ten rows of ten with the blocks named down the side, because that is what
- * turns a syllabus into a map: a child can see the whole course, see the two
- * rows they have finished, and see that the row they are on ends in a
- * checkpoint. A list of a hundred titles is the same data and none of that.
- *
- * Everything on it is **derived** — `LESSONS` for the shape of the ladder and
- * `ladderProgress` for where this child is on it (§6.5). There is no stored
- * "unlocked" flag anywhere behind this screen, which is why re-tuning a
- * lesson's criteria re-draws the map for every child with no backfill.
- *
- * Choosing a tile opens the lesson's brief (§9, #145) — what it teaches, the
- * three bars it wants, your best, and how much of the keyboard will be on
- * screen. The tile is the door and the brief is what is written on it, which
- * is why a locked tile still says what would open it: a lesson that turns out
- * to be too hard costs a child nothing but the run (§6.6), and one they cannot
- * reach yet should at least say so.
+ * Everything on it is **derived**: `LESSONS` for the shape of the ladder and
+ * `ladderProgress` for where this child is on it (§6.5), which is why re-tuning
+ * a lesson's criteria re-draws the map for every child with no backfill.
  */
 
 /**
  * The ten blocks by name (§5.5), in the order the ladder walks them.
  *
- * The same names `lessons.ts` carries as section comments over its own table,
- * because a block is a stretch of that table and the two would look wrong side
- * by side if they disagreed. Written here rather than in the engine on
- * purpose: `lessons.ts` is imported by `decks/index.ts`, which is the front
- * door for every island on the site (§5.3), and a label only this screen draws
- * has no business being shipped to the flash cards.
+ * The same names `lessons.ts` carries as section comments over its own table.
+ * Written here rather than in the engine on purpose: `lessons.ts` is imported
+ * by `decks/index.ts`, which is the front door for every island on the site
+ * (§5.3), and a label only this screen draws has no business being shipped to
+ * the flash cards.
  */
 const BLOCK_NAMES = [
   "Home row",
@@ -67,8 +54,7 @@ export function LessonLadder({
   progress: LadderProgress;
   /**
    * Whether this device looks like it has a physical keyboard
-   * (`useKeyboardPresence`), which decides what the Hailstorm tiles say
-   * (§8.8).
+   * (`useKeyboardPresence`), which decides what the Hailstorm tiles say (§8.8).
    *
    * A prop rather than a hook call in here, so this screen stays a pure
    * function of what it is handed — the same reason `progress` arrives as one.
@@ -86,10 +72,9 @@ export function LessonLadder({
         </span>
       </div>
 
-      {/* The rule of the ladder in two sentences, and the second is the one
-          that matters: the express lane is invisible unless it is said. A
-          child who can already type has no reason to guess that the tile forty
-          rungs up is one they are allowed to press (§6.6, decision 16). */}
+      {/* The express lane is invisible unless it is said: a child who can
+          already type has no reason to guess that the tile forty rungs up is
+          one they are allowed to press (§6.6, decision 16). */}
       <p className="muted ladder__lede">
         A hundred lessons, ten to a block. Pass one and the next opens — and
         every checkpoint is open from the start, so if you can already type, try
@@ -145,10 +130,10 @@ export function LessonLadder({
           <span className="ladder__tile is-open is-storm" aria-hidden="true" />
           {/* The one place the keyboard is explained rather than merely
               enforced, and the one place the way out of a wrong guess is
-              offered (§8.8, #155). It is said once, here, because a hundred
-              tiles each carrying "press any key" is wallpaper rather than
-              advice — and it corrects itself the instant a key is pressed,
-              with nothing to reload. */}
+              offered (§8.8). Said once, here, because a hundred tiles each
+              carrying "press any key" is wallpaper rather than advice — and it
+              corrects itself the instant a key is pressed, with nothing to
+              reload. */}
           {hasKeyboard
             ? `${STORM_NOTE} Nothing on the ladder waits on one`
             : `${STORM_NOTE} It needs a keyboard, so these stay shut here. Press any key if you have one`}

--- a/src/games/typing/LessonResults.tsx
+++ b/src/games/typing/LessonResults.tsx
@@ -20,26 +20,16 @@ import type { Lesson } from "@/engine/typing/lessons";
 import type { Profile } from "@/engine/types";
 
 /**
- * Whether the lesson was passed, and what to do next (docs/typing.md §6.1, §9).
+ * Whether the lesson was passed, and what to do next (§6.1, §9).
  *
- * The free-play screen next door is a **scoreline** — a wpm, an accuracy, a
- * clock and a rival — because free play is a race and a race is decided on a
- * number. A lesson is not (§7). What is on trial here is three criteria, and
- * the job of this screen is to turn a failure into an instruction: not "68%",
- * but "you were fast enough; the `z` key needs more practice". A child who
- * misses a lesson and cannot tell which of the three cost them has been handed
- * a wall, and a wall is what makes a seven-year-old stop climbing.
+ * The free-play screen next door is a scoreline, because a race is decided on a
+ * number. A lesson is marked rather than ranked (§7), so the bars lead, in
+ * §6.1's order, and the sentence under the headline names the gap. `missNote`
+ * and `nextNote` decide what that sentence says; this file only puts it on the
+ * screen.
  *
- * So the bars lead, in §6.1's order, and the sentence under the headline names
- * the gap. `missNote` and `nextNote` decide what that sentence says; this file
- * only puts it on the screen.
- *
- * **Retries are unlimited and unpenalised.** There is no attempt counter here
- * and nothing anywhere that stores one — a lesson is passed if a session exists
- * that meets its criteria (§6.5), so a failed run costs a child exactly the
- * time it took and nothing else. Trying a checkpoint you are nowhere near
- * being free is the whole of the levelling advice (§6.6), and it is only true
- * because failing is.
+ * There is no attempt counter here and nothing anywhere that stores one:
+ * retries are unlimited and unpenalised (§6.5, §6.6).
  */
 export default function LessonResults({
   lesson,
@@ -73,22 +63,18 @@ export default function LessonResults({
 
   /**
    * A Hailstorm level is a different game on a different route (§8, §9), and
-   * this screen is only ever reached by one because a storm run is an ordinary
-   * `Session` and the results route is shared. Until #159 builds the wave there
-   * is nothing here that could start one, so the two run actions stand down
-   * rather than hand a child a lesson-shaped run of a level that has no
-   * passage. Everything else on the screen — the bars, the reason, the rewards
-   * — reads a storm correctly.
+   * this screen is reached by one only because a storm run is an ordinary
+   * `Session` and the results route is shared. `run` below builds a
+   * lesson-shaped passage run, which a storm has no passage for, so the two run
+   * actions stand down. Everything else on the screen — the bars, the reason,
+   * the rewards — reads a storm correctly.
    */
   const storm = lesson.pass.kind === "storm";
 
   /**
-   * Where the ladder lives (§9).
-   *
-   * `#/p/:id` is the hundred tiles, with free play under them. Every way off
-   * this screen points at the route rather than at the screen behind it, which
-   * is what made turning the setup screen into the ladder a swap rather than a
-   * hunt for the links that had guessed.
+   * Where the ladder lives (§9). Every way off this screen points at the route
+   * rather than at the screen behind it, so a screen swapped in behind it needs
+   * no link here changed.
    */
   const ladder = `/p/${profile.id}`;
 
@@ -105,7 +91,7 @@ export default function LessonResults({
     : undefined;
 
   /**
-   * What the child chose in the brief, if they chose anything (#145, §4.2).
+   * What the child chose in the brief, if they chose anything (§4.2).
    *
    * Carried onto "Try again" and onto nothing else. A retry is the same lesson
    * with fresh words, and a child who turned the guide off to sit lesson 40
@@ -147,9 +133,6 @@ export default function LessonResults({
         <h1 className="u-display results__title">
           {verdict.passed ? "You passed" : "Not yet"}
         </h1>
-        {/* The whole point of the screen, in one line: a lesson that was
-            missed says which of the three cost it, and one that was passed
-            says which lesson that just opened. */}
         <p className="results__lede">
           {verdict.passed ? opened.text : missNote(lesson, verdict)}
         </p>
@@ -171,11 +154,10 @@ export default function LessonResults({
         </div>
         <div className="stat">
           <span className="stat__value">{clock(session.durationMs)}</span>
-          {/* The clock, and only the clock. A lesson carries no
-              `WRONG_ANSWER_PENALTY_MS` (§7) — charging three seconds a miss
-              would double-count the accuracy bar right above it — so there is
-              no "+ penalties" to label here. Free play is a race and still
-              has both; see the label it draws next door. */}
+          {/* The clock, and only the clock: a lesson carries no
+              `WRONG_ANSWER_PENALTY_MS` (§7), so there is no "+ penalties" to
+              label here. Free play is a race and still has both; see the label
+              it draws next door. */}
           <span className="stat__label">Time</span>
         </div>
         <div className="stat stat--xp">

--- a/src/games/typing/LessonTile.tsx
+++ b/src/games/typing/LessonTile.tsx
@@ -4,12 +4,10 @@ import type { Lesson } from "@/engine/typing/lessons";
 import { lockNote } from "./lessonNotes";
 
 /**
- * One rung of the ladder, as a square on a map (docs/typing.md §9).
+ * One rung of the ladder, as a square on a map (§9).
  *
- * A tile carries three things and only three: which lesson it is, what state
- * that lesson is in for this child, and what happens when it is pressed. The
- * shape of the map — ten rows, blocks named down the side — is `LessonLadder`'s
- * problem; a tile does not know it has ninety-nine neighbours.
+ * The shape of the map is `LessonLadder`'s problem; a tile does not know it has
+ * ninety-nine neighbours.
  *
  * **Every state is in the accessible name, not only in the colour.** The number
  * is the visible label and the sentence beside it is the spoken one, which is
@@ -21,37 +19,22 @@ import { lockNote } from "./lessonNotes";
 /**
  * What a tile is, in the order the states are decided.
  *
- * Four rather than a pair of booleans because they are exclusive on screen —
- * a tile is filled, or lit, or outlined, or dim — and a component that took
- * `cleared` and `open` separately would have to answer what a cleared-but-
- * locked tile looks like, which is not a thing.
+ * Four rather than a pair of booleans because they are exclusive on screen, and
+ * a component that took `cleared` and `open` separately would have to answer
+ * what a cleared-but-locked tile looks like, which is not a thing.
  */
 export type TileState = "cleared" | "next" | "open" | "locked";
 
 /**
  * Which of the four this lesson is, for this child — **the whole unlock rule**
- * (docs/typing.md §6.6, decision 16).
+ * (§6.6, decision 16): everything up to and including `next`, plus every
+ * checkpoint always.
  *
- * `LadderProgress.next` is the pointer and NOT the rule, and its own docstring
- * says so at length. A screen that opened a tile on `n <= next` alone would
- * pass every test anyone thought to write and quietly delete the placement
- * test, because the thing it removes is not on screen to look broken. So, in
- * full:
- *
- *   - **Everything up to and including `next` is open.** The pointer is
- *     carried over Hailstorm levels rather than made to jump them (§8.8), so
- *     the storm it stepped past is at or below `next` and stays playable —
- *     skippable is not the same as skipped, and no storm ever gates the
- *     lesson after it.
- *   - **Every checkpoint is open, always.** All ten, at every value of `next`,
- *     including on a profile that has never run anything. That is the express
- *     lane: a nine-year-old who already types opens checkpoint 40, passes it,
- *     and starts at 41 rather than spending a week on `fff jjj`. Passing one
- *     clears everything below it by the same `max` rule that opens the next
- *     lesson, so it is a placement test without a placement test existing.
- *
- * Nothing else gates, and a failed attempt costs nothing (§6.6) — which is
- * what makes "just try one" the whole of the levelling advice.
+ * `LadderProgress.next` is the pointer and NOT the rule. A screen that opened a
+ * tile on `n <= next` alone would pass every test anyone thought to write and
+ * quietly delete the placement test, because what it removes is not on screen
+ * to look broken. The pointer is also carried over Hailstorm levels rather than
+ * made to jump them (§8.8), so a storm it stepped past stays playable.
  */
 export function tileState(lesson: Lesson, progress: LadderProgress): TileState {
   if (progress.cleared.has(lesson.n)) return "cleared";
@@ -65,28 +48,19 @@ export function tileState(lesson: Lesson, progress: LadderProgress): TileState {
  *
  * The tile's accessible name and the ladder's legend both open with it, and a
  * third copy would be one to keep in step: a legend that described a different
- * kind of tile from the tiles it is a legend for is a legend that has quietly
- * stopped being one.
+ * kind of tile from the tiles it is a legend for has quietly stopped being one.
  */
 export const STORM_NOTE = "Hailstorm — worth playing, never required.";
 
 /**
- * Why a Hailstorm tile cannot be entered, or `null` when it can be.
+ * Why a Hailstorm tile cannot be entered, or `null` when it can be. One reason,
+ * and it is about the child's device (§8.8).
  *
- * **One reason now, and it is about the child's device** (docs/typing.md §8.8,
- * #155, #156). The "coming soon" arm this had while the twenty waves were
- * being built is gone with them: a keyboard is the only thing between a child
- * and a storm, and the tile opens off this same answer.
- *
- * It is deliberately not "you have no keyboard" said as a fact. The detection
- * is a guess (`useKeyboardPresence`), and a guess that has been wrong is
- * undone by one keystroke — which is why the ladder's legend, where there is
- * room to say it once rather than a hundred times, offers exactly that.
- *
- * The lock is only ever the reason a storm cannot be *entered*, and never a
- * reason it cannot be skipped: nothing on the ladder waits on a storm (§8.8,
- * decision 24), so a device with no keys costs a child twenty tiles and not
- * one rung of the course.
+ * Deliberately not "you have no keyboard" said as a fact: the detection is a
+ * guess (`useKeyboardPresence`) undone by one keystroke, which is what the
+ * ladder's legend offers, once, where there is room to say it. And it is never
+ * a reason a storm cannot be *skipped* (§8.8), so a device with no keys costs a
+ * child twenty tiles and not one rung of the course.
  */
 export function stormReason(hasKeyboard: boolean): string | null {
   return hasKeyboard
@@ -118,24 +92,16 @@ function tileLabel(
 ): string {
   const what = `Lesson ${lesson.n}, ${lesson.title}`;
 
-  // What unlocks it, on the tile as well as in the brief (#145). The tile is
-  // the only place a locked rung is met by a child who never presses it, and
-  // "Locked" on its own is a state rather than a way out of one. One
-  // definition for both kinds of tile: a diamond a child has not climbed to
-  // yet needs the same sentence a square does, and `lockNote` is already the
-  // one that walks down past any storm in the way.
+  // What unlocks it, on the tile as well as in the brief: the tile is the only
+  // place a locked rung is met by a child who never presses it, and "Locked" on
+  // its own is a state rather than a way out of one. `lockNote` is one
+  // definition for both kinds of tile.
   const how = state === "locked" ? ` ${lockNote(lesson)}` : "";
 
-  // A storm level says what it is, and — where there is one — why it cannot be
-  // entered, rather than being a tile that does nothing when pressed. Its
-  // place on the map is worth drawing either way: it is what makes lesson 4
-  // arriving before the first word look deliberate.
-  //
-  // Its state is the same `tileState` every other rung is drawn from, which is
-  // what a storm this far up the ladder needs. What it can never say is that
-  // something is waiting on it — a storm opens no door and closes none (§8.8),
-  // and `STORM_NOTE` is the sentence that carries that, first, on every one of
-  // the twenty.
+  // A storm says what it is, and — where there is one — why it cannot be
+  // entered, rather than being a tile that does nothing when pressed. What it
+  // can never say is that something is waiting on it (§8.8), which is what
+  // `STORM_NOTE` carries, first, on every one of the twenty.
   if (lesson.kind.type === "storm")
     return `${what}. ${STORM_NOTE} ${blocked ?? `${SAID[state]}.${how}`}`;
 

--- a/src/games/typing/PassBars.test.tsx
+++ b/src/games/typing/PassBars.test.tsx
@@ -7,7 +7,7 @@ import type { Verdict } from "@/engine/typing/verdict";
 import { PassBars } from "./PassBars";
 
 /**
- * The bars, drawn (docs/typing.md §6.1).
+ * The bars, drawn (§6.1).
  *
  * The lesson arm is exercised end to end next door in `LessonBars.test.tsx`,
  * over a real `verdictFor` — three bars, their order, and a bar that cannot
@@ -39,11 +39,10 @@ const deadInTheStorm: Verdict = {
 describe("PassBars", () => {
   /**
    * The bug this arm exists to avoid. §6.1's verdict gives a storm `wpm: {
-   * got: 0, need: 0, ok: true }` — a bar a storm cannot fail — and a `need` of
-   * zero draws as a full one. Three full bars over the word "failed" is a
-   * child being shown a screen that contradicts itself, so the column a storm
-   * was never asked for is not drawn at all and `missNote` says what the wave
-   * did instead.
+   * got: 0, need: 0, ok: true }`, and a `need` of zero draws as a full bar —
+   * so three full bars over the word "failed" is a screen contradicting
+   * itself. The column a storm was never asked for is not drawn at all, and
+   * `missNote` says what the wave did instead.
    */
   it("draws no speed bar on a Hailstorm level", () => {
     expect(labels(deadInTheStorm)).toEqual(["Accuracy"]);

--- a/src/games/typing/PassBars.tsx
+++ b/src/games/typing/PassBars.tsx
@@ -4,14 +4,7 @@ import type { Bar, Verdict } from "@/engine/typing/verdict";
 import { weakestKey } from "./lessonNotes";
 
 /**
- * The three bars a lesson is judged on (docs/typing.md §6.1).
- *
- * Three rather than one score, for a reason about a seven-year-old and not
- * about statistics: a single number tells you that you failed and not what to
- * do, where "fast enough, not accurate enough" is an instruction. Each bar is
- * visibly full or visibly short of its mark, and they are shown in the order
- * they matter — **accuracy, then the new keys, then speed** — which is also the
- * order they should be fixed in.
+ * The three bars a lesson is judged on, in the order they matter (§6.1).
  *
  * One component for both places the bars appear: filling live under a lesson in
  * `LessonBars`, and standing still under its verdict on the results screen. The
@@ -37,9 +30,8 @@ export function PassBars({
         target={percent(verdict.accuracy.need)}
       />
       {/* Absent on a review lesson and on every checkpoint — they introduce
-          nothing, so there is no third thing being asked and a bar for it
-          would be a bar that can never move (§6.1). Which of many keys gets
-          the room is `weakestKey`'s to say. */}
+          nothing, so a bar for it would be one that can never move (§6.1).
+          Which of many keys gets the room is `weakestKey`'s to say. */}
       {key && (
         <Meter
           label={`New key ${key.key}`}
@@ -48,14 +40,12 @@ export function PassBars({
           target={percent(key.need)}
         />
       )}
-      {/* ── No speed bar on a Hailstorm level (§5.6, §6.1) ──────────────────
-          A storm has no passage, so it has no words per minute, and §6.1's
-          verdict says so with `{ got: 0, need: 0, ok: true }` — a bar that can
-          never fail one. That is right for the model and unreadable on screen:
-          drawn, it is a full green bar sitting over the word the child has
-          just been told, which reads as a bug rather than as "not asked for".
-          §5.6 prints — in that column for the same reason. So the column is
-          simply not there, and `missNote` says in words what the wave did. */}
+      {/* No speed bar on a Hailstorm level: a storm has no passage and so no
+          words per minute, and §6.1's verdict says so with a bar that can never
+          fail. Drawn, that is a full green bar over the word the child has just
+          been told they missed, which reads as a bug rather than as "not asked
+          for". So the column is not there, and `missNote` says in words what
+          the wave did. */}
       {lesson.pass.kind !== "storm" && (
         <Meter
           label="Speed"

--- a/src/games/typing/Passage.tsx
+++ b/src/games/typing/Passage.tsx
@@ -72,7 +72,8 @@ export function Passage({
                 );
               })}
               {/* Anything typed past the end of the word is wrong but has to
-                  be visible, or a doubled letter looks like nothing happened. */}
+                  be visible, or a doubled letter looks like nothing
+                  happened. */}
               {entry.length > card.answer.length && (
                 <span className="passage__ch is-miss">
                   {entry.slice(card.answer.length)}

--- a/src/games/typing/StormBrief.test.tsx
+++ b/src/games/typing/StormBrief.test.tsx
@@ -8,19 +8,17 @@ import { isStormLesson, type StormLesson } from "@/engine/typing/storms";
 import { StormBrief } from "./StormBrief";
 
 /**
- * What is written on a storm's door (docs/typing.md §8.1, §8.8, §9).
+ * What is written on a storm's door (§8.1, §8.8, §9).
  *
  * A storm gets a brief of its own rather than an arm inside `LessonBrief`,
  * because the three things that screen is made of — the bars, the best and the
- * keyboard control — are three things a storm does not have. What this one has
- * to carry instead is on trial here:
+ * keyboard control — are three things a storm does not have. What it carries
+ * instead is on trial here:
  *
- *   - **How it is played**, for the child meeting a falling-letter game at
- *     lesson 4 who cannot guess §8.4's rule by watching.
+ *   - **How it is played**, since §8.4's rule cannot be guessed by watching.
  *   - **What THIS storm is**, so that "First ice" and "Whiteout" are not the
  *     same screen with different numbers behind them.
- *   - **That nothing waits on it** (§8.8, decision 24), which is the promise
- *     the tile can only carry as a phrase.
+ *   - **That nothing waits on it** (§8.8, decision 24).
  */
 
 const storm = (id: string): StormLesson => {
@@ -103,13 +101,10 @@ describe("StormBrief", () => {
 
   it("names the shift on every storm that can rain a capital", () => {
     /*
-     * Decision 70. A capital is shot with a shift held, and it was not always
-     * — so the level a child meets it on has to say so, or it is a rule that
-     * announces itself by taking ten points.
-     *
-     * Asked of the pool and not of `focus`: capitals are unlocked at lesson
-     * 34 and are in every wave's pool from there up (§5.6), so "Pairs" rains
-     * them without being about them and needs the sentence exactly as much.
+     * Decision 70. Asked of the pool and not of `focus`: capitals are
+     * unlocked at lesson 34 and are in every wave's pool from there up
+     * (§5.6), so "Pairs" rains them without being about them and needs the
+     * sentence exactly as much.
      */
     for (const id of ["L34", "L39", "L45", "L99"])
       expect(words(storm(id)), id).toContain("A capital needs a shift");
@@ -120,10 +115,8 @@ describe("StormBrief", () => {
   });
 
   /**
-   * §8.8, said in full on the one screen with room for it. The tile carries
-   * "worth playing, never required" and this says what that MEANS: the rung
-   * above opens off the rung below, so a storm can be skipped, failed or never
-   * opened at no cost at all.
+   * §8.8, said in full on the one screen with room for it — the tile only has
+   * room for the phrase.
    */
   it("promises that nothing on the ladder waits on it", () => {
     expect(words(L04)).toContain("worth playing, never required");
@@ -137,9 +130,9 @@ describe("StormBrief", () => {
   });
 
   /**
-   * And refuses on one they have not — the same `tileState` the tile is drawn
-   * from, asked twice on purpose: a screen that can say "locked" must not also
-   * be able to start the thing it just called locked.
+   * The same `tileState` the tile is drawn from, asked twice on purpose: a
+   * screen that can say "locked" must not also be able to start the thing it
+   * just called locked.
    */
   it("refuses a storm above the pointer, and says what opens it", () => {
     const shut = render(L04, FRESH);

--- a/src/games/typing/StormBrief.tsx
+++ b/src/games/typing/StormBrief.tsx
@@ -12,34 +12,17 @@ import { lockNote } from "./lessonNotes";
 import { STORM_NOTE, tileState } from "./LessonTile";
 
 /**
- * What a Hailstorm level is, before a child presses Play (docs/typing.md §8.1,
- * §8.8, §9).
+ * What a Hailstorm level is, before a child presses Play (§8.1, §8.8, §9).
  *
- * The other eighty rungs open `LessonBrief`, which is three bars, a best and a
- * keyboard control — and a storm has none of the three. It is marked on
- * surviving a wave, it holds no record at all (decision 50), and its keyboard
- * is not a hint under a passage but the gun itself (§8.2), so there is nothing
- * on that screen a storm could honestly fill in. Hence a second door rather
- * than a fourth arm inside the first: what the two briefs share is a shape, and
- * what they say is entirely different.
- *
- * Three things are on it and each earns its line:
- *
- *   - **How it is played.** A child arriving at lesson 4 has never seen a
- *     falling-letter game and the rule that decides everything — only the
- *     lowest letter can be shot (§8.4) — is not guessable from watching.
- *   - **What this storm is.** How many letters, how deep the shield, whether
- *     it repairs, and what it mostly rains. The twenty levels differ in
- *     exactly those four things (§5.6's storm table), so they are what makes
- *     "First ice" and "Whiteout" different screens rather than the same screen
- *     with different numbers behind it.
- *   - **That it is not required.** Said here in full, because the tile can only
- *     carry it as a phrase: nothing on the ladder waits on a storm, and the
- *     lesson above it opens off the lesson *below* it (§8.8, decision 24).
+ * A second door rather than a fourth arm inside `LessonBrief`: what the two
+ * share is a shape, and what they say is entirely different — a storm has no
+ * three bars, no best and no keyboard control to fill in. What it says instead,
+ * and why each of the three lines is there, is §8.8.
  *
  * There is deliberately no "your best". A storm is unranked everywhere on the
- * site (`isRanked`), so a brief that quoted one would be inventing a record
- * that `bestRun` refuses to hold — and a run that ended early would hold it.
+ * site (`isRanked`, §8.7), so a brief that quoted one would be inventing a
+ * record that `bestRun` refuses to hold — and a run that ended early would hold
+ * it.
  */
 export function StormBrief({
   lesson,
@@ -70,8 +53,7 @@ export function StormBrief({
      nothing on screen that had ever mentioned it (decision 70).
 
      `unlockedAt(n)` is the same set `stormWave` draws this level's letters
-     from, so this cannot disagree with what actually falls. Below lesson 34
-     nothing in it is shifted and the sentence never appears. */
+     from, so this cannot disagree with what actually falls. */
   const shifts = [...unlockedAt(lesson.n)].some(
     (ch) => strokeFor(ch)?.shift != null,
   );

--- a/src/games/typing/TypingResults.tsx
+++ b/src/games/typing/TypingResults.tsx
@@ -14,17 +14,15 @@ import { sfx } from "@/services/sound";
 import LessonResults from "./LessonResults";
 
 /**
- * What the run was worth.
+ * What a free-play run was worth.
  *
  * Words per minute leads, because that's the number a typist thinks in — but
- * accuracy sits beside it rather than being folded into a single "net WPM".
- * A child who types fast and gets half of it wrong should see both, not one
- * blended figure that hides which half is the problem.
+ * accuracy sits beside it rather than being folded into a single "net WPM"
+ * (§6.1). A child who types fast and gets half of it wrong should see both.
  *
  * That is **free play**, which is a race. A run from the ladder is marked
  * against three criteria rather than ranked against a rival, so it gets a
- * screen of its own (`LessonResults`, docs/typing.md §6.1) and this one is
- * left exactly as it was — the wpm, the accuracy, the splits and the ghost.
+ * screen of its own (`LessonResults`) and this one is left to the race.
  */
 export default function TypingResults() {
   const { profileId } = useParams();
@@ -38,11 +36,8 @@ export default function TypingResults() {
    * the navigate that follows it is batched with that update. So there is
    * exactly one render where the outcome has gone and the route is still
    * here — and without the `pending` arm below, this guard fires in that gap
-   * and replaces the navigation to the track with one back to setup.
-   *
-   * That is not theoretical: it is what "Type it again" did on this screen from the day
-   * it shipped. The mirror image of it is guarded in `TypingTrack`, and this is the half
-   * that was missed.
+   * and replaces the navigation to the track with one back to setup. The
+   * mirror image of it is guarded in `TypingTrack`.
    */
   if (!outcome) {
     return <Navigate to={`/p/${profile.id}${pending ? "/go" : ""}`} replace />;
@@ -139,11 +134,10 @@ export default function TypingResults() {
         <div className="stat">
           <span className="stat__value">{clock(raceTimeMs(session))}</span>
           {/* `raceTimeMs` is the clock plus three seconds a miss, and that is
-              the truth about a free-play run: it is a race, the penalty is
-              what stops "guess fast" beating "know it", and it is the number
-              the personal best and the ghost are decided on. A lesson has no
-              penalty at all (§7) and says so with a plain "Time" — the label
-              is per-screen because the thing it names is. */}
+              the truth about a free-play run: it is a race, the penalty is what
+              stops "guess fast" beating "know it", and it is the number the
+              personal best and the ghost are decided on. A lesson has no
+              penalty at all (§7) and says so with a plain "Time". */}
           <span className="stat__label">
             {session.incorrect > 0 ? "Time + penalties" : "Time"}
           </span>

--- a/src/games/typing/TypingSetup.tsx
+++ b/src/games/typing/TypingSetup.tsx
@@ -29,17 +29,11 @@ import type { KeyboardMode, TypingConfig } from "@/engine/types";
 const LENGTHS = [20, 30, 50, 80];
 
 /**
- * The ladder, and free play under it (docs/typing.md §9).
+ * The ladder, and free play under it (§9).
  *
- * `#/p/:id` is the way into the typing world, and after LES10 that means the
- * hundred lessons first: `LessonLadder` is the screen's subject and the panel
- * below it is the game that was here before the course existed.
- *
- * **Free play stays, and stays whole** — the five levels, the four lengths,
- * the keyboard setting and the rival list, unchanged. A hundred lessons is a
- * course, and a child who has come here to type a psalm and race their brother
- * has not asked to be enrolled in one. Nothing on the ladder gates it, and
- * nothing about it is worse than it was the day before the ladder landed.
+ * `LessonLadder` is the screen's subject and the panel below it is the game
+ * that was here before the course existed. Free play stays whole and nothing on
+ * the ladder gates it (§7).
  *
  * The two halves share this screen and nothing else. A lesson is not a race
  * (§7): it carries its own words, no ghost and no rival, which is why the
@@ -63,26 +57,24 @@ export default function TypingSetup() {
   /**
    * The lesson whose brief is up, or `null` for none (§9).
    *
-   * A tile no longer starts a run — it opens the door and the brief is what is
-   * written on it. Holding the lesson rather than a boolean is what lets the
-   * brief be mounted per lesson below, which is how the keyboard control gets
-   * seeded afresh each time instead of carrying the last lesson's choice onto
-   * one that suggests something else.
+   * Holding the lesson rather than a boolean is what lets the brief be mounted
+   * per lesson below, which is how the keyboard control gets seeded afresh each
+   * time instead of carrying the last lesson's choice onto one that suggests
+   * something else.
    *
    * One piece of state for both kinds of rung, and the lesson itself decides
-   * which brief opens over it (`isStormLesson`). Two flags would be two ways
-   * to have both open at once, over a ladder where a tile is exactly one of
-   * the two.
+   * which brief opens over it (`isStormLesson`). Two flags would be two ways to
+   * have both open at once, over a ladder where a tile is exactly one of the
+   * two.
    */
   const [briefing, setBriefing] = useState<Lesson | null>(null);
 
   /**
-   * Whether this device looks like it can play Hailstorm at all (§8.8, #155).
+   * Whether this device looks like it can play Hailstorm at all (§8.8).
    *
    * Asked here rather than inside the ladder so that screen stays a pure
-   * function of its props, and asked at all because a storm tile that opened a
-   * game a child physically cannot play is the "fails mysteriously" this is
-   * against. It is a guess that costs a keystroke to overturn — see the hook.
+   * function of its props. It is a guess that costs a keystroke to overturn —
+   * see the hook.
    */
   const hasKeyboard = useKeyboardPresence();
 
@@ -100,8 +92,7 @@ export default function TypingSetup() {
 
   /**
    * Where this child is on the ladder, from the runs the hub has already
-   * loaded (§6.5). Nothing is stored: pass a lesson and the tile fills because
-   * the session it was passed in is in this array.
+   * loaded (§6.5).
    *
    * Memoised over the slice as well as the derivation, because `sessionsFor`
    * builds a fresh array every call and `ladderProgress` remembers its answer
@@ -122,9 +113,8 @@ export default function TypingSetup() {
 
   /**
    * Saved to the profile the moment it moves, unlike everything else on this
-   * screen: a level and a length describe one run, but how much of the
-   * keyboard you need is about the child, and it should still be true next
-   * week without being chosen again. Same shape as the sound toggle in
+   * screen: a level and a length describe one run, but how much of the keyboard
+   * you need is about the child (§4.2). Same shape as the sound toggle in
    * `TopBar` — write, and say so if the write didn't land, because the pills
    * are drawn from the profile and would otherwise silently spring back.
    */
@@ -146,10 +136,9 @@ export default function TypingSetup() {
    * its own results are the same run, filed under the same `configKey`, or a
    * child's best would depend on which button they reached it by.
    *
-   * `keyboard` is what the child chose in the brief, and it is absent when
-   * they were not offered a choice — a locked lesson hands back nothing rather
-   * than handing back the mode it insisted on, so what is saved with the run
-   * says "chosen" and not merely "shown" (§4.2).
+   * `keyboard` is absent when the child was not offered a choice — a locked
+   * lesson hands back nothing rather than the mode it insisted on — so what is
+   * saved with the run says "chosen" and not merely "shown" (§4.2).
    */
   function runLesson(lesson: Lesson, keyboard?: KeyboardMode) {
     sfx.whoosh();
@@ -232,8 +221,7 @@ export default function TypingSetup() {
 
           {/* Said once, under the ladder, because a screen that led with a
               hundred lessons and then showed a level picker without a word
-              would read as the course being over. Free play is the other
-              game here, not the leftovers of this one. */}
+              would read as the course being over. */}
           <p className="muted">
             No lesson, no bars to meet — a passage, a clock, and anyone
             you&apos;ve raced before.

--- a/src/games/typing/TypingTrack.tsx
+++ b/src/games/typing/TypingTrack.tsx
@@ -36,36 +36,29 @@ import type {
 } from "@/engine/types";
 
 /**
- * The typing race.
+ * The typing race, and — with the race taken out of it — the lesson run.
  *
- * Structurally the flash-card loop with the pauses taken out. A word is a
- * card, space commits it, and the run is scored and saved by exactly the same
- * machinery — which is what makes a rival's pace visible word by word instead
- * of as a WPM at the end.
+ * Structurally the flash-card loop with the pauses taken out. A word is a card,
+ * space commits it, and the run is scored and saved by exactly the same
+ * machinery, which is what makes a rival's pace visible word by word instead of
+ * as a WPM at the end.
  *
- * The two real differences, and both are deliberate:
+ * The two real differences from a card race, and both are deliberate:
  *
- * - **No feedback pause.** A card race holds the screen for a second and a
- *   half on a wrong answer so it can be read. Doing that here would break the
- *   one thing typing practice is for, which is not stopping. A wrong word goes
- *   red in the passage behind you and the next word is already live.
- * - **Space is the whole interface.** No Enter, no submit button. Backspace
- *   works inside the current word and nowhere else, because a typing test that
- *   lets you walk back through a finished passage isn't measuring anything.
+ * - **No feedback pause.** A card race holds the screen for a second and a half
+ *   on a wrong answer so it can be read. Doing that here would break the one
+ *   thing typing practice is for, which is not stopping. A wrong word goes red
+ *   in the passage behind you and the next word is already live.
+ * - **Space is the whole interface.** No submit button; Enter only exists for
+ *   the last word of a passage, which has no space after it. Backspace works
+ *   inside the current word and nowhere else, because a typing test that lets
+ *   you walk back through a finished passage isn't measuring anything.
  *
- * ── And the same loop with the race taken out ────────────────────────────────
- * A run from the ladder is a lesson, and a lesson is not a race
- * (docs/typing.md §7). It is this component with four things removed and one
- * added, all of them off `config.lessonId` and none of them a second loop:
- * no ghost, no lane, no wrong-answer penalty, no starting gun in the copy —
- * and the three pass bars filling live where the rival's gap would be.
- *
- * One component rather than two because of what is NOT different: space still
- * commits a word and a word is still a `Card`. Keeping that is what makes the
- * record book, the splits, the trouble list, XP and the drill builder work on
- * lessons for free, and it is the single highest-leverage thing here not to
- * change. Free play — the five levels, their ghosts and their personal bests —
- * runs through these same lines and is untouched by any of it.
+ * A run from the ladder is a lesson, and a lesson is not a race (§7): this same
+ * component with the ghost, the lane, the penalty and the starting gun taken
+ * out and the three pass bars put in, all of it off `config.lessonId` and none
+ * of it a second loop. One component rather than two because of what is NOT
+ * different: space still commits a word and a word is still a `Card`.
  */
 export default function TypingTrack() {
   const { profileId } = useParams();
@@ -186,13 +179,10 @@ function Track({
   /**
    * The clock a rival is measured against — and on a lesson, just the clock.
    *
-   * **No `WRONG_ANSWER_PENALTY_MS` on a lesson** (§7). Three seconds a miss is
-   * a race mechanic: it is there to make a wrong answer cost something when the
-   * only thing a race counts is time. A lesson already counts accuracy, on a
-   * bar of its own, so charging for it again double-counts it — and it would
-   * make the wpm figure a lie, because a "minute" with penalties folded into it
-   * is not a minute and the number stops being words per minute of anything.
-   * Free play keeps every second of it; free play is a race.
+   * **No `WRONG_ANSWER_PENALTY_MS` on a lesson** (§7): a lesson already counts
+   * accuracy on a bar of its own, and a penalty would double-count it and make
+   * the wpm figure a lie. Free play keeps every second of it; free play is a
+   * race.
    */
   const raceElapsed =
     elapsed() + (lesson ? 0 : misses.current * WRONG_ANSWER_PENALTY_MS);
@@ -294,17 +284,10 @@ function Track({
    * How much of the board is on screen — §4.2's one line, resolved in the one
    * place that resolves it (`keyboardFor`).
    *
-   * Three inputs and the same three the brief showed before the run started: a
-   * locked lesson wins outright, then what the child chose in the brief
-   * (`config.keyboard`, travelling with the run exactly as its words do), then
-   * the lesson's own suggestion, the player's setting and `guide`. Free play
-   * has no lesson and makes no choice, so it lands on the profile's setting and
-   * is untouched by any of it.
-   *
-   * Reading the choice off the config rather than off a prop is what makes it
-   * survive the navigation: `pending` is what the countdown, the save and the
-   * results screen all read, and a mode that lived anywhere else would be gone
-   * by the time this component mounted.
+   * Reading the child's choice off the config rather than off a prop is what
+   * makes it survive the navigation: `pending` is what the countdown, the save
+   * and the results screen all read, and a mode that lived anywhere else would
+   * be gone by the time this component mounted.
    */
   const board = keyboardFor(lesson, profile.keyboard, config.keyboard);
 
@@ -330,10 +313,9 @@ function Track({
           <span key={countdown} className="countdown__num u-display">
             {countdown === 0 ? "GO" : countdown}
           </span>
-          {/* The 3·2·1 stays on a lesson, because it is the moment the hands go
-              on the home row and that is worth keeping for its own sake — but
-              it is not a starting gun there, so it doesn't talk like one
-              (§7). */}
+          {/* The 3·2·1 stays on a lesson, because it is the moment the hands
+              go on the home row — but it is not a starting gun there, so it
+              doesn't talk like one (§7). */}
           {lesson && <p className="countdown__note">Fingers on home row</p>}
         </div>
       )}

--- a/src/games/typing/keyboard/Keyboard.test.tsx
+++ b/src/games/typing/keyboard/Keyboard.test.tsx
@@ -11,17 +11,11 @@ import { Keyboard } from "./Keyboard";
 /**
  * What the board owes a child, a screen reader, and the next story.
  *
- * The two things worth pinning here are both things a well-meaning change
- * would undo. The first is that this board is INERT: no control, no tab stop,
- * nothing to press. "Make the keys tappable" is the single most natural
- * feature request this component will ever attract, and saying yes to it turns
- * a touch-typing tutor into a hunt-and-peck trainer (docs/typing.md §4.5).
- *
- * The second is the palette. The finger hues are checked against the telemetry
- * five by reading the stylesheet, because that rule lives in CSS and there is
- * no other place it can be asserted — a keyboard that tinted the left index
- * finger `--lime` would spend a hundred lessons teaching a child to unlearn
- * what green means (§4.6).
+ * Two things are pinned here, and both are things a well-meaning change would
+ * undo: that the board is INERT — no control, no tab stop, nothing to press
+ * (§4.5) — and that the finger hues borrow none of the telemetry five (§4.6).
+ * The palette rule is checked by reading the stylesheet, because it lives in
+ * CSS and there is nowhere else it can be asserted.
  *
  * That split is per BLOCK, not per file: the board is scenery and borrows none
  * of the five, and the press echo below it is signal and borrows exactly two.
@@ -141,25 +135,19 @@ describe("Keyboard", () => {
       ...sheet.matchAll(/--key:\s*clamp\([^;]*?,\s*([^,;]+)\s*\);/g),
     ].map(([, ceiling]) => ceiling.trim());
 
-    // 19.05mm of key pitch is three quarters of an inch, which CSS defines as
-    // exactly 72px, which is 4.5rem. The board is a map a child glances at
-    // while their hands are on the real thing, so the ceiling is that
-    // measurement and not a taste — at half of it they do the scaling, which
-    // is the work looking down would have saved them (§4.7, decision 61).
+    // 4.5rem is 19.05mm of key pitch, the measurement rather than a taste
+    // (§4.7, decision 61).
     //
     // Asserted of EVERY declaration rather than of the board's, because the
-    // storm has no board and is capped at pitch for the same reason anyway: a
-    // lane claims to be where that key is, so a field wider than a keyboard
-    // teaches a reach nobody's hand makes (decision 64).
+    // storm has no board and is capped at pitch for the same reason anyway —
+    // a lane claims to be where that key is (decision 64).
     expect(ceilings.length).toBeGreaterThan(0);
     for (const ceiling of ceilings) expect(ceiling).toBe("4.5rem");
 
     // The root value is the storm's — the lanes, the stones and the shield —
     // and the passage screen overrides it. Written out whole because the two
-    // floor terms are load-bearing too: `6vw` is what keeps fifteen units
-    // inside 90% of a narrow viewport whatever is under them, and the dvh term
-    // is what stops a hailstone growing until there is no sky to read it
-    // against.
+    // floor terms are load-bearing too, and each of the three is a separate
+    // decision (§4.7).
     const root = /:root\s*{[^}]*--key:\s*([^;]+)/.exec(sheet)![1];
     expect(root.replace(/\s+/g, " ")).toBe(
       "clamp(1.05rem, min(6vw, 15dvh), 4.5rem)",
@@ -169,17 +157,11 @@ describe("Keyboard", () => {
   it("centres the board on the arithmetic when it overflows the race column", () => {
     const sheet = css("game.css").replace(/\/\*[\s\S]*?\*\//g, "");
 
-    // A life-size board is fifteen units of 72px — 1080px — and `.race` is
-    // `min(720px, 100%)`, a measure chosen for reading a line of words. So on
-    // the passage screen the board overflows its column, evenly, on purpose
-    // (decision 62).
-    //
-    // Half the column minus half of fifteen units, and NOT `margin-inline:
-    // auto`: an auto margin is defined to resolve to zero against negative
-    // free space, so the board would hug the left edge and hang off the right.
-    // `justify-self: center` loses the same way — Chrome start-aligns an
-    // overflowing grid item. This expression is the one that means the same
-    // thing in both directions.
+    // A life-size board overflows the 720px race column on purpose, and is
+    // centred with half the column minus half of fifteen units rather than
+    // with an alignment property — neither `margin-inline: auto` nor
+    // `justify-self: center` centres against negative free space (§4.7,
+    // decision 62).
     //
     // Filtered rather than taken first, because `.typing .keyboard` is written
     // twice: the other one is the short-viewport rule that drops the board
@@ -194,11 +176,10 @@ describe("Keyboard", () => {
     );
 
     // And the height budget on the same screen is divided by the board's own
-    // height in key units — five rows, and the four gaps between them at
-    // whatever the board insets its caps by. Read out of `--key-gap` rather
-    // than pinned at 5.36, so a chunkier keycap moves the budget with it
-    // instead of leaving the board a fraction too tall on a short window and
-    // scrolling a race under a child's thumb (decision 63).
+    // height in key units — five rows, and the four gaps between them (§4.7,
+    // decision 63). Derived from `--key-gap` rather than pinned at 5.36, so a
+    // chunkier keycap moves the budget with it rather than leaving the board a
+    // fraction too tall on a short window.
     const gap = Number(
       /--key-gap:\s*calc\(var\(--key\) \* ([\d.]+)\)/.exec(sheet)![1],
     );
@@ -240,8 +221,7 @@ describe("Keyboard", () => {
     const game = css("game.css");
     const hint = game.slice(game.indexOf(HINT_BLOCK), game.indexOf(ECHO_BLOCK));
 
-    // `--go` is per-world and already means "press this" — the button that
-    // started the run is the same colour. A hint drawn in `--lime` would be
+    // `--go` already means "press this". A hint drawn in `--lime` would be
     // indistinguishable from the flash that says "you just pressed that".
     expect(hint).toMatch(/\.is-next\s*{/);
     expect(hint).toContain("var(--go)");
@@ -259,9 +239,8 @@ describe("Keyboard", () => {
   });
 
   it("lights a shifted character's letter AND the shift on the other hand", () => {
-    // The whole point of the hint. Left-pinky shift plus left-pinky `a` is
-    // physically impossible, so `A` is right-shift-plus-left-`a` — and which
-    // hand takes the shift is what typing courses for children skip.
+    // Left-pinky shift plus left-pinky `a` is physically impossible, so `A` is
+    // right-shift-plus-left-`a`.
     expect(hinted("A")).toEqual(["KeyA", "ShiftRight"]);
 
     // The mirror, so this can't pass by always naming the right shift: `?` is

--- a/src/games/typing/keyboard/Keyboard.tsx
+++ b/src/games/typing/keyboard/Keyboard.tsx
@@ -6,60 +6,33 @@ import { KEY_ROWS, strokeFor } from "@/engine/keyboard";
 const NONE: ReadonlySet<string> = new Set();
 
 /**
- * The keyboard, as a picture (docs/typing.md §4).
+ * The keyboard, as a picture (§4).
  *
- * The board itself is not defined here — `@/engine/keyboard` owns the layout,
- * the finger assignment and the geometry, because three of its four consumers
- * are not pictures (§3.1). This file is the fourth: markup and class names over
- * that table, and nothing that a lesson generator or Hailstorm would have to
- * import a component to read.
+ * The layout is not defined here — `@/engine/keyboard` owns it, because three
+ * of its four consumers are not pictures (§3.1). This file is the fourth:
+ * markup and class names over that table.
  *
- * ── Spans, and why every one of them ──────────────────────────────────────
- * Sixty-odd `<span>`s rather than sixty-odd `<button>`s, and the whole board is
- * `aria-hidden="true"`. Both halves of that are the story, not an oversight:
+ * Sixty-odd `<span>`s rather than `<button>`s, and the whole board is
+ * `aria-hidden="true"`: it is never tappable on any device (§4.5, decision 5),
+ * and announcing sixty keys is a denial of service rather than an
+ * accommodation (§4.4). The spans carry no handler and `pointer-events: none`
+ * covers the rest.
  *
- *   - **Never tappable, on any device** (§4.5). A board you can press is a
- *     hunt-and-peck trainer — it teaches finding a key by eye and pressing it
- *     with whichever finger is closest, which is exactly the habit this world
- *     exists to prevent. On a tablet the software keyboard is already the
- *     interface; this is a map of it, not a second one. The `<span>`s carry no
- *     handler and `pointer-events: none` covers the rest.
- *   - **Silent to a screen reader** (§4.4). Announcing sixty keys is a denial
- *     of service, not an accommodation, and every piece of state this shows is
- *     already in the passage: the live word is `aria-current`, the characters
- *     are text, the errors are in the DOM. So the picture stays a picture.
- *
- * ── One dial ──────────────────────────────────────────────────────────────
  * The board is fifteen key units wide and each key knows its own left edge in
- * those units, so the whole thing scales off a single `--key` custom property
- * in `game.css`. A phone in landscape and a laptop get the same layout at
- * different sizes rather than two layouts — there is no breakpoint here to keep
- * in step with the row stagger.
+ * those units, so the whole thing scales off a single `--key` in `game.css` —
+ * one layout at two sizes, with no breakpoint to keep in step with the row
+ * stagger. That dial tops out at real key pitch (§4.7), which is why on a wide
+ * screen the board is wider than the 720px race column and is allowed to
+ * overflow it; the CSS says how.
  *
- * That dial tops out at real key pitch — 19.05mm, which is 4.5rem (§4.7) —
- * because this is a map read while the hands are on the actual keyboard, and a
- * map at half scale makes the child do the scaling. On a wide screen the board
- * is therefore wider than the 720px column the race is written in, and is
- * allowed to overflow it; the CSS says how.
+ * The echo arrives as props rather than from a hook called here (§4.3): the
+ * board stays a pure function of its props, testable by rendering it, and
+ * Hailstorm can want the same echo for its gun without a second copy of the
+ * listener fighting this one.
  *
- * ── The echo arrives as props, not as a hook ──────────────────────────────
- * Which keys are lit is `useKeyEcho`'s answer, passed in (§4.3). Calling the
- * hook in here would look tidier and would cost the two things that matter:
- * the board would stop being a pure function of its props — untestable by
- * rendering it — and Hailstorm, which needs the same echo for its own gun
- * (§8.2), would end up with a second copy of the listener fighting this one.
- *
- * ── The hint is a character, not a set of codes ───────────────────────────
- * `next` is the character the passage is waiting on, and the board asks
- * `strokeFor` which keys produce it (§3.3). It is not two code props, because
- * "which shift goes with `A`" is a fact about the layout and the layout lives
- * in the engine — a caller that computed it would be a second copy of the
- * table's opinion, free to disagree with the one Hailstorm and the curriculum
- * read.
- *
- * WHEN the hint is on is not decided here: that is `KeyboardMode` (#133), and
- * a mode of "keys" simply passes `next={null}`. #134 puts the board under the
- * passage.
+ * `next` is the character the passage is waiting on, not two code props —
+ * which shift goes with `A` is the layout's to answer (§3.3). WHEN the hint is
+ * on is `KeyboardMode`'s: mode "keys" passes `next={null}`.
  */
 export function Keyboard({
   down = NONE,
@@ -80,19 +53,12 @@ export function Keyboard({
 }) {
   /**
    * The keys the hint lights: the character's own key, and — for a capital or
-   * any other shifted character — the shift on the OPPOSITE hand.
+   * any other shifted character — the shift on the OPPOSITE hand, which
+   * `strokeFor` has already chosen and this does not second-guess (§3.3).
    *
-   * That opposite hand is the whole pedagogical point rather than a detail.
-   * Left-pinky-shift plus left-pinky-`a` is physically impossible; `A` is
-   * right-shift-plus-left-`a`, and which shift to reach for is the single
-   * most-skipped thing in typing courses aimed at children. Lighting both keys
-   * is what makes the hint teach the technique instead of merely locating the
-   * letter.
-   *
-   * `strokeFor` has already decided the hand (§3.3) and this does not
-   * second-guess it. It also answers `null` for a character this layout cannot
-   * produce — a curly quote that survived the passage filter — which lights
-   * nothing rather than throwing, exactly as `next: null` does.
+   * `strokeFor` answers `null` for a character this layout cannot produce — a
+   * curly quote that survived the passage filter — which lights nothing rather
+   * than throwing, exactly as `next: null` does.
    */
   const hint = next === null ? null : strokeFor(next);
 
@@ -119,12 +85,10 @@ export function Keyboard({
                 // `is-wrong` is written alongside `is-down` rather than
                 // instead of it: a wrong key is still a key that went down,
                 // and the CSS orders the two so the flare wins the colour.
-                // `is-next` stacks the same way and loses the cap to both —
-                // border, fill and legend go to the echo, whose rules are
-                // written after it — but only the cap: the hint's ring and
-                // its pulse are properties the echo never declares, so they
-                // ride out the strike. On the frame a hinted key is struck,
-                // the strike is the louder of the two, not the only one.
+                // `is-next` stacks the same way and loses the cap to both,
+                // but only the cap — the hint's ring and its pulse are
+                // properties the echo never declares, so a hinted key that is
+                // struck shows both.
                 className={[
                   "keyboard__key",
                   key.home && "is-home",
@@ -135,18 +99,17 @@ export function Keyboard({
                 ]
                   .filter(Boolean)
                   .join(" ")}
-                // The finger is an attribute rather than a class because it is
-                // one of a closed set the CSS enumerates once, and because
-                // `[data-finger]` is what the tint rules select on.
+                // The finger is an attribute rather than a class: it is one of
+                // a closed set the CSS enumerates once, and `[data-finger]` is
+                // what the tint rules select on.
                 data-finger={key.finger}
                 style={{ "--x": key.x, "--w": key.width ?? 1 } as CSSProperties}
               >
                 {/* The unshifted legend only. A real keycap prints `A` over a
-                    key that types `a` unshifted; a child comparing the board
-                    against the passage needs the character they are about to
-                    type. The shifted half is never printed — a capital is
-                    shown by lighting the shift beside the letter, which is
-                    the thing being taught. */}
+                    key that types `a`; a child comparing the board against
+                    the passage needs the character they are about to type,
+                    and a capital is shown by lighting the shift beside the
+                    letter. */}
                 {key.cap[0]}
               </span>
             );

--- a/src/games/typing/keyboard/KeyboardSetting.test.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.test.tsx
@@ -8,18 +8,15 @@ import { KeyboardSetting } from "./KeyboardSetting";
 /**
  * The setting, and the profile that predates it.
  *
- * `Profile.keyboard` is optional and gets no migration on purpose
- * (docs/typing.md §10): profiles are read straight out of IndexedDB, unlike
- * sessions, and the only copy of a child's record book is the one on their
- * device. The price of that decision is that "the field isn't there" — and
- * "the field says something else", since a restored backup is stored whole and
- * unchecked — are states the UI meets forever, not states that get tidied up
- * one release later. So both are pinned here, in the file that resolves them.
+ * `Profile.keyboard` is optional and gets no migration on purpose (§10, §4.2).
+ * The price is that "the field isn't there" — and "the field says something
+ * else", since a restored backup is stored whole and unchecked — are states
+ * the UI meets forever rather than states that get tidied up one release
+ * later. So both are pinned here, in the file that resolves them.
  *
  * The other assertion is that this is a control. The board it governs is sixty
  * inert spans and must stay that way (§4.5); the thing that shows and hides it
- * is the opposite, and "reachable by keyboard, announced with a name" is the
- * difference between the two.
+ * is the opposite.
  */
 
 /** A player from before this shipped: every field but `keyboard`. */
@@ -81,10 +78,9 @@ describe("KeyboardSetting", () => {
   });
 
   /**
-   * The lessons that insist (docs/typing.md §4.2, #145). Shown rather than
-   * hidden, disabled rather than silently overridden, and with the reason on
-   * the panel — a control that ignores the setting a child chose and a control
-   * greyed out with no explanation are the same bug at different volumes.
+   * The lessons that insist (§4.2). A control that ignores the setting a child
+   * chose and one greyed out with no explanation are the same bug at different
+   * volumes, so the panel shows all three pills, disabled, with the reason.
    */
   it("shows a locked keyboard, disabled, with the reason", () => {
     const html = renderToStaticMarkup(

--- a/src/games/typing/keyboard/KeyboardSetting.tsx
+++ b/src/games/typing/keyboard/KeyboardSetting.tsx
@@ -2,53 +2,35 @@ import { SegmentedControl, type SegmentedOption } from "@/components/ui/kit";
 import type { KeyboardMode } from "@/engine/types";
 
 /**
- * Choosing how much of the keyboard is on screen (docs/typing.md §4.2).
+ * Choosing how much of the keyboard is on screen (§4.2).
  *
- * The board itself is deliberately inert — sixty `<span>`s, `aria-hidden`,
- * nothing to press, because a tappable keyboard is a hunt-and-peck trainer
- * (§4.5). This is the opposite case and it is why the two live side by side:
- * *this* is a control, so it is a real kit primitive with a name, a role and
- * arrow keys, and not a row of `<Button pressed>` dressed as one.
+ * The board itself is inert and `aria-hidden` (§4.4, §4.5); *this* is a
+ * control, so it is a real kit primitive with a name, a role and arrow keys,
+ * and not a row of `<Button pressed>` dressed as one.
  *
- * ── Three pills, because there are three modes ────────────────────────────
- * `SegmentedControl` rather than a `Toggle`: a switch can only say on or off,
- * and the whole point of `KeyboardMode` is that "board without the hint" is a
- * real place to stand between the two (§4.1). It is the rung a child climbs
- * before turning the board off entirely, and it is where most of the learning
- * happens — so it cannot be the thing you reach by unchecking half a pair.
+ * `SegmentedControl` rather than a `Toggle`, because there are three modes and
+ * "board without the hint" is a real place to stand between the two (§4.1) —
+ * not somewhere you arrive by unchecking half a pair.
  *
- * ── Its own component, and its own defaulting ─────────────────────────────
  * `mode` is the profile's raw optional field, not a resolved one, so the
- * fallback to "guide" lives here — one resolver, exported, rather than a copy
- * of it at each caller. That is also what makes the cases that matter testable
- * without a database or a router: a profile saved before this shipped has no
- * `keyboard` key at all, and a restored backup can carry a value no version of
- * this app ever wrote. Either one must land on "guide" rather than on nothing
- * selected. `KeyboardSetting.test.tsx` is that test.
+ * fallback lives here: one resolver, exported, rather than a copy of it at each
+ * caller.
  *
- * ── Two homes, and only one of them saves ─────────────────────────────────
- * On the free-play panel this writes straight through to the profile: how much
- * of the keyboard you need is a fact about the child and should still be true
- * next week. In the lesson brief it is seeded by the lesson and governs that
- * run alone (`lessonKeyboard.ts`). The component does not know the difference —
- * it renders a mode and reports a change — which is what keeps the two screens
- * showing one control instead of two that look alike.
+ * Two homes, and only one of them saves. On the free-play panel this writes
+ * straight through to the profile; in the lesson brief it is seeded by the
+ * lesson and governs that run alone (`lessonKeyboard.ts`). The component does
+ * not know the difference — it renders a mode and reports a change — which is
+ * what keeps the two screens showing one control instead of two that look
+ * alike.
  */
 
-/**
- * What a player who has never chosen gets.
- *
- * "guide" rather than "off" because the two mistakes are not the same size:
- * showing the hint to a child who didn't need it costs a glance, and hiding it
- * from a child who did costs a downward look at the real keyboard — which is
- * the habit this whole world exists to prevent, and it sets in fast.
- */
+/** What a player who has never chosen gets — "guide", and why (§4.2). */
 export const DEFAULT_KEYBOARD_MODE: KeyboardMode = "guide";
 
 /**
  * Named for what a child sees, not for what the field is called. The hints do
- * the explaining, because "Keys" and "Guide" only differ in a way you can
- * describe — one draws the board, the other also points at the next key.
+ * the explaining, because "Keys" and "Guide" differ only in a way you can
+ * describe.
  */
 const OPTIONS: SegmentedOption<KeyboardMode>[] = [
   { value: "off", label: "Off", hint: "No keyboard" },
@@ -68,20 +50,18 @@ const LOCKED: SegmentedOption<KeyboardMode>[] = OPTIONS.map((option) => ({
  *
  * Not `mode ?? DEFAULT_KEYBOARD_MODE`, because `??` only catches an absent
  * field and absent is not the only bad state. `Profile` is deliberately not
- * read-migrated (docs/typing.md §10), and a restored backup is written into
- * the store exactly as the file had it (`services/storage/db.ts`, driven by
- * `services/hub.ts#importAll`) — so a hand-edited record reaches this
- * component with a `keyboard` the type says is impossible. Handed straight to
- * `SegmentedControl`, that draws a radiogroup with no pill checked: a child
- * looking at a setting that claims to be on none of its three settings.
+ * read-migrated (§10), and a restored backup is written into the store exactly
+ * as the file had it (`services/storage/db.ts`, driven by
+ * `services/hub.ts#importAll`) — so a hand-edited record reaches this component
+ * with a `keyboard` the type says is impossible. Handed straight to
+ * `SegmentedControl`, that draws a radiogroup with no pill checked.
  *
  * Resolved against `OPTIONS` rather than against a second copy of the three
  * mode names, so what comes back is by construction a pill that exists.
  *
  * Exported because the race reads the same field to decide what to draw
- * (`TypingTrack`, #134), and the two must agree: a setting whose pills say
- * "guide" over a run with no board is worse than either alone. One resolver,
- * so there is nothing for a second read site to disagree with.
+ * (`TypingTrack`), and the two must agree: a setting whose pills say "guide"
+ * over a run with no board is worse than either alone.
  */
 export const keyboardMode = (mode?: KeyboardMode): KeyboardMode =>
   OPTIONS.find((option) => option.value === mode)?.value ??
@@ -102,13 +82,12 @@ export function KeyboardSetting({
   onChange: (next: KeyboardMode) => void;
   /**
    * Why this run's keyboard cannot be changed, on the lessons that insist
-   * (docs/typing.md §4.2). Absent everywhere else, which is free play and
-   * every unlocked lesson.
+   * (§4.2). Absent everywhere else, which is free play and every unlocked
+   * lesson.
    *
    * A sentence rather than a `disabled` flag, because a control that can be
    * greyed out without saying why is a control that will be. The pills still
-   * show which mode the run is in — a lesson that hid them would be deciding
-   * for a child and not telling them what it decided.
+   * show which mode the run is in.
    */
   lockedBecause?: string | null;
 }) {
@@ -128,9 +107,7 @@ export function KeyboardSetting({
       />
       {/* Under the pills, in reading order, because a disabled radiogroup has
           no focus stop left to hang a description on — every input in it is
-          `disabled`, so nothing in the group can be tabbed to and told. Plain
-          text after the thing it explains is what a screen reader meets on the
-          way past, and what everyone else reads without looking for it. */}
+          `disabled`, so nothing in the group can be tabbed to and told. */}
       {lockedBecause && <p className="control__why muted">{lockedBecause}</p>}
     </div>
   );

--- a/src/games/typing/keyboard/LiveKeyboard.test.tsx
+++ b/src/games/typing/keyboard/LiveKeyboard.test.tsx
@@ -6,19 +6,16 @@ import { KEYS } from "@/engine/keyboard";
 import { LiveKeyboard } from "./LiveKeyboard";
 
 /**
- * The one decision this component makes: who gets the hint.
+ * The one decision this component makes: who gets the hint (§4.1).
  *
  * Everything else about the board is pinned next door — `Keyboard.test.tsx`
  * owns the picture and the palette, `useKeyEcho.test.ts` owns the flash and
  * the release timer. What is only true here is that "keys" and "guide" differ
- * in the hint and in NOTHING else, which is the distinction a child is choosing
- * between on the setup screen (docs/typing.md §4.1).
+ * in the hint and in NOTHING else.
  *
- * Rendered rather than reasoned about, and rendered on the server, so the
- * assertions survive a change to how the hint is expressed in markup. The echo
- * is absent from every case below for the same reason it is absent from a real
- * first frame: `useKeyEcho` wires itself up in an effect, and no key has been
- * struck yet.
+ * The echo is absent from every case below for the same reason it is absent
+ * from a real first frame: `useKeyEcho` wires itself up in an effect, and no
+ * key has been struck yet.
  */
 
 /** Which keys the hint lit, by code — the board draws `KEYS` in order. */

--- a/src/games/typing/keyboard/LiveKeyboard.tsx
+++ b/src/games/typing/keyboard/LiveKeyboard.tsx
@@ -5,32 +5,26 @@ import type { KeyboardMode } from "@/engine/types";
 
 /**
  * The board as a typist actually meets it: the picture, plus what their hands
- * are doing to it (docs/typing.md §4).
+ * are doing to it (§4).
  *
- * Four pieces built apart meet here and nowhere else — `Keyboard` draws
- * (#130), `useKeyEcho` listens (#131), `useKeyClack` answers out loud (§4.8),
- * `KeyboardMode` decides how much of it a child wants (#133). It exists as its
- * own component for two reasons, both about what a keystroke is allowed to
+ * Its own component for two reasons, both about what a keystroke is allowed to
  * cost:
  *
  *   - **The echo re-renders this and not the passage.** `useKeyEcho` publishes
- *     on every keydown and again when each key's 120ms release fires. Called
+ *     on every keydown and again when each key's release timer fires. Called
  *     up in `TypingTrack`, every one of those would re-render the twenty words
  *     of the passage and the lane behind them, at the speed a child types.
  *     Called here, they re-render sixty spans and stop.
  *   - **"Off" is off, not hidden.** The caller mounts this only when the mode
  *     is not "off" — which is why `mode` excludes it rather than returning
  *     `null` for it. A board that returned `null` after calling the hooks
- *     would still hold two window listeners and a timer per key for a child
- *     who asked to be rid of it — and would go on clacking at a child who
- *     turned the keyboard off, which is the one thing "off" has to mean.
+ *     would still hold two window listeners and a timer per key, and would go
+ *     on clacking at a child who turned the keyboard off.
  *
- * Nothing here can take focus. That is not a promise this file keeps by being
- * careful; the board is sixty inert `<span>`s under `pointer-events: none`
- * (§4.5), so there is no element to focus and no handler to move it. It
- * matters more than it sounds: on a phone the OS keyboard is raised only by
- * the focused `<input>`, so a board that stole focus would take the real
- * keyboard away with it and end the run.
+ * Nothing here can take focus, and not by being careful: the board is inert
+ * `<span>`s under `pointer-events: none` (§4.5), so there is no element to
+ * focus. On a phone the OS keyboard is raised only by the focused `<input>`, so
+ * a board that stole focus would take the real keyboard away and end the run.
  */
 export function LiveKeyboard({
   mode,
@@ -60,12 +54,8 @@ export function LiveKeyboard({
   const { down, wrong } = useKeyEcho({ expect: next });
 
   /**
-   * The board's other half of the same answer (§4.8).
-   *
-   * Deliberately not handed `next`: a wrong key clacks exactly like a right
-   * one, because the flash above is already saying which it was and a sound
-   * played on every keystroke is the wrong place to say it twice
-   * (`soundForKey`).
+   * The board's other half of the same answer, and deliberately not handed
+   * `next`: a wrong key clacks exactly like a right one (§4.8, `soundForKey`).
    */
   useKeyClack();
 

--- a/src/games/typing/keyboard/keySounds.test.ts
+++ b/src/games/typing/keyboard/keySounds.test.ts
@@ -3,13 +3,12 @@ import { describe, expect, it } from "vitest";
 import { soundForKey } from "./keySounds";
 
 /**
- * What the board is allowed to say out loud (docs/typing.md §4.8).
+ * What the board is allowed to say out loud (§4.8).
  *
  * The rule is one function over one event, so the whole of it is testable
- * without a mixer or a DOM — the same split `stormSounds.ts` uses, and for the
- * same reason: the questions worth asking here ("does a held key machine-gun",
- * "does a wrong key sound wrong") are questions about the rule, and
- * `playKeySound` is a `switch` with nothing in it to get wrong.
+ * without a mixer or a DOM — the same split `stormSounds.ts` uses. Nothing
+ * here stubs the mixer, because `playKeySound` is a `switch` with no decision
+ * left in it.
  *
  * Three of the four silences below are decisions a well-meaning change would
  * undo, so they are written as the cases that would have made a noise.

--- a/src/games/typing/keyboard/keySounds.ts
+++ b/src/games/typing/keyboard/keySounds.ts
@@ -6,19 +6,10 @@ import { sfx } from "@/services/sound";
 import { HELD } from "./useKeyEcho";
 
 /**
- * What the board sounds like under a child's hands (docs/typing.md §4.8).
+ * What the board sounds like under a child's hands (§4.8).
  *
- * `useKeyEcho` is the board's eyes — which key went down, and whether it was
- * the wrong one. This is the board's ears, and it is deliberately the simpler
- * of the two: it looks at one keystroke, in isolation, and says which of three
- * noises a typewriter would have made. It knows nothing about the passage, the
- * expectation, the streak or the clock, and that is the point — see
- * `soundForKey` below.
- *
- * ── Why it is a second hook and not a line in `useKeyEcho` ────────────────────
- * The two are mounted and unmounted together and listen to the same event, so
- * merging them would work. They are apart for two reasons that outlast the
- * convenience:
+ * A second hook rather than a line in `useKeyEcho`, though the two mount
+ * together and listen to the same event:
  *
  *   - **The echo publishes React state on every keystroke; this publishes
  *     nothing.** A clack is a side effect with no render behind it, and
@@ -33,61 +24,34 @@ import { HELD } from "./useKeyEcho";
 /**
  * One thing a keystroke can sound like.
  *
- * Three, and not one per key, because a typewriter only has three voices: the
- * typebars, the space bar, and the bell-and-carriage on Return. Everything
- * else on the board — every letter, every digit, `Tab`, `Caps`, `Backspace` —
- * is a lever that swings and hits the paper, and they sound alike because they
- * *are* alike.
+ * Three, and not one per key: a typewriter has three voices, and every other
+ * key on the board is a lever that swings and hits the paper (§4.8).
  */
 export type KeySound = "strike" | "space" | "return";
 
 /**
  * What this keystroke sounds like, or `null` for one that makes no sound.
  *
- * ── It is not told whether the key was right ─────────────────────────────────
- * The signature takes the event and nothing else: no expectation, no verdict.
- * A wrong key clacks exactly like a right one, and that is a decision rather
- * than an omission. The board already flares the wrong key `--flare` (§4.3),
- * the passage already goes red behind you, and the run already plays
- * `sfx.wrong` at the word. A keyboard that scolded a child on the way *down*
- * would be a fourth opinion about one keystroke, arriving before any of the
- * other three knew the answer — and it would make the one sound a child hears
- * constantly into a running commentary on their mistakes.
+ * The signature takes the event and nothing else: a wrong key clacks exactly
+ * like a right one, which is a decision rather than an omission (§4.8).
  *
- * So the clack says "that key went down" and nothing more. It is the sound of
- * a machine working, which is what makes it bearable eight times a second.
- *
- * ── Three silences ───────────────────────────────────────────────────────────
- * Split from the player below so all three are testable without a mixer, in
- * the same shape `stormSounds.ts` uses for the same reason.
+ * Split from the player below so the three silences are testable without a
+ * mixer, in the same shape `stormSounds.ts` uses for the same reason.
  */
 export function soundForKey(
   event: Pick<KeyboardEvent, "code" | "repeat">,
 ): KeySound | null {
-  // 1. A held key is one stroke, not thirty a second of it.
-  //
-  // The board relights on auto-repeat, because its light is a timer that has
-  // to be re-armed by something (`HOLD_MS`). The sound has the opposite
-  // failure: a flash re-fired every 33ms reads as a key still held, and a
-  // clack re-fired every 33ms is a drone. Hailstorm made the same call for the
-  // same reason — a held key is not a shot there either (decision 44).
+  // 1. A held key is one stroke. The board relights on auto-repeat because its
+  // light is a timer that has to be re-armed (`HOLD_MS`); a clack re-fired
+  // every 33ms is a drone instead (§4.8, decision 44).
   if (event.repeat) return null;
 
-  // 2. A modifier is held, not struck.
-  //
-  // The same `HELD` set the echo never flares, so one rule covers both: a
-  // capital is right-shift and a left-hand letter (§3.3), and it should be one
-  // sound, on the letter — not a clack for the reach and a clack for the key.
-  // It also keeps a child switching windows with Cmd-Tab from typing at their
-  // own desktop.
+  // 2. A modifier is held, not struck — the same `HELD` set the echo never
+  // flares, so one list covers both (§4.8).
   if (HELD.has(event.code)) return null;
 
-  // 3. A key the board does not draw makes no sound.
-  //
-  // The clack is the board's voice, so it says exactly what the picture says:
-  // a numpad `7`, a media key or `F7` lights nothing and so clacks nothing. It
-  // is the same rule that keeps a keyboard shortcut on some layout this build
-  // has never heard of from sounding like a letter being typed.
+  // 3. The clack is the picture's voice, so a key the board does not draw — a
+  // numpad `7`, a media key, `F7` — makes no sound (§4.8).
   const key = keyFor(event.code);
   if (!key) return null;
 

--- a/src/games/typing/keyboard/lessonKeyboard.test.ts
+++ b/src/games/typing/keyboard/lessonKeyboard.test.ts
@@ -5,16 +5,11 @@ import { LESSONS, lessonById } from "@/engine/typing/lessons";
 import { keyboardFor, keyboardLock } from "./lessonKeyboard";
 
 /**
- * Who wins the keyboard, and the bug this file exists to keep dead
- * (docs/typing.md §4.2).
+ * Who wins the keyboard, and the bug this file exists to keep dead (§4.2).
  *
- * §4.2 reads as `lesson.keyboard ?? profile.keyboard ?? "guide"`, which looks
- * like a chain with three live arms. It is not: **every one of the hundred
- * lessons names a mode**, so read as an override the lesson wins on all
- * hundred rungs, the player's setting is ignored the length of the ladder, and
- * `keyboardLocked` marks no difference between the lessons that insist and the
- * ninety-odd that were only making a suggestion. #142's review reproduced it —
- * profile on Off, lesson 7 unlocked, board still on.
+ * The bug is that every one of the hundred lessons names a mode, so a resolver
+ * read as a plain override beats the player's setting on all hundred rungs
+ * while looking like a chain with three live arms.
  *
  * So the sweeps below are the point of the file rather than decoration. One
  * asserts that every unlocked lesson hands the choice back; the other that
@@ -41,7 +36,6 @@ describe("keyboardFor", () => {
     expect(keyboardFor(L07, "off")).toBe("guide");
   });
 
-  /** The bug, exactly as #142's review found it. */
   it("lets an unlocked lesson be run the way the child chose", () => {
     expect(keyboardFor(L07, "off", "off")).toBe("off");
     expect(keyboardFor(L07, undefined, "keys")).toBe("keys");
@@ -74,11 +68,7 @@ describe("keyboardLock", () => {
     expect(keyboardLock(L07)).toBeNull();
   });
 
-  /**
-   * The two ends of the ladder, and the two reasons worth giving. A control
-   * greyed out with no reason is the same bug as one that silently ignores the
-   * setting; it just looks tidier.
-   */
+  /** A control greyed out with no reason is the bug that looks tidier. */
   it("gives the reason at both ends of the ladder", () => {
     expect(keyboardLock(L01)).toContain("new keys");
     expect(keyboardLock(L10)).toContain("Checkpoints");

--- a/src/games/typing/keyboard/lessonKeyboard.ts
+++ b/src/games/typing/keyboard/lessonKeyboard.ts
@@ -3,36 +3,22 @@ import { forcedKeyboard, type Lesson } from "@/engine/typing/lessons";
 import { keyboardMode } from "./KeyboardSetting";
 
 /**
- * How much of the board a run puts on screen — the one resolution
- * (docs/typing.md §4.2).
+ * How much of the board a run puts on screen — the one resolution (§4.2).
  *
- * §4.2 writes it as `lesson.keyboard ?? profile.keyboard ?? "guide"`, and that
- * is still the chain. What it does not say, because it reads as an edge case
- * until you count the table, is that **every one of the hundred lessons names
- * a mode**: the `??` never falls through on the ladder, so a child who set
- * their keyboard to Off had it turned back on by lesson 7 and `keyboardLocked`
- * distinguished nothing at all. #142's review reproduced exactly that.
- *
- * So a lesson's mode **seeds** rather than overrides. The brief opens on the
- * lesson's suggestion, an unlocked lesson may be changed before Start, and the
- * choice travels with the run in `config.keyboard` — which is what `chosen` is
+ * A lesson's mode **seeds** the run rather than overriding it, because every
+ * one of the hundred names a mode (§4.2, decision 27): read as a plain `??`
+ * chain the player's own setting would lose on all hundred rungs. What the
+ * child chose travels with the run in `config.keyboard`, which is `chosen`
  * here. Three arms, in the order they win:
  *
- *   - **A locked lesson.** The lesson insists and nothing overrules it, this
- *     function included: the control is disabled in the brief, and this arm is
- *     what makes that a rule rather than a piece of UI politeness. The two ends
- *     of the ladder are why it exists — lesson 1 forces `guide`, because a
- *     child who has never seen a keyboard cannot be asked to guess, and every
- *     checkpoint forces `off`, because a checkpoint passed while reading the
- *     answer off the screen measures nothing. Which lesson insists on what is
- *     `forcedKeyboard`'s to say, in the engine: `eyes-up` (§6.7) has to tell a
- *     board a child turned off from one the lesson turned off for them, and a
- *     rule only this file knew would be a rule the badge had to guess at.
+ *   - **A locked lesson**, which nothing overrules, this function included —
+ *     the disabled control in the brief is UI, and this arm is the rule. Which
+ *     lesson insists on what is `forcedKeyboard`'s to say, in the engine,
+ *     because `eyes-up` (§6.7) has to tell a board a child turned off from one
+ *     the lesson turned off for them.
  *   - **What the child chose**, for the run they chose it on.
  *   - **The lesson's own mode, then the player's, then `guide`** — §4.2's line,
- *     unchanged, and the arm free play takes. Free play has no lesson and makes
- *     no choice, so it reads the profile exactly as it did before the ladder
- *     existed.
+ *     unchanged, and the arm free play takes.
  *
  * Called from the brief (to seed its control) and from the track (to draw the
  * board). One function, so those two can't disagree about a run that is already
@@ -53,12 +39,8 @@ export function keyboardFor(
 /**
  * Why this lesson's keyboard cannot be changed, or `null` when it can.
  *
- * A sentence and not a boolean, because the disabled control has to **say what
- * it is doing**. A toggle that silently ignores the setting a child chose is
- * the bug #142's review found; a toggle greyed out with no reason is the same
- * bug wearing a nicer suit. Both ends of the ladder have a reason worth giving,
- * and giving it is the difference between "this is broken" and "this lesson is
- * about something".
+ * A sentence and not a boolean, because a disabled control has to say what it
+ * is doing (§4.2).
  *
  * Keyed on the mode the lesson insists on rather than on its number, so the
  * copy follows the table: re-cut the ladder and the checkpoints move with it.
@@ -68,10 +50,9 @@ export function keyboardFor(
  *
  * A lock over `keyboard: null` is not a lock, and says so by handing back
  * `null` here: a lesson that names no mode is insisting on nothing, and
- * `keyboardFor` above lets the player through for the same reason. The two have
- * to agree — a control greyed out with a reason while the run honoured the
- * child's setting anyway would be the first bug all over again, inverted — so
- * both ask `forcedKeyboard` rather than each reading the two fields itself.
+ * `keyboardFor` above lets the player through for the same reason. Both ask
+ * `forcedKeyboard` rather than each reading the two fields itself, so a control
+ * greyed out with a reason cannot sit over a run that honoured the child.
  */
 export function keyboardLock(lesson: Lesson): string | null {
   const forced = forcedKeyboard(lesson);

--- a/src/games/typing/keyboard/useKeyEcho.test.ts
+++ b/src/games/typing/keyboard/useKeyEcho.test.ts
@@ -3,24 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HOLD_MS, createKeyEcho } from "./useKeyEcho";
 
 /**
- * What the echo owes a child who is not allowed to look at their hands.
+ * What the echo owes a child who is not allowed to look at their hands (§4.3).
  *
- * Two of these protect decisions that a well-meaning change would undo, and
- * they are the reason this state machine is a plain object rather than only a
- * hook (docs/typing.md §4.3):
+ * Two decisions are pinned, and both are visible in how the cases are written:
  *
- *   - **A key releases on a timer, never on `keyup`.** "Wouldn't `keyup` be
- *     simpler?" is the obvious question, and the answer is only visible in the
- *     cases where the `keyup` never comes — lost focus, key repeat, unmount
- *     mid-chord. So the suite presses keys and never releases them, which is
- *     the failure mode, not an omission.
- *   - **Wrongness comes from the code, decided on the press.** The tests type
- *     `$` and shift+`4` at the same expectation to pin that a buffer
+ *   - **A key releases on a timer, never on `keyup`.** The suite presses keys
+ *     and never releases them, which is the failure mode `keyup` cannot cover
+ *     — lost focus, key repeat, unmount mid-chord — not an omission.
+ *   - **Wrongness comes from the code, decided on the press.** `$` and
+ *     shift+`4` are typed at the same expectation, because a buffer
  *     comparison could not tell them apart.
  *
- * These drive the machine directly: the unit suite has no DOM, so a rendered
- * hook could not be pressed at all. What that leaves untested is the listener
- * and the `useState` around it.
+ * The machine is driven directly, and is a plain object rather than only a
+ * hook so that it can be: the unit suite has no DOM, so a rendered hook could
+ * not be pressed at all. What that leaves untested is the listener and the
+ * `useState` around it.
  */
 
 /** A board with its latest published echo kept to hand. */
@@ -112,11 +109,10 @@ describe("createKeyEcho", () => {
   });
 
   it("does not blame the space that commits a word", () => {
-    // The keystroke a child makes most often and the one this got backwards:
-    // a finished word expects SPACE, so the space bar is the RIGHT key here.
-    // It flared for a while because the echo read the expectation after the
-    // commit had already advanced it — see the capture-phase note in
-    // `useKeyEcho`. The machine's half of that contract is this assertion.
+    // The keystroke a child makes most often: a finished word expects SPACE,
+    // so the space bar is the RIGHT key here. The other half of the contract
+    // is the capture-phase note in `useKeyEcho` — the expectation has to be
+    // read before the commit advances it.
     const keys = board();
     keys.press("Space", " ");
     expect(keys.down()).toEqual(["Space"]);

--- a/src/games/typing/keyboard/useKeyEcho.ts
+++ b/src/games/typing/keyboard/useKeyEcho.ts
@@ -3,29 +3,20 @@ import { useEffect, useRef, useState } from "react";
 import { strokeFor } from "@/engine/keyboard";
 
 /**
- * Press echo: which keys are lit, and which of them were the wrong one
- * (docs/typing.md §4.3).
+ * Press echo: which keys are lit, and which of them were the wrong one (§4.3).
  *
- * This is the half of the board that moves. `Keyboard.tsx` draws the plastic;
- * this decides, keystroke by keystroke, what a child's hands just did — so
- * they can see it without looking down, which is the entire point of the
- * world.
+ * `Keyboard.tsx` draws the plastic; this decides, keystroke by keystroke, what
+ * a child's hands just did.
  */
 
 /**
  * How long a key stays lit, in milliseconds.
  *
- * A key releases on THIS TIMER and not on `keyup`, which is the one decision
- * in this file worth defending. `keyup` is missed more often than you would
- * think: the window loses focus mid-chord and the release lands somewhere
- * else, the OS eats it during a key-repeat, a modifier comes up after the
- * element has unmounted. Every one of those leaves a key stuck lit, and a key
- * stuck lit is worse than no highlight at all — it is a lie about where the
- * hand is, told to a child who is trusting the picture precisely because they
- * are not allowed to look at the real keyboard.
- *
- * A timer cannot get stuck. It also happens to feel better: a flash reads as
- * "that fired", a hold reads as "something is wrong".
+ * A key releases on THIS TIMER and never on `keyup`, which is missed often
+ * enough — focus lost mid-chord, the OS eating it during a key-repeat, a
+ * modifier released after the element unmounts — that a key would be left stuck
+ * lit, which is a lie about where the hand is (§4.3). Nothing in this file
+ * waits on a release event.
  */
 export const HOLD_MS = 120;
 
@@ -42,20 +33,17 @@ const SILENT: KeyEcho = { down: new Set(), wrong: new Set() };
 /**
  * The keys that are HELD rather than typed, and so are never wrong.
  *
- * Exported because Hailstorm's gun has to agree with the board about what a
- * stroke even is: the same set decides which keys never flare here and which
- * keys are never a shot there (`useStormClock`). Two lists would be a shift
- * that flared red without costing anything, or cost something without saying
- * so.
+ * Exported because two other readers have to agree with the board about what a
+ * stroke even is: the same set decides which keys never flare here, which are
+ * never a shot in Hailstorm (`useStormClock`), and which make no sound
+ * (`keySounds.ts`, §4.8). Two lists would be a shift that flared red without
+ * costing anything, or cost something without saying so.
  *
- * Shift is the reason this set exists. Shift is not a mistake, it is the
- * technique: a capital is right-shift plus a left-hand letter (§3.3), and the
- * child who reaches for the far shift a beat before the letter — the thing
- * this course is trying hardest to teach — would otherwise be told in red that
- * they had erred by doing it right. They still light, because a lit shift is
- * exactly the "where is my hand" the board exists to answer. Ctrl, Alt and the
- * Cmd keys are here for the duller version of the same reason: a child
- * switching windows is not attempting the letter.
+ * Shift is the reason the set exists: it is not a mistake, it is the technique
+ * (§3.3), and the child who reaches for the far shift a beat before the letter
+ * would otherwise be told in red that they had erred by doing it right. Held
+ * keys still light, because a lit shift is exactly the "where is my hand" the
+ * board exists to answer.
  *
  * CapsLock is deliberately NOT here. It is not held to make a character, no
  * stroke on this layout uses it, and hitting it in place of `a` is precisely
@@ -76,26 +64,13 @@ export const HELD = new Set([
 /**
  * Was this the wrong key for the character we are waiting on?
  *
- * Decided from `event.code` against `strokeFor(expect)`, and never by
- * comparing what landed in the input against what was wanted. Two reasons,
- * both fatal to the buffer version: a buffer cannot tell shift+`4` from `$`
- * — same character, different keys, and only one of them is a mistake — and
- * it cannot answer at all until React has re-rendered, by which point the
- * flash is late enough to belong to the next keystroke. The keydown handler
- * already holds the code; the comparison here is immediate and exact.
+ * Decided from `event.code` against `strokeFor(expect)`, and never by comparing
+ * what landed in the input against what was wanted (§4.3).
  *
  * Nothing is wrong when there is nothing to be wrong about: the beat between
  * two words has no expected character, and a character this layout cannot
  * produce (a curly quote that escaped the passage filter) has no key to blame.
  * Neither is a mistake, so neither flares.
- *
- * There used to be an `emptyIsWrong` for the caller whose nothing meant the
- * opposite — "there is nothing that could be RIGHT" — and Hailstorm was the
- * only one, because a stroke at an empty sky costs score there (§8.4). The
- * storm no longer draws a board (decision 64), so the flag had no caller left
- * to mean anything for; a wrong key is answered by the score, which flashes
- * `--flare` for exactly that (§8.6). The passage is the only consumer now, and
- * a passage never wanted it.
  */
 function isWrong(code: string, expect: string | null): boolean {
   if (HELD.has(code)) return false;
@@ -117,8 +92,8 @@ export type KeyEchoBoard = {
  * Split out of the hook below because it is the part with behaviour, and the
  * unit suite runs in Node with no DOM (`vitest.config.ts`) — a rendered hook
  * could not be driven at all here, and "a press with no keyup still releases"
- * is the assertion this story most needs to hold in a year. What is left in
- * the hook is a `keydown` listener and a `useState`.
+ * is the assertion this most needs to keep holding. What is left in the hook is
+ * a `keydown` listener and a `useState`.
  *
  * `emit` is handed fresh sets rather than the live ones, so a consumer holding
  * last render's echo is holding what it was actually shown.
@@ -139,15 +114,13 @@ export function createKeyEcho(emit: (echo: KeyEcho) => void): KeyEchoBoard {
       // One release per code, re-armed rather than stacked: every keydown for
       // a code — the first, and each OS auto-repeat behind it — replaces that
       // code's pending release, so the light goes out HOLD_MS after the last
-      // keydown seen for it. Nothing waits on a `keyup`, so no key can be left
-      // stuck lit by one that never arrives.
+      // keydown seen for it.
       //
       // What that is not is a picture of which keys are still held down.
       // Auto-repeat does not begin for a few hundred ms, well past HOLD_MS, so
       // a key held down goes dark and relights once the repeats arrive, and a
       // held modifier — which does not repeat at all — simply goes dark. The
-      // board echoes strokes, and §4.3 asks for the timer with no exception
-      // for either.
+      // board echoes strokes (§4.3).
       clearTimeout(timers.get(code));
       timers.set(
         code,
@@ -175,10 +148,6 @@ export function createKeyEcho(emit: (echo: KeyEcho) => void): KeyEchoBoard {
  * stay honest wherever focus went — a click on the page background moves focus
  * off the field, and a board that stopped echoing there would read as a
  * keyboard that had stopped working.
- *
- * Both sets change at most ten times a second, so a `useState` per keystroke
- * costs nothing next to the race clock already re-rendering this screen
- * sixteen times a second.
  */
 export function useKeyEcho({ expect }: { expect: string | null }): KeyEcho {
   const [echo, setEcho] = useState<KeyEcho>(SILENT);
@@ -189,13 +158,12 @@ export function useKeyEcho({ expect }: { expect: string | null }): KeyEcho {
    * churned on every keystroke, and a stale closure would judge this key
    * against the last one.
    *
-   * A ref has the opposite hazard, and it is the one that actually bit: an
-   * expectation too FRESH for the key being judged. The keystroke that commits
-   * a word is the keystroke that moves this ref, so anything reading it after
-   * the commit has re-rendered is asking "was SPACE the right key for the NEXT
-   * word's first letter?" — and telling a child in red that they finished a
-   * word correctly. The capture flag below is what keeps the read in front of
-   * the write.
+   * A ref has the opposite hazard: an expectation too FRESH for the key being
+   * judged. The keystroke that commits a word is the keystroke that moves this
+   * ref, so anything reading it after the commit has re-rendered is asking "was
+   * SPACE the right key for the NEXT word's first letter?" — and telling a
+   * child in red that they finished a word correctly. The capture flag below is
+   * what keeps the read in front of the write.
    */
   const expected = useRef(expect);
   expected.current = expect;
@@ -213,9 +181,9 @@ export function useKeyEcho({ expect }: { expect: string | null }): KeyEcho {
     // so it runs first; on SPACE it commits the word, queueing `setEntry("")`
     // and `setIndex(i + 1)`. React flushes a discrete update in a microtask,
     // and a microtask checkpoint runs BETWEEN two listeners of one real event
-    // — so by the time a bubble-phase echo saw the SPACE, the track had already
-    // re-rendered and the expectation had already advanced to the next word.
-    // Every correctly finished word flared red on the space bar.
+    // — so a bubble-phase echo sees the SPACE after the track has re-rendered
+    // and the expectation has advanced, and flares every correctly finished
+    // word red on the space bar.
     //
     // Capture runs at the very start of propagation, ahead of every handler
     // that could move the expectation. It also survives a `stopPropagation()`

--- a/src/games/typing/keyboard/useKeyboardPresence.test.ts
+++ b/src/games/typing/keyboard/useKeyboardPresence.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, it } from "vitest";
 import { keyboardPresent, provesKeyboard } from "./useKeyboardPresence";
 
 /**
- * The two rules that decide whether anybody is locked out of Hailstorm
- * (docs/typing.md §8.8, decision 53).
+ * The two rules that decide whether anybody is locked out of Hailstorm (§8.8,
+ * decision 53).
  *
- * Neither needs a browser, and that is the point of them being functions: what
- * `useKeyboardPresence` adds around these is a listener, a media query and a
- * `useState`, all of which a real device answers better than a fake one — the
- * browser half is measured in `e2e/smoke.mjs`. What is *decidable* here is the
- * asymmetry the story turns on: detection is a guess, and a guess that has
- * gone wrong must leave a child a way in rather than a locked door.
+ * Neither needs a browser, which is the point of them being functions: what
+ * `useKeyboardPresence` adds around them is a listener, a media query and a
+ * `useState`, all of which a real device answers better than a fake one — so
+ * the browser half is measured in `e2e/smoke.mjs`. What is decidable here is
+ * the asymmetry: detection is a guess, and a guess that has gone wrong must
+ * leave a child a way in rather than a locked door.
  */
 
 describe("what proves a keyboard", () => {

--- a/src/games/typing/keyboard/useKeyboardPresence.ts
+++ b/src/games/typing/keyboard/useKeyboardPresence.ts
@@ -1,51 +1,15 @@
 import { useEffect, useState } from "react";
 
 /**
- * Does this device have a physical keyboard? (docs/typing.md §4.5, §8.8,
- * decision 53.)
+ * Does this device have a physical keyboard? (§4.5, §8.8, decision 53.)
  *
- * Hailstorm is the one screen on this site that cannot be played without one:
- * it needs raw `keydown` with a `code`, and there is no software keyboard on
- * screen during it (§8.8). A tile that opened a game a child cannot play is
- * the "fails mysteriously" this exists to prevent — so the ladder asks this
- * and says so instead.
+ * Hailstorm is the one screen that cannot be played without one, so the ladder
+ * asks and says so on the tile rather than failing mysteriously.
  *
- * ── It is a guess, and it is built to be wrong safely ────────────────────────
- * There is no browser API for "a keyboard is attached". Everything available
- * is a proxy, and every proxy is wrong about somebody: an iPad in a
- * keyboard-only folio has a keyboard and reports the pointer of a tablet; a
- * laptop with a touchscreen reports the pointer of a tablet and has always had
- * one. So the answer is built out of two signals of very different strength,
- * and the weak one only ever decides the case the strong one has not.
- *
- *   - **Proof: a key arrived.** Any `keydown` carrying a `code` is a physical
- *     keyboard, full stop, and no media query can argue with it. This latches
- *     for the life of the page and nothing takes it back.
- *   - **A guess: the pointer.** `(any-pointer: coarse) and (any-hover: none)`
- *     is "every input this device has is a fingertip" — no mouse, no trackpad,
- *     nothing that can hover. That is a tablet or a phone. A desktop with a
- *     touchscreen fails the second half (its mouse hovers) and is not caught
- *     by it, which is the false negative that would have mattered most.
- *
- * **The default is yes.** Anything this cannot answer — an old browser with no
- * `matchMedia`, the server, a device whose pointer says nothing — is treated
- * as having a keyboard, because the two ways of being wrong are not the same
- * size. Wrongly open is a tile that does nothing when a child presses it;
- * wrongly shut is a child locked out of the game with no way to argue. And the
- * way back from wrongly shut is the proof above: press any key and the guess
- * is over, live, with nothing to reload.
- *
- * User-agent sniffing is deliberately not among the signals. It is a list of
- * strings that goes stale, it cannot see a keyboard plugged in after the page
- * loaded, and it would answer the one question here — "can this child press a
- * key" — with a fact about who made the device.
- *
- * ── Not stored ───────────────────────────────────────────────────────────────
- * Proof lives in this module and dies with the page. It could be written to
- * the profile and remembered, and deliberately is not: a device is shared, a
- * keyboard is unplugged, and a stored "yes" from March is exactly the kind of
- * stale fact that would lock the honest answer out. Re-proving it costs one
- * keystroke, and a child at a keyboard makes hundreds.
+ * There is no browser API for it, so the answer is two signals of very
+ * different strength: a `keydown` that latches, and a pointer media query that
+ * only ever decides what the keydown has not. Everything neither can answer is
+ * a yes, and nothing is stored (§8.8).
  */
 
 /** Every mounted `useKeyboardPresence`, so proof reaches all of them at once. */
@@ -55,15 +19,12 @@ const watchers = new Set<() => void>();
 let proven = false;
 
 /**
- * A keydown that proves a physical keyboard.
+ * A keydown that proves a physical keyboard: a `code`, which is the same field
+ * the gun reads (`useStormClock`), so proof is "a key the storm could have been
+ * played with" (§8.8).
  *
- * `code` is the whole test, and it is the same field the gun reads
- * (`useStormClock`) — so what counts as proof here is exactly "a key the storm
- * could have been played with", rather than a second, looser idea of a
- * keystroke. A software keyboard is not expected to produce one: `code` is
- * the physical key's position, which an on-screen key does not have, and both
- * the empty string and `"Unidentified"` are what browsers put there when they
- * have nothing to say.
+ * Both the empty string and `"Unidentified"` are what browsers put in `code`
+ * when they have nothing to say.
  *
  * Exported for its test, and because "what counts as proof" is the kind of
  * rule that gets quietly restated at a call site.
@@ -104,11 +65,9 @@ function touchOnly(): MediaQueryList | null {
  * pointer says (`true` touch-only, `false` not, `null` for a browser that
  * cannot be asked).
  *
- * Separate from the browser so that the half of this story that matters can be
- * tested without one: **nothing but a definite "every pointer here is a
- * fingertip", with no key ever seen, closes the door.** An unanswerable
- * device, a device with a mouse and a device that has proved itself are all
- * open, and the asymmetry is deliberate — see the file header.
+ * Separate from the browser so the half that matters can be tested without one:
+ * nothing but a definite "every pointer here is a fingertip", with no key ever
+ * seen, closes the door (§8.8).
  */
 export function keyboardPresent(
   seenKey: boolean,
@@ -123,20 +82,17 @@ function look(): boolean {
 }
 
 export function useKeyboardPresence(): boolean {
-  // Server-rendered as `true` for the same reason an unanswerable device is:
-  // the markup a screen ships with must not be the one that shuts a door.
+  // Server-rendered as `true`, like any other device this cannot answer
+  // (§8.8): the markup a page ships with must not be the one that shuts a door.
   const [present, setPresent] = useState(look);
 
   useEffect(() => {
     const wake = () => setPresent(look());
     watchers.add(wake);
 
-    // The proof listener outlives this component on purpose, and is removed
-    // only by the proof itself. A child who leaves the ladder for a lesson and
-    // types four hundred characters has proved the point, and a listener that
-    // came off with the screen would have watched none of it. It is one
-    // capture listener per page load, on the same window the gun binds to, and
-    // it takes itself off the moment it has its answer.
+    // The proof listener outlives this component and is removed only by the
+    // proof itself (§8.8). One capture listener per page load, on the same
+    // window the gun binds to.
     if (!proven) window.addEventListener("keydown", onKeyDown, true);
 
     // A trackpad case being attached moves `any-hover` under a tablet, which

--- a/src/games/typing/lessonNotes.test.ts
+++ b/src/games/typing/lessonNotes.test.ts
@@ -7,7 +7,7 @@ import type { Verdict } from "@/engine/typing/verdict";
 import { lockNote, missNote, nextNote, weakestKey } from "./lessonNotes";
 
 /**
- * The sentence a results screen says (docs/typing.md §6.1).
+ * The sentence a results screen says (§6.1).
  *
  * What the numbers mean is `verdict.test.ts`'s, and which door a set of runs
  * opens is `ladder.test.ts`'s. What is only true here is the reading: given
@@ -61,9 +61,8 @@ describe("weakestKey", () => {
 
 describe("missNote", () => {
   /**
-   * The one the whole screen exists for. Three bars, one of them short, and
-   * the sentence says which — plus the half that says *don't change that*,
-   * without which a child fixes `j` by slowing under the speed bar.
+   * The praise is the load-bearing half: without it a child fixes `j` by
+   * slowing down, and drops under the speed bar instead.
    */
   it("names the key holding the run up, and says the speed was fine", () => {
     const note = missNote(
@@ -114,10 +113,9 @@ describe("missNote", () => {
   });
 
   /**
-   * The storm arm, and the reason it needed handling at all: §6.1's verdict
-   * gives a dead wave a full speed bar and no key bars, so the bars alone say
-   * "all met" over the word the child has just been told. Surviving is not a
-   * bar, so it is a sentence.
+   * §6.1's verdict gives a dead wave a full speed bar and no key bars, so the
+   * bars alone say "all met" over the word the child has just been told.
+   * Surviving is not a bar, so it is a sentence.
    */
   it("says the wave got through when a storm run met its accuracy", () => {
     expect(
@@ -182,9 +180,8 @@ describe("lockNote", () => {
   });
 
   /**
-   * §8.8: a Hailstorm level never gates, so the lesson that opens 10 is 8 —
-   * and pointing a child at the storm at 9 would be sending them at a wave
-   * they cannot play at all on a tablet.
+   * A Hailstorm level never gates (§8.8), so the lesson that opens 10 is 8 —
+   * and on a tablet the storm at 9 is a wave that cannot be played at all.
    */
   it("looks past a Hailstorm level to the lesson that really opens it", () => {
     expect(lessonNumbered(9)!.kind.type).toBe("storm");

--- a/src/games/typing/lessonNotes.ts
+++ b/src/games/typing/lessonNotes.ts
@@ -4,15 +4,11 @@ import type { LadderProgress } from "@/engine/typing/ladder";
 import type { KeyBar, Verdict } from "@/engine/typing/verdict";
 
 /**
- * A verdict, in a sentence a seven-year-old reads once (docs/typing.md §6.1).
+ * A verdict, in a sentence a seven-year-old reads once (§6.1).
  *
- * The whole reason there are three bars rather than one score is that **a
- * single number tells you that you failed and not what to do**. Bars alone are
- * only most of the way there: a child who has just missed something has to
- * read three of them, compare each against its mark and work out which one
- * cost them the lesson. This file does that reading for them and says it in
- * words — "you were fast enough; the `z` key needs more practice" — which is
- * the difference between a score and an instruction.
+ * Three bars leave a child to compare each against its mark and work out which
+ * one cost them the lesson. This file does that reading for them and says it in
+ * words — "you were fast enough; the `z` key needs more practice".
  *
  * Strings rather than JSX on purpose. What is hard here is the *choice* — which
  * bar to name, which to praise, and what a storm says instead — and keeping it
@@ -23,11 +19,9 @@ import type { KeyBar, Verdict } from "@/engine/typing/verdict";
 /**
  * The new keys, as one bar.
  *
- * A lesson introduces two characters as a rule, six at lesson 67 and fifteen at
- * lesson 31 — and fifteen bars is a wall rather than a signal. So the bar shown
- * is the key that is holding you up, because the gate is every key at once
- * (§6.4): the run is only through when the weakest one is, and naming it is the
- * instruction the child needs.
+ * A lesson introduces two characters as a rule, but fifteen at lesson 31 — and
+ * fifteen bars is a wall rather than a signal. So the bar shown is the key
+ * holding you up, because the gate is every key at once (§6.4).
  *
  * "Weakest" is a not-yet-passed key before a lower fraction, which is not the
  * same ordering. A key struck right three times reads 100% and is still not
@@ -50,34 +44,26 @@ const sentence = (text: string) =>
 /**
  * Why this run did not pass, and what was already there.
  *
- * Two clauses, and the order of the first is §6.1's order — accuracy, then the
- * new keys, then speed — because that is the order the criteria matter in and
- * therefore the order to fix them in. A child failing accuracy *and* speed is
- * told about accuracy: speeding up would only make it worse.
+ * Two clauses. The first names the gap in §6.1's order, which is the order to
+ * fix them in: a child failing accuracy *and* speed is told about accuracy,
+ * because speeding up would only make it worse.
  *
  * The praise is the last bar that was met, read the other way down the same
  * list, which is why it can never name the bar the fix just named. It is not
- * decoration. "You were fast enough" is the half of the instruction that says
- * *don't change that* — without it, a child who slows down to fix `z` and
- * drops under the speed bar has been taught the wrong lesson by a screen that
- * only ever said no.
+ * decoration: without it, a child who slows down to fix `z` and drops under the
+ * speed bar has been taught the wrong lesson by a screen that only ever said
+ * no.
  *
  * Only ever called on a run that did not pass.
  */
 export function missNote(lesson: Lesson, verdict: Verdict): string {
-  // ── The storm arm (§6.1, §8.7) ────────────────────────────────────────────
-  // A Hailstorm level is marked on surviving the wave and on accuracy, and
-  // `Verdict` carries no bar for the first of them — surviving is a fact about
-  // the run's length, so §6.1's type leaves `wpm` full and `keys` empty and
-  // lets `passed` carry it. That is right for the model and wrong on a screen:
-  // full bars over the word "failed" read as a bug at seven. So the storm's
-  // reason is stated in words here, and `PassBars` draws no bar a storm was
-  // never asked for.
-  //
-  // Which reason is decidable from the verdict alone: `passed` is accuracy AND
-  // survival, so a failed run with its accuracy bar met can only have died in
-  // the wave. Nothing about how a wave works is invented here — that is #159's
-  // to build, and this is what the screen says until it does.
+  // `Verdict` carries no bar for surviving the wave — §6.1's type leaves `wpm`
+  // full and `keys` empty and lets `passed` carry it. Right for the model and
+  // wrong on a screen: full bars over the word "failed" read as a bug at seven.
+  // So the storm's reason is stated in words here, and `PassBars` draws no bar
+  // a storm was never asked for. Which of the two reasons is decidable from the
+  // verdict alone: `passed` is accuracy AND survival, so a failed run with its
+  // accuracy bar met can only have died in the wave.
   if (lesson.pass.kind === "storm") {
     return verdict.accuracy.ok
       ? sentence("the wave got through — you have to face the whole storm")
@@ -109,16 +95,13 @@ export function missNote(lesson: Lesson, verdict: Verdict): string {
  *
  * Unlock is `max(cleared) + 1`, so the run that just cleared the frontier is
  * the one whose number `best` now IS — which is the whole test for "did this
- * open anything". A child at lesson 41 replaying lesson 3 opens nothing, and
- * is told where they are up to instead of being told a lie; passing checkpoint
- * 40 from a standing start opens 41, because clearing a checkpoint clears
- * everything below it by that same `max`.
+ * open anything". A child at lesson 41 replaying lesson 3 opens nothing, and is
+ * told where they are up to instead.
  *
- * `next` is the ladder's own pointer, already carried over any Hailstorm level
- * standing in the way (§8.8) — so the lesson this hands back is never a storm,
- * and the button built on it never sends a child to a wave they did not ask
- * for. At the top of the hundred it is `null`, and there is no next lesson to
- * offer.
+ * `next` is already carried over any Hailstorm level standing in the way
+ * (§8.8), so the lesson this hands back is never a storm and the button built
+ * on it never sends a child to a wave they did not ask for. At the top of the
+ * hundred it is `null`.
  */
 export function nextNote(
   lesson: Lesson,
@@ -141,15 +124,14 @@ export function nextNote(
 /**
  * What opens a lesson that is not open yet (§6.6).
  *
- * The rung below it — skipping any Hailstorm level in between, because the
- * pointer is carried over a storm rather than made to jump it (§8.8), so
- * clearing lesson 44 is what opens lesson 46 and saying "pass lesson 45" would
- * send a child at a wave they cannot play on a tablet.
+ * The rung below it, skipping any Hailstorm level in between (§8.8): clearing
+ * lesson 44 is what opens lesson 46, and "pass lesson 45" would send a child at
+ * a wave they cannot play on a tablet.
  *
- * One sentence, because it is read on a tile as well as in the brief and
- * ninety tiles all offering the same advice about checkpoints is not advice,
- * it is wallpaper. The nudge towards the express lane belongs on the screen
- * where a child is actually stopped, which is the brief.
+ * One sentence, because it is read on a tile as well as in the brief and ninety
+ * tiles offering the same advice about checkpoints is wallpaper — the nudge
+ * towards the express lane belongs where a child is stopped, which is the
+ * brief.
  *
  * A locked lesson always has a rung below it — lesson 1 is `next` on a profile
  * with no runs at all and can never be locked — but the fallback is written

--- a/src/games/typing/lessonRun.test.ts
+++ b/src/games/typing/lessonRun.test.ts
@@ -49,8 +49,9 @@ describe("lessonConfig", () => {
   /**
    * The choice made in the brief, travelling with the run (§4.2). In the
    * config rather than in memory because the run outlives the navigation that
-   * starts it, and because `eyes-up` (§6.7) is a badge for having made it.
-   * Absent when nobody chose: a locked lesson, or a route with no brief.
+   * starts it, and because `eyes-up` (§6.7) is a badge for what the run was
+   * typed under. Absent when nobody chose: a locked lesson, or a route with no
+   * brief.
    */
   it("carries the keyboard the child chose, and nothing when they didn't", () => {
     expect(lessonConfig(L01, 1, "off").keyboard).toBe("off");

--- a/src/games/typing/lessonRun.test.ts
+++ b/src/games/typing/lessonRun.test.ts
@@ -7,7 +7,7 @@ import { lessonById } from "@/engine/typing/lessons";
 import { lessonConfig, lessonKey } from "./lessonRun";
 
 /**
- * Starting a lesson from inside the island (docs/typing.md §5.3, §5.4).
+ * Starting a lesson from inside the island (§5.3, §5.4).
  *
  * Two things have to hold of the config this hands back, and both of them are
  * about runs that already exist rather than about the one about to start: the
@@ -47,13 +47,10 @@ describe("lessonConfig", () => {
   });
 
   /**
-   * The choice made in the brief, travelling with the run (§4.2, #145).
-   *
-   * In the config rather than in memory because the run outlives the
-   * navigation that starts it — and because a lesson passed with the board off
-   * is a different thing from one passed reading the answers, which is what
-   * `eyes-up` (§6.7) is a badge for. Absent when nobody chose, which is a
-   * locked lesson and every route that starts a run without a brief.
+   * The choice made in the brief, travelling with the run (§4.2). In the
+   * config rather than in memory because the run outlives the navigation that
+   * starts it, and because `eyes-up` (§6.7) is a badge for having made it.
+   * Absent when nobody chose: a locked lesson, or a route with no brief.
    */
   it("carries the keyboard the child chose, and nothing when they didn't", () => {
     expect(lessonConfig(L01, 1, "off").keyboard).toBe("off");

--- a/src/games/typing/lessonRun.ts
+++ b/src/games/typing/lessonRun.ts
@@ -4,28 +4,25 @@ import type { Lesson } from "@/engine/typing/lessons";
 import type { KeyboardMode, TypingConfig } from "@/engine/types";
 
 /**
- * A lesson, as a config the race loop can be handed
- * (docs/typing.md §5.3, §5.4).
+ * A lesson, as a config the race loop can be handed (§5.3, §5.4).
  *
  * The passage is generated **here, inside the island**, and travels in
- * `config.words`. That is the whole of §5.3's bargain: `decks/index.ts` is the
- * front door for every island on the site, so a corpus reachable from it is a
- * corpus every island downloads — 222 KB, the last time it was got wrong. The
- * deck layer builds the run from the words it is given and never learns where
- * they came from, and `local/no-corpus-in-decks` is what keeps that true.
+ * `config.words`: a corpus reachable from `decks/index.ts` is a corpus every
+ * island on the site downloads (§5.3), and `local/no-corpus-in-decks` is what
+ * keeps that true.
  *
- * `levelId` carries the lesson's own id, exactly as §5.4 says: `modeOf` and
- * `configKey` both prefer `lessonId`, so the level field is inert on a ladder
- * run and setting it to anything else would only invite a screen to read it.
+ * `levelId` carries the lesson's own id (§5.4): `modeOf` and `configKey` both
+ * prefer `lessonId`, so the level field is inert on a ladder run and setting it
+ * to anything else would only invite a screen to read it.
  *
- * `wordCount` is the lesson's, not the generated array's — it is half of
+ * `wordCount` is the lesson's, not the generated array's: it is half of
  * `configKey` (`typing|L07|25`), and a key that moved with the passage would
  * file every attempt in a bucket of one and never show a child their own best.
  *
  * Fresh words every time, which is why this takes a seed rather than caching:
- * lesson 7 is a lesson, not a passage, and a child handed the same words back
- * on every attempt would be sitting a memory test by the third one. The seed
- * is saved with the run, so the passage is still reproducible after the fact.
+ * the same words back on every attempt would be a memory test by the third one.
+ * The seed is saved with the run, so the passage is still reproducible after
+ * the fact.
  */
 export function lessonConfig(
   lesson: Lesson,
@@ -50,11 +47,10 @@ export function lessonConfig(
  * Everything about a lesson's config that the record book keys on, which is
  * everything except the passage and the choice made in the brief.
  *
- * Split out so that `lessonKey` below can be built from the same three fields
- * `lessonConfig` sets rather than from a second opinion about them. The two
- * drifting is the failure that matters: a brief showing a best from one bucket
- * over a Start that files into another would be wrong in the direction nobody
- * checks, because both halves look right on their own.
+ * Split out so that `lessonKey` below is built from the same three fields
+ * `lessonConfig` sets rather than from a second opinion about them. A brief
+ * showing a best from one bucket over a Start that files into another would be
+ * wrong in the direction nobody checks: both halves look right on their own.
  */
 const identity = (lesson: Lesson): TypingConfig => ({
   kind: "typing",
@@ -66,9 +62,8 @@ const identity = (lesson: Lesson): TypingConfig => ({
 /**
  * Where this lesson's runs are filed, without generating a passage to ask.
  *
- * `configKey` leaves the words out whenever a `lessonId` is there to stand in
- * for them (§5.4), so this is the same string `lessonConfig`'s output produces
- * — and the brief can look up a child's best on a lesson they may never start
- * without paying for a passage it would then throw away.
+ * `configKey` leaves the words out whenever a `lessonId` stands in for them
+ * (§5.4), so this is the same string `lessonConfig`'s output produces — and the
+ * brief can look up a best without paying for a passage it would throw away.
  */
 export const lessonKey = (lesson: Lesson) => configKey(identity(lesson));

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -26,22 +26,15 @@ import type { StormState, WaveSpec } from "@/engine/typing/storm";
 import type { ComponentProps } from "react";
 
 /**
- * The one claim this screen exists to keep: a letter falls down the column of
- * its own key (docs/typing.md §8.2, decision 19).
+ * A letter falls down the column of its own key (§8.2, decision 19).
  *
- * It is worth testing at this altitude because it can be broken by a change to
- * either half and looks fine from both. The engine can hand over a lane it
- * measured from the wrong edge of a key; the stylesheet can multiply it by the
- * wrong unit, or forget that the keycap is drawn inset inside its slot. Every
- * one of those type-checks, renders, and teaches a child that `y` lives
- * somewhere it does not — which is worse than not drawing the hint at all,
- * because they will believe it.
- *
- * So the geometry is checked in KEY UNITS, end to end: the lane the component
- * writes, against the cap the board draws, through the arithmetic game.css
- * actually performs — both sides read out of the stylesheet rather than
- * restated here, for the reason `capCentre` gives. No pixels are involved on
- * either side, which is the property being defended.
+ * Worth testing at this altitude because either half can break it and look
+ * fine from both: a lane measured off the wrong edge of a key, or a stylesheet
+ * that forgets the keycap is drawn inset inside its slot, both type-check and
+ * both render. So the geometry is checked in KEY UNITS end to end — the lane
+ * the component writes against the cap the board draws, through the arithmetic
+ * game.css actually performs. No pixels are involved on either side, which is
+ * the property being defended.
  */
 
 const css = readFileSync(
@@ -53,20 +46,15 @@ const css = readFileSync(
 const STORM_BLOCK = "/* ── Hailstorm: the field";
 
 /**
- * The field's rules with the prose taken out.
- *
- * The comments in this block quote the very things being asserted against —
- * "`height`, not `min-height`", "390px of height" — so a test reading them
- * would be marking the explanation rather than the stylesheet.
+ * The field's rules with the prose taken out. The comments in this block quote
+ * the very things asserted against — "`height`, not `min-height`" — so a test
+ * that read them would be marking the explanation rather than the stylesheet.
  */
 const storm = css
   .slice(css.indexOf(STORM_BLOCK))
   .replace(/\/\*[\s\S]*?\*\//g, "");
 
-/**
- * The whole stylesheet with its prose taken out, so a declaration is read from
- * the rule that ships and never from a comment describing it.
- */
+/** The whole stylesheet with its prose taken out, for the same reason. */
 const sheet = css.replace(/\/\*[\s\S]*?\*\//g, "");
 
 /**
@@ -151,11 +139,10 @@ const unitsOf = (expr: string, vars: Record<string, number>): number => {
 };
 
 /**
- * The keycap inset, as the fraction of a key unit game.css sets it to.
- *
- * Read out of the stylesheet rather than written down here, because the whole
- * point of the arithmetic below is that one number governs both the cap and
- * the lane. A test carrying its own copy could agree with neither.
+ * The keycap inset, as the fraction of a key unit game.css sets it to. Read
+ * out of the stylesheet because the point of the arithmetic below is that one
+ * number governs both the cap and the lane; a test carrying its own copy could
+ * agree with neither.
  */
 const GAP = unitsOf(declaration(":root", "--key-gap"), { "--key": 1 });
 
@@ -171,10 +158,9 @@ const only = (ch: string, count = 1, fallMs = 1000): WaveSpec => ({
 
 /*
  * Every absolute moment in this file is measured from the instant the first
- * letter starts to DROP, not from the start of the wave — hence the offset.
- * A real letter hangs at the top for `QUEUE_MS` before it moves (§8.3), and
- * that beat is the same for every letter of every level, so folding it in here
- * once leaves each schedule below saying exactly what it always said.
+ * letter starts to DROP, not from the start of the wave — hence the offset. A
+ * letter hangs at the top for `QUEUE_MS` first (§8.3), and folding that in
+ * once here leaves each schedule below saying what it says.
  */
 const frameOf = (spec: WaveSpec, atMs: number): StormState =>
   tick(startStorm(buildWave(spec, 7)), QUEUE_MS + atMs);
@@ -206,11 +192,10 @@ const stones = (state: StormState) =>
   }));
 
 /**
- * Where a falling letter's middle lands, in key units.
- *
- * The field's own `left` declaration, run rather than restated. `translate:
- * -50% 0` — pinned below, because this depends on it — centres the stone on
- * that point, so what comes back is the middle and not the left edge.
+ * Where a falling letter's middle lands, in key units: the field's own `left`
+ * declaration, run rather than restated. `translate: -50% 0` — pinned below,
+ * because this depends on it — centres the stone on that point, so what comes
+ * back is the middle and not the left edge.
  */
 const stoneCentre = (lane: number) =>
   unitsOf(declaration(".storm__letter", "left"), {
@@ -222,15 +207,14 @@ const stoneCentre = (lane: number) =>
 /**
  * Where a drawn keycap's middle sits, in the same units — from the board's own
  * `left` and `width`, which is where the inset the lane compensates for is
- * actually written down.
+ * written down.
  *
  * Both sides coming out of the sheet is the whole point. Two hand-written
  * models would each carry the half-gap term they were meant to be checking,
  * and it would cancel across the assertion: subtract half a gap from the lane,
- * fold half a gap into the cap, and the two agree for ANY gap — including
- * none, and including a board that insets its caps by twice what the field
- * compensates for. Reading the declarations means a change to either half
- * moves one side of the comparison and not the other.
+ * fold half a gap into the cap, and the two agree for ANY gap — including a
+ * board that insets its caps by twice what the field compensates for. Reading
+ * the declarations moves one side of the comparison and not the other.
  */
 const capSpan = (key: KeyDef): [number, number] => {
   const vars = {
@@ -272,10 +256,6 @@ const cap = (code: string) => KEYS.find((k) => k.code === code)!;
 
 describe("StormField", () => {
   it("puts a letter over the cap that types it, to the pixel", () => {
-    // The claim, at last: `f` falls onto `f`. Not "near" it and not "over its
-    // slot" — the middle of the falling letter and the middle of the drawn
-    // keycap are the same point on the screen, because the lane steps back by
-    // exactly the half-gap the cap is inset by.
     const [f] = stones(frameOf(only("f"), 500));
 
     expect(f.ch).toBe("f");
@@ -289,12 +269,9 @@ describe("StormField", () => {
     expect(centre).toBeGreaterThan(capCentre(cap("KeyG")));
     expect(centre).toBeLessThan(capCentre(cap("KeyH")));
 
-    // And where between them: a quarter of a unit left of `h` and three
-    // quarters right of `g`, because the top row is staggered a quarter unit
-    // out from the home row rather than half. That is the plastic — `y` really
-    // does sit up and slightly left of `h` — and it is the whole spatial hint:
-    // a child who reaches towards `h` for a falling `y` has learnt something
-    // true about where their finger has to go.
+    // A quarter of a unit left of `h` and three quarters right of `g`, because
+    // the top row is staggered a quarter unit out from the home row rather
+    // than half — which is where `y` sits on the plastic.
     expect(capCentre(cap("KeyH")) - centre).toBeCloseTo(0.25, 10);
     expect(centre - capCentre(cap("KeyG"))).toBeCloseTo(0.75, 10);
   });
@@ -314,9 +291,9 @@ describe("StormField", () => {
     expect(rule).toContain(
       "left: calc(var(--lane) * var(--key) - var(--key-gap) / 2)",
     );
-    // And that `left` is the letter's CENTRE rather than its left edge, which
-    // is what `stoneCentre` above reads it as. Lose the translate and every
-    // letter moves half a stone right of the key it names.
+    // `left` is the letter's CENTRE rather than its left edge, which is what
+    // `stoneCentre` above reads it as. Lose the translate and every letter
+    // moves half a stone right of the key it names.
     expect(rule).toContain("translate: -50% 0");
     // No length in this block is absolute except a hairline border: a field
     // measured in pixels would come apart from the board the moment `--key`
@@ -325,18 +302,16 @@ describe("StormField", () => {
   });
 
   it("falls on a transform, down the sky rather than down itself", () => {
-    // The fall is a transform and not `top`: twelve stones moving sixty times
-    // a second is twelve layouts a frame written the other way (§8.9). And it
-    // is `translateY`, which is what leaves `translate: -50% 0` free to hold
-    // the lane centring without the two writing over each other.
+    // A transform and not `top`, so twelve moving stones are not twelve
+    // layouts a frame (§8.9). `translateY` specifically, which leaves
+    // `translate: -50% 0` free to hold the lane centring.
     expect(declaration(".storm__letter", "transform")).toBe(
       "translateY(calc(var(--drop) * var(--fall)))",
     );
-    // `top` is where the fall begins and nothing else; the fall itself is not
-    // written there. It is the sky's whole travel minus this letter's, so a
-    // stone that is capped comes into view lower — and `top + --fall` is
-    // `--sky-fall` for every letter, which is the promise that a capped stone
-    // still lands exactly on the shield rather than short of it.
+    // `top` is where the fall begins and nothing else: the sky's travel minus
+    // this letter's (§8.2). So `top + --fall` is `--sky-fall` for every
+    // letter, which is the promise that a capped stone still lands exactly on
+    // the shield rather than short of it.
     expect(declaration(".storm__letter", "top")).toBe(
       "calc(var(--sky-fall) - var(--fall))",
     );
@@ -354,26 +329,22 @@ describe("StormField", () => {
 
   it("caps how fast a stone falls, in stone heights rather than pixels", () => {
     // The travel is the SHORTER of the sky and what the speed cap allows
-    // (decision 65). Without the `min` the fall is whatever the viewport
-    // happens to be, so the same level is faster on a bigger monitor — which
-    // is how a 900ms fall came to cross about 720px a second once #197 took
-    // the board off the screen, and how `i` and `l` stopped being different
-    // letters at speed.
+    // (§8.2, decision 65). Without the `min` the fall is whatever the viewport
+    // happens to be, so the same level is faster on a bigger monitor.
     expect(declaration(".storm__letter", "--fall").replace(/\s+/g, " ")).toBe(
       "min( var(--sky-fall), " +
         "calc(var(--fall-ms, 1000) / 1000 * var(--hail-speed) * var(--stone)) )",
     );
 
-    // In stone heights a second, and therefore a number with no unit: what
-    // blurs a moving glyph is how far it travels against its own size, so a
-    // cap written in pixels would mean something different at every `--key`.
-    // High enough that an ordinary screen uses the whole sky — the reading
-    // time is the beat a letter hangs for first (`QUEUE_MS`), not a slower
-    // fall — and low enough that a very tall one cannot run away with it.
+    // Stone heights a second, and therefore unitless (§8.2). Pinned rather
+    // than left open because the number is the whole of the backstop: high
+    // enough that an ordinary screen uses the whole sky, low enough that a
+    // very tall one cannot run away with it.
     expect(declaration(".storm", "--hail-speed")).toBe("9");
 
-    // And the letter's own fall time is a render's to write, not the loop's:
-    // it is fixed when the wave is built, where `--drop` moves every frame.
+    // The letter's own fall time is fixed when the wave is built, where
+    // `--drop` moves every frame — so it is a render's to write, not the
+    // loop's.
     for (const fallMs of [900, 2600]) {
       const [stone] = stones(frameOf(only("f", 1, fallMs), 100));
       expect(stone.fallMs).toBe(fallMs);
@@ -381,27 +352,18 @@ describe("StormField", () => {
   });
 
   it("draws one key unit, shared with the board it is aiming at", () => {
-    // The AC's "one source of truth" is the `KEY_ROWS` table for the lanes and
-    // this custom property for the scale. Two declarations of it reachable
-    // from THIS screen — one on the board, one on the field — is exactly how a
-    // lane and a cap start disagreeing about how wide a key is. So the storm's
-    // own block declares it nowhere at all: every rule under `.storm` reads
-    // the root's value, and a falling letter has no second opinion available
-    // to land by.
+    // Two declarations reachable from THIS screen is how a lane and a cap
+    // start disagreeing about how wide a key is (§8.2, decision 37). So the
+    // storm's own block declares it nowhere: every rule under `.storm` reads
+    // the root's value, and a falling letter has no second opinion to land by.
     expect(storm).not.toMatch(/--key:\s/);
     expect(/:root\s*{\s*--key:/.test(sheet)).toBe(true);
 
-    // There is one other declaration in the stylesheet, and it is deliberately
-    // not on a screen with lanes. `.race.typing` re-scales the dial to subtract
-    // the chrome a passage screen carries above the board — the HUD, the bars,
-    // the line you type on — because that chrome is a constant and a share of
-    // the viewport cannot express it (§4.7, decision 63). It may, because the
-    // board is the only thing on that screen that reads `--key` at all.
-    //
-    // Pinned at two rather than left open, so that a third has to be argued
-    // for here first. The count is taken off `sheet` and not `css`: the prose
-    // in this stylesheet quotes the property by name, and a test that counted
-    // comments would be marking the explanation.
+    // The one other declaration is `.race.typing`, which is allowed because
+    // the passage screen has no lanes (§4.7, decision 63). Pinned at two
+    // rather than left open, so a third has to be argued for here first. The
+    // count is off `sheet` and not `css`, because the prose in this stylesheet
+    // quotes the property by name.
     expect(sheet.match(/--key:\s/g)).toHaveLength(2);
     expect(/\.race\.typing\s*{\s*--key:/.test(sheet)).toBe(true);
   });
@@ -417,16 +379,12 @@ describe("StormField", () => {
   });
 
   it("lets the field scroll once the run is over, and only then", () => {
-    // The rule above is the hazard while letters are falling; after the run it
-    // is a different one, because what stands in the board's track by then is
-    // the ending, and it is taller than the five rows of keycaps it replaced.
-    // Measured in Chromium at 740×390 on a breached run, `.storm` wants 299px
-    // of a 270px box — the sky has already given everything it has (§8.2) —
-    // and the last button, which is the way off this screen for a child who is
-    // not holding a mouse, is below the fold until this one declaration brings
-    // it back. So it is asserted here rather than left to the comment beside
-    // it: deleted, nothing else in the suite notices, and the screen keeps its
-    // exit somewhere no thumb can reach.
+    // After the run the hazard reverses: the ending stands in the board's
+    // track and is taller than the five rows of keycaps it replaced. Measured
+    // in Chromium at 740×390 on a breached run, `.storm` wants 299px of a
+    // 270px box — the sky has already given everything it has — and the last
+    // button is below the fold until this declaration brings it back. Deleted,
+    // nothing else in the suite notices.
     expect(declaration(".storm:has(.storm__over)", "overflow-y")).toBe("auto");
 
     // Lifted for the ending and for nothing else. Two overflow declarations in
@@ -503,14 +461,10 @@ describe("StormField", () => {
   });
 
   it("borrows exactly the two telemetry colours it has something to say with", () => {
-    // The field itself borrows none of the five — a hailstone in `--lime`
-    // would be saying something was right about it. The shield and the HUD
-    // borrow two, and only where they already mean what they mean everywhere
-    // else on this site: `--flare` is a wrong, and damage, a hole and a wrong
-    // key are the three wrongs this game has; `--lime` is a right, and both a
-    // repair and a live combo are bought with a run of them (§8.5, §8.6). The
-    // other three would each be a lie about what happened — nothing on this
-    // screen is a ghost, a record or a badge.
+    // The field itself borrows none of the five. The shield and the HUD borrow
+    // two, and only where they already mean what they mean everywhere else on
+    // this site (§8.5, §8.6). The other three would each be a lie about what
+    // happened — nothing on this screen is a ghost, a record or a badge.
     const rules = [...storm.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(
       ([, selector, body]) => ({ selector: selector.trim(), body }),
     );
@@ -534,11 +488,9 @@ describe("StormField", () => {
   });
 
   it("puts each shield segment over the keys of its own finger", () => {
-    // The other half of §8.2's claim, for the other end of the fall: a letter
-    // is over the cap that types it, and the segment it lands on is over the
-    // whole column of keys that finger is responsible for. Both are read out
-    // of the stylesheet in key units, so a change to the board's inset moves
-    // the caps and the segments together or fails here.
+    // The other end of the fall (§8.2). Both are read out of the stylesheet in
+    // key units, so a change to the board's inset moves the caps and the
+    // segments together or fails here.
     for (const finger of SHIELD_FINGERS) {
       const [left, right] = zoneSpan(FINGER_ZONES[finger]);
       const home = KEYS.filter((k) => k.row === 2 && k.finger === finger);
@@ -565,15 +517,11 @@ describe("StormField", () => {
     for (let i = 1; i < spans.length; i++)
       expect(spans[i][0], SHIELD_FINGERS[i]).toBeCloseTo(spans[i - 1][1], 10);
 
-    // And the rail as a whole is centred on the DRAWN board rather than on the
-    // grid of slots behind it — which is what the half-gap step-back buys, and
-    // the reason a segment is allowed to overhang the DRAWN BOARD by the same
-    // half gap at each end. The board, not the sky: the step-back moves the
-    // whole rail left, so measured against the sky it hangs half a gap past
-    // the left edge and stops half a gap short of the right. The caps are the
-    // frame that matters — they are what the assertion below compares against,
-    // and what a child aims at. Take the correction out and this fails by a
-    // whole gap on one side.
+    // The rail is centred on the DRAWN board, not on the sky: the half-gap
+    // step-back moves the whole rail left, so against the sky it hangs half a
+    // gap past the left edge and stops half a gap short of the right. The caps
+    // are what a child aims at, so they are what this compares against. Take
+    // the correction out and it fails by a whole gap on one side.
     const board: [number, number] = [
       capSpan(cap("CapsLock"))[0],
       capSpan(cap("Enter"))[1],
@@ -587,12 +535,10 @@ describe("StormField", () => {
   it("drops every letter within a quarter unit of its own segment", () => {
     // What a vertical seam can and cannot do. The rows are staggered, so a
     // finger's keys are a slanted column and no straight segment covers all of
-    // it: `6` is typed by the right index and its lane is a quarter unit left
-    // of where the right index's segment starts, because `6` really does sit
-    // that far left of `h` and `j` (§8.5, decision 41). The home row — the row
-    // the segments are drawn on, and the row the hands rest on — is always
-    // strictly inside. A quarter unit is the whole of the error, and this is
-    // where a change that made it worse would have to be argued for.
+    // it — `6` is a quarter unit left of where the right index's segment
+    // starts (§8.5, decision 41). The home row, which the segments are drawn
+    // on, is always strictly inside. A quarter unit is the whole of the error,
+    // and this is where a change that made it worse has to be argued for.
     const strays = [];
     for (const key of KEYS) {
       const finger = key.finger;
@@ -642,11 +588,9 @@ describe("StormField", () => {
   it("draws no letter at all while the wave is waiting to be started", () => {
     /*
      * The beat before it falls (§8.13, decision 71). A wave's first letter
-     * spawns at time zero (`buildWave`), so a field that only held the clock
-     * would be showing it — an untimed look at the first target, where every
-     * other letter of the run gets exactly `QUEUE_MS` to be read in. One prop
-     * both puts the panel in the sky and takes the stones out of it, so the
-     * two cannot come apart.
+     * spawns at time zero, so a field that only held the clock would be
+     * showing it. One prop both puts the panel in the sky and takes the
+     * stones out of it, so the two cannot come apart.
      */
     const state = frameOf(only("j", 4, MIN_FALL_MS), 0);
     expect(
@@ -663,8 +607,8 @@ describe("StormField", () => {
   it("draws the rest of the field while it waits, so nothing moves on start", () => {
     // The HUD at nothing and the shield whole, both exactly where the run will
     // find them: pressing a key has to start a storm, not rearrange a screen.
-    // The way out is in there too, which is the whole of what a device that
-    // cannot press a key is left with (§8.8).
+    // The way out is in there too, which is all a device that cannot press a
+    // key is left with (§8.8).
     const waiting = draw(frameOf(only("j"), 0), {
       ready: <StormReady />,
       onQuit: () => {},
@@ -680,11 +624,9 @@ describe("StormField", () => {
   });
 
   it("draws no keyboard at all, live or ended", () => {
-    // A storm is the exam for the lessons that taught the layout (§8.1), so
-    // the picture of the answer is the one thing this screen must not show:
-    // the quickest way to shoot a falling `y` would become reading the board
-    // for where `y` is, which is hunt-and-peck with a countdown on it
-    // (decision 64).
+    // A storm is the exam for the lessons that taught the layout, so the
+    // picture of the answer is the one thing it must not show (§8.2, decision
+    // 64).
     const live = draw(frameOf(only("f"), 500));
     expect(live).not.toContain("keyboard__key");
     expect(live).not.toContain('class="keyboard"');
@@ -701,11 +643,11 @@ describe("StormField", () => {
   });
 
   it("hands the way out to the HUD, and says which key does it too", () => {
-    // Forwarding, which is all this file does with it — where the control
-    // goes and when it goes away are `StormHud`'s (§8.8, #155). What is worth
-    // pinning here is that a screen which offers a destination gets one, and
-    // that the key doing the same job is named for a child who cannot see the
-    // button: while the gun is live, `Tab` is one of the keys it swallows.
+    // Forwarding, which is all this file does with it — where the control goes
+    // and when it goes away are `StormHud`'s (§8.8). What is pinned here is
+    // that a screen which offers a destination gets one, and that the key
+    // doing the same job is named: while the gun is live, `Tab` is one of the
+    // keys it swallows, so the button cannot be tabbed to.
     const live = frameOf(only("f"), 500);
     const html = renderToStaticMarkup(
       <StormField state={live} skyRef={{ current: null }} onQuit={() => {}} />,
@@ -729,9 +671,7 @@ describe("StormField", () => {
     expect(html).toContain("Hailstorm");
 
     // Everything that moves is hidden: the two HUD numbers, every stone and
-    // the eight shield segments. None of it is an announcement anybody could
-    // act on, and a live region reading out a hailstorm is a denial of service
-    // rather than an accommodation (§4.4).
+    // the eight shield segments (§4.4).
     for (const cls of [
       "storm__score",
       "storm__combo",
@@ -741,9 +681,9 @@ describe("StormField", () => {
       expect(tag(cls), cls).toContain('aria-hidden="true"');
 
     // The sky itself is NOT, and that is the point of putting the attribute on
-    // its parts (#155): the way out is drawn in the HUD, and a screen whose
-    // only exit sat inside a hidden subtree would be a trap for the child
-    // least able to get out of it.
+    // its parts: the way out is drawn in the HUD, and a screen whose only exit
+    // sat inside a hidden subtree would be a trap for the child least able to
+    // get out of it.
     expect(tag("storm__sky")).not.toContain("aria-hidden");
   });
 });

--- a/src/games/typing/storm/StormField.test.tsx
+++ b/src/games/typing/storm/StormField.test.tsx
@@ -644,7 +644,7 @@ describe("StormField", () => {
 
   it("hands the way out to the HUD, and says which key does it too", () => {
     // Forwarding, which is all this file does with it — where the control goes
-    // and when it goes away are `StormHud`'s (§8.8). What is pinned here is
+    // and when it goes away are `StormHud`'s (§8.11). What is pinned here is
     // that a screen which offers a destination gets one, and that the key
     // doing the same job is named: while the gun is live, `Tab` is one of the
     // keys it swallows, so the button cannot be tabbed to.

--- a/src/games/typing/storm/StormField.tsx
+++ b/src/games/typing/storm/StormField.tsx
@@ -8,89 +8,52 @@ import type { CSSProperties } from "react";
 
 /**
  * Hailstorm's field: the sky the letters fall through, and the shield they
- * land on (docs/typing.md §8.2, decision 19).
+ * land on (§8.2, decision 19).
  *
- * ── A letter falls down the column of its own key ────────────────────────────
- * `f` falls onto `f`. `y` falls between `g` and `h`, because that is where `y`
- * is. That is the whole design and it is the reason `KeyDef.x` is in the
- * engine rather than in the picture of a keyboard: the horizontal position of
- * a falling letter is a spatial hint about where its key is, handed to a child
- * a second or two before they have to find it. The game is not themed around a
- * keyboard — it is teaching the layout geometrically the entire time it is
- * being played.
+ * Each letter falls down its own key's column, and no keyboard is drawn under
+ * it (§8.2, decision 64). Nothing here computes a lane: `StormLetter.lane` was
+ * resolved when the wave was built (§8.3), and this writes it into a custom
+ * property `game.css` multiplies by `--key`, so a lane and the finger zone it
+ * lands on cannot disagree about where a key is.
  *
- * Nothing here computes a lane. `StormLetter.lane` is `keyX(code)` resolved
- * once when the wave was built (§8.3), and this writes it into a custom
- * property that `game.css` multiplies by `--key`. So a lane and the finger
- * zone it lands on cannot disagree about where a key is: they read one
- * `KEY_ROWS` table and one `--key` unit, and neither of them holds a pixel.
- *
- * ── There is no board here, and that is the point ────────────────────────────
- * The lessons draw one under the passage; this does not (§8.2, decision 64).
- * A storm is the exam for the forty lessons that taught the layout, and §8.1's
- * whole claim is that it drills the one thing a passage cannot — finding a key
- * nobody told you about, at speed. A picture of the keyboard on that screen is
- * the answer sheet: the fastest way to shoot a falling `y` becomes reading the
- * board for where `y` is, which is hunt-and-peck with a countdown on it.
- *
- * What is left at the bottom is the shield, and it is a better teacher for
- * being the only thing there. Eight finger zones rather than forty-odd keys,
- * so what a child watches crumble is a FINGER — the thing that is a lesson, a
- * drill and a habit (§8.5). The lane still says which key; the zone under it
- * still says which finger; nothing that was doing work has gone.
- *
- * It buys the sky, too. The board was five rows of keycaps at real pitch
- * (§4.7) and it was taking about 45% of the screen from the only track that
- * gives — so the fall is now roughly twice as long as it was, on the screen
- * whose entire job is giving a child time to read a letter and find its key.
- *
- * ── Still a pure function of one frame ───────────────────────────────────────
- * Hand it a `StormState` and it draws that state; it holds no clock of its
- * own. What moves the stones between frames is `useStormClock`, which writes
- * `--drop` straight onto them on every animation frame and re-renders this
- * only when the picture changes — so the two writers of that property never
- * disagree: React's value is `progressAt` at the frame it is rendering, which
- * is the frame the loop just painted.
+ * **A pure function of one frame.** Hand it a `StormState` and it draws that
+ * state; it holds no clock of its own. What moves the stones between frames is
+ * `useStormClock`, which writes `--drop` straight onto them on every animation
+ * frame and re-renders this only when the picture changes — so the two writers
+ * of that property never disagree: React's value is `progressAt` at the frame
+ * it is rendering, which is the frame the loop just painted.
  *
  * `skyRef` is how the loop finds the stones, and `data-stone` is how it knows
- * which letter each one is. A rendered index rather than the loop counting
- * children, for the same reason the React key is the index (§8.3): a filtered
- * list renumbers itself the instant something in the middle of it is shot.
- * The HUD and the shield are in the sky beside them and carry no such
- * attribute, which is what makes the loop skip both: `Number(undefined)` is
- * `NaN`, which indexes no letter. An EMPTY one would not — `Number("")` is
- * `0` — and whichever of them held it would be written the first letter's
- * fall, sixty times a second, as though it were the stone.
+ * which letter each one is. The HUD and the shield are in the sky beside them
+ * and carry no such attribute, which is what makes the loop skip both:
+ * `Number(undefined)` is `NaN`, which indexes no letter. An EMPTY one would
+ * not — `Number("")` is `0` — and whichever of them held it would be written
+ * the first letter's fall, sixty times a second, as though it were the stone.
  *
  * The trigger is not here either. A press has to be answered against the run
  * as the last FRAME left it, and what this component is handed is the last
  * frame whose picture changed — which can be several behind — so the gun is in
- * `useStormClock` beside the loop, and the rules it fires are in the engine
- * (§8.6, §8.9).
+ * `useStormClock` beside the loop (§8.9).
  */
 
 /**
  * Is the field drawing this letter at `state.timeMs`?
  *
- * Two things have to agree about that and would drift apart written twice:
- * the sky draws exactly these, and the clock re-renders the sky when the
- * count of them changes — a letter appearing is a time crossing that no field
- * of a `StormState` records, so the loop has nothing else to notice it by.
+ * Two things have to agree about that and would drift apart written twice: the
+ * sky draws exactly these, and the clock re-renders the sky when the count of
+ * them changes — a letter appearing is a time crossing that no field of a
+ * `StormState` records, so the loop has nothing else to notice it by.
  *
  * `resolved` first, because it is the half of the answer the clock cannot
  * give: a letter that was shot left the screen at the press, and one that
- * landed left it at the shield. `isAirborne` is the other half, and it is
- * asked rather than restated — it is the half-open `[spawnMs, landMs)` the
- * reducer damages the shield on (decision 30), and re-deciding which side of a
- * millisecond a landing falls on is how a stone becomes both shootable and
- * already spent.
+ * landed left it at the shield. `isAirborne` is the other half, asked rather
+ * than restated — re-deciding which side of a millisecond a landing falls on
+ * is how a stone becomes both shootable and already spent (decision 30).
  *
- * It is `isAirborne` and never `isFalling`: a letter hangs at the top of the
- * sky for a beat before it moves (`QUEUE_MS`, decision 67), and that beat is
- * the whole reason it is legible — the one moment it is new is the one moment
- * it is standing still. A field that drew only what was falling would hide the
- * letter exactly while a child was meant to be reading it, and would still let
- * them shoot it, which the gun would have no way to explain.
+ * It is `isAirborne` and never `isFalling`, because a queued letter is on the
+ * field and shootable (§8.3): drawing only what falls would hide a letter
+ * exactly while a child was meant to be reading it, and would still let them
+ * shoot it.
  */
 export function isDrawn(state: StormState, index: number): boolean {
   return (
@@ -117,54 +80,40 @@ export function StormField({
   /**
    * Ask to leave mid-run, or absent on a screen with no way out (`StormHud`).
    *
-   * Handed to the HUD rather than drawn here, because the HUD is the row that
-   * already owns the top of the sky and its two corners — a way out placed by
-   * this file would be a second opinion about where that row is.
+   * Handed to the HUD rather than drawn here, because the HUD already owns the
+   * top of the sky and its two corners.
    */
   onQuit?: () => void;
   /**
-   * What stands in the sky while the wave is still waiting to be started, or
-   * absent once it is running (§8.13, decision 71).
+   * What stands in the sky while the wave is waiting to be started, or absent
+   * once it is running (§8.13, decision 71).
    *
    * **Its presence is what says the run has not begun**, and that is why it is
-   * one prop and not a node beside a boolean. A waiting storm draws no stones:
-   * the first letter of a wave spawns at time zero (`buildWave`), so a field
-   * that only froze the clock would be handing a child a free, untimed look at
-   * the first target — the reading beat every other letter gets (`QUEUE_MS`)
-   * made unlimited for exactly the one that sets the pace. Two props could
-   * disagree about that; one cannot.
+   * one prop and not a node beside a boolean: a waiting storm draws no stones,
+   * and two props could disagree about that where one cannot.
    *
    * The rest of the field is drawn as it always is — the HUD at nothing, the
    * shield whole — because that is the picture a child is about to have to
-   * read, and there is nothing to be gained by making them meet it for the
-   * first time on the frame the hail starts.
+   * read.
    */
   ready?: React.ReactNode;
   /**
-   * What stands under the sky once the run is over (§8.5, STM07).
-   *
-   * The ending takes a track of its own rather than being drawn over the sky,
-   * which leaves the hail frozen where it stopped and the hole still open
-   * under the finger that let it through. While the run is live that track is
-   * empty and the sky has the whole field; the ending is the only thing this
-   * screen ever puts below it. The panel itself is the route's, because
-   * everything it offers is navigation: a drill, a retry, the way out.
+   * What stands under the sky once the run is over (§8.5).
    *
    * WHEN it appears is decided here and not by the caller, off the same
    * `ending` the gun dies on — one rule, in the file that draws the sky it
-   * appears under.
+   * appears under. The panel itself is the route's, because everything it
+   * offers is navigation: a drill, a retry, the way out.
    */
   over?: React.ReactNode;
 }) {
   return (
     <main className="storm">
       {/* The screen's name and what it is, for the one visitor who cannot see
-          any of it. Everything that moves is hidden one level down — see the
-          sky — so this and the way out are all there is to announce, which is
-          honest: the game is a physical keyboard and a reaction time, and a
-          child who cannot see the letters cannot play it (§8.8). What they can
-          still do is leave, and while the gun is live `Tab` is a key it
-          swallows, so the key that does it is worth naming. */}
+          any of it. Everything that moves is hidden one level down, so this
+          and the way out are all there is to announce (§8.8) — and while the
+          gun is live `Tab` is a key it swallows, so the key that leaves is
+          worth naming. */}
       <h1 className="u-sr">Hailstorm</h1>
       {state.ending === null && (
         <p className="u-sr">
@@ -174,28 +123,16 @@ export function StormField({
         </p>
       )}
 
-      {/*
-        Not `aria-hidden` itself, though nearly everything in it is: the way
-        out lives in the HUD (`StormHud`), and a screen whose only exit was
-        inside a hidden subtree would be a trap for exactly the child least
-        able to get out of it. So the attribute sits on each churning part —
-        the two HUD numbers, every stone, the shield — for the reason the board
-        carries one (§4.4): what is in here changes sixty times a second, and a
-        live region reading out a hailstorm is a denial of service rather than
-        an accommodation.
-      */}
+      {/* Not `aria-hidden` itself, though nearly everything in it is: the
+          way out lives in the HUD, so the attribute sits on each churning
+          part instead (§8.11, §4.4). */}
       <div className="storm__sky" ref={skyRef}>
         {/* First in the sky, so every stone paints over the numbers rather
             than under them: a score must never hide a letter that has to be
-            shot. It is in here rather than in a row of its own because the sky
-            is the only track `.storm` can take a row FROM, and on a short
-            viewport it has nothing left to give (decision 45, `StormHud`). */}
+            shot. */}
         <StormHud state={state} onQuit={onQuit} />
 
-        {/* Either the wave, or the beat before it — never both. See `ready`:
-            a storm that has not been started has nothing in the sky to read,
-            which is the whole of what "we don't show them the first letter
-            yet" means. */}
+        {/* Either the wave, or the beat before it — never both (`ready`). */}
         {ready}
 
         {state.wave.letters.map((letter, index) => {
@@ -206,25 +143,19 @@ export function StormField({
               // Hidden for the reason the sky's other churn is: a letter is on
               // screen for a second and a half and is not a thing to announce.
               aria-hidden="true"
-              // The index is the letter's identity (§8.3): the wave is built
-              // once and never grows, so this key cannot shift under a letter
-              // mid-fall — which it would if the drawn letters were numbered
-              // by their position in a filtered list. `data-stone` carries the
-              // same number into the DOM, so the loop moving this element
-              // knows which letter it is holding.
+              // The index is the letter's identity (§8.3): the wave never
+              // grows, so this key cannot shift under a letter mid-fall — as
+              // it would if the drawn letters were numbered by their position
+              // in a filtered list. `data-stone` carries it into the DOM.
               key={index}
               className="storm__letter"
               style={
                 {
                   "--lane": letter.lane,
-                  // How long this letter falls for, which the stylesheet turns
-                  // into how FAR: a stone is capped at `--hail-speed` stone
-                  // heights a second, so a short fall uses less of the sky
-                  // rather than crossing all of it faster (decision 65).
-                  // Written here beside the lane because it is the same kind
-                  // of fact — fixed when the wave was built, and never the
-                  // loop's to touch. The loop writes `--drop` and nothing
-                  // else.
+                  // How long this letter falls for, which the stylesheet
+                  // turns into how FAR (§8.2, decision 65). Written here
+                  // beside the lane because it is fixed when the wave is
+                  // built; the loop writes `--drop` and nothing else.
                   "--fall-ms": letter.fallMs,
                   "--drop": progressAt(letter, state.timeMs),
                 } as CSSProperties
@@ -237,17 +168,13 @@ export function StormField({
         })}
 
         {/* Last in the sky, so a letter reaching the bottom passes BEHIND the
-            wall it is breaking rather than in front of it — the only place the
-            two ever overlap, and the last frame of a fall is exactly where it
-            should read as a stone hitting something. */}
+            wall it is breaking rather than in front of it. */}
         <StormShield state={state} />
       </div>
 
-      {/* Nothing at all while the run is live — the sky has the whole field,
-          and what a child looks at is the letters and their own hands (see
-          the header). The ending is the one thing this screen ever puts below
-          the sky, and it is rendered rather than overlaid so the frozen hail
-          and the broken shield stay readable above it. */}
+      {/* The ending is the one thing this screen ever puts below the sky, and
+          it is rendered rather than overlaid so the frozen hail and the broken
+          shield stay readable above it (§8.5). */}
       {state.ending !== null && over}
     </main>
   );

--- a/src/games/typing/storm/StormHud.test.tsx
+++ b/src/games/typing/storm/StormHud.test.tsx
@@ -115,7 +115,7 @@ describe("StormHud", () => {
   });
 
   /*
-   * The way out (§8.8). A storm fills the viewport with no site chrome over
+   * The way out (§8.11). A storm fills the viewport with no site chrome over
    * it, so until the run ends this is the only exit there is.
    */
 

--- a/src/games/typing/storm/StormHud.test.tsx
+++ b/src/games/typing/storm/StormHud.test.tsx
@@ -10,15 +10,12 @@ import { StormHud } from "./StormHud";
 import type { StormState, WaveSpec } from "@/engine/typing/storm";
 
 /**
- * The HUD, as a child reads it: what the run is worth, what the last clean hit
- * was paid at, and one flash of red when a wrong key takes points off
- * (docs/typing.md §8.6).
+ * The HUD, as a child reads it (§8.6).
  *
  * Everything here is a rendering of numbers the reducer already holds, and
- * that is the property this file is really defending: not one of these
- * assertions computes what a hit was worth. `storm.test.ts` decides that a
- * fifth hit is worth fifteen points; this decides only that fifteen is what
- * ends up on the screen.
+ * that is the property this file is defending: not one of these assertions
+ * computes what a hit was worth. `storm.test.ts` decides that a fifth hit is
+ * worth fifteen points; this decides only that fifteen reaches the screen.
  */
 
 const only = (ch: string, over: Partial<WaveSpec> = {}): WaveSpec => ({
@@ -62,21 +59,16 @@ describe("StormHud", () => {
   });
 
   it("shows the multiplier the last hit was paid at", () => {
-    // `comboMultiplier(state.combo)`: what the hit that just landed was paid
-    // at — the third hit paid 13 and the HUD reads ×1.3 — which is also the
-    // streak the next hit builds on, so a fourth would pay ×1.4. A run with
-    // nothing shot yet rests at ×1.0. The same `comboMultiplier` scales the
-    // score and `cardXp`: one streak, one multiplier, so the figure a child
-    // watches climb is the figure their XP is worth.
+    // What the hit that JUST LANDED was paid at rather than a forecast: the
+    // third hit paid 13 and the HUD reads ×1.3, and a fourth would pay ×1.4.
     expect(readOut(played(0))).toContain("×1.0");
     expect(readOut(played(3))).toContain("×1.3");
     expect(readOut(played(3))).toContain(
       `×${comboMultiplier(played(3).combo).toFixed(1)}`,
     );
 
-    // And it goes back to nothing the moment a wrong key breaks the streak,
-    // which is what "immediately and visibly" means for the half of the cost
-    // that is not points.
+    // And back to nothing the moment a wrong key breaks the streak, which is
+    // the half of a miss's cost that is not points.
     expect(readOut(played(3, 1))).toContain("×1.0");
   });
 
@@ -123,10 +115,8 @@ describe("StormHud", () => {
   });
 
   /*
-   * The way out (docs/typing.md §8.8, #155). A storm fills the viewport with
-   * no site chrome over it, so until the run ends this is the only exit there
-   * is — and on a tablet, where the game cannot be played at all, it is the
-   * only thing on the screen that does anything.
+   * The way out (§8.8). A storm fills the viewport with no site chrome over
+   * it, so until the run ends this is the only exit there is.
    */
 
   it("draws a way out while the gun is live", () => {
@@ -175,11 +165,10 @@ describe("StormHud", () => {
   });
 
   it("says nothing about XP, in a run or at the end of one", () => {
-    // The payout is the ending screen's line now (`StormOver`), where there is
-    // room to put it beside the finger that let the storm through. Here it
-    // would be a second number moving on different rules from the score beside
-    // it — XP is computed once at the end and floored at zero (§8.6), and the
-    // HUD is the run's own running total.
+    // The payout is the ending screen's line (`StormOver`). Here it would be a
+    // second number moving on different rules from the score beside it — XP is
+    // computed once at the end and floored at zero (§8.6), where the HUD is a
+    // running total.
     const running = played(2);
     expect(running.ending).toBeNull();
     expect(readOut(running)).not.toContain("XP");

--- a/src/games/typing/storm/StormHud.tsx
+++ b/src/games/typing/storm/StormHud.tsx
@@ -4,84 +4,35 @@ import { comboMultiplier } from "@/engine/combo";
 import type { StormState } from "@/engine/typing/storm";
 
 /**
- * The two numbers a run keeps, over the sky it is being played in
- * (docs/typing.md §8.6).
+ * The two numbers a live run keeps, drawn inside the sky (docs/typing.md §8.6).
  *
- * ── Score, and the multiplier it is paid at ──────────────────────────────────
- * `comboMultiplier(state.combo)` is the multiplier the hit that JUST LANDED
- * was paid at, and not a forecast for the next one. `fire` sets `combo` to
- * `state.combo + 1` and pays that hit at the streak it lands on, so this is
- * the figure the score has already moved by — measured in a browser, the HUD
- * reads ×1.4 the instant after a fourth clean hit, and that hit paid 14. The
- * next one is a step higher, ×0.1 more until the ×2 cap, which is the same
- * fact said forwards: this is the streak the next hit builds on.
+ * Nothing here decides any of it: `score`, `combo` and the miss stamp are read
+ * off the reducer, because a HUD that worked out what a hit was worth would be
+ * a second opinion about it at sixty frames a second, and the one on screen is
+ * the one a child would believe. `comboMultiplier(state.combo)` is the
+ * multiplier the hit that JUST LANDED was paid at rather than a forecast —
+ * `fire` pays a hit at the streak it lands on, so the ×1.4 that appears the
+ * instant after a fourth clean hit is what that hit was worth.
  *
- * It is the prominent half on purpose all the same. The score is a running
- * total and says nothing about how the run is going now; `×1.7` says seven
- * clean hits in a row and still climbing, and that is the whole of what this
- * screen is trying to teach — that a run of clean hits is worth more than the
- * same hits scattered. It is `comboMultiplier`, the same curve `cardXp` pays a
- * flash card at, so the figure a child watches climb here is the figure their
- * XP is worth (`stormXp`). One streak, one multiplier, two currencies.
+ * The two numbers are `aria-hidden`, which is the right side of a trade worth
+ * saying out loud. Hailstorm is a physical keyboard and a reaction time, so a
+ * child who cannot see the falling letters cannot play it at all (§8.8), and a
+ * live region reciting a score that moves every 300ms is a denial of service
+ * rather than an accommodation (§4.4). The attribute is on each number rather
+ * than on the sky that holds them, because the way out is in here too and that
+ * is the one thing on this screen everybody needs.
  *
- * Nothing here decides any of that. `score`, `combo` and the miss stamp are
- * read off the reducer, where every rule about them lives (§8.9): a HUD that
- * worked out what a hit was worth would be a second opinion about it at sixty
- * frames a second, and the one on screen is the one a child would believe.
+ * `QUIT_KEY` has to exist alongside this button rather than instead of it:
+ * while the gun is live, `Tab` is one of the keys it swallows, so the button
+ * cannot be reached by tabbing to it. The button goes when the gun does,
+ * because `StormOver` then carries the way out and two of them would be two
+ * answers to "how do I leave" on one screen.
  *
- * ── In the sky, not beside it (decision 45) ──────────────────────────────────
- * `.storm` is a two-track grid — the sky, and the board that never gives — and
- * the sky is what gives: about 78px of it at 1280×360, and about 21px at
- * 1280×250 (§8.2). A HUD row would be taken out of the one track with nothing
- * left to give, so this is drawn INSIDE the sky instead, and costs it no
- * height at all. It is first in the sky so the stones paint over it rather
- * than under it: a number must never hide a letter that has to be shot, which
- * is also why the score sits in the HUD's dim ink rather than in `--chalk`.
- *
- * The two numbers are `aria-hidden`, which is the right side of that trade and
- * worth saying out loud. Hailstorm is a physical keyboard and a reaction time —
- * a child who cannot see the falling letters cannot play it at all (§8.8) —
- * and a live region reciting a score that moves every 300ms is a denial of
- * service rather than an accommodation (§4.4). The attribute is on each of
- * them rather than on the sky that holds them, because the way out is in here
- * too and that is the one thing on this screen everybody needs (below).
- *
- * ── The way out ─────────────────────────────────────────────────────────────
- * A storm fills the viewport and there is no site chrome over a game
- * (CLAUDE.md), so without this a child who cannot play — the tablet §8.8 is
- * about, or anyone who has simply had enough — is on a screen with no exit but
- * the browser's own. It sits between the two numbers because those are the two
- * corners already taken, and because the middle of the HUD is the part of the
- * sky a child is least often reading: the letters that matter are the low
- * ones.
- *
- * It is a real control and not a decoration: `pointer-events` are given back
- * to it in `game.css` (the sky refuses them, so a drag cannot select a
- * hailstorm), and it is the one thing in the sky a finger is allowed to land
- * on. `QUIT_KEY` is the same door for a child who has a keyboard, and it has
- * to exist separately: while the gun is live, `Tab` is one of the keys it
- * swallows, so this button cannot be reached by tabbing to it.
- *
- * It goes when the gun does. Once the run has an ending, the panel that stands
- * where the board did carries the way out (`StormOver`), and two of them would
- * be two answers to "how do I leave" on one screen.
- *
- * ── One flash per miss, and never a sequence ─────────────────────────────────
- * The `--flare` wash over the score is a child element keyed by `missTintAt`,
- * a wave-time stamp that only ever goes forward — the mechanism the shield's
- * damage tint already uses (§8.10, decision 42). A fresh node runs its
- * animation once, an unchanged key is the same node and does not restart it,
- * and there is no timer here to be left mid-flash by a screen that unmounted.
- *
- * **The stamp rather than `misses`, and that is the whole of decision 57.** A
- * wave's tint rate is a property of its own schedule, and each of the twenty
- * levels ships at two a second — but a miss is a child pressing a wrong key,
- * and eight or ten a second is a hand rather than a bug. The gun already
- * ignores key auto-repeat (decision 44), which takes 30Hz off the table; what
- * holds the rest of it to the same two a second, under WCAG 2.3.1's line of
- * more than three, is `MIN_TINT_GAP_MS` in the reducer, where the clock is. So
- * this element mounts at most once every 500ms however fast the keys come, and
- * every other cost of a miss is charged in full whether it lights or not.
+ * The `--flare` wash over the score is a child element keyed by `missTintAt`
+ * (§8.10, decision 57). A fresh node runs its animation once, an unchanged key
+ * is the same node and does not restart it, and there is no timer here to be
+ * left mid-flash by a screen that unmounted. What holds it to WCAG 2.3.1 is
+ * `MIN_TINT_GAP_MS` in the reducer, where the clock is.
  */
 export function StormHud({
   state,

--- a/src/games/typing/storm/StormOver.test.tsx
+++ b/src/games/typing/storm/StormOver.test.tsx
@@ -12,14 +12,12 @@ import { StormOver } from "./StormOver";
 import type { StormLetter, StormState, WaveSpec } from "@/engine/typing/storm";
 
 /**
- * The screen a child meets when the storm stops (docs/typing.md §8.5).
+ * The screen a child meets when the storm stops (§8.5).
  *
  * What is on trial here is the WORDS, because the numbers are already decided:
  * `storm.test.ts` proves which finger let it through, how many it let through
  * and which keys that finger owns, and this file only asks whether the
- * sentence a five-year-old reads is the one those numbers make. Two of its
- * claims are acceptance criteria in their own right — the finger is named, and
- * nothing here is a grade.
+ * sentence a five-year-old reads is the one those numbers make.
  */
 
 /** One letter, placed by hand, off the same board the game is played on. */
@@ -37,8 +35,7 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
     fallMs,
     // No queue: a hand-placed letter falls the instant it appears, so every
     // absolute moment below is the one the test wrote down. The beat a real
-    // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it belongs to the
-    // tests of the schedule rather than to every test of what a landing costs.
+    // wave gives a letter (`QUEUE_MS`) belongs to the tests of the schedule.
     dropMs: spawnMs,
     landMs: spawnMs + fallMs,
   };
@@ -108,8 +105,6 @@ describe("StormOver", () => {
   });
 
   it("names the finger that let it through, and how many", () => {
-    // The story, in one line: a child is told whose fault it was on their own
-    // hand, in words they can look down at.
     expect(BREACHED.ending).toEqual({
       kind: "breached",
       finger: "r-ring",
@@ -145,10 +140,9 @@ describe("StormOver", () => {
   });
 
   it("has no grade in it, on the worst run there is", () => {
-    // The acceptance criterion, as the three things that would break it: a
-    // word that marks the child rather than the weather, a percentage, and the
-    // telemetry red that means "you got that wrong" everywhere else on this
-    // site (§8.5). What is on screen instead is what the storm did.
+    // The three things that would break it: a word that marks the child rather
+    // than the weather, a percentage, and the telemetry red that means "you
+    // got that wrong" everywhere else on this site (§8.5).
     const html = draw(BREACHED);
     const text = readOut(BREACHED);
 
@@ -162,10 +156,9 @@ describe("StormOver", () => {
   });
 
   it("shows what a losing run still earned", () => {
-    // XP cannot go down (§8.6), so a run that ended early has something honest
-    // to say to a child who has just lost — and it is the one figure on this
-    // screen that can only ever have gone up. An `o` through the right ring
-    // zone, an `f` shot clean, and then the `l` into the hole the o made.
+    // XP cannot go down (§8.6), so it is the one figure on this screen a
+    // losing run can still show. An `o` through the right ring zone, an `f`
+    // shot clean, and then the `l` into the hole the o made.
     const paid = tick(
       fire(
         tick(

--- a/src/games/typing/storm/StormOver.tsx
+++ b/src/games/typing/storm/StormOver.tsx
@@ -15,58 +15,23 @@ import type { StormState } from "@/engine/typing/storm";
 /**
  * What a storm came to, and what to do about it (docs/typing.md §8.5, §8.7).
  *
- * ── Which finger let it through ──────────────────────────────────────────────
- * This is the screen the whole epic is for. A child who has just lost is told
- * *whose fault it was on their own hand* — "your right ring finger let three
- * through" — and handed a drill of exactly the keys behind that finger. No
- * accuracy percentage can say that, and it is a thing a five-year-old can act
- * on within a second of reading it: they can look down at the finger.
+ * **It decides nothing.** Everything this screen concludes is
+ * `stormReport(state)`, computed in the engine beside the rules that produced
+ * it — which finger, how many it let through, which keys that finger owns, how
+ * much armour is left, the longest streak. This file chooses words and puts
+ * them in boxes, which is what makes "your right ring finger let three
+ * through" a claim a unit test can hold still without a browser.
  *
- * ── It decides nothing ───────────────────────────────────────────────────────
- * Everything this screen concludes is `stormReport(state)`, computed in the
- * engine beside the rules that produced it — which finger, how many it let
- * through, which keys that finger owns, how much armour is left, the longest
- * streak. This file chooses words and puts them in boxes. That is the same
- * division the loop keeps (§8.9), and it is what makes "your right ring finger
- * let three through" a claim a unit test can hold still without a browser.
+ * Two of the four figures come from elsewhere (§8.5). XP cannot be in the
+ * report — `stormXp` reaches the deck layer that `storm.ts` is kept clear of
+ * (§5.3) — so it is read here, where `buildDrill` has already brought that
+ * door into the graph. The score need not be in it: it is the run's own live
+ * number, straight off `state`.
  *
- * Two of the four figures on the panel come from somewhere else, for two
- * different reasons. XP cannot be in the report: `stormXp` lives in
- * `progress.ts`, which reaches `decks/index.ts`, and `storm.ts` is one
- * type-only hop from the deck layer (`lessons.ts` names a `WaveSpec`). It is read here instead, where the deck
- * layer is already in the graph — this screen builds a drill through
- * `buildDrill`, which is that same front door. The score need not be in it:
- * it is the run's own live number, taken straight off `state`, and it was on
- * the HUD the whole time. A report field restating it would be a second copy
- * of a figure nothing here derives — and the report exists for the figures
- * that ARE derived, which is why neither of these two is in it.
- *
- * ── No grade, in any of it ───────────────────────────────────────────────────
- * A run that ended early is "the storm got through", never a mark out of ten.
- * Everything on the two endings a child could read as a grade is identical:
- * the same panel, the same order, the same four figures in the same places,
- * drawn in the same colours. What differs is what there is to say and to do —
- * the heading, the lede under it, and, after a breach only, the "Its keys"
- * line and the drill button that offers them (the one hue a breach adds is
- * that finger's own, which is identity and not judgement). So there is no
- * arrangement, no colour and no ranking here that a child could read as a
- * score for themselves rather than a report of what the weather did. The
- * score is shown because it is the run's own number and it was on screen the
- * whole time anyway; the XP beside it can only ever have gone up (§8.6),
- * which is the honest thing a losing run has to say.
- *
- * ── Under the sky, not over it ───────────────────────────────────────────────
- * The panel stands in `.storm`'s second grid track, which is empty for the
- * whole of a live run — this is the only thing the screen ever puts below the
- * sky (`StormField`). That leaves the sky above it whole: the hail frozen
- * where it was, and the shield with the hole still in it under the finger this
- * screen is naming. A panel drawn over the sky would have covered the one
- * picture that explains the sentence.
- *
- * It used to share that track with the keyboard, which stood there while the
- * gun was live and handed it over on the ending. There is no board now
- * (decision 64), so the track is the panel's alone and an ending taller than
- * five rows of keycaps costs the sky nothing.
+ * **No grade, in any of it** (§8.5). The two endings are the same panel with
+ * the same four figures in the same places and the same colours; what differs
+ * is the heading, the lede, and — after a breach only — the "Its keys" line
+ * and the drill button that offers them.
  */
 export function StormOver({
   state,
@@ -88,9 +53,9 @@ export function StormOver({
   const { start } = useRace();
   const report = stormReport(state);
 
-  // No ending, nothing to say. `StormField` only puts this where the board was
-  // once the run is over, so this is that rule at the type level rather than a
-  // second opinion about it — and it is what narrows `report` for the body.
+  // No ending, nothing to say. `StormField` only puts this under the sky once
+  // the run is over, so this is that rule at the type level — and it is what
+  // narrows `report` for the body.
   if (report === null) return null;
 
   const { breach, bestCombo, shieldLeft, shieldFull, through } = report;
@@ -101,13 +66,10 @@ export function StormOver({
    * other drill on the site goes through.
    *
    * `buildDrill` is the trouble-facts machinery pointed at a different
-   * question (§8.5): the record book asks it for the facts a child keeps
-   * missing, and this asks it for the keys behind one finger — but a fact id
-   * in a typing deck is a character either way, so the same call builds the
-   * same shape of deck and `TypingTrack` runs it with no idea where the list
-   * came from. Both options are dropped for a typing deck (`buildDrill`), and
-   * passed anyway rather than branched on: a drill has no input mode to
-   * choose and no per-word clock.
+   * question (§8.5): a fact id in a typing deck is a character either way, so
+   * the same call builds the same shape of deck and `TypingTrack` runs it with
+   * no idea where the list came from. Both options are dropped for a typing
+   * deck (`buildDrill`), and passed anyway rather than branched on.
    */
   function practise(keys: string[]) {
     sfx.select();

--- a/src/games/typing/storm/StormReady.tsx
+++ b/src/games/typing/storm/StormReady.tsx
@@ -1,44 +1,16 @@
 /**
  * The beat before a storm falls (docs/typing.md §8.13, decision 71).
  *
- * ── Why a storm waits, where a race counts ───────────────────────────────────
- * Every other run on this site opens with the 3·2·1 (`useCountdown`), and the
- * reason that works there is that a race is entered with the hands already
- * where they are going to be: a flash card is answered on the number row or
- * with a tap, and a passage lesson puts the caret in an input a child has
- * clicked into. A storm is entered from a tile with a mouse, and then asks for
- * eight fingers on the home row and a reaction time — so a three-second count
- * is three seconds of a child moving one hand off a trackpad while the first
- * letter is already being scheduled.
+ * A storm waits for a key rather than counting down, because readiness is not
+ * an amount of time (§8.13). The two lines are the only place this game says
+ * how to put hands down, and with no keyboard drawn (decision 64) they name
+ * what a real one has: the ridges on `F` and `J`.
  *
- * A clock cannot fix that, because the thing being waited for is not an amount
- * of time. It is a child being ready, which only they can know. So the storm
- * waits, indefinitely and with no counter running, for the one signal that
- * proves the hands are where they need to be: a key.
- *
- * ── Nothing is falling yet, and nothing is drawn ─────────────────────────────
- * The first letter of a wave spawns at time zero (`buildWave`), so a field
- * that merely held the clock still would be showing it — a free look at the
- * first target for as long as a child cared to take one, and the reading beat
- * `QUEUE_MS` gives every OTHER letter turned into an unlimited one for the
- * first. So the same prop that puts this panel in the sky is what takes the
- * stones out of it (`StormField`): the letters begin when the storm does.
- *
- * ── The bumps ────────────────────────────────────────────────────────────────
- * The two lines here are the only place on this screen a child is told how to
- * put their hands down, and the storm is the one screen in the epic with no
- * keyboard drawn on it (decision 64) — so it names the thing a keyboard has
- * instead of a picture: the ridges on `F` and `J`. That is the actual
- * technique for finding the home row without looking, which is the habit every
- * lesson below is trying to build, and it is a thing a five-year-old can do in
- * the two seconds they are reading it.
- *
- * ── It holds no listener ─────────────────────────────────────────────────────
- * "Press any key" is answered in `useStormClock`, beside the gun it becomes
- * (`started`). One window listener on this screen is the rule the whole file
- * is built on: while a run is live every stroke is a shot, so a second
- * listener is a press answered twice — and the press that starts a storm is
- * exactly the one that would otherwise be a miss on the way in.
+ * **It holds no listener.** "Press any key" is answered in `useStormClock`,
+ * beside the gun it becomes (`started`): while a run is live every stroke is a
+ * shot, so a second listener is a press answered twice — and the press that
+ * starts a storm is exactly the one that would otherwise be a miss on the way
+ * in.
  */
 export function StormReady() {
   return (

--- a/src/games/typing/storm/StormRun.tsx
+++ b/src/games/typing/storm/StormRun.tsx
@@ -19,53 +19,34 @@ import type { StormLesson } from "@/engine/typing/storms";
 import type { Profile } from "@/engine/types";
 
 /**
- * The Hailstorm route (docs/typing.md §9), playing one of the twenty levels.
+ * The Hailstorm route (§9), playing one of the twenty levels.
  *
  * The screen is six things joined: a field that draws a `StormState`, a clock
- * that produces one per animation frame, a keyboard that shoots, the way out
- * (below), the ending that says which finger let it through and offers a drill
- * of that finger's keys (`StormOver`), and — the moment the storm stops — the
- * run written to the record book as a `Session` (§8.7, `stormSession.ts`).
+ * that produces one per animation frame, a keyboard that shoots, the way out,
+ * the ending that names the finger that let the storm through (`StormOver`),
+ * and — the moment the storm stops — the run written to the record book as a
+ * `Session` (§8.7, `stormSession.ts`).
  *
- * **Which storm is in the URL** (`#/p/:profileId/storm/:lessonId`), because a
- * level is a rung of the ladder and the ladder is where a child chose it. The
- * lesson is the whole of what this route reads: the wave comes from it
- * (`stormWave`, which draws the pool from `unlockedAt(n)` — §5.6), the run
- * files itself under it (`typing:L39`, §8.7), and nothing here holds a spec of
- * its own for the two to drift apart from.
+ * **Which storm is in the URL** (`#/p/:profileId/storm/:lessonId`). The lesson
+ * is the whole of what this route reads: the wave comes from it (`stormWave`),
+ * the run files itself under it (`typing:L39`), and nothing here holds a spec
+ * of its own for the two to drift apart from.
  *
  * A `lessonId` that is not a storm — a passage, a level id, a typo — goes back
- * to the ladder rather than rendering an empty sky. It is not an error case so
- * much as the ordinary end of a hand-edited URL, and the ladder is where the
- * answer to "which storms are there" is drawn.
+ * to the ladder rather than rendering an empty sky. It is the ordinary end of
+ * a hand-edited URL rather than an error case.
  */
 
 /**
  * The route, which owns nothing but which attempt is being played.
  *
- * **A retry is a new run, not the same one rewound** (decision 51), and that is
- * why it is a remount rather than a fresh wave handed to a component that stays
- * put. Three things a second go has to get right come free from starting the
- * component again, and every one of them would have to be undone by hand
- * otherwise:
- *
- *   - **It has not been saved.** `useRaceFinish` guards its own double-finish
- *     with a ref that latches for the life of the hook, so a screen that kept
- *     that hook across a retry would write the first run and silently never
- *     write another. A new instance is a new latch — which is the guard, said
- *     structurally rather than kept in step by a second flag.
- *   - **Its history includes the run before it.** `history` is snapshotted at
- *     mount so the run being saved cannot alter its own scoring; a second
- *     attempt badged against the first attempt's snapshot would be counting a
- *     record book that no longer exists.
- *   - **Its clock starts at zero.** `useStormClock` starts a fresh run when it
- *     is handed a different wave, and a remount is the plainest way to hand it
- *     one.
- *
- * The wave itself is rebuilt from the same `(spec, seed)`, so "try this wave
- * again" means the same letters in the same lanes at the same speeds (§8.3) —
- * a different run of the same storm, which is the only version of beating it
- * that means a child got better.
+ * **A retry is a new run, not the same one rewound** (§8.7, decision 51), and
+ * a remount is what makes that structural rather than three things to undo by
+ * hand: `useRaceFinish`'s double-finish latch is fresh, so a second attempt is
+ * written at all; `history` is snapshotted at mount, so that attempt is badged
+ * against a record book which includes the first; and the clock starts at
+ * zero, because `useStormClock` starts a fresh run when it is handed a
+ * different wave.
  */
 export default function StormRun() {
   const { profileId, lessonId } = useParams();
@@ -85,9 +66,7 @@ export default function StormRun() {
      which runs once per mount — so a route that stayed mounted across
      `#/…/storm/L39` → `#/…/storm/L45` (same pattern, different param, no
      remount) would go on playing lesson 39's storm under lesson 45's name, and
-     save it under lesson 45's id. Every reason a retry is a remount is a
-     reason a different level is one too (see below); the difference is that a
-     retry means to meet the same wave and this must not. */
+     save it under lesson 45's id. */
   return (
     <StormPlay
       key={`${lesson.id}:${attempt}`}
@@ -101,35 +80,23 @@ export default function StormRun() {
 /**
  * One attempt: the wave, the clock, the field, and the write at the end of it.
  *
- * ── Saved through the race's own finish ──────────────────────────────────────
- * `useRaceFinish` and not a second save path, because a storm is a `Session`
- * and every hard part of writing one has already been solved there: scoring
- * through `summariseRun`, the badges, the XP into the profile, and the failure
- * that matters — IndexedDB refusing a write on a full disk or in private
- * browsing — held in state so the answers are still in memory and `SaveFailed`
- * can offer to try again (§8.7's "no new code downstream", from the other
- * side).
+ * Saved through `useRaceFinish` and not a second save path, because a storm is
+ * a `Session` and every hard part of writing one is solved there — scoring,
+ * badges, XP into the profile, and IndexedDB refusing a write on a full disk
+ * or in private browsing, held in state so `SaveFailed` can offer to try again
+ * (§8.7).
  *
  * What it is handed that a race is not:
  *
- *   - **No ghost, and no previous best.** Nothing chases a storm, and a storm
- *     holds no record: `compareRuns` ranks runs on time, and a run that ended
- *     at letter three took less of it than one that cleared the wave — so a
- *     best would go to dying early, and pay a personal-best bonus for it. XP
- *     must never reward the thing the game is against (§8.6, decision 50).
- *
- *     `previousBest: null` is only half of that, and the smaller half: it
- *     buys this run's own 150 XP bonus and its `personalRecord` flag, and
- *     nothing else. What stops the record book, the house best and every
- *     future rival list from ranking the run is `config.storm`, which
- *     `stormConfig` sets and `isRanked` reads — the run is still filed under
- *     its `configKey`, so a later story that wants to rank storms on
- *     something other than time has every run it needs.
- *   - **A results path that is the screen it is already on.** The ending
- *     stands where the board did (decision 47) and IS this run's results
- *     screen, so the navigation `useRaceFinish` performs on a good save is a
- *     replace onto the current route: it commits the history entry a race
- *     would, and moves nothing.
+ *   - **No ghost, and no previous best.** `previousBest: null` buys this run's
+ *     own 150 XP bonus and its `personalRecord` flag, and nothing else. What
+ *     keeps the record book, the house best and every future rival list from
+ *     ranking a storm is `config.storm`, which `stormConfig` sets and
+ *     `isRanked` reads (§8.7, decision 50).
+ *   - **A results path that is the screen it is already on.** The ending IS
+ *     this run's results screen, so the navigation `useRaceFinish` performs on
+ *     a good save is a replace onto the current route: it commits the history
+ *     entry a race would, and moves nothing.
  */
 function StormPlay({
   lesson,
@@ -147,39 +114,25 @@ function StormPlay({
   const navigate = useNavigate();
 
   /**
-   * Is the quit sheet up? (§8.8, decision 54.)
+   * Is the quit sheet up? (§8.11, decision 54.)
    *
    * It is the storm's pause as well as its question, and the two are one flag
-   * because they are one moment: a wave that went on falling behind the sheet
-   * would break a child's shield while they read "it won't be saved", and a
-   * gun still listening would fire `Space` and `Enter` at the letters instead
-   * of at the two buttons in front of them. `useStormClock` takes it as
-   * `paused` and stops the loop, which costs the run nothing — wave time is
-   * measured between frames, and there are none.
+   * because they are one moment: `useStormClock` takes it as `paused` and
+   * stops the loop, which costs the run nothing — wave time is measured
+   * between frames, and there are none.
    *
-   * **Quitting saves nothing, and there is no code here that makes that true.**
-   * The run is written by the effect below, which fires on an `ending` the
-   * reducer stamps; a wave abandoned halfway has none, so leaving is a
-   * navigation and the route unmounts with the run still only in memory. That
-   * is worth stating because it is the kind of guarantee somebody later adds a
-   * "save the partial run" line against without noticing it was a promise.
+   * **Quitting saves nothing, and no code here makes that true**: the effect
+   * below writes on an `ending` the reducer stamps, and a wave abandoned
+   * halfway has none (§8.11).
    */
   const [quitting, setQuitting] = useState(false);
 
   /**
    * Has the child started this wave? (§8.13, decision 71.)
    *
-   * A storm does not begin on mount. It hangs at time zero, with an empty sky
-   * and a panel in it, until a key says go — the reason being that this is the
-   * one game on the site entered with the hands in the wrong place: a tile is
-   * clicked with a mouse, and what the first letter then asks for is eight
-   * fingers on the home row (`StormReady`). The 3·2·1 every race opens with
-   * cannot serve for that, because three seconds is a guess at something only
-   * the child knows.
-   *
-   * False on every attempt, and a retry is a new component (`StormRun`), so
-   * the beat is offered again after a loss — which is exactly when a child is
-   * most likely to have taken a hand off the keys.
+   * A storm hangs at time zero, with an empty sky and a panel in it, until a
+   * key says go. False on every attempt, and a retry is a new component
+   * (`StormRun`), so the beat is offered again after a loss.
    *
    * It is `useStormClock`'s to end and this screen's to hold, for the reason
    * `quitting` is: the key that starts a run has to be taken by the same
@@ -192,24 +145,22 @@ function StormPlay({
    * This attempt's wave, and the config the run will be filed under.
    *
    * Built once per mount and never rebuilt: a run's wave is fixed for its
-   * whole life (`StormState.wave`), and the config is its length and its
-   * lesson, both of which are decided before the first letter falls. Which is
-   * safe only because a different lesson is a different mount — see the key in
-   * `StormRun`, without which this initialiser would keep the first storm a
-   * child opened for as long as they stayed on the route.
+   * whole life (`StormState.wave`). Which is safe only because a different
+   * lesson is a different mount — see the key in `StormRun`, without which
+   * this initialiser would keep the first storm a child opened for as long as
+   * they stayed on the route.
    */
   const [wave] = useState(() => stormWave(lesson));
   const config = useMemo(() => stormConfig(lesson.id, wave), [lesson.id, wave]);
   const { state, skyRef } = useStormClock(wave, {
     paused: quitting,
     started,
-    // The first press is spent starting the wave rather than shot at it — see
-    // `started`, and the gun's own note about why it is taken there.
+    // The first press is spent starting the wave rather than shot at it
+    // (§8.13, `started`).
     onStart: () => setStarted(true),
-    // The keyboard's way to the same sheet the button opens. It is taken
-    // inside the gun's own listener because every other key while the run is
-    // live is a shot, and a way out that cost ten points would be a trap
-    // (`QUIT_KEY`).
+    // The keyboard's way to the same sheet the button opens, taken inside the
+    // gun's own listener because every other key while the run is live is a
+    // shot (`QUIT_KEY`).
     onQuit: () => setQuitting(true),
   });
 
@@ -224,8 +175,8 @@ function StormPlay({
     history,
     previousBest: null,
     // Read at save time, off the frame that ended the run — which is the
-    // frame this render is of, because `useStormClock` publishes an ending
-    // and the effect below fires on it.
+    // frame this render is of, because `useStormClock` publishes an ending and
+    // the effect below fires on it.
     readTally: () => stormTally(state),
     saveSession,
     finish,
@@ -233,26 +184,23 @@ function StormPlay({
     navigate,
     resultsPath: `/p/${profile.id}/storm/${lesson.id}`,
     // Nothing to disarm. The gun dies with the run inside `useStormClock` and
-    // the field is frozen where the clock stopped, so there is no phase a
-    // saving storm is in that it is not in already.
+    // the field is frozen where the clock stopped.
     onSaving: () => {},
-    // And nothing to play. A storm can end by being lost, so the sound of an
-    // ending is decided off the ending itself, on the frame the reducer
-    // stamped it — `sfx.finish` for a wave cleared, `sfx.breach` for a shield
-    // that failed (`stormSounds.ts`). The race's default would congratulate a
-    // child for dying.
+    // And nothing to play: a storm can end by being lost, so its ending is
+    // announced off the frame the reducer stamped it (§8.12,
+    // `stormSounds.ts`). The race's default would congratulate a child for
+    // dying.
     fanfare: () => {},
   });
 
   /**
    * Save the run, once, on the frame it ends.
    *
-   * Through a ref for the reason `TypingTrack` uses one: `complete` is a fresh
-   * closure on every render, so naming it as a dependency would re-run this on
-   * every re-render — and the ending screen re-renders whenever the hub's
-   * sessions change, which the save itself does. The dependency is
-   * `state.ending`, which the reducer replaces exactly once per run and then
-   * leaves alone, so this fires on the ending frame and on no other.
+   * Through a ref because `complete` is a fresh closure on every render, so
+   * naming it as a dependency would re-run this on every re-render — and the
+   * ending screen re-renders whenever the hub's sessions change, which the
+   * save itself does. The dependency is `state.ending`, which the reducer
+   * replaces exactly once per run and then leaves alone.
    *
    * `complete` refuses a second call for the life of this component anyway;
    * across attempts, a retry is a new component (`StormRun`).
@@ -265,10 +213,9 @@ function StormPlay({
     void completeRef.current();
   }, [state.ending]);
 
-  // The same screen a race shows, and for the same reason: the run is over,
-  // the answers are still in memory, and nothing is lost until the player
-  // leaves. It stands in for the whole field rather than beside it, because a
-  // storm that could not be written down is not a storm to go on looking at.
+  // The same screen a race shows, and it stands in for the whole field rather
+  // than beside it: a storm that could not be written down is not a storm to
+  // go on looking at.
   if (saveError)
     return (
       <SaveFailed
@@ -285,11 +232,10 @@ function StormPlay({
         skyRef={skyRef}
         onQuit={() => setQuitting(true)}
         // Present exactly while the wave is waiting, which is also what takes
-        // the stones out of the sky: nothing is shown of the storm before the
-        // storm starts (`StormField`).
+        // the stones out of the sky (`StormField`).
         ready={started ? undefined : <StormReady />}
-        // Drawn where the board was, and only once the run is over — which is
-        // `StormField`'s call to make, off the same `ending` the gun dies on.
+        // Drawn where the ending goes, and only once the run is over — which
+        // is `StormField`'s call to make.
         over={
           <StormOver
             state={state}
@@ -300,11 +246,10 @@ function StormPlay({
         }
       />
 
-      {/* The race's sheet and not a second one, because it is the same
-          question with a different noun: the storm is paused behind it, the
-          run is not saved either way, and "it won't be saved and no XP is
-          earned" is the one thing being weighed. Quitting goes back to the
-          ladder, which is where the tile that will send a child here lives. */}
+      {/* The race's sheet and not a second one: it is the same question with a
+          different noun, and "it won't be saved and no XP is earned" is the
+          one thing being weighed. Quitting goes back to the ladder, which is
+          where the tile that sent a child here lives. */}
       {quitting && (
         <QuitSheet
           title="Quit this storm?"

--- a/src/games/typing/storm/StormShield.test.tsx
+++ b/src/games/typing/storm/StormShield.test.tsx
@@ -19,13 +19,12 @@ import type { ShieldFinger, StormState, WaveSpec } from "@/engine/typing/storm";
 
 /**
  * The shield, as a child reads it: eight segments, how much is left of each,
- * and one event apiece when something happens to one (docs/typing.md §8.5).
+ * and one event apiece when something happens to one (§8.5).
  *
  * The geometry is NOT here. That a segment sits over its own finger's keys is
- * a claim about this component's numbers *and* game.css's arithmetic, and
- * `StormField.test.tsx` is where the stylesheet is read and run in key units —
- * so the alignment lives beside the lane it shares its half-gap correction
- * with, rather than in a second, weaker copy here.
+ * a claim about this component's numbers *and* game.css's arithmetic, so it
+ * lives in `StormField.test.tsx` beside the lane it shares its half-gap
+ * correction with, rather than in a second, weaker copy here.
  */
 
 const only = (ch: string, over: Partial<WaveSpec> = {}): WaveSpec => ({
@@ -43,10 +42,9 @@ const only = (ch: string, over: Partial<WaveSpec> = {}): WaveSpec => ({
 
 /*
  * Every absolute moment in this file is measured from the instant the first
- * letter starts to DROP, not from the start of the wave — hence the offset.
- * A real letter hangs at the top for `QUEUE_MS` before it moves (§8.3), and
- * that beat is the same for every letter of every level, so folding it in here
- * once leaves each schedule below saying exactly what it always said.
+ * letter starts to DROP, not from the start of the wave — hence the offset. A
+ * letter hangs at the top for `QUEUE_MS` first (§8.3), and folding that in
+ * once here leaves each schedule below saying what it says.
  */
 const frameOf = (spec: WaveSpec, atMs: number): StormState =>
   tick(startStorm(buildWave(spec, 7)), QUEUE_MS + atMs);

--- a/src/games/typing/storm/StormShield.tsx
+++ b/src/games/typing/storm/StormShield.tsx
@@ -8,51 +8,31 @@ import type { CSSProperties } from "react";
  * The shield: eight segments across the bottom of the field, one per finger
  * (docs/typing.md §8.5, decision 21).
  *
- * ── Why finger zones, and not one segment per key ────────────────────────────
- * A per-key shield is the obvious build and it is the wrong one, because of
- * what a child can do with what it tells them. A hole under `o` tells you
- * nothing: `o` is one of forty-odd keys, it will not come round again for a
- * while, and "get better at `o`" is not a thing anybody can practise. A hole
- * under the **right ring finger** tells you what to practise — that finger is
- * a lesson, a drill and a habit, and `o l . 9` are all behind it. It is also
- * the one thing this game can teach that no accuracy percentage ever will: a
- * child watching their own right ring finger crumble is learning something
- * about their hands. Eight is small enough to read at a glance while a storm
- * is falling, and forty-odd would be a strip of noise nobody could read at
- * all.
+ * Nothing here computes a position. The spans are `FINGER_ZONES` — the home
+ * row grouped by finger, in key units off the same `--key` the board and the
+ * lanes use — and the stylesheet multiplies them, so there is no arithmetic in
+ * this file for the shield and the keyboard to disagree about. The half
+ * `--key-gap` step back that a segment shares with a lane is written in
+ * `game.css` as `var(--key-gap) / 2` on both, never as the number it currently
+ * works out to (§8.2).
  *
- * ── Over the fingers that broke it ───────────────────────────────────────────
- * A segment is only that lesson if it is over the right keys, so the spans are
- * `FINGER_ZONES` — the home row grouped by finger, in key units off the same
- * `--key` the board and the lanes use (§8.2). Nothing here computes a
- * position: the engine says which stretch of the board a finger owns, the
- * stylesheet multiplies it, and there is no arithmetic in this file for the
- * shield and the keyboard to disagree about. The one correction they share is
- * half a `--key-gap`, which both the lane and the segment step back by, so a
- * seam lands in the gutter between two keycaps rather than down the middle of
- * one — written in `game.css` as `var(--key-gap) / 2` on both, and never as
- * the number it currently works out to.
+ * **One tint per landing, and never a flash sequence** (§8.10). The mechanism
+ * is what keeps that true rather than the duration in the stylesheet: each
+ * pulse is a child element keyed by a counter that only ever goes up —
+ * landings for the tint, repairs for the mend — so React mounts a fresh node
+ * exactly when one more of them has happened, and the animation on that node
+ * runs once. It cannot restart on a frame where nothing happened to that zone,
+ * because the key did not change; and two letters landing on one zone in a
+ * single `tick` move the counter by two, which is still one mount and
+ * therefore still one tint. Nothing here holds a timer, so there is no state
+ * that could be left mid-flash by a screen that unmounted.
  *
- * ── One tint per landing, and never a flash sequence ─────────────────────────
- * Damage is a single ~150ms tint (§8.10), and the mechanism is what keeps that
- * true rather than the duration in the stylesheet. Each pulse is a child
- * element keyed by a **counter that only ever goes up** — landings for the
- * tint, repairs for the mend — so React mounts a fresh node exactly when one
- * more of them has happened, and the animation on that node runs once. It
- * cannot restart on a frame where nothing happened to that zone, because the
- * key did not change; and two letters landing on one zone inside a single
- * `tick` move the counter by two, which is still one mount and therefore still
- * one tint. Nothing here holds a timer, and there is no state that could be
- * left mid-flash by a screen that unmounted.
- *
- * The counters are read off the run rather than stored on it, which is what
- * `StormState` asks of anything wanting a per-finger tally: `resolved` says
- * what landed and where, and a zone's hit points say what is left, so the only
- * unknown is how many repairs went in and that falls out of the other two.
- * `zoneTally` does that arithmetic, and it is in the engine beside the reducer
- * rather than here — the ending screen names a finger out of the same numbers
- * ("your right ring finger let three through", §8.5), and a view that owned
- * them would have made a second screen import a component to count landings.
+ * The counters are read off the run rather than stored on it: `resolved` says
+ * what landed and where, a zone's hit points say what remains, and the repairs
+ * fall out of the two. `zoneTally` does that arithmetic in the engine beside
+ * the reducer, because the ending screen names a finger out of the same
+ * numbers and a view that owned them would have made a second screen import a
+ * component to count landings.
  */
 
 /**
@@ -96,11 +76,10 @@ export function StormShield({ state }: { state: StormState }) {
                 // A fraction, so the stylesheet needs to know neither how deep
                 // this level's shield is nor how much of it is left. The
                 // division is guarded because `full` can be zero — a wave may
-                // declare no shield at all, and every zone of it starts as a
-                // hole — and `0 / 0` is a `NaN` that CSS cannot multiply, so
-                // the armour's height would be dropped for `auto`. That
-                // happens to look like the hole it is, which is exactly the
-                // kind of accident not to leave load-bearing.
+                // declare no shield at all — and `0 / 0` is a `NaN` that CSS
+                // cannot multiply, so the armour's height would be dropped for
+                // `auto`. That happens to look like the hole it is, which is
+                // exactly the kind of accident not to leave load-bearing.
                 "--hp": full > 0 ? hp / full : 0,
               } as CSSProperties
             }

--- a/src/games/typing/storm/stormSession.test.ts
+++ b/src/games/typing/storm/stormSession.test.ts
@@ -23,15 +23,12 @@ import type { StormLetter, StormState, WaveSpec } from "@/engine/typing/storm";
 import type { Profile, Session } from "@/engine/types";
 
 /**
- * A storm, as a `Session` (docs/typing.md §8.7, decision 23).
+ * A storm, as a `Session` (§8.7, decision 23).
  *
  * What is on trial here is the MAPPING, because the run itself is already
  * decided: `storm.test.ts` proves what was shot, what got through and on what
  * streak, and this file asks only whether the record book is told the truth
- * about it. Four of its claims are acceptance criteria in their own right —
- * a letter is a `CardResult`, a run that ends early saves honestly, `configKey`
- * keys on the lesson rather than on how far a child got, and nothing
- * downstream needs a line of new code.
+ * about it.
  */
 
 const LESSON = "L39";
@@ -57,8 +54,7 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
     fallMs,
     // No queue: a hand-placed letter falls the instant it appears, so every
     // absolute moment below is the one the test wrote down. The beat a real
-    // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it belongs to the
-    // tests of the schedule rather than to every test of what a landing costs.
+    // wave gives a letter (`QUEUE_MS`) belongs to the tests of the schedule.
     dropMs: spawnMs,
     landMs: spawnMs + fallMs,
   };
@@ -190,12 +186,8 @@ describe("a falling letter is a CardResult", () => {
 
 describe("a run that ends early", () => {
   /**
-   * §8.7's own example: dying at letter 18 of 40 saves a session with 18
-   * cards, `correct`, `incorrect` and `durationMs` all honest, and the
-   * `survive` criterion simply not met.
-   *
-   * Four shot at the front, then thirteen landings empty the zone and the
-   * fourteenth is the one nothing was left to stop.
+   * §8.7's own example, built: four shot at the front, then thirteen landings
+   * empty the zone and the fourteenth is the one nothing was left to stop.
    */
   const died = (() => {
     let state = drumbeat(40, { shield: 13 });
@@ -271,11 +263,10 @@ describe("what a storm files itself as", () => {
       storm: true,
       wordCount: 12,
     });
-    // The rung has a wave of its own now (§5.6, #156) and it is not twelve
-    // letters long — which is the point of reading the length off the wave in
-    // hand. A saved run outlives the ladder it was played on (§5.4): re-tune
-    // lesson 39 and this run is still a run of the twelve it actually faced,
-    // and `survived` still asks the right question of it.
+    // The rung has a wave of its own and it is not twelve letters long — which
+    // is the point of reading the length off the wave in hand. A saved run
+    // outlives the ladder it was played on (§5.4): re-tune lesson 39 and this
+    // is still a run of the twelve it faced.
     const rung = lessonById(LESSON);
     expect(rung?.kind.type).toBe("storm");
     expect(rung?.wordCount).toBeGreaterThan(0);
@@ -292,20 +283,12 @@ describe("what a storm files itself as", () => {
 
 describe("a storm holds no record", () => {
   /**
-   * **Decision 50, as the record book actually reaches it.**
+   * Decision 50, as the record book actually reaches it (§8.7).
    *
-   * `previousBest: null` on the playing screen buys one thing: this run's own
-   * `personalRecord` flag and the 150 XP behind it. Every OTHER best on the
-   * site — the record book's "your best" column, the house best beside it, the
-   * `previousBest` a lesson's results screen is handed, and every rival a
-   * setup screen offers — is `bestRun`, which groups runs by `configKey` and
-   * picks with `compareRuns`, i.e. on time. A storm ends when the shield does,
-   * so on that rule the child who died first wins.
-   *
-   * These are the reviewer's two runs, played by the reducer rather than
-   * hand-built: one twelve-letter wave cleared, and the same wave with nothing
-   * pressed at all. Both file under `typing|L39|12`, which is the point of the
-   * key (§5.4) and therefore also the trap.
+   * Two runs played by the reducer rather than hand-built: one twelve-letter
+   * wave cleared, and the same wave with nothing pressed at all. Both file
+   * under `typing|L39|12`, which is the point of the key (§5.4) and therefore
+   * also the trap — on `compareRuns`'s rule the child who died first wins.
    */
   const WAVE = Array.from({ length: 12 }, (_, i) => at("f", i * 100, 3000));
 
@@ -324,14 +307,14 @@ describe("a storm holds no record", () => {
   };
 
   /**
-   * A lesson run at the identical key — the trap, no longer a dry run.
+   * A lesson run at the identical key.
    *
-   * Lesson 39 carries a `WaveSpec` now (#156), so `lessonKey(lesson)` and
-   * `configKey(stormConfig(...))` really are one string — `storm` is inert in
-   * `configKey` and must stay so, or every storm already saved is orphaned.
-   * `TypingSetup`'s brief and its rival list read this run and the two storms
-   * as one group. It is SLOWER than either storm and still has to be the best
-   * of the three, which it can only be if the other two are refused.
+   * `lessonKey(lesson)` and `configKey(stormConfig(...))` are one string —
+   * `storm` is inert in `configKey` and must stay so, or every storm already
+   * saved is orphaned. So `TypingSetup`'s brief and its rival list read this
+   * run and the two storms as one group. It is SLOWER than either storm and
+   * still has to be the best of the three, which it can only be if the other
+   * two are refused.
    *
    * Its twelve letters are the hand-built wave above rather than the rung's
    * own count, which is why the key here is `typing|L39|12`; the twenty rungs
@@ -396,16 +379,7 @@ describe("a storm holds no record", () => {
 
 describe("what `incorrect` counts", () => {
   /**
-   * **Letters that got through, and not keys that missed** (decision 48).
-   *
-   * A wrong key resolves no letter, so it is not a card — the same bargain
-   * decision 13 struck for the lessons, where a keystroke backspaced away
-   * costs nothing because what ended up on the line is right. Two things hang
-   * on it, and both would break if a miss were given a card of its own:
-   * `survived` is `cards.length >= wordCount`, so a run that died at letter
-   * three and sprayed forty wrong keys would read as having faced the whole
-   * wave; and the `unbroken` badge reads "nothing marked wrong" as "nothing
-   * got through", which is the sentence its own description makes.
+   * Letters that got through, and not keys that missed (§8.7, decision 48).
    */
   it("is not moved by a wrong key", () => {
     let state = drumbeat(3);
@@ -469,19 +443,16 @@ describe("what `incorrect` counts", () => {
 
 describe("the `unbroken` badge, over a wave the reducer really played", () => {
   /**
-   * "Clear a Hailstorm wave with the shield untouched" is read in
-   * `progress.ts` as `incorrect === 0`, and the mapping above is what decides
-   * which of two badges that sentence describes. Counting wrong keys into
-   * `incorrect` would have re-tuned it from **untouched shield** to
-   * **flawless run** — a behaviour change invisible in a diff that never
-   * touches `progress.ts`. These two pin the meaning that shipped.
+   * `progress.ts` reads "shield untouched" as `incorrect === 0`, so the
+   * mapping above is what decides which of two badges that sentence describes
+   * — untouched shield, or flawless run. A change of mind there would be
+   * invisible in a diff that never touches `progress.ts`, so these two pin the
+   * meaning that shipped.
    *
    * The rung's own `wordCount` is lent for the length of the test, exactly as
-   * `progress.test.ts` does. Lesson 39's wave is a real length now (§5.6), and
-   * borrowing it is what keeps these two about the badge's meaning rather than
-   * about the table: they are ten-letter runs, and the rung is asked to say
-   * ten so that `survived` is the thing being tested and not the difficulty
-   * pass that last edited the row.
+   * `progress.test.ts` does. These are ten-letter runs, and the rung is asked
+   * to say ten so that `survived` is the thing being tested rather than the
+   * difficulty pass that last edited the row.
    */
   const withWave = (count: number, body: () => void) => {
     const of = lessonById(LESSON);
@@ -551,10 +522,8 @@ describe("nothing downstream needs a line of new code", () => {
     expect(summary.draft.beatGhost).toBeNull();
     // `previousBest` is null, so this run's own results can never call
     // themselves a personal record or pay the 150 XP for one (decision 50).
-    // That is ALL it decides — it is a fact about this summary and about
-    // nothing else in storage. What keeps a run that died early from taking
-    // a record off one that cleared the wave is `config.storm`, which the
-    // block below is about.
+    // That is ALL it decides. What keeps a run that died early from taking a
+    // record off one that cleared the wave is `config.storm`, above.
     expect(summary.personalRecord).toBe(false);
   });
 
@@ -609,18 +578,9 @@ describe("nothing downstream needs a line of new code", () => {
 
 describe("every storm keys exactly as its own rung does", () => {
   /**
-   * **The trap above, over the twenty as they ship** (§5.4, §8.7, decision
-   * 50).
-   *
-   * A storm's `configKey` is built from the wave in hand and a lesson's from
-   * the rung, and #156 made those the same number — `wordCount` IS the wave's
-   * `count`. That is deliberate and load-bearing: retries of a level have to
-   * compare with each other, so they must share a bucket. It is also exactly
-   * what makes `config.storm` necessary, because sharing a bucket with a
-   * lesson is sharing it with `bestRun`.
-   *
-   * So both halves are asserted here, on the real waves rather than on a
-   * fixture: the keys match, and the storm still holds nothing at that key.
+   * The trap above, over the twenty as they ship (§5.4, §8.7, decision 50).
+   * Both halves on the real waves rather than on a fixture: the keys match,
+   * and the storm still holds nothing at that key.
    */
   it("shares its bucket with the lesson, and holds no best in it", () => {
     for (const lesson of STORM_LESSONS) {

--- a/src/games/typing/storm/stormSession.ts
+++ b/src/games/typing/storm/stormSession.ts
@@ -8,26 +8,13 @@ import type { CardResult, TypingConfig } from "@/engine/types";
 /**
  * A storm, as the record book holds it (docs/typing.md §8.7, decision 23).
  *
- * A falling letter maps onto a `CardResult` with nothing forced — `prompt` and
- * `answer` are the character, `given` is what was pressed, `ms` is how long it
- * was in the air, `factId` is the character — so a Hailstorm run **is** a
- * `Session`, filed under `typing:L39` exactly as the lesson at that rung is.
- * Everything downstream then works with no new code at all: the record book
- * lists it, `sessionService.record` pays its XP into the profile, the badge
- * evaluator asks it the same questions it asks a race, and `troubleFacts`
- * ranks its characters for the drill builder.
+ * A falling letter is a `CardResult`, so a run **is** a `Session` and nothing
+ * downstream needs new code — the record book, the XP, the badges and the
+ * drill builder all read it as they read a race (§8.7).
  *
- * ── Here rather than in the engine ───────────────────────────────────────────
- * Beside the screen that plays a storm, exactly as `lessonRun.ts` sits beside
- * the screen that runs a lesson, and for the same two reasons. It needs
- * `stormXp`, which lives in `progress.ts`, which imports `decks/index.ts` —
- * and `storm.ts` is deliberately kept a hop clear of the deck layer, because
- * each storm lesson names a `WaveSpec` and `lessons.ts` is reachable from
- * `decks/index.ts` (§5.3, decision 7). And what a run of a lesson is
- * filed as is the island's answer to give: the engine is handed a config, it
- * does not compose one.
- *
- * Every function here is pure and takes a finished — or unfinished — run, so
+ * It sits beside the screen that plays a storm, as `lessonRun.ts` does for
+ * the one that runs a lesson: it needs `stormXp`, which reaches the deck layer
+ * `storm.ts` is kept clear of (§5.3). Every function here is pure, so
  * `stormSession.test.ts` can ask all of it without a browser.
  */
 
@@ -36,33 +23,21 @@ import type { CardResult, TypingConfig } from "@/engine/types";
  *
  * `lessonId` is the identity of the run and the one field `modeOf` and
  * `configKey` prefer (§5.4), so a storm is `typing:L39` and keys as
- * `typing|L39|28`. `levelId` carries the same id for the same reason
- * `lessonConfig` does: both fields are read through `lessonId` on a ladder run,
- * and putting anything else in the level would only invite a screen to read it.
+ * `typing|L39|28`. `levelId` carries the same id, as `lessonConfig` has it:
+ * both are read through `lessonId` on a ladder run, and anything else in the
+ * level would only invite a screen to read it.
  *
- * **`wordCount` is the WAVE's length, never the letters that were faced.**
- * That is the whole of the acceptance criterion about ghosts: `configKey` has
- * to key on the lesson so that retries of a level compare with each other, and
- * a count that moved with how far a child got would file every attempt in a
- * bucket of one — the same failure §5.4 keeps a lesson's generated passage out
- * of the key to avoid. It is also what `survived` reads back off a saved run
- * (`verdict.ts`): "you faced every letter the wave had" is `cards.length >=
- * wordCount`, which only means anything if the second number is the wave's.
+ * **`wordCount` is the wave's length, not the run's** (§8.7). A count that
+ * moved with how far a child got would file every attempt in a bucket of one,
+ * and it is also what `survived` reads back off a saved run (`verdict.ts`):
+ * `cards.length >= wordCount` only means anything if the second number is the
+ * wave's. It is read off the wave in hand, since a saved run outlives its
+ * ladder (§5.4).
  *
- * A storm lesson's own `wordCount` is that same figure (§5.7), so the two
- * agree — which is what makes this key and `lessonKey(lesson)` one string. The
- * wave in hand is still where the run reads it, because a saved run outlives
- * the ladder it was played on (§5.4): re-tune lesson 39 from twelve letters to
- * forty and this run is still a run of twelve.
- *
- * **`storm: true` is what keeps it out of the record book's ranking**
- * (decision 50). The key above is deliberately the lesson's, so retries
- * compare with each other — and that is exactly what makes the flag necessary:
- * a group of runs sharing a key is what `bestRun` ranks, and it ranks on time,
- * so without the flag the run that died first would hold the record. It is the
- * only thing here a `lessonConfig` does not also write, and it is inert in
- * `configKey`, so the two configs still key identically — which they must, or
- * the twenty waves landing would have orphaned every storm already saved.
+ * **`storm: true` is what keeps it out of the record book's ranking** (§8.7,
+ * decision 50). It is the only thing here a `lessonConfig` does not also
+ * write, and it is inert in `configKey`, so a storm and its lesson still key
+ * to one string.
  */
 export function stormConfig(lessonId: string, wave: Wave): TypingConfig {
   return {
@@ -78,41 +53,31 @@ export function stormConfig(lessonId: string, wave: Wave): TypingConfig {
  * The run's letters, as cards — one per letter that was resolved, in wave
  * order.
  *
- * ── `resolved`, and never `hasLanded` ────────────────────────────────────────
- * The list is walked over `state.resolved` because that is the only honest
- * account of what a run faced. After a breach the clock stops at the fatal
- * `landMs` rather than at the end of the tick that found it, so a letter from a
- * higher index tying that exact millisecond is left unresolved while
- * `hasLanded(letter, state.timeMs)` reads true of it (`tick`). Counting the
- * clock would put a card in a child's record book for a letter the run ended
- * before — the same over-count `zoneTally` refuses on the ending screen.
+ * The list is walked over `state.resolved` and never over `hasLanded`. The
+ * clock stops at the fatal `landMs` after a breach rather than at the end of
+ * the tick that found it, so a letter tying that millisecond from a higher
+ * index is left unresolved while `hasLanded` still reads true of it (`tick`) —
+ * and counting the clock would file a card for a letter the run ended before
+ * (§8.5).
  *
- * ── A card per letter, and not per keystroke ─────────────────────────────────
- * A wrong key resolves no letter, so it is not a card. That is decision 13's
- * bargain — per-key stats come from cards and not from keystrokes — kept for
- * the storm, and it is what makes `cards.length` mean "letters faced" for
- * `survived`. What a wrong key cost is still in the saved run: it broke the
- * streak, and `bestStreak` is the longest one that survived (`stormTally`).
+ * A card is a letter's outcome and never a keystroke (§8.7, decision 48), so a
+ * wrong key resolves nothing and is not a card — which is what makes
+ * `cards.length` mean "letters faced" for `survived`.
  *
- * ── The four fields, and why each is what it is ──────────────────────────────
- *   - `prompt`, `answer`, `factId` — the character. One character is one fact,
- *     so `troubleFacts` ranks per key and the drill `buildDrill` returns is a
+ * The four fields:
+ *
+ *   - `prompt`, `answer`, `factId` — the character. One character is one
+ *     fact, so `troubleFacts` ranks per key and `buildDrill` hands back a
  *     passage of exactly the keys a child keeps losing letters on.
- *   - `given` — the character for a letter that was shot, and `null` for one
- *     that got through, because nothing was pressed at it. There is no third
- *     case to worry about: a shot only resolves a letter when it matched both
- *     the key and the shift (decision 70), so what was typed IS the character,
- *     and a capital can never be recorded as cleared by the bare letter.
- *   - `ms` — `atMs - spawnMs`: how long the letter was in the air. `atMs` is
- *     the letter's own moment (`LetterOutcome`) — the press for a letter that
- *     was shot and its own `landMs` for one that landed — never the tick that
- *     noticed it, so a run played through a stalled frame is timed by the fall
- *     rather than by the stall.
- *   - `timedOut` — set on a letter that reached the shield. It is what the
- *     flag has always meant: the clock ran out before an answer arrived, and
- *     the clock here is the fall. `troubleFacts` weights a timeout above a
- *     wrong answer, which is the right order for a key whose letter a child
- *     never touched at all. It cannot reach `beat-the-clock`, whose gate is a
+ *   - `given` — `null` for a letter that got through, because nothing was
+ *     pressed at it. There is no third case: a shot resolves a letter only
+ *     when it matched the key AND the shift (decision 70), so a capital can
+ *     never be recorded as cleared by the bare letter.
+ *   - `ms` — `atMs - spawnMs`. `atMs` is the letter's own moment
+ *     (`LetterOutcome`) and never the tick that noticed it, so a run played
+ *     through a stalled frame is timed by the fall rather than by the stall.
+ *   - `timedOut` — set on a letter that reached the shield (§8.7,
+ *     decision 49). It cannot reach `beat-the-clock`, whose gate is a
  *     `timeLimitMs` that a typing config never carries.
  */
 export function stormCards(state: StormState): CardResult[] {
@@ -140,14 +105,12 @@ export function stormCards(state: StormState): CardResult[] {
  * What the run was worth, in the shape `summariseRun` scores every run on.
  *
  * `cardXp` is `stormXp` — the same `cardXp(ms, streak)` a flash card is paid
- * at, folded over the hits and floored at zero (§8.6), so a Hailstorm level
- * and a times-table race pay into one profile on one scale. It is not
- * accumulated here: `resolved` already says which letters were shot, when, and
- * on what streak.
+ * at, folded over the hits and floored at zero (§8.6). It is not accumulated
+ * here: `resolved` already says which letters were shot, when, and on what
+ * streak.
  *
- * `bestStreak` is `bestCombo`, which is the run's own streak and the place a
- * wrong key's cost survives into the record book: the combo it broke is a
- * combo the maximum never saw.
+ * `bestStreak` is `bestCombo`, which is where a wrong key's cost survives into
+ * the record book: the combo it broke is a combo the maximum never saw.
  *
  * `maxDeficitMs` is 0 because a storm has no ghost to fall behind. It feeds
  * the `comeback` badge, which also wants `beatGhost`, so nothing reads it.

--- a/src/games/typing/storm/stormSounds.test.ts
+++ b/src/games/typing/storm/stormSounds.test.ts
@@ -8,14 +8,13 @@ import { soundsFor } from "./stormSounds";
 import type { StormLetter, StormState, WaveSpec } from "@/engine/typing/storm";
 
 /**
- * What a storm sounds like (docs/typing.md §8.12).
+ * What a storm sounds like (§8.12).
  *
- * The whole point of `soundsFor` being a diff over two states is that this can
- * be asked without a mixer, a browser or a clock: every run below is built
- * from `fire` and `tick` — the same two functions the game is played through —
- * and the assertion is on the list of names that comes back. Nothing here
- * stubs `sfx`, because nothing here calls it; `playStormSounds` is a `switch`
- * over exactly these names and has no decision left in it.
+ * `soundsFor` being a diff over two states is what lets this be asked without
+ * a mixer, a browser or a clock: every run below is built from `fire` and
+ * `tick` and the assertion is on the list of names that comes back. Nothing
+ * here stubs `sfx`, because nothing here calls it — `playStormSounds` is a
+ * `switch` over exactly these names with no decision left in it.
  */
 
 /** One letter, placed by hand, off the same board the game is played on. */
@@ -33,8 +32,7 @@ const at = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
     fallMs,
     // No queue: a hand-placed letter falls the instant it appears, so every
     // absolute moment below is the one the test wrote down. The beat a real
-    // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it belongs to the
-    // tests of the schedule rather than to every test of what a landing costs.
+    // wave gives a letter (`QUEUE_MS`) belongs to the tests of the schedule.
     dropMs: spawnMs,
     landMs: spawnMs + fallMs,
   };

--- a/src/games/typing/storm/stormSounds.ts
+++ b/src/games/typing/storm/stormSounds.ts
@@ -4,29 +4,17 @@ import { sfx } from "@/services/sound";
 import type { StormState } from "@/engine/typing/storm";
 
 /**
- * What a storm sounds like, as a function of two frames (docs/typing.md §8.12).
+ * What a storm sounds like, as a function of two frames (docs/typing.md §8.12,
+ * decision 66).
  *
- * ── Read off the state, not raised by the code that changed it ───────────────
- * `fire` and `tick` are the only two things that move a run, and neither of
- * them returns an event list — they return the next `StormState`, and every
- * event worth a sound is a difference between that and the one before it: a
- * hit is the combo going up, a miss is the miss count going up, a letter
- * getting through is a shield zone going down, and the end of the run is
- * `ending` arriving. So the sound is a diff, and the diff is a pure function
- * that a unit test can drive a whole wave through in a millisecond.
+ * `fire` and `tick` hand back states rather than event lists, so every sound
+ * is a difference between two of them. That makes it a pure function a unit
+ * test can drive a whole wave through in a millisecond, and it keeps
+ * `storm.ts` a model with no events in it (§8.12).
  *
- * The alternative is the reducer handing back "and here is what happened",
- * which is a second description of the run living beside the run — and the
- * copy is the one that drifts. `storm.ts` is deliberately a model with no
- * events in it (§8.9); this is the view asking it what changed.
- *
- * ── Why it is not derived from what the screen draws ─────────────────────────
- * `useStormClock` publishes to React only when the PICTURE changes, and every
- * event here does change it — so a hook watching rendered states would see all
- * of them today. It would be one React batching decision away from not seeing
- * them, though: two publishes inside one flush render once, and the sound for
- * the first would simply never play. Diffing where the state is produced has
- * no such window, which is why the clock calls this and the field does not.
+ * It is called by the clock and not by the view. A hook watching rendered
+ * states would see every one of these today, but two publishes inside one
+ * React flush render once — and the sound for the first would never play.
  */
 
 /** One thing a run can be heard doing. */
@@ -37,17 +25,14 @@ export type StormSound =
  * Everything that happened between two frames, in the order it should be
  * heard.
  *
- * The shot comes first and the answer to it second, so a hit is a `pew` with a
- * chime on top rather than the other way round — a stroke's own sound must
+ * The shot comes first and the answer to it second: a stroke's own sound must
  * never arrive after the sound of what it did.
  *
- * At most three: a stroke is `shoot` plus exactly one of `hit`/`miss`, and a
+ * At most three — a stroke is `shoot` plus exactly one of `hit`/`miss`, and a
  * tick is at most one shield sound plus the ending. **A tick that resolves
- * several landings is still one shield sound.** A backgrounded tab hands the
- * loop a second's worth of wave at once (`MAX_STEP_MS`), and a dozen crunches
- * fired inside one frame is a burst of noise that says nothing about which
- * zone or how many — the same reasoning that makes several landings on one
- * zone a single tint rather than several (§8.10, decision 42).
+ * several landings is still one shield sound** (§8.12, §8.10): a backgrounded
+ * tab hands the loop a second's worth of wave at once (`MAX_STEP_MS`), and a
+ * dozen crunches at once is noise rather than an answer.
  */
 export function soundsFor(
   before: StormState,
@@ -57,9 +42,9 @@ export function soundsFor(
 
   // Every stroke the gun takes moves exactly one of these two: `fire` either
   // resolves the lowest letter, which is the combo going up, or charges a
-  // miss. So the trigger does not have to be reported separately — a shot is
-  // recoverable from its own outcome, and a `shoot` with no outcome would be
-  // a keydown the rules refused (an ended run, a held modifier, the way out).
+  // miss. So the trigger needs no separate report — and a `shoot` with no
+  // outcome would be a keydown the rules refused (an ended run, a held
+  // modifier, the way out).
   if (after.combo > before.combo) sounds.push("shoot", "hit");
   else if (after.misses > before.misses) sounds.push("shoot", "miss");
 
@@ -129,10 +114,9 @@ export function playStormSounds(before: StormState, after: StormState): void {
         break;
       case "cleared":
         // The race's own fanfare, because surviving a wave is the same good
-        // news as finishing a race and should not have a second tune. What is
-        // different is that a storm can also end badly, which is why the run
-        // screen takes `fanfare` off `useRaceFinish` and the ending is
-        // announced from here instead (`sfx.breach`).
+        // news as finishing a race. What is different is that a storm can also
+        // end badly, which is why the run screen takes `fanfare` off
+        // `useRaceFinish` and the ending is announced from here (§8.12).
         sfx.finish();
         break;
     }

--- a/src/games/typing/storm/useStormClock.test.ts
+++ b/src/games/typing/storm/useStormClock.test.ts
@@ -127,8 +127,7 @@ const letterOf = (ch: string, spawnMs: number, fallMs: number): StormLetter => {
     fallMs,
     // No queue: a hand-placed letter falls the instant it appears, so every
     // absolute moment below is the one the test wrote down. The beat a real
-    // wave gives a letter (`QUEUE_MS`) is `buildWave`'s, and it belongs to the
-    // tests of the schedule rather than to every test of what a landing costs.
+    // wave gives a letter (`QUEUE_MS`) belongs to the tests of the schedule.
     dropMs: spawnMs,
     landMs: spawnMs + fallMs,
   };
@@ -182,12 +181,10 @@ describe("redrawn", () => {
     expect(hit.combo).toBe(1);
     expect(redrawn(hit, fire(hit, "KeyQ"))).toBe(true);
 
-    // And to a miss on an unbroken nothing, which changes no combo at all:
-    // the score fell, and the HUD flashes a `--flare` over it (§8.6). Before
-    // scoring landed this was the case that changed nothing a screen could
-    // see — the one where `fire` hands back a fresh object saying "different"
-    // and means it about the clock. Now the only thing left in that shape is
-    // a miss on a run that has already ended, which `fire` refuses outright.
+    // And to a miss on an unbroken nothing, which changes no combo at all: the
+    // score fell, and the HUD flashes a `--flare` over it (§8.6). The only
+    // frame left that changes nothing a screen can see is a miss on a run that
+    // has already ended, which `fire` refuses outright.
     const cold = run(120);
     const missed = fire(cold, "KeyQ");
     expect(missed.combo, "there was no streak to break").toBe(cold.combo);
@@ -202,13 +199,10 @@ describe("redrawn", () => {
   it("says no when only the target changes mid-air", () => {
     // Two letters at different speeds cross (decision 32), and nothing else
     // moves: nothing is resolved, nothing spawns, and the count of stones on
-    // the field is the same on both sides of it.
-    //
-    // That crossing used to be a redraw, because the board was marked against
-    // the lowest letter and would go on marking against the wrong one. There
-    // is no board now (decision 64) and nothing else on the screen names the
-    // target — a stone carries no target class and the HUD does not print it —
-    // so the picture is identical and React is not asked to draw it again.
+    // the field is the same on both sides of it. Nothing on the screen names
+    // the target — a stone carries no target class, the HUD does not print it,
+    // and there is no board (decision 64) — so the picture is identical and
+    // React is not asked to draw it again.
     const before = tick(startStorm(crossing), 600);
     const after = tick(before, 200);
 

--- a/src/games/typing/storm/useStormClock.ts
+++ b/src/games/typing/storm/useStormClock.ts
@@ -12,111 +12,61 @@ import type { StormState, Wave } from "@/engine/typing/storm";
 
 /**
  * The clock a storm falls on: one `requestAnimationFrame` loop, `tick`, and
- * one number written straight onto each stone (docs/typing.md §8.9).
+ * one number written straight onto each stone (§8.9).
  *
- * ── The loop holds no rules ──────────────────────────────────────────────────
- * All it does per frame is measure the delta, hand it to `tick`, write each
- * drawn stone's `--drop`, play whatever the frame turned out to sound like,
- * and re-render when the picture — rather than the clock — has changed. Which letters exist, where they are, what a landing
- * costs, what a hit is worth, what a wrong key costs and when a run is over
- * were all settled in `engine/typing/storm.ts` before the first frame. That is
- * what makes the shield's rules answerable by a unit test in a millisecond
- * instead of by somebody watching and hoping, so a rule that migrates into
- * this file is a rule that has stopped being testable. The two engine
- * predicates called here — `progressAt` for where a stone is, `isDrawn` for
- * whether it is on the field — are asked, never restated.
+ * The loop holds no rules. Per frame it measures the delta, hands it to
+ * `tick`, writes each drawn stone's `--drop`, plays whatever the frame turned
+ * out to sound like, and re-renders only when the picture — rather than the
+ * clock — has changed. `progressAt` and `isDrawn` are asked, never restated,
+ * and a rule that migrates into this file is a rule that has stopped being
+ * answerable by a unit test in a millisecond.
  *
- * The sound is the same shape of thing. `playStormSounds` is handed the frame
- * before and the frame after and works out what changed between them
- * (`stormSounds.ts`); nothing here decides what a hit or a breach sounds like,
- * and nothing in `storm.ts` has grown an event list to tell it. It is called
- * from beside `tick` and `fire` rather than from a hook watching the rendered
- * state for the same reason the trigger is here: those two are the only things
- * that move a run, and a state that never reaches a render is still a state
- * something happened in.
+ * `playStormSounds` is called beside `tick` and `fire` rather than from a hook
+ * watching the rendered state: those two are the only things that move a run,
+ * and a state that never reaches a render is still a state something happened
+ * in (§8.12).
  *
- * ── The trigger is here because the clock is ─────────────────────────────────
- * A shot is fired at `live.current` — the run as this frame left it — and not
- * at the state React last rendered. The rendered one is the last frame whose
- * PICTURE changed, which can be a long way behind: a wave with nothing
- * spawning, landing or being shot re-renders nothing at all, and this
- * stand-in's letters are 300ms apart. Fire from it and a shot resolves against
- * a target read at a stale clock, on a state with every tick since thrown
- * away. So the keydown listener is armed and cancelled with the loop, in the
- * same effect, and hands `fire` the ref.
+ * **The trigger is here because the clock is.** A shot is fired at
+ * `live.current` — the run as this frame left it — and never at the state
+ * React last rendered, which is the last frame whose PICTURE changed and can
+ * be a long way behind: a wave with nothing spawning, landing or being shot
+ * re-renders nothing at all. Fire from that and a shot resolves against a
+ * target read at a stale clock, on a state with every tick since thrown away.
+ * So the keydown listener is armed and cancelled with the loop, in the same
+ * effect, and hands `fire` the ref.
  *
- * ── DOM, not canvas ──────────────────────────────────────────────────────────
- * Twelve absolutely-positioned `<span>`s moved with a transform, not a canvas,
- * and the reason is specific to this site rather than a preference about
- * rendering. The whole app changes biome by swapping one `[data-world]` block
- * of custom properties in `src/styles/worlds.css`: every colour on this screen
- * — the stone's `--ink-800` fill, its `--accent` rim and glow, the `--chalk`
- * glyph, the `--hairline` it lands on — is inherited from that block, which is
- * why the field sits in the glacier without a single `[data-world="ice"]` rule
- * written under it.
- *
- * A canvas is a hole in exactly that. Nothing inside a bitmap inherits, so
- * every one of those colours would have to be read back out with
- * `getComputedStyle` and re-plumbed by hand into fill and stroke calls — and
- * the moment somebody adds the eighth world, the one screen in the app that
- * is *most* about scenery would be the one screen that silently kept the old
- * one. The cost of the DOM here is a style recalculation on twelve small
- * elements per frame; the cost of the canvas is a biome that stops being one
- * declaration.
- *
- * It is also the pattern the race already uses. `useRaceClock`'s fuse writes
- * `--left` straight to an element and lets `transform: scaleX(var(--left))` in
- * the stylesheet do the moving, for the same two reasons this does: it has to
- * move at full frame rate, and it has to keep moving for a player who asked
- * for reduced motion, so it cannot be a CSS animation.
- *
- * ── `--drop`, not a `translateY` computed here ───────────────────────────────
- * The loop writes the fraction the engine computed and nothing else; the
- * stylesheet multiplies it by the height of the sky (§8.2). That keeps the one
- * property this file has no business holding — geometry — where the lanes and
- * the keycaps already are, off a single `--key` and the sky's own size. A loop
- * that wrote pixels would have to learn how tall the field is, and would be a
- * second opinion about it at every viewport width.
+ * The stones are DOM elements moved by a custom property rather than a
+ * canvas, and the loop writes only the fraction the engine computed — the
+ * geometry is the stylesheet's (§8.9, §8.2).
  */
 
 /**
- * The longest step the storm accepts from one frame, in ms.
+ * The longest step the storm accepts from one frame, in ms (§8.9,
+ * decision 38).
  *
- * `tick` is deliberately honest about any interval it is handed and resolves
- * every landing inside it, however long — so clamping is the clock's call and
- * not the rule's (decision 35). This is that call, and it is what stops a
- * backgrounded tab from fast-forwarding the wave: `requestAnimationFrame` is
- * suspended while a tab is hidden, so coming back is a single frame carrying
- * however many seconds the child was away, and an unclamped one would teleport
- * a dozen letters through the shield before the screen had repainted once.
+ * `tick` resolves every landing inside whatever interval it is handed, however
+ * long, so clamping is the clock's call and not the rule's. Without it a
+ * backgrounded tab — where rAF is suspended, so coming back is a single frame
+ * carrying however many seconds the child was away — would teleport a dozen
+ * letters through the shield before the screen had repainted once.
  *
- * 100ms is six frames at 60Hz and three at 30Hz, so a step longer than this is
- * not a slow frame — it is a gap: a hidden tab, a laptop resumed from sleep, a
- * long stall. Below ten frames a second the storm therefore runs slow rather
- * than skipping, which is the right way round for a game whose whole demand is
- * a reaction time. Above it the wall clock is authoritative, so the storm is
- * not quietly easier on a slower machine.
- *
- * Pausing on `visibilitychange` is the other half of the option `storm.ts`
- * leaves open, and it is not taken: rAF is already suspended for a hidden tab,
- * so the clamp is the thing that has to be right on the way back — and unlike
- * a visibility listener it also covers the stalls that are not tab switches.
+ * No `visibilitychange` listener goes with it: rAF is already suspended for a
+ * hidden tab, and the clamp covers the stalls that are not tab switches as
+ * well (§8.9).
  */
 export const MAX_STEP_MS = 100;
 
 /**
- * The key that leaves a storm (§8.8, decision 55).
+ * The key that leaves a storm (§8.11, decision 55).
  *
- * `Escape` is not on the board — `keyX` says so, which is what keeps it out of
- * the `preventDefault` below — so it is the one key on a keyboard this game
- * has no use for, and therefore the one it can spend on the way out.
+ * The `Quit` button in the HUD cannot be reached by tabbing, because `Tab` is
+ * one of the keys the live gun swallows — so the keyboard needs its own way
+ * out. One listener takes it, and takes it before the trigger: answered
+ * anywhere else on this screen it would be charged as a miss first — ten
+ * points and the streak for reaching for the door (§8.11).
  *
- * It has to be known HERE and not only by the screen that acts on it. Every
- * other keydown while the gun is live is a shot, and a shot that missed costs
- * ten points and the streak: an `Escape` handled by a second listener beside
- * this one would still be fired at as a miss on the way past, so a child
- * reaching for the way out would be charged for reaching for it. One listener,
- * one decision, and the quit is taken before the trigger.
+ * `Escape` is not on the layout (`keyX`), which is what excludes it from the
+ * `preventDefault` below as well.
  */
 export const QUIT_KEY = "Escape";
 
@@ -126,12 +76,8 @@ export const QUIT_KEY = "Escape";
  *
  * Non-finite and negative deltas are floored to zero rather than passed on.
  * The engine floors negatives too, but it cannot defend itself against a
- * `NaN`: `timeMs + NaN` is `NaN` for the rest of the run, no letter ever lands
- * again, and the run has no ending to leave by — an unrecoverable state, from
- * a clock that only has to be wrong once. Two subtractions of real
- * `performance.now()` readings do not produce one, which is exactly why this
- * belongs at the boundary where a reading first becomes a number the rules
- * trust.
+ * `NaN`: one poisons `timeMs` permanently, no letter ever lands again, and a
+ * run with no ending has no way out of it.
  */
 export function stepMs(now: number, last: number | null): number {
   if (last === null) return 0;
@@ -151,47 +97,27 @@ function onField(state: StormState): number {
 /**
  * Would React draw a different picture than the one it is already showing?
  *
- * The loop needs this because neither `tick` nor `fire` can answer it:
- * an empty tick and a missed shot both return a fresh object, so `===` on the
- * state says "changed" sixty times a second and means nothing. What the screen
- * is actually a function of is every field of a run except the clock and the
- * wave — so `resolved`, `shield`, `combo`, `score`, `misses` and `ending`,
- * compared here — plus the one thing the clock alone moves: a letter appearing,
- * which no field of `StormState` records because it is a time crossing.
+ * Neither `tick` nor `fire` can answer it: an empty tick and a missed shot
+ * both return a fresh object, so identity reads as "changed" on every frame
+ * and means nothing. What the screen is a function of is every field of a run
+ * except the clock and the wave, plus a letter appearing — a time crossing
+ * that `StormState` does not record (§8.9).
  *
- * The target used to be compared here as well, because two letters at
- * different speeds can cross mid-air with nothing else happening at all
- * (decision 32) and the board went on marking a child's keys against a letter
- * that was no longer the lowest. There is no board now (decision 64), and
- * nothing else on this screen is a function of which letter is the target —
- * the stones carry no target class and the HUD does not name it — so the
- * crossing changes no picture and is no longer a redraw.
+ * `score` and `misses` move on every miss and `missTintAt` only on the ones
+ * the throttle lets light, so the stamp is covered by the other two today. It
+ * is compared anyway: that cover is a coincidence of two constants in
+ * `storm.ts`, and a `MISS_POINTS` of zero would leave the HUD's `--flare`
+ * flash — which mounts from `missTintAt` — silently undrawn.
  *
- * `score` and `misses` move on **every** miss; `missTintAt` moves only on the
- * ones the throttle lets light, which is `MIN_TINT_GAP_MS` apart at the most
- * (decision 57). So the stamp is covered by the other two today — a frame it
- * moves on is a frame the score moved on as well — and all three are compared
- * anyway, because "the score happens to change whenever the flash does" is a
- * coincidence of two constants in `storm.ts` rather than a property of the
- * screen. A `MISS_POINTS` of zero would leave the HUD's `--flare` flash
- * undrawn, which is a bug nobody would think to look for here — and
- * `missTintAt` is the field the HUD actually mounts that flash from, so it is
- * the one whose absence would be silent.
- *
- * `wave` is the field left out, and deliberately: a run's wave is fixed for
- * its whole life, so it cannot change under a running loop, and a screen
- * handed a different one is a different run rather than a redraw. The effect
- * below is what notices that — it starts the new storm from zero and
- * `setState`s it — so comparing `wave` here would be a second, later answer to
- * a question already settled before the frame.
+ * `wave` is the field left out: the effect below is what notices a different
+ * one, and it starts that storm from zero.
  *
  * `resolved`, `shield` and `ending` are compared by identity on purpose: the
- * reducer rebuilds each of them only when it changes one, so identity is a
- * true answer for them where it is a false one for the state that holds them.
- * `useStormClock.test.ts` pins the whole shape of a `StormState` against that
- * list — an optional field included — so a story that adds one has to come
- * here and decide whether it is drawn, rather than find out from a screen that
- * stopped updating.
+ * reducer rebuilds each only when it changes one, so identity is a true answer
+ * for them where it is a false one for the state that holds them.
+ * `useStormClock.test.ts` pins the whole shape of a `StormState` against this
+ * list — optional fields included — so a story that adds one has to come here
+ * and decide whether it is drawn.
  */
 export function redrawn(drawn: StormState, next: StormState): boolean {
   return (
@@ -211,10 +137,8 @@ export function redrawn(drawn: StormState, next: StormState): boolean {
  *
  * The state handed back is the last frame whose *picture* differed, not the
  * live one — the live one advances every frame and is the loop's own business.
- * Anything that needs the clock to the millisecond is answered from inside the
- * effect against `live.current` — the trigger below is exactly that — rather
- * than from a render, which is the same reason `useRaceClock` keeps its marks
- * in refs.
+ * Anything that needs the clock to the millisecond is answered inside the
+ * effect against `live.current`, which is where the trigger is.
  */
 export function useStormClock(
   wave: Wave,
@@ -225,54 +149,40 @@ export function useStormClock(
     onQuit,
   }: {
     /**
-     * Freeze the run: no frames, no wave time, no gun (§8.8, decision 54).
+     * Freeze the run: no frames, no wave time, no gun (§8.11, decision 54).
      *
-     * This file's cleanup used to say that a quit which kept the field on
-     * screen would be a pause, and that a pause is an input rather than an
-     * omission. This is that input. A storm with the quit sheet up must not go
-     * on falling behind it — a child reading "this won't be saved" while their
-     * shield breaks is being charged for asking the question — and it must not
-     * go on shooting either, because `Space` and `Enter` are the keys the
-     * sheet's own buttons answer to.
-     *
-     * Both come free from tearing the effect down. rAF is what moves wave
-     * time, and `last` starts over at `null` when the loop re-arms, so however
-     * long the sheet is up is worth exactly zero to the storm. Nothing here
-     * holds a paused-at timestamp for a resume to get wrong.
+     * The effect is torn down rather than skipped, so a paused storm neither
+     * falls nor listens — `Space` and `Enter` are the keys the quit sheet's
+     * own buttons answer to. Resuming re-arms with `last` at `null`, a first
+     * frame worth zero, so nothing here holds a paused-at timestamp for a
+     * resume to get wrong.
      */
     paused?: boolean;
     /**
      * Has the child said they are ready? (§8.13, decision 71.)
      *
-     * A wave does not begin the moment the route mounts. It hangs at zero —
-     * no frames, no wave time, and, because `StormField` draws no stones
-     * before it starts, nothing on screen to read yet — until a key says go.
+     * The wave hangs at zero — no frames, no wave time — until a key says go.
      * The screen owns the flag; what is owned here is the key that flips it,
-     * for the same reason `QUIT_KEY` is (below): while the gun is live every
-     * stroke is a shot, so a second window listener sitting beside this one is
-     * a way for one press to be answered twice.
+     * because while the gun is live every stroke is a shot, so a second window
+     * listener beside this one is a way for one press to be answered twice.
      *
-     * It defaults to started, which is what a caller with no ready screen —
-     * a test, a story that renders a wave to look at it — should get.
+     * It defaults to started, which is what a caller with no ready screen — a
+     * test, a story that renders a wave to look at it — should get.
      *
-     * Distinct from `paused`, and the two are not interchangeable. Pausing is
-     * a run held mid-fall with a sheet over it; this is a run that has not
-     * had its first frame. Both stop the clock, and only this one is waiting
-     * for a key to end it.
+     * Distinct from `paused`: pausing is a run held mid-fall with a sheet over
+     * it, this is a run that has not had its first frame. Both stop the clock,
+     * and only this one is waiting for a key to end it.
      */
     started?: boolean;
     /**
      * Start the run: what the first key press does while `started` is false.
-     *
-     * Absent on a screen that begins by itself, in which case nothing here
-     * ever asks for it.
+     * Absent on a screen that begins by itself, which never asks for it.
      */
     onStart?: () => void;
     /**
      * What `QUIT_KEY` does, or nothing where a screen offers no way out.
-     *
-     * Taken here rather than by a listener of the screen's own, because the
-     * gun is here: see `QUIT_KEY`.
+     * Taken here rather than by a listener of the screen's own: see
+     * `QUIT_KEY`.
      */
     onQuit?: () => void;
   } = {},
@@ -288,9 +198,9 @@ export function useStormClock(
   const skyRef = useRef<HTMLDivElement | null>(null);
 
   /**
-   * Through a ref for the reason `StormRun`'s finish is: a fresh closure every
-   * render, and naming it as a dependency would re-arm the loop — and reset
-   * `last` — on every re-render of a screen that re-renders on the picture.
+   * Through a ref because a fresh closure every render, named as a dependency,
+   * would re-arm the loop — and reset `last` — on every re-render of a screen
+   * that re-renders on the picture.
    */
   const quitRef = useRef<(() => void) | undefined>(undefined);
   quitRef.current = onQuit;
@@ -307,10 +217,7 @@ export function useStormClock(
       setState(live.current);
     }
 
-    // Nothing is armed while the sheet is up: no frame is requested, so no
-    // wave time passes, and no listener is bound, so no key fires or is
-    // swallowed. Resuming re-runs this effect from the top with `last` null
-    // again, which is a first frame worth zero (`stepMs`).
+    // Nothing is armed while the sheet is up — see `paused`.
     if (paused) return;
 
     let frame = 0;
@@ -325,76 +232,39 @@ export function useStormClock(
 
     /**
      * The gun (§8.6). Every stroke is a shot at the lowest letter for as long
-     * as the run is live; the rules for what that is worth are `fire`'s, and
-     * none of them are here.
+     * as the run is live; what that is worth is `fire`'s to say, and a stroke
+     * is a code and a shift together because that is what a character is
+     * (§8.4, decision 70).
      *
-     * **A stroke is a code and a shift, and both are handed over**
-     * (decision 70). `event.shiftKey` is the difference between `A` and `a`,
-     * and it is read off the same event as the code rather than tracked across
-     * keydown and keyup: a shift released while the tab was in the background
-     * is a `keyup` this window never saw, and a gun that believed its own
-     * bookkeeping would go on demanding a shift nobody was holding. The
-     * browser's answer is the one on the event, every time.
+     * Four keydowns are not strokes even while the run is live. `QUIT_KEY` is
+     * taken before the trigger, so the way out is not a miss (§8.11). `HELD`
+     * is imported from `useKeyEcho` rather than listed again, so one list
+     * covers both the keys that never flare and the keys that never cost.
+     * `event.repeat` is one stroke and not thirty (§8.6, decision 44). And a
+     * browser chord is the one place the gun and the board part company —
+     * `useKeyEcho` judges the code alone, so cmd+`r` still flares — because a
+     * flare is 120ms and costs nothing, while a shot costs ten points and a
+     * streak.
      *
-     * Four keydowns are not strokes even while the run is live, and each is left
-     * out for a reason the board already agrees with:
+     * The default is taken for the keys the layout carries and only those —
+     * `keyX` answers that without a second list of codes. This screen has no
+     * input to swallow a space that would otherwise scroll the page or a `/`
+     * that opens Firefox's quick-find mid-run, and anything else (F5, F12, the
+     * browser's own) is left alone: a game screen that ate the reload key
+     * would be a screen with no way out.
      *
-     *   - **`QUIT_KEY`** — the way out (§8.11). It is taken before the trigger
-     *     rather than beside it, because a key that reached `fire` would be a
-     *     miss: ten points off and the streak gone for asking to leave.
-     *   - **`HELD`** — shift, ctrl, alt and the cmd keys. It is the very set
-     *     `useKeyEcho` never flares, imported rather than restated: a capital
-     *     is a shift and a letter (§3.3), and a game that charged a child for
-     *     reaching for the far shift would be charging them for doing it
-     *     right.
-     *   - **`event.repeat`** — the OS repeating a key that is being held down,
-     *     which is one stroke and not thirty a second (decision 44). Firing on
-     *     it would let a child spray by leaning on a key, drain a score they
-     *     never pressed for, and flash the HUD's miss at 30Hz, which is the
-     *     strobe §8.10 forbids.
-     *   - A **browser chord** — ctrl or cmd held. Reloading the page is not a
-     *     shot at a hailstone, and cmd+`r` is how a child restarts a storm
-     *     that is going badly. This is the one place the gun and the board
-     *     part company: `useKeyEcho` judges the code alone, so that `r` still
-     *     flares. A flare is 120ms and costs nothing; a shot costs ten points
-     *     and a streak, and the two are not worth the same benefit of the
-     *     doubt.
-     *
-     * The default is taken for the keys the board draws, and only those: this
-     * screen has no input to swallow a space that would otherwise scroll the
-     * page, or a `/` that opens Firefox's quick-find mid-run. `keyX` answers
-     * "is this key on the layout" without a second list of codes — the layout
-     * being the engine's table, since this screen draws no board (decision 64). Anything else
-     * — F5, F12, the browser's own — is left alone, because a game screen that
-     * ate the reload key would be a screen with no way out.
-     *
-     * **Before the run starts, one press does one thing: it starts it**
-     * (`started`). No wave time has passed, no letter is on screen, and `fire`
-     * is not called at all — so the key that says "I'm ready" cannot also be
-     * the first miss of the run. All four guards above hold there too, and two
-     * more keys are left out of "any key":
-     *
-     *   - **`Tab`**, because it is how the way out in the HUD is reached
-     *     without a mouse (`StormHud`). The gun swallows it once the run is
-     *     live, which is exactly why the button is worth being able to reach
-     *     before then — and a game that began the instant a child went looking
-     *     for the exit would be the trap that button exists to prevent.
-     *   - **Anything the layout does not carry** — F5, F12, a media key. Same
-     *     test as the paragraph above, put to a second use: they are not a
-     *     child putting their hands down, and treating them as one would mean
-     *     swallowing the reload key on a screen whose whole state is "nothing
-     *     has happened yet".
+     * Before the run starts one press does one thing: it starts it, and `fire`
+     * is not called, so the key that says "I'm ready" cannot also be the first
+     * miss (§8.13). All four guards hold there, and `Tab` is left out on top
+     * of them because it is how the HUD's way out is reached without a mouse.
      */
     const onKeyDown = (event: KeyboardEvent) => {
-      // The gun dies with the run, and the listener has to know it rather than
-      // leaning on `fire` refusing an ended state. What it would otherwise
-      // still do is swallow the default, and by then the track under the sky
-      // holds the ending's buttons (`StormField`) — three after a breach, two
-      // after a cleared wave, and never none: `Tab`, `Space` and `Enter` are
-      // all keys the LAYOUT carries, so all three of those keys pass the very
-      // test that calls `preventDefault` below. A gun still eating them
-      // after the storm has stopped would leave a child who is not holding a
-      // mouse unable to focus a button, let alone press one.
+      // The gun dies with the run rather than leaning on `fire` refusing an
+      // ended state, because what it would still do is swallow the default —
+      // and by then the track under the sky holds the ending's buttons.
+      // `Tab`, `Space` and `Enter` all pass the test that calls
+      // `preventDefault` below, so a live gun would leave a child who is not
+      // holding a mouse unable to focus one, let alone press it (§8.5).
       if (live.current.ending !== null) return;
       if (event.repeat || event.ctrlKey || event.metaKey) return;
       // Before the trigger, and after the chord guard: the way out is not a
@@ -405,12 +275,9 @@ export function useStormClock(
       }
       if (HELD.has(event.code)) return;
 
-      // Asked once and read by both branches below: is this a key the layout
-      // carries? It is what decides the `preventDefault` (see the block
-      // above), and it is also what "any key" means before the run starts —
-      // F5, F12 and the media keys are not a child saying they are ready, and
-      // a ready screen that swallowed the reload key would be worse than one
-      // that ignored it.
+      // Asked once and read by both branches below: it is what decides the
+      // `preventDefault`, and it is also what "any key" means before the run
+      // starts.
       const onBoard = keyX(event.code) !== null;
 
       // The run has not begun: this press begins it, and is spent doing so.
@@ -431,12 +298,10 @@ export function useStormClock(
     };
 
     const loop = (now: number) => {
-      // Cleared before anything else, so `frame` never holds a handle that has
-      // already been delivered. It is what the cleanup cancels, and on the
-      // frame that ends a run nothing is re-requested below — so this is the
-      // difference between "nothing is pending" and a stale number that only
-      // looks like it was cancelled. (`cancelAnimationFrame` of an unknown
-      // handle is a no-op, which is why the lie would never show.)
+      // Cleared before anything else, so `frame` never holds a handle that
+      // has already been delivered: on the frame that ends a run nothing is
+      // re-requested below, and this is the difference between "nothing is
+      // pending" and a stale number that only looks like it was cancelled.
       frame = 0;
       const next = tick(live.current, stepMs(now, last));
       last = now;
@@ -448,8 +313,7 @@ export function useStormClock(
         for (let i = 0; i < sky.children.length; i++) {
           const stone = sky.children[i] as HTMLElement;
           // Anything in the sky that is not a stone is skipped rather than
-          // assumed away, and there are two of them: the HUD at the top of the
-          // sky and the shield at the bottom. Neither carries `data-stone`, so
+          // assumed away — the HUD and the shield carry no `data-stone`, so
           // `Number(undefined)` is `NaN` and indexes no letter.
           const letter = next.wave.letters[Number(stone.dataset.stone)];
           if (letter)
@@ -461,17 +325,15 @@ export function useStormClock(
 
       publish(next);
 
-      // Death and the last letter both stop the clock here, in the frame that
-      // ended the run, rather than one render later: `tick` on an ended run is
-      // a no-op, so a frame scheduled past the ending would do nothing at all
-      // and still be a frame this screen owes the browser.
+      // The clock stops in the frame that ended the run rather than a render
+      // later: `tick` on an ended run is a no-op, so a frame scheduled past
+      // the ending is one this screen owes the browser for nothing.
       if (next.ending === null) frame = requestAnimationFrame(loop);
     };
 
-    // No frame until a child says go, so a wave that is waiting stays at zero
-    // for as long as it waits — the whole of `started`, since wave time is
-    // what rAF moves and `last` starts over at `null` when the loop is armed.
-    // The listener is bound either way: it is what does the saying.
+    // No frame until a child says go, so a waiting wave stays at zero for as
+    // long as it waits. The listener is bound either way — it is what does the
+    // saying.
     if (started) frame = requestAnimationFrame(loop);
     // Capture, and on the window, exactly as `useKeyEcho` binds: this screen
     // has no focused element for a stroke to land on, and capture runs ahead
@@ -479,19 +341,16 @@ export function useStormClock(
     window.addEventListener("keydown", onKeyDown, true);
 
     // Every way in or out of a run runs this, and there are four: the route
-    // being left, the run ending, the pause above, and the moment a waiting
-    // wave is started. Quitting is the first of them by way of the third — the
-    // sheet pauses the storm, and confirming it navigates — which is why
-    // `paused` is an input to this effect rather than something it could have
-    // been left to infer, and `started` is one for the same reason: a run
-    // begins by re-arming from the top, with a first frame worth zero.
+    // being left, the run ending, a pause, and a waiting wave being started.
+    // Quitting is the first by way of the third — the sheet pauses the storm,
+    // and confirming it navigates.
     //
-    // The listener goes with the frame, for a plainer reason than the loop's:
-    // one left on the window outlives the screen. It would hold this run's
-    // state alive, call `setState` on a component that has gone, and stack a
-    // second copy of itself the next time the route is entered. What it would
-    // not do is move a score — `fire` refuses an ended run — so the leak would
-    // be invisible until the third or fourth storm.
+    // The listener goes with the frame for a plainer reason than the loop's:
+    // one left on the window would hold this run's state alive, `setState` on
+    // a component that has gone, and stack a second copy of itself the next
+    // time the route is entered. What it would not do is move a score — `fire`
+    // refuses an ended run — so the leak stays invisible for two or three
+    // storms.
     return () => {
       cancelAnimationFrame(frame);
       window.removeEventListener("keydown", onKeyDown, true);


### PR DESCRIPTION
Closes #206.

## What changed

`docs/typing.md` is now the single owner of the typing subsystem's rationale. Where a comment restated something the doc already said, the comment is gone. Where a comment held rationale the doc did not have, that rationale moved into the doc first, then the comment came out — nothing was lost, only relocated.

The non-obvious constraints named in the issue stay in the modules that need them, because they are facts about the code and not about the design:

- the `aria-hidden` trade in `StormHud`
- `QUIT_KEY` existing because the gun swallows `Tab`
- the keyed-node flash that avoids a timer
- the `MIN_TINT_GAP_MS` WCAG 2.3.1 throttle

Scope is `src/engine/typing/`, `src/games/typing/` and `src/engine/keyboard.ts`. `lexicon.ts`'s corpus data is untouched; only its header was in scope.

## Before / after (acceptance criterion 5)

| Measure | Before | After |
|---|---|---|
| Comment lines (subtree total) | 8,196 | 6,101 |
| — `src/engine/typing/` | 3,806 | 2,846 |
| — `src/games/typing/` | 4,147 | 3,092 |
| — `src/engine/keyboard.ts` | 243 | 163 |
| Comment-to-code ratio | 0.698 | 0.519 |
| Comment blocks of 20+ lines | 73 | 25 |
| Verbatim 8-word phrases shared with `docs/typing.md` | 3,331 | 618 |

## No behaviour change

Verified by comparing comment-stripped TypeScript token streams across all 68 changed source files: 67 are token-identical before and after. The single difference removes an empty JSX expression container that wrapped only a comment, which renders nothing either way.

No test cases were removed.

## Validation

`npm run type-check`, `npm run lint`, `npm run test:unit` (2,231 passing), `npm run build`, `npm run format:check` and the browser smoke test all pass.
