### PR TITLE
Read the rest of the tree against the standard, and cut what docs/ already owns

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,10 +11,10 @@ import prettier from "eslint-config-prettier/flat";
 /**
  * Architecture enforced by lint, not by convention.
  *
- * Ported from monilibrium_2's `apps/web/eslint.config.mjs`, whose own rule
- * comments record why: the boundary that was merely a convention drifted from
- * 30 to 37 violating files while the lint-enforced one held perfectly. So every
- * boundary that matters here is a rule with a message naming the alternative.
+ * A boundary that is only a convention drifts. Measured on a codebase carrying
+ * both kinds side by side, the convention went from 30 violating files to 37
+ * while the lint-enforced one held at zero. So every boundary that matters here
+ * is a rule, with a message naming the alternative.
  *
  * The layers, and what plays each MVC role in this codebase:
  *
@@ -32,9 +32,9 @@ import prettier from "eslint-config-prettier/flat";
  * ── The flat-config clobbering hazard ────────────────────────────────────────
  * Flat config REPLACES same-rule options across matching blocks rather than
  * merging them. Two blocks naming `no-restricted-imports` over overlapping file
- * sets means the later one silently wins and the earlier one is dead. This bit
- * monilibrium (its MVC view boundary was inert for a while), so the rule ids
- * here are allocated deliberately:
+ * sets means the later one silently wins and the earlier one is dead. A whole
+ * view boundary can sit inert that way without anything failing, so the rule
+ * ids here are allocated deliberately:
  *
  *   `@typescript-eslint/no-restricted-imports`  layer boundaries (A/B/C/E),
  *                                               whose file sets are DISJOINT —
@@ -62,27 +62,19 @@ import prettier from "eslint-config-prettier/flat";
 // describes.
 const MAX_COMPONENT_LINES = 300;
 
-// Storage is an implementation detail of the service layer — the direct
-// analogue of monilibrium's "Prisma client only in services/" boundary. A React
-// component that reaches for `localStorage` bypasses the profile/session
-// schema, the quota handling, and `navigator.storage.persist()`.
+// Storage is an implementation detail of the service layer. A React component
+// that reaches for `localStorage` bypasses the profile/session schema, the
+// quota handling, and `navigator.storage.persist()`.
 const STORAGE_BAN =
   "Storage is owned by src/services/storage/. Don't touch localStorage, sessionStorage or indexedDB directly — call a service (e.g. profiles.load(), sessions.record()). Storage shape, migrations and quota handling live in one place on purpose.";
 
 const FRAMEWORK_BAN =
   "This layer must stay framework-agnostic so it can be reused by a build-time script, a test, or a future native app. Don't import React or Astro here — return plain data and let the view render it.";
 
-// The typing corpus, banned from the one layer every island imports. This is
-// the only boundary here that was drawn by a measurement rather than by a
-// principle, so the measurement is in the message: a reader who deletes the
-// rule should have to argue with the number.
-//
-// The requirement is REACHABILITY, not a direct import ("this file must never
-// become reachable from decks/index.ts", docs/typing.md §5.3), so the message
-// names the one hop that would otherwise slip through: `engine/typing/
-// lessons.ts` is deliberately importable from the deck layer, and a corpus
-// import inside it lands in the shared chunk exactly as a corpus import inside
-// `decks/typing.ts` would.
+// The typing corpus, banned from the one layer every island imports
+// (docs/typing.md §5.3, which owns the reasoning). The only boundary here drawn
+// by a measurement rather than by a principle, so the measurement is in the
+// message: a reader who deletes the rule should have to argue with the number.
 const CORPUS_BAN =
   "The typing corpus and its generator must not be REACHABLE from src/engine/decks/. decks/index.ts is the front door for every island — flash cards, spelling, the record book, the print shop — and a module in its import graph ships to all of them: an import of the passage library from decks/typing.ts took the shared chunk from 46 KB to 222 KB once already, which is why thirty-three verses are written out by hand in that file today. Reachability is transitive, so the ban covers the whole engine and not decks/ alone — engine/typing/lessons.ts is deliberately importable from the deck layer, so a corpus import there would ship to every island one hop away, with nothing in decks/ looking wrong. Only lexicon.ts, generate.ts and their tests may read the corpus. Everywhere else: generate the words inside the typing island and hand them over in TypingConfig.words — the deck layer builds cards from config.words and never has to know where they came from (docs/typing.md §5.3, decision 7).";
 
@@ -311,8 +303,8 @@ export default defineConfig([
   // ── A · MODEL boundary ──────────────────────────────────────────────────────
   // src/engine/ is pure logic over plain data: build a deck, score a run, rank
   // trouble facts. Keeping React out of it is what lets the same functions run
-  // in a vitest unit test and in a build-time script that pre-renders a
-  // worksheet PDF. It may not import services either — the dependency direction
+  // in a vitest unit test and in the build-time pass that prerenders a
+  // worksheet. It may not import services either — the dependency direction
   // is services → engine, never back.
   {
     files: ["src/engine/**/*.{ts,tsx}"],
@@ -458,9 +450,8 @@ export default defineConfig([
   // violation usually means, and `local/no-cross-game-imports` for why it is a
   // local rule rather than another `no-restricted-imports` block.
   //
-  // No allowlist. The two imports that broke this — typing reading the flash
-  // cards' `SplitsTable` — were fixed by moving the table into the kit first
-  // (DEBT09), so the rule goes in green with nothing to grandfather.
+  // No allowlist and nothing grandfathered: a game that needs another game's
+  // code needs it in `src/games/race/` instead.
   {
     files: ["src/games/**/*.{ts,tsx}"],
     rules: { "local/no-cross-game-imports": "error" },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,8 +13,8 @@ import prettier from "eslint-config-prettier/flat";
  *
  * A boundary that is only a convention drifts. Measured on a codebase carrying
  * both kinds side by side, the convention went from 30 violating files to 37
- * while the lint-enforced one held at zero. So every boundary that matters here
- * is a rule, with a message naming the alternative.
+ * while the lint-enforced one held. So every boundary that matters here is a
+ * rule, with a message naming the alternative.
  *
  * The layers, and what plays each MVC role in this codebase:
  *

--- a/src/components/ToastRail.tsx
+++ b/src/components/ToastRail.tsx
@@ -2,8 +2,7 @@ import { useHub } from "@/components/state/HubContext";
 
 /**
  * Lives outside `components/ui/` deliberately: it reads the hub, so it is a
- * connected component, not a primitive. The kit boundary caught this during
- * the port — the original `ui.tsx` mixed the two.
+ * connected component, not a primitive.
  */
 export function ToastRail() {
   const { toasts } = useHub();

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -124,7 +124,7 @@ export default function Progress() {
   const isTypingMode = mode.startsWith(TYPING_MODE_PREFIX);
   // Both render as a list of words rather than a 12×12 grid.
   const isWords = mode.startsWith(WORD_MODE_PREFIX) || isTypingMode;
-  /** Null for a typing level, and for a list a parent has since deleted. */
+  /** Undefined for a typing level, and for a list a parent has since deleted. */
   const shippedList = isTypingMode
     ? undefined
     : WORD_LISTS_BY_ID.get(listIdOf(mode));

--- a/src/components/screens/progress/FactMap.tsx
+++ b/src/components/screens/progress/FactMap.tsx
@@ -10,9 +10,8 @@ const AXIS = Array.from({ length: 12 }, (_, i) => i + 1);
  *
  * A real <table> with header cells on both axes: a grid of 144 divs would be
  * unreadable to a screen reader, and each cell already carries its own
- * spoken-only summary. The deck switcher sits in the heading rather than
- * above the map because it changes what the map *is*, not how it's filtered —
- * pick a word list and `WordMap` renders in this one's place.
+ * spoken-only summary. Pick a word list in the heading's switcher and
+ * `WordMap` renders in this one's place (`DeckSwitch`).
  */
 export function FactMap({
   spec,

--- a/src/components/screens/progress/RecordBook.tsx
+++ b/src/components/screens/progress/RecordBook.tsx
@@ -75,7 +75,10 @@ export function RecordBook({
   );
 }
 
-/** The last 40 runs, newest first. Older ones live in the record book above. */
+/**
+ * The last 40 runs, newest first. Capped because beyond that it is a scroll
+ * nobody reads; anything older survives only as a best in the table above.
+ */
 export function RunList({ sessions }: { sessions: Session[] }) {
   return (
     <section className="panel anim-rise">

--- a/src/components/screens/progress/TroubleSpots.tsx
+++ b/src/components/screens/progress/TroubleSpots.tsx
@@ -40,8 +40,8 @@ export function TroubleSpots({
    */
   elsewhere?: WorldInfo;
   /**
-   * The same facts as a worksheet, or null where this build has no sheet for
-   * them — a typing passage is not a page of problems.
+   * The same facts as a worksheet, or null where this build has no sheet
+   * family for them. `Progress` builds it.
    */
   printable: SheetConfig | null;
 }) {

--- a/src/components/site/SiteFooter.astro
+++ b/src/components/site/SiteFooter.astro
@@ -24,14 +24,10 @@ const guides = WORLDS.flatMap((w) => (w.guide ? [w.guide] : []));
  * The signature under the fine print — a reference, and deliberately not a
  * verse (docs/printables.md §12).
  *
- * This is the author's own voice already ("Made for four kids, then shared"),
- * which is the whole reason it is the one piece of chrome a reference belongs
- * in: it reads as a signature rather than a banner, and it is on every page
- * without being on any one page's pitch. Nothing is quoted, so nothing needs
- * crediting — but the reference is still read out of the passage library
- * rather than typed here, so the footer cannot name a passage the site does
- * not actually hold. `passage()` answers `undefined` rather than throwing, and
- * a footer that lost its signature is a footer, so this renders nothing.
+ * Read out of the passage library rather than typed here, so the footer cannot
+ * name a passage the site does not hold. `passage()` answers `undefined`
+ * rather than throwing, and a footer that lost its signature is still a
+ * footer, so a retired id renders nothing.
  */
 const signature = passage("the-day-of-small-things")?.title;
 ---

--- a/src/components/site/SiteHeader.astro
+++ b/src/components/site/SiteHeader.astro
@@ -62,13 +62,11 @@ const { world } = Astro.props;
 
     {
       /*
-       * Play goes to the map, not into a game.
-       *
-       * It used to open /flash-cards, which made the times tables the default
-       * meaning of "play" on every page of the site — including the spelling
-       * one. The named links to its left already go straight into a world for
-       * anyone who knows which they want; this is the button for everyone
-       * else, so it should ask rather than choose.
+       * Play goes to the map, not into a game. The named links to its left
+       * already go straight into a world for anyone who knows which they
+       * want; this is the button for everyone else, so it asks rather than
+       * choosing — and sending it into one game would make that game the
+       * default meaning of "play" on every page, the spelling one included.
        *
        * Absolute, because this bar is on every page. From the home page it
        * scrolls (the `data-scroll` script lives there); from anywhere else

--- a/src/components/site/ads.ts
+++ b/src/components/site/ads.ts
@@ -11,32 +11,28 @@
  *     relies on. Personalised ads here would need verifiable parental
  *     consent, which a free static site cannot obtain.
  *   - Google's own AdSense policy for child-directed content says the same
- *     thing from the other side. The FTC's $170M action against YouTube in
- *     2019 was precisely this configuration.
+ *     thing from the other side.
  *
  * So: non-personalised only, everywhere, unconditionally. There is no toggle
  * and no per-page opt-out, because a page that got it wrong would be a
  * compliance incident rather than a bug.
  *
  * ── Two things here are NOT sufficient on their own ─────────────────────────
- * 1. The age signal in Base.astro is NOT PROVEN. `tagForChildDirectedTreatment`
- *    used to be set there and did nothing: the live ad request was captured
- *    from production and carried `npa=1` but no `tfcd` and no
- *    `tag_for_child_directed_treatment` at all. It is a GPT/AdMob mechanism
- *    that AdSense's loader ignores, so it has been replaced with the variable
- *    AdSense actually documents — `google_tag_for_age_treatment = 1`, where 1
- *    is child-restricted (support.google.com/adsense/answer/3248194).
+ * 1. The age signal in Base.astro is NOT PROVEN. It is
+ *    `google_tag_for_age_treatment = 1`, where 1 is child-restricted, which is
+ *    the variable AdSense documents (support.google.com/adsense/answer/3248194)
+ *    — `tagForChildDirectedTreatment` is a GPT/AdMob mechanism the AdSense
+ *    loader ignores, so do not reach for it.
  *
- *    That replacement is UNVERIFIED. Nothing has served yet, so no ad request
- *    exists to check it against, and the last thing believed about this line
- *    turned out to be false. Capture a live request the first time an ad
- *    fills and confirm `tfat=1` is on it. Until then assume it does nothing.
+ *    UNVERIFIED because nothing has served yet, so there is no ad request to
+ *    check it against. Capture a live request the first time an ad fills and
+ *    confirm `tfat=1` is on it. Until then assume it does nothing.
  *
  *    Which means: the site-level child-directed declaration in SEARCH CONSOLE
  *    (search.google.com/search-console/coppa — not the AdSense UI) is the only
  *    thing known to set this signal, and it is where Google's own COPPA
- *    guidance points publishers. `requestNonPersonalizedAds`, by contrast, was
- *    confirmed working: `npa=1` was present on every request.
+ *    guidance points publishers. `requestNonPersonalizedAds` is confirmed
+ *    working — `npa=1` is on every request.
  * 2. Auto ads MUST be off for this site in the AdSense account. With them on,
  *    Google injects placements wherever its model likes — including on top of
  *    a race, next to the answer keypad, regardless of anything written here.
@@ -49,17 +45,14 @@ export const AD_CLIENT = "ca-pub-2742485876369367";
 /**
  * Ad unit ids, created in the AdSense account.
  *
- * Empty until they exist. A slot with no id renders nothing at all rather than
- * an `<ins>` Google will never fill, so the site is never shipping dead markup
- * — and the reserved space is still reserved, so turning a slot on later
- * cannot shift a layout that people have already learned.
+ * Empty until they exist in the account. `adSlotId` answers null for an empty
+ * one, so nothing renders — see `AdSlot.tsx` for what happens to the space.
  */
 export const AD_SLOTS = {
   /**
-   * In-article, between sections of a content page. Placed by hand at points
-   * where a reader has just finished something rather than mid-thought, and
-   * reused at more than one such point on a long page — this is where the
-   * viewable impressions are, because the reader is still on screen.
+   * In-article, between sections of a content page. Placed by hand where a
+   * reader has just finished a section rather than mid-thought, and reusable
+   * at more than one such point on a long page.
    */
   article: "",
   /** Content pages: after the article, above the footer. */
@@ -71,25 +64,20 @@ export const AD_SLOTS = {
 export type AdSlotName = keyof typeof AD_SLOTS;
 
 /**
- * Should the loader ship at all?
- *
- * TRUE. Turning it off is a one-line kill switch for every ad request the site
- * makes — reach for it if the account is suspended, if a placement turns out
- * to be wrong on a child's screen, or if anything about Google's behaviour
- * stops matching what /privacy says.
+ * A one-line kill switch for every ad request the site makes — reach for it if
+ * the account is suspended, if a placement turns out to be wrong on a child's
+ * screen, or if anything about Google's behaviour stops matching /privacy.
  *
  * It moves TOGETHER with the advertising sections of /privacy, in both
  * directions. That page has to describe what the site actually does, and a
  * policy claiming ad requests that aren't happening is as wrong as one hiding
- * requests that are. It was false for exactly that reason once already: the
- * site was removed from AdSense while the loader kept calling
- * pagead2.googlesyndication.com on every page load, from a child's device,
- * getting `unfilled` back — all of the privacy cost, none of the revenue.
+ * requests that are — a loader still calling pagead2.googlesyndication.com
+ * from a child's device for an account that has been removed is all of the
+ * privacy cost and none of the revenue.
  *
- * Note what true does NOT mean. Verification and review never needed it:
- * AdSense accepts ad code, ads.txt, OR a meta tag, and Base.astro emits the
- * meta tag unconditionally while public/ads.txt names the same publisher. So
- * this being false was never what stood between the site and approval.
+ * AdSense verification does not depend on this: it accepts ad code, `ads.txt`
+ * OR a meta tag, and `Base.astro` emits the meta tag unconditionally while
+ * `public/ads.txt` names the same publisher.
  */
 const ADS_LIVE = true;
 
@@ -106,19 +94,12 @@ export const ADS_ENABLED =
   import.meta.env.PUBLIC_ADS_PREVIEW === "1";
 
 /**
- * Looking at the layout rather than at real ads.
- *
- * Before the units exist in the AdSense account there is nothing to render,
- * and a reserved box with nothing in it is invisible — which makes a preview
- * build useless for the one question worth asking early: does the band change
- * how the game feels, and does it crowd the race on a small screen?
- *
- * So in preview only, an empty slot draws itself at exactly the reserved size.
- * Never in production: there the same absence is silence, because a visible
- * frame with no advert in it reads as broken rather than empty.
+ * Looking at the layout rather than at real ads: in preview an empty slot draws
+ * itself at the reserved size, so the band can be judged before any unit
+ * exists. Never in production, where a visible frame with no advert in it
+ * reads as broken rather than empty.
  */
 export const ADS_PREVIEW = import.meta.env.PUBLIC_ADS_PREVIEW === "1";
 
-/** A slot is live only when ads are on AND its unit exists. */
 export const adSlotId = (name: AdSlotName): string | null =>
   ADS_ENABLED && AD_SLOTS[name] ? AD_SLOTS[name] : null;

--- a/src/components/site/ads.ts
+++ b/src/components/site/ads.ts
@@ -46,7 +46,8 @@ export const AD_CLIENT = "ca-pub-2742485876369367";
  * Ad unit ids, created in the AdSense account.
  *
  * Empty until they exist in the account. `adSlotId` answers null for an empty
- * one, so nothing renders — see `AdSlot.tsx` for what happens to the space.
+ * one, so no `<ins>` is emitted — the reserved space stays reserved; see
+ * `AdSlot.tsx`.
  */
 export const AD_SLOTS = {
   /**

--- a/src/components/state/SubjectContext.tsx
+++ b/src/components/state/SubjectContext.tsx
@@ -24,7 +24,7 @@ import type { World } from "@/engine/worlds";
  * an origin, not a route, so `/spelling/play` and `/flash-cards` share one
  * IndexedDB and one profile list — which is the whole reason a child's level,
  * badges and record book follow them between subjects. Splitting by subdomain
- * would have partitioned that; splitting by path costs nothing. See CLAUDE.md.
+ * would have partitioned that; splitting by path costs nothing.
  */
 export type SubjectId = "numbers" | "words";
 
@@ -32,8 +32,7 @@ export type Subject = {
   id: SubjectId;
   /**
    * The world this app is played in — and, because a deck names its own world,
-   * the test for which saved runs belong here. One rule, no mode prefixes
-   * duplicated outside the deck front door.
+   * the test for which saved runs belong here.
    */
   world: World;
   /** How the hub introduces itself. */
@@ -66,7 +65,7 @@ export const SUBJECTS: Record<SubjectId, Subject> = {
       "Hear a word and spell it from memory, against the clock — or against a ghost of your best run, or one of your siblings'.",
     // Borrows the age tuning the maths presets already do: how long a race is,
     // whether it's typed or tapped, and how tight the card clock starts. Only
-    // what's ON the cards is different, which is the point of the split.
+    // what's ON the cards is different.
     startingConfig: (age) => {
       const { cardCount, inputMode, timeLimitMs } = presetForAge(age).config;
       return {
@@ -80,7 +79,6 @@ export const SUBJECTS: Record<SubjectId, Subject> = {
   },
 };
 
-/** Whether a saved run belongs to this app. */
 export const ownsMode = (subject: Subject, mode: string) =>
   deckSpec(mode).world === subject.world;
 

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -7,14 +7,13 @@ import type { InputHTMLAttributes } from "react";
  * that acts the moment it moves — sound on, sound off — and there is usually
  * one of them. A checkbox is a statement about a thing being built: "include
  * negatives", "print an answer key". Several sit in one panel, several are on
- * at once, and none of them do anything until the thing is rebuilt. Reaching
- * for the wrong one tells a parent the wrong story about what just happened.
+ * at once, and none of them do anything until the thing is rebuilt.
  *
  * The native box is kept, not redrawn. `accent-color` recolours it to the
  * world's `--go` while leaving the platform's own checkmark, its
  * `:focus-visible` ring (base.css draws that for every real control) and its
  * behaviour under forced colours intact. A hand-drawn box has to reproduce all
- * three, and the tick is the one glyph a custom box always draws worse.
+ * three.
  *
  * The label is structural — the `<input>` sits inside the `<label>`, as in
  * `Field` — so there is no `htmlFor`/`id` pair to keep in step and the hit

--- a/src/components/ui/NumberStepper.tsx
+++ b/src/components/ui/NumberStepper.tsx
@@ -23,8 +23,7 @@ import { Button } from "./Button";
  * takes the caret with it. So a keystroke only reaches the caller once it is
  * already the value a commit would produce; anything else lives in a draft
  * until blur or Enter, where `commitValue` clamps it and snaps it to the step
- * grid. `ClockPicker` does this by hand for the race clock — this is that
- * behaviour, moved somewhere it can be reused.
+ * grid.
  *
  * **At a bound the button is `aria-disabled`, not `disabled`.** The real
  * attribute would be the tidier markup and the worse control: the browser
@@ -65,8 +64,7 @@ export function NumberStepper({
   decreaseLabel = `Decrease ${label.toLowerCase()}`,
   increaseLabel = `Increase ${label.toLowerCase()}`,
 }: NumberStepperProps) {
-  // `null` means "showing the committed value". Any string means the field is
-  // mid-edit and what the person typed wins over what the caller holds.
+  // `null` means "showing the committed value"; any string is a live edit.
   const [draft, setDraft] = useState<string | null>(null);
 
   // `value` and not the draft, which is correct because blur fires — and React
@@ -75,8 +73,6 @@ export function NumberStepper({
   const nudge = (delta: number) => {
     const next = Math.min(max, Math.max(min, value + delta));
     setDraft(null);
-    // A press at the bound reaches here because the button stayed focusable;
-    // there is simply nowhere left to go, so the caller is not told anything.
     if (next !== value) onChange(next);
   };
 
@@ -113,9 +109,8 @@ export function NumberStepper({
           onChange={(event) => {
             const text = event.target.value;
             setDraft(text);
-            // Only when what is typed already *is* what a commit would
-            // produce. A half-typed "1" below the minimum, or an off-grid
-            // "12.5", waits for blur instead of fighting the caret.
+            // A half-typed "1" below the minimum, or an off-grid "12.5",
+            // waits for blur instead of fighting the caret.
             const parsed = Number(text);
             if (
               text.trim() !== "" &&
@@ -150,9 +145,9 @@ export function NumberStepper({
 }
 
 /**
- * What a draft typed into the box should become — the only real decision in
- * this module, and exported so it can be tested as a function rather than as
- * an interaction the project has no DOM to simulate.
+ * What a draft typed into the box should become. Exported so it can be tested
+ * as a function rather than as an interaction the project has no DOM to
+ * simulate.
  *
  * Returns `current` for anything that isn't a number to keep, so an empty box
  * or a typo falls back to the value already there rather than to zero, which
@@ -169,8 +164,7 @@ export function commitValue(
   if (draft.trim() === "" || !Number.isFinite(parsed)) return current;
   const clamp = (n: number) => Math.min(max, Math.max(min, n));
   // Snapped to the grid `step` describes, measured from `min` and not from
-  // zero: a stepper from 5 to 60 by 5 offers 5, 10, 15 — never 23, and never
-  // the 12.5 that "a small whole number" promised it would not hand back.
-  // Clamped a second time because rounding up from the last cell can overshoot.
+  // zero: a stepper from 5 to 60 by 5 offers 5, 10, 15 and never 23. Clamped a
+  // second time because rounding up from the last cell can overshoot.
   return clamp(min + Math.round((clamp(parsed) - min) / step) * step);
 }

--- a/src/components/ui/Range.tsx
+++ b/src/components/ui/Range.tsx
@@ -21,9 +21,10 @@ import type { InputHTMLAttributes } from "react";
  *
  * A native `<input type="range">`, so the platform's own keyboard handling and
  * the focus ring base.css draws are kept. `label` is required, because a
- * slider with no name announces as a number belonging to nothing — and it and
- * `aria-valuetext` are omitted from the passthrough so a caller cannot spread
- * them back over the top.
+ * slider with no name announces as a number belonging to nothing — and the
+ * name attributes (`aria-label`, `aria-labelledby`) and `aria-valuetext` are
+ * omitted from the passthrough, because all three are computed from `label`
+ * and `format` and a caller must not be able to spread them back over the top.
  */
 export interface RangeProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,

--- a/src/components/ui/Range.tsx
+++ b/src/components/ui/Range.tsx
@@ -19,16 +19,11 @@ import type { InputHTMLAttributes } from "react";
  * is nothing to add, the attribute is left off, and the platform's own
  * announcement of the raw number stands.
  *
- * Everything the platform gives a range is kept: arrow keys by `step`,
- * Page Up/Down by a larger stride, Home and End to the ends, and the focus
- * ring base.css draws for every real control. `label` is required, because a
- * slider with no name announces as a number belonging to nothing.
- */
-/**
- * The name and the spoken value are computed from `label` and `format`, so
- * they are taken out of the passthrough rather than left where a caller could
- * spread them back over the top of the two things this doc block calls
- * non-negotiable.
+ * A native `<input type="range">`, so the platform's own keyboard handling and
+ * the focus ring base.css draws are kept. `label` is required, because a
+ * slider with no name announces as a number belonging to nothing — and it and
+ * `aria-valuetext` are omitted from the passthrough so a caller cannot spread
+ * them back over the top.
  */
 export interface RangeProps extends Omit<
   InputHTMLAttributes<HTMLInputElement>,

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -8,9 +8,9 @@ import { useId } from "react";
  * at the one they want rather than opening a list, reading it and remembering
  * what was in it. `Select` exists for the long lists where that stops working.
  *
- * **Radios, not buttons.** The screens that grew this pattern each built it
- * from `<Button pressed>`, which announces as a row of unrelated toggles and
- * tabs through one stop per option. Real radios sharing a `name` are announced
+ * **Radios, not buttons.** A row of `<Button pressed>` announces as unrelated
+ * toggles and tabs through one stop per option. Real radios sharing a `name`
+ * are announced
  * as "one of four", move with the arrow keys and skip to the chosen one with a
  * single Tab — none of which is worth hand-rolling when the platform ships it.
  * The inputs are visually hidden (not `display: none`, which would remove them
@@ -49,7 +49,6 @@ export type SegmentedOption<T extends string> = {
 };
 
 export interface SegmentedControlProps<T extends string> {
-  /** Names the group. Required — see the doc block. */
   label: string;
   value: T;
   onChange: (value: T) => void;
@@ -107,9 +106,7 @@ export function SegmentedControl<T extends string>({
             {option.symbol ? (
               <span aria-hidden="true">{option.symbol}</span>
             ) : null}
-            {/* `.segmented__word` hides under 560px, so it is worn only when a
-                symbol is there to take the pill's place. A row of words that
-                all vanished at once would be a row of empty pills. */}
+            {/* Worn only when a symbol is there to take the pill's place. */}
             <span className={option.symbol ? "segmented__word" : undefined}>
               {option.label}
             </span>

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -10,9 +10,9 @@ import { useId } from "react";
  *
  * **Radios, not buttons.** A row of `<Button pressed>` announces as unrelated
  * toggles and tabs through one stop per option. Real radios sharing a `name`
- * are announced
- * as "one of four", move with the arrow keys and skip to the chosen one with a
- * single Tab — none of which is worth hand-rolling when the platform ships it.
+ * are announced as "one of four", move with the arrow keys and skip to the
+ * chosen one with a single Tab — none of which is worth hand-rolling when the
+ * platform ships it.
  * The inputs are visually hidden (not `display: none`, which would remove them
  * from the tab order); the `<label>` around each one is the pill, and it wears
  * the focus ring on their behalf.

--- a/src/components/ui/kit.tsx
+++ b/src/components/ui/kit.tsx
@@ -201,10 +201,10 @@ export function usePrefersReducedMotion() {
 /**
  * The dimmed backdrop behind a modal, as a real control.
  *
- * It was a <div onClick> in the original, which is mouse-only: no focus, no
- * Enter/Space, invisible to a screen reader. Rendering a button gives all of
- * that for free — and since the kit is the one place native controls belong,
- * the feature code loses a raw <button> too.
+ * A <div onClick> is mouse-only: no focus, no Enter/Space, invisible to a
+ * screen reader. A real button gives all three for free — and since the kit is
+ * the one place native controls belong, the feature code loses a raw <button>
+ * too.
  */
 export function Scrim({
   onClose,

--- a/src/engine/combo.ts
+++ b/src/engine/combo.ts
@@ -3,9 +3,9 @@
  *
  * A leaf module rather than two more exports on `progress.ts`, because
  * `engine/typing/storm.ts` needs the curve and may not import that file
- * (docs/typing.md §8.6). The alternative was a second `1 + min(streak, 10) / 10`
- * written in the storm, and a second copy of a curve is how a race and a
- * shooter end up paying out on scales that only look the same.
+ * (docs/typing.md §8.6). The alternative was writing the curve out a second
+ * time in the storm, and a second copy is how a race and a shooter end up
+ * paying out on scales that only look the same.
  */
 
 /**

--- a/src/engine/combo.ts
+++ b/src/engine/combo.ts
@@ -1,33 +1,29 @@
 /**
  * What a streak is worth: one multiplier, for every game that keeps one.
  *
- * It is its own module rather than a pair of exports in `progress.ts` because
- * of who needs it now. `cardXp` folds this curve into the XP for a card, the
- * race draws it on the combo badge, and Hailstorm scales a hit by it and
- * prints it in the HUD (docs/typing.md §8.6) — and `engine/typing/storm.ts`
- * may not import `progress.ts`. That file is reachable from
- * `engine/decks/index.ts`, the front door every island on the site downloads,
- * and `progress.ts` pulls the deck registry, the hundred lessons and the
- * ladder in behind it (§5.3, decision 7); the hundred lessons name a
- * `WaveSpec` on each storm row, which would close the import into a cycle.
- *
- * The alternative was a second `1 + min(streak, 10) / 10` written in the storm,
- * and a second copy of a curve is how a race and a shooter end up paying out
- * on scales that only look the same. A leaf module both can import is three
- * lines and cannot drift.
+ * A leaf module rather than two more exports on `progress.ts`, because
+ * `engine/typing/storm.ts` needs the curve and may not import that file
+ * (docs/typing.md §8.6). The alternative was a second `1 + min(streak, 10) / 10`
+ * written in the storm, and a second copy of a curve is how a race and a
+ * shooter end up paying out on scales that only look the same.
  */
 
 /**
  * How many hits a combo counts before it stops growing.
  *
- * Ten, so the ceiling is ×2 — worth chasing, and reachable inside a run that
- * a five-year-old will finish. Uncapped it would make the last card of a long
- * race worth more than the first twenty put together, which stops rewarding
- * accuracy and starts rewarding length.
+ * Ten, so the ceiling is reachable inside a run a five-year-old will finish.
+ * Uncapped, the last card of a long race would be worth more than the first
+ * twenty put together, which stops rewarding accuracy and starts rewarding
+ * length.
  */
 const MAX_COMBO_STEPS = 10;
 
-/** What the next answer is worth, given the streak it lands on: ×1 to ×2. */
+/**
+ * What the next answer is worth, given the streak it lands on: ×1 to ×2.
+ *
+ * The ceiling is the cap divided by itself, so retuning `MAX_COMBO_STEPS`
+ * changes how fast a child climbs and never what they climb to.
+ */
 export function comboMultiplier(streak: number) {
-  return 1 + Math.min(streak, MAX_COMBO_STEPS) / 10;
+  return 1 + Math.min(streak, MAX_COMBO_STEPS) / MAX_COMBO_STEPS;
 }

--- a/src/engine/decks/biblelists.ts
+++ b/src/engine/decks/biblelists.ts
@@ -51,11 +51,11 @@
  * are where a memory list actually gets used — print every one of the sixty-six
  * as it is written here.
  *
- * One of those seven had to learn what a space is to do that. Word shapes draws
- * a box per character, and a box is a thing a child writes a letter into — so
- * `1 Samuel` used to ask for a letter in the box where the space is. A space is
- * a `gap` in `words/shapes.ts` now: the slot is still reserved, so the boxes
- * either side of it stay where they were, and nothing is drawn in it.
+ * One of those seven needs to know what a space is to do that. Word shapes
+ * draws a box per character, and a box is a thing a child writes a letter into,
+ * so a space is a `gap` in `words/shapes.ts` rather than a box: the slot is
+ * still reserved, so the boxes either side of it stay put, and nothing is drawn
+ * in it. Without that, `1 Samuel` asks for a letter where the space is.
  *
  * ── Why these lists break two of the Dolch rules ────────────────────────────
  * `wordlists.ts` holds its entries to lower case and to one word each, and the

--- a/src/engine/decks/flashcards.test.ts
+++ b/src/engine/decks/flashcards.test.ts
@@ -118,8 +118,8 @@ describe("factLabel", () => {
 
   it("names a division fact as the question it asks, not as its two numbers", () => {
     // The pair behind "21 ÷ 3 = 7" is [3, 7]. Rendering that literally gives
-    // "3 ÷ 7", which is a different — and wrong — sum. The trouble list and
-    // the drill chips both used to show it that way.
+    // "3 ÷ 7", which is a different — and wrong — sum, on both the trouble
+    // list and the drill chips.
     expect(OPERATIONS.divide.factLabel("3:7")).toBe("21 ÷ 3");
   });
 

--- a/src/engine/decks/typing.ts
+++ b/src/engine/decks/typing.ts
@@ -172,14 +172,12 @@ const SENTENCES = [
  *     that trails off mid-list would arrive as a fragment with a comma on it.
  *
  * ── Why the words are written out here ──────────────────────────────────────
- * Because `decks/index.ts` is the front door for every island — the flash
- * cards, the spelling mount, the record book, the print shop — and a module is
- * assigned to a chunk whole. An import of the passage library from this file
- * puts all of it into all of them: the WEBu, the KJV beside it and thirty
- * other passages, shipped to every game to type thirty-three verses in one of
- * them. It was measured on the way past — 46KB of shared chunk became 222KB —
- * which is also why the credit comes from `passages/credit.ts` and not from
- * the file the verses are in.
+ * A module is assigned to a chunk whole, and this file is reachable from
+ * `decks/index.ts`, so an import of the passage library here puts the WEBu,
+ * the KJV beside it and thirty other passages into every island on the site to
+ * type thirty-three verses in one of them (docs/typing.md §5.3, which has the
+ * measurement). It is also why the credit comes from `passages/credit.ts` and
+ * not from the file the verses are in.
  *
  * So the text is repeated, and `typing.test.ts` pins every line of it to
  * `passage()` character for character. That is the arrangement `scripture.ts`

--- a/src/engine/keyboard.test.ts
+++ b/src/engine/keyboard.test.ts
@@ -359,7 +359,7 @@ describe("FINGER_ZONES", () => {
   });
 
   it("has no zone for the thumbs", () => {
-    // Nothing falls on the space bar (§8.3), so the shield has no segment for
+    // Nothing falls on the space bar (§8.5), so the shield has no segment for
     // it — and the home row this is grouped from carries no thumb key, which
     // is what lets the record be exactly the eight without excluding one.
     expect(Object.keys(FINGER_ZONES)).not.toContain("thumb");

--- a/src/engine/keyboard.ts
+++ b/src/engine/keyboard.ts
@@ -221,7 +221,7 @@ export type FingerZone = {
  * `keyX` is here — a second opinion about which keys the right ring finger
  * covers would put the hole over the wrong hand.
  *
- * The thumbs have no zone: nothing falls on the space bar (§8.3), and the home
+ * The thumbs have no zone: nothing falls on the space bar (§8.5), and the home
  * row carries no thumb key for the cast below to have to exclude.
  */
 export const FINGER_ZONES: Readonly<

--- a/src/engine/progress.test.ts
+++ b/src/engine/progress.test.ts
@@ -416,12 +416,11 @@ describe("Eyes Up", () => {
 /**
  * Run one test against a storm level whose wave is a given length.
  *
- * The twenty waves are real now (#156), so this is no longer standing in for a
- * deploy — it is how a test about the badge's *guard* asks its question
- * without being a test about lesson 4's `count`. Three of the cases below turn
- * on the relationship between a run's cards and the wave's length, and pinning
- * them to whatever the table says today would make a difficulty pass look like
- * a badge regression.
+ * How a test about the badge's *guard* asks its question without becoming a
+ * test about lesson 4's `count`. Three of the cases below turn on the
+ * relationship between a run's cards and the wave's length, and pinning them to
+ * whatever the table says today would make a difficulty pass look like a badge
+ * regression.
  */
 function withWave(n: number, count: number, body: () => void) {
   const of = lesson(n);
@@ -436,14 +435,11 @@ function withWave(n: number, count: number, body: () => void) {
 
 describe("Unbroken", () => {
   /**
-   * The premise of the guard, the other way up from how it started life.
-   *
-   * It used to read "no storm level has a wave yet", which is what made the
-   * badge unearnable before the waves landed (decision 29). Now every one of
-   * the twenty has a length, so what has to stay true is that they all do: a
-   * storm whose `count` slipped back to zero would be a rung that quietly
-   * cannot earn a badge it advertises, and `survived` would pass every run of
-   * it — including one that died at letter one.
+   * The premise of the guard (decision 29): every one of the twenty storms has
+   * a wave length, and all twenty have to keep one. A storm whose `count`
+   * slipped to zero would be a rung that quietly cannot earn a badge it
+   * advertises, and `survived` would pass every run of it — including one that
+   * died at letter one.
    */
   it("has a wave on every Hailstorm level to fire on", () => {
     const storms = LESSONS.filter((l) => l.pass.kind === "storm");

--- a/src/engine/progress.ts
+++ b/src/engine/progress.ts
@@ -53,41 +53,20 @@ export function cardXp(ms: number, streakAfter: number) {
 }
 
 /**
- * What a Hailstorm run pays into the profile (docs/typing.md §8.6).
- *
- * ── Score can fall; XP cannot ────────────────────────────────────────────
- * The storm's own score goes DOWN on a wrong key, because losing points has
- * to be visible and immediate or it is not a consequence. This number is the
- * other one, and it is floored at zero on purpose: XP is cumulative across
- * years and across four games, and it is what a child's level ring is drawn
- * from. A mechanic that could take XP away would mean a level going BACKWARDS
- * because they had a bad five minutes in a shooter — a punishment that
- * outlives the run it was earned in, aimed at the youngest player on the site.
- * So the run's misses cost score and nothing else, and the two numbers are
- * kept apart at exactly this line.
+ * What a Hailstorm run pays into the profile: a fold over the finished run's
+ * hits at `cardXp`, so a storm and a race pay on one scale (docs/typing.md
+ * §8.6). `ms` is how long the letter was in the air (§8.7) and the streak is
+ * the combo the shot landed on, so both arguments mean here what they mean on
+ * a card.
  *
  * **The `max(0, …)` is deliberate and must not be removed.** It cannot bite as
  * the sum stands — every term below is a `cardXp`, which is never negative —
  * so no input can drive it, no test can pin it, and deleting it leaves the
- * suite entirely green. That is the reason it is written down here rather than
- * left to be rediscovered: it guards the NEXT term somebody adds, not today's.
- * A penalty per miss, or a charge for a letter that got through, would look
- * local and correct at the fold below and would be a child's level ring
- * running backwards on their profile. Nothing in the tooling can say that to
- * whoever adds one, so this paragraph does; unreachable is not unnecessary.
- *
- * ── Computed once, at the end, from the run's hits ───────────────────────
- * Not accumulated frame by frame: `resolved` already says which letters were
- * shot, when, and on what streak, so this is a fold over a finished run rather
- * than a second tally kept in step with the reducer sixty times a second.
- *
- * `cardXp` is reused UNCHANGED, and that is the point of it. It already
- * rewards a hit under four seconds and a streak up to ×2, which is the shape a
- * shooter wants — and using it means a Hailstorm level and a flash-card race
- * pay out on the same scale, which they must, because it is one profile and
- * one level ring. `ms` is how long the letter was in the air (§8.7) and the
- * streak is the combo the shot landed on, so both arguments mean here what
- * they mean on a card.
+ * suite entirely green. It guards the NEXT term somebody adds, not today's: a
+ * penalty per miss, or a charge for a letter that got through, would look
+ * local and correct at the fold below, and would be a child's level ring
+ * running backwards on their profile. Score can fall; XP cannot, and this is
+ * the line the two are kept apart at.
  */
 export function stormXp(state: StormState): number {
   return Math.max(
@@ -227,10 +206,9 @@ export const BADGES: BadgeDef[] = [
   /* ── Frost Keys, the typing course (docs/typing.md §6.7) ───────────────────
      Appended, and only ever appended. A badge id is written into
      `Profile.badges` the moment it is earned and that list is the only copy
-     there is, so adding to this table is free and renaming or removing an
-     entry takes a badge off a child who has it — the row would simply stop
-     resolving in `BADGES_BY_ID` and the tile would vanish from their shelf.
-     Five, and no more (§6.7). */
+     there is, so adding to this table is free while renaming or removing an
+     entry takes a badge off a child who has it — the row stops resolving in
+     `BADGES_BY_ID` and the tile vanishes from their shelf. */
   {
     id: "home-keys",
     name: "Home Keys",
@@ -328,9 +306,9 @@ export function evaluateBadges({
    Split out rather than added to the list above because they are asked in a
    different tense. The seventeen above are questions about *this race* —
    perfect, fast, thirty cards, a streak of fifteen. Three of these five are
-   questions about a child's whole climb, and the climb is derived from every
-   run they have ever saved (§6.5). Keeping them apart is what stops the
-   history pass being paid for by a badge that only needed the card count.     */
+   questions about a child's whole climb, derived from every run they have ever
+   saved (§6.5). Keeping them apart is what stops the history pass being paid
+   for by a badge that only needed the card count.                             */
 
 /**
  * Whichever of the five this run has just earned, plus the ladder ones the
@@ -338,9 +316,8 @@ export function evaluateBadges({
  *
  * Like `evaluateBadges` itself this returns what is *true*, not what is new —
  * `summariseRun` diffs against `Profile.badges` to find the ones worth
- * celebrating. Which is also how a child who cleared checkpoint 10 before this
- * shipped is given Home Keys: the next run of anything at all re-asks the
- * question, and the answer has been yes for months.
+ * celebrating. That is also what backfills: a child who cleared checkpoint 10
+ * long before the badge existed is handed it by their next run of anything.
  */
 function courseBadges(
   session: BadgeContext["session"],
@@ -349,18 +326,12 @@ function courseBadges(
   const earned: string[] = [];
 
   /* ── The three ladder badges ───────────────────────────────────────────────
-     Asked of `ladderProgress` rather than of this run, because "clear
-     checkpoint 10" is a fact about a child and not about a race, and the
-     ladder is the only place that knows what clearing means. This run is
-     handed over beside the history because it is not saved yet: a checkpoint
-     cleared *by this run* has to award its badge on this run's results screen,
-     not on the next one's.
+     Asked of `ladderProgress` rather than of this run, and read off `best`
+     rather than `cleared.has(n)`, which is the ladder's own rule (§6.6, §6.7).
 
-     `best`, not `cleared.has(n)`, and that is the ladder's own rule rather
-     than a shortcut (§6.6). Passing checkpoint 50 clears 1–49 with it — that
-     is the whole of the placement test — so a nine-year-old who opens
-     checkpoint 50 cold has cleared checkpoint 10, and a Touch Typist without
-     Home Keys would be a shelf that disagreed with the ladder next to it.   */
+     This run is handed over beside the history because it is not saved yet: a
+     checkpoint cleared *by this run* has to award its badge on this run's
+     results screen, not on the next one's.                                  */
   const ladder = ladderProgress([...history, session]);
   if (ladder.best >= 10) earned.push("home-keys");
   if (ladder.best >= 50) earned.push("touch-typist");
@@ -376,33 +347,12 @@ function courseBadges(
   const verdict = verdictFor(session, lesson);
 
   /* ── `eyes-up`, the one that matters ───────────────────────────────────────
-     Three conditions, and "the child chose it" is deliberately not one of
-     them: the lesson must not have forced the board off (`forcedKeyboard` is
-     the one definition of that, shared with the island's resolver), the run
-     must have been typed with it off, and it must have passed.
-
-     What excluding the forced ones buys is *compulsion*, not authorship. Every
-     checkpoint forces the board off (§4.2), so a badge that read the resolved
-     mode — or `config.keyboard` on its own, the day a screen starts writing
-     that field on a locked lesson — would fire on exactly the ten runs where
-     being eyes-up was not optional. That is the inverse of the badge.
-
-     Hidden rather than chosen is where the line belongs, and it is worth being
-     plain about the difference. A lesson's mode only *seeds* the brief's
-     control (§4.2, #145) and Start hands over whatever that control is showing,
-     so on an unlocked lesson `config.keyboard` records the mode the run was
-     actually typed under — touched or untouched. Twenty-three unlocked rows
-     seed `off` themselves, so a child who opens lesson 46, presses Start and
-     passes earns this. That is right: they typed a lesson blind. Insisting on
-     authorship would mean comparing the config against the seed and refusing
-     that child for doing exactly what the ladder asked — same lesson, same
-     empty screen, same work — while rewarding a neighbour who flipped a pill
-     the ladder had already flipped for them. "Pass a lesson with the keyboard
-     hidden" is what the badge promises, and hidden is what this reads.
-
-     A `keyboard` absent from the config is not evidence of a hidden board —
-     free play, or a run started without a brief in front of it — so `=== "off"`
-     refuses it rather than guessing.
+     Hidden, not chosen: three conditions, and "the child chose it" is
+     deliberately not one of them (§6.7). `forcedKeyboard` is the one definition
+     of a lesson that insists, shared with the island's resolver. The test is
+     `=== "off"` rather than anything looser, because a `keyboard` absent from
+     the config is not evidence of a hidden board — free play, or a run started
+     without a brief in front of it.
 
      Lessons only. A Hailstorm level's ⌨ column is about the *field*, which is
      the keyboard (§8.2), so "hidden" does not mean there what it means here. */
@@ -414,36 +364,19 @@ function courseBadges(
   )
     earned.push("eyes-up");
 
-  /* ── `unbroken`, and the guard that retired itself ─────────────────────────
-     Guarded on the wave rather than on the absence of a screen that could
-     start one. A storm level's `wordCount` is its wave's `count` (§5.7, §8.3),
-     and every one of the twenty was `0` until the waves landed — so `survived`
-     was vacuously true, "cleared a wave" was a claim about a wave that did not
-     exist, and the badge had to be refused for it. Stating the guard as "the
-     wave has a length" is what let it retire itself the day the twenty rows
-     were written, rather than being a line someone had to remember to delete
-     (decision 29). It stays because it is still the badge's own sentence.
+  /* ── `unbroken` ────────────────────────────────────────────────────────────
+     "Shield untouched" is read as nothing marked wrong, which is the badge's
+     own sentence rather than an approximation of it (§6.7, §8.5). The wave
+     guard is a guard and not a line to delete: with no wave, `survived` is
+     vacuously true (§6.7, decision 29).
 
-     "Shield untouched" is read as **no letter reached the bottom**, which is
-     what takes a point off a segment (§8.5). A storm's cards are its falling
-     letters and nothing else (§8.7, decision 48), so a run with nothing marked
-     wrong is exactly a run where nothing got through: a wrong key resolves no
-     letter and so costs no card, and the one letter that lands without costing
-     a shield point is the fatal one, which is itself a card marked wrong. So
-     this is the badge's own sentence rather than an approximation of it —
-     which is worth saying out loud, because counting a storm's wrong KEYS into
-     `incorrect` would quietly re-tune it from "untouched shield" to "flawless
-     run" without a line of this file changing.
-
-     `correct > 0` cannot change the answer, and is kept on purpose. A run with
-     no cards at all has an accuracy of 0 (`accuracyOf` returns 0 rather than
-     NaN for an empty run), which is under every storm's 0.9 bar, so
-     `verdict.passed` has already refused it. It stays because it says the
-     second half of what "nothing got through" means — nothing wrong *and*
-     something faced — the same pair `perfect` is built from above, and because
-     the thing holding it up is a bar in the criteria table that a future
-     re-tune could lower. Redundant, deliberately; not a condition somebody
-     forgot to finish.                                                        */
+     `correct > 0` cannot change the answer and is kept on purpose. A run with
+     no cards has an accuracy of 0 (`accuracyOf` returns 0 rather than NaN for
+     an empty run), which is under every storm's 0.9 bar, so `verdict.passed`
+     has already refused it. It stays because it says the second half of what
+     "nothing got through" means — nothing wrong *and* something faced — and
+     because the thing holding it up is a bar a future re-tune could lower.
+     Redundant, deliberately; not a condition somebody forgot to finish.      */
   if (
     lesson.pass.kind === "storm" &&
     lesson.wordCount > 0 &&

--- a/src/engine/records.test.ts
+++ b/src/engine/records.test.ts
@@ -11,10 +11,10 @@ import {
 import type { CardResult, Profile, Session } from "./types";
 
 /**
- * What counts as "the same fact" is now the deck's answer, not this module's.
- * These pin the two rules that used to be a hard-coded table here, because
- * getting either one wrong is invisible: the record book still renders, it
- * just quietly merges or splits facts that shouldn't be.
+ * What counts as "the same fact" is the deck's answer, not this module's.
+ * These pin the two rules, because getting either one wrong is invisible: the
+ * record book still renders, it just quietly merges or splits facts that
+ * shouldn't be.
  */
 
 const card = (over: Partial<CardResult> = {}): CardResult => ({

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,10 +1,6 @@
 /**
- * What the typing game puts on screen under the passage (docs/typing.md §4.1).
- *
- * One field rather than `showKeyboard` + `showHint`, because three of the four
- * boolean combinations are meaningful and the fourth — a hint pointing at a
- * board that isn't drawn — is nonsense. A union cannot express the nonsense,
- * so no reader has to decide what to do when it arrives.
+ * What the typing game puts on screen under the passage — one field rather
+ * than `showKeyboard` + `showHint` (docs/typing.md §4.1).
  */
 export type KeyboardMode =
   /** Not on screen at all. */
@@ -22,14 +18,10 @@ export type Profile = {
   age: number;
   soundOn: boolean;
   /**
-   * How much of the keyboard this player wants (§4.2). Absent means "guide",
-   * and absent is the ordinary state: every profile made before this shipped
-   * lacks the field, and nothing writes it until a child chooses. One default,
-   * at one read site, rather than a value copied into `create` as well.
-   *
-   * Optional precisely so this costs no `DB_VERSION` bump and no migration —
-   * profiles are read straight through, unlike sessions, whose widening lives
-   * in `engine/migrate.ts`.
+   * How much of the keyboard this player wants (§4.2). Absent is the ordinary
+   * state, and reads as "guide" — one default at one read site, rather than a
+   * value `create` also writes. Optional because profiles are read straight
+   * through, unlike sessions, whose widening lives in `engine/migrate.ts`.
    */
   keyboard?: KeyboardMode;
   xp: number;
@@ -114,65 +106,43 @@ export type TypingConfig = {
   kind: "typing";
   levelId: string;
   /**
-   * Set when this run is a lesson from the ladder (docs/typing.md §5.4).
-   *
-   * The discriminator for a ladder run, and the one field `Session.mode` and
-   * the ghost key prefer when it is there — a lesson is the identity, not the
-   * passage. Every run of lesson 7 generates its own words, so a key built
-   * from them would file each run in a bucket of one and a child would never
-   * be shown their own best. Optional, because every run saved before the
-   * ladder existed is a level and must key exactly as it always has.
+   * Set when this run is a lesson from the ladder, and what `Session.mode` and
+   * the ghost key prefer over the passage when it is there (§5.4). Optional,
+   * because every run saved before the ladder existed is a level and must key
+   * exactly as it always has.
    */
   lessonId?: string;
   /**
    * How much of the board this run puts on screen, when the child chose it
-   * (docs/typing.md §4.2).
+   * (docs/typing.md §4.2). Absent means nobody chose: free play never sets it,
+   * and a lesson whose keyboard is locked has nothing to record.
    *
-   * Absent is the ordinary case and means "nobody chose": free play never sets
-   * it, and a lesson whose keyboard is locked has nothing to record. It is set
-   * by the lesson brief, which seeds its control from `lesson.keyboard` and
-   * lets an unlocked lesson be run with the board turned down — the choice
-   * belongs to the run it was made for, so it travels with the run's config
-   * rather than being written back over the player's own setting.
+   * On the config rather than in `PendingRace` because the run outlives the
+   * navigation: a lesson passed with the board off is a different thing from
+   * one passed reading the answers, and `eyes-up` (§6.7) is a badge for exactly
+   * that choice. A mode kept in memory would be gone by the time anything could
+   * award it.
    *
-   * Carried in the config rather than in `PendingRace` because the run outlives
-   * the navigation: a lesson passed with the board off is a different thing
-   * from one passed reading the answers, and `eyes-up` (§6.7) is a badge for
-   * exactly that choice. A mode kept in memory would be gone by the time
-   * anything could award it.
-   *
-   * Inert in `configKey` on purpose (`decks/typing.ts#typingConfigKey`) — a
-   * child's best at lesson 7 is their best at lesson 7, and splitting the
-   * record book by how much help was on screen would hide their own record
-   * from them the first time they turned the guide off.
+   * Inert in `configKey` (`decks/typing.ts#typingConfigKey`) — a child's best
+   * at lesson 7 is their best at lesson 7, and splitting the record book by how
+   * much help was on screen would hide their own record from them the first
+   * time they turned the guide off.
    */
   keyboard?: KeyboardMode;
   /**
-   * Set only by a Hailstorm run (docs/typing.md §8.7, decision 50).
+   * Set only by a Hailstorm run, and the field that says a run is not ranked
+   * (docs/typing.md §8.7, decision 50). `isRanked` (`decks/index.ts`) reads it
+   * and `bestRun` (`engine/records.ts`) refuses those runs, so every "best" on
+   * the site inherits one judgement.
    *
-   * A storm is not ranked, and this is the field that says so. Every "best" on
-   * the site is `compareRuns`, which decides on time — and a storm run ends
-   * when the shield does, so a child who died at letter three took less time
-   * than one who cleared the wave and would hold the record for it. `isRanked`
-   * (`decks/index.ts`) reads this and `bestRun` (`engine/records.ts`) refuses
-   * those runs, so the record book's two columns, the `previousBest` that pays
-   * the personal-best bonus and every ghost a setup screen offers all inherit
-   * one judgement.
+   * On the run rather than derived from `lessonById(lessonId)`, because what a
+   * run *was* is a fact about the run: re-tune lesson 39 out of a Hailstorm and
+   * a derived rule would start ranking every storm already saved.
    *
-   * ── On the run, not derived from the lesson ─────────────────────────────
-   * `lessonById(lessonId)?.kind.type === "storm"` would answer the same
-   * question today without a field. It is not used, because a saved run
-   * outlives the ladder it was played on (§5.4, and `UNKNOWN_DECK`): re-tune
-   * lesson 39 out of a Hailstorm — or retire the id — and a derived rule would
-   * quietly start ranking every storm already in the record book, awarding the
-   * record to the shortest life. What a run *was* is a fact about the run, and
-   * facts about a run travel with it.
-   *
-   * Optional and never `false`, exactly like `lessonId` and `keyboard` above,
-   * so it costs no `DB_VERSION` bump and no migration. Inert in `configKey`
-   * (`decks/typing.ts#typingConfigKey`): that key decides which runs may race
-   * each other as ghosts, and changing its format orphans every personal best
-   * already saved (CLAUDE.md, §10).
+   * Optional and never `false`, like `lessonId` and `keyboard` above, so it
+   * costs no `DB_VERSION` bump and no migration. Inert in `configKey`, which
+   * decides which runs may race each other as ghosts and so may not change
+   * shape for anything already saved (CLAUDE.md, §10).
    */
   storm?: true;
   /** An explicit set, for a drill of the words a player keeps fumbling. */
@@ -209,12 +179,12 @@ export type CustomDeck = {
 };
 
 /* ── Cards ───────────────────────────────────────────────────────────────
-   A card is text in and text out, deliberately. Answers were numbers until
-   spelling arrived, and every alternative to widening them was worse: a
-   `number | string` union puts a branch at every comparison, and a generic
-   `Card<T>` leaks type parameters into components that only ever render the
-   thing. What a deck family *does* know about its own answers — how to
-   compare "07" with "7", or "Cat" with "cat" — lives on its `DeckSpec`.     */
+   A card is text in and text out, deliberately. Both alternatives to a string
+   answer are worse: a `number | string` union puts a branch at every
+   comparison, and a generic `Card<T>` leaks type parameters into components
+   that only ever render the thing. What a deck family *does* know about its
+   own answers — how to compare "07" with "7", or "Cat" with "cat" — lives on
+   its `DeckSpec`.                                                           */
 
 export type Card = {
   /** Rendered prompt, e.g. "7 × 8". */

--- a/src/games/flashcards/App.tsx
+++ b/src/games/flashcards/App.tsx
@@ -50,10 +50,10 @@ function Shell() {
   }
 
   if (status === "error") {
-    // There's no server to be down any more — reaching here means the browser
-    // refused storage (private windows in some browsers block IndexedDB) or
-    // the database failed to open. Say that, rather than the old "is the
-    // server running?", which would send someone hunting for a terminal.
+    // Reaching here means the browser refused storage (private windows in
+    // some browsers block IndexedDB) or the database failed to open. There is
+    // no server to be down, so say that rather than sending someone hunting
+    // for a terminal.
     return (
       <div className="boot">
         <p className="u-eyebrow">School Skills</p>
@@ -75,11 +75,9 @@ function Shell() {
 
   return (
     <RaceProvider>
-      {/* Above everything, on every screen including a live race. Its height is
-          reserved in CSS at first paint and subtracted from the viewport by
-          `--ad-h`, so it cannot move the card or the keypad whenever it fills —
-          see src/styles/ads.css. Placed at the top of the island because that
-          is the furthest point in the layout from the answer controls. */}
+      {/* Above everything, on every screen including a live race — the
+          furthest point in the layout from the answer controls. See
+          `AdSlot` for why filling it cannot move the card. */}
       <AdSlot name="game" className="ad--game" />
       <Routes>
         <Route path="/" element={<PlayerSelect />} />
@@ -97,9 +95,8 @@ function Shell() {
 
 /**
  * Mounted twice, at `/flash-cards` and at `/spelling/play`, with `subject`
- * deciding which decks exist inside. Same origin either way, so both mounts
- * read the same profiles out of the same IndexedDB — see SubjectContext for
- * why that matters more than the routing does.
+ * deciding which decks exist inside. See `SubjectContext` for why both mounts
+ * are one origin, which matters more than the routing does.
  */
 export default function FlashCardsApp({
   subject = "numbers",

--- a/src/games/flashcards/RaceResults.tsx
+++ b/src/games/flashcards/RaceResults.tsx
@@ -55,11 +55,8 @@ export default function RaceResults() {
    * the navigate that follows it is batched with that update. So there is
    * exactly one render where the outcome has gone and the route is still
    * here — and without the `pending` arm below, this guard fires in that gap
-   * and replaces the navigation to the track with one back to setup.
-   *
-   * That is not theoretical: it is what "Race again" did on this screen from the day
-   * it shipped. The mirror image of it is guarded in `RaceTrack`, and this is the half
-   * that was missed.
+   * and replaces the navigation to the track with one back to setup. The
+   * mirror of this guard is in `RaceTrack`.
    */
   if (!outcome) {
     return (
@@ -136,9 +133,9 @@ export default function RaceResults() {
   const selfGhost = { session, profile: outcome.profileAfter, isSelf: true };
   const practiceFirst = missedFacts.length > 0;
   /**
-   * The same facts as a worksheet (docs/printables.md §14) — the one thing no
-   * other worksheet site can print, offered at the moment it is most obviously
-   * wanted. Null for a deck this build has no sheet family for.
+   * The same facts as a worksheet (docs/printables.md §14), offered at the
+   * moment it is most obviously wanted. Null for a deck this build has no
+   * sheet family for.
    */
   const printable = practiceFirst
     ? practiceSheet(session.mode, missedFacts)

--- a/src/games/flashcards/race/CardFace.tsx
+++ b/src/games/flashcards/race/CardFace.tsx
@@ -60,7 +60,7 @@ export function CardFace({
       )}
       {card.speak ? (
         <WordPrompt
-          // `prompt`, not `speak`: what's spoken is now the word AND the
+          // `prompt`, not `speak`: what is spoken is the word AND the
           // sentence it sits in, and the no-voice fallback flashes the word.
           word={card.prompt}
           clue={card.clue}

--- a/src/games/flashcards/race/useCardSubmit.ts
+++ b/src/games/flashcards/race/useCardSubmit.ts
@@ -136,9 +136,6 @@ export function useCardSubmit({
         },
         ok ? RIGHT_PAUSE_MS : lateOut ? TIMEOUT_PAUSE_MS : WRONG_PAUSE_MS,
       );
-      // Everything above that changes comes from `live` or a ref; every name
-      // below is pinned with an empty dependency list of its own, precisely so
-      // this callback can stay stable.
     },
     [
       spec,

--- a/src/games/flashcards/race/useCardVoice.ts
+++ b/src/games/flashcards/race/useCardVoice.ts
@@ -24,17 +24,12 @@ export function useCardVoice({
   // twice still gets read out. Gated on `racing` so nothing talks over the
   // countdown or carries on into the results screen.
   //
-  // If the engine turns out not to work after all, drop to showing the word.
-  // A card that can neither be heard nor read is unanswerable, and the clock
-  // is running. That verdict arrives two ways, and the second one matters
-  // more: `say` returns false when it couldn't even start, and calls back
-  // when a voice accepted the word and then failed to say it — a stalled
-  // engine, a revoked autoplay permission, a device that simply went quiet.
-  // Only the first was ever handled, so the commonest silent card wasn't.
-  //
-  // Demotion is one-way. Re-testing per card would let a child who has settled
-  // into listening be handed a flashing word halfway through a race, which is
-  // the change of exercise this hook exists to prevent.
+  // If the engine turns out not to work after all, drop to showing the word:
+  // a card that can neither be heard nor read is unanswerable, and the clock
+  // is running. The verdict arrives two ways — `say` returns false when it
+  // could not even start, and calls back when a voice accepted the word and
+  // then failed to say it (a stalled engine, a revoked autoplay permission, a
+  // device that went quiet). Demotion is one-way, for the reason above.
   useEffect(() => {
     if (!racing || !audible || !card.speak) return;
     const mute = () => setAudible(false);

--- a/src/games/flashcards/setup/MathsSettings.tsx
+++ b/src/games/flashcards/setup/MathsSettings.tsx
@@ -12,9 +12,8 @@ const ascending = (list: number[]) => [...list].sort((a, b) => a - b);
 /**
  * Which sums end up on the cards: the operation, and the two number grids.
  *
- * Lifted out of RaceSetup when spelling arrived — that screen now picks a
- * subject first and mounts this or `WordSettings`, and neither has to know
- * the other exists.
+ * `RaceSetup` picks a subject first and mounts this or `WordSettings`, and
+ * neither has to know the other exists.
  */
 export function MathsSettings({
   config,

--- a/src/games/race/Hud.tsx
+++ b/src/games/race/Hud.tsx
@@ -17,15 +17,10 @@ export function Hud({
   total: number;
   onQuit: () => void;
   /**
-   * Whether a wrong answer costs time, which is a thing about the run rather
-   * than about this header. True in a race, and default because a race is what
-   * this header was built for. False on a typing lesson: three seconds a miss
-   * is a race mechanic, and on a lesson it double-counts accuracy — which has a
-   * bar of its own there — and makes the wpm figure a lie, because the number
-   * stops being words per minute of anything (docs/typing.md §7).
-   *
-   * The miss count still comes in, because it is still true; what changes is
-   * whether it is charged for.
+   * Whether a wrong answer costs time — a thing about the run rather than about
+   * this header. True in a race, false on a typing lesson (docs/typing.md §7).
+   * The miss count still comes in either way; what changes is whether it is
+   * charged for.
    */
   penalty?: boolean;
 }) {

--- a/src/games/race/index.ts
+++ b/src/games/race/index.ts
@@ -6,11 +6,9 @@
  * quit sheet, and scoring-and-saving at the end. None of it knows what a card
  * asks.
  *
- * It lived in `src/games/flashcards/race/` until the typing game needed it.
- * The alternative was one island importing from another, which would have made
- * the flash-card game a dependency of every game after it — and the timing
- * code in `useRaceClock` is the last thing that should acquire callers by
- * accident.
+ * Shared from here rather than imported across islands, which would make one
+ * game a dependency of every game after it — and the timing code in
+ * `useRaceClock` is the last thing that should acquire callers by accident.
  *
  * **What belongs here:** anything a second game would otherwise copy. What
  * doesn't: how an answer is entered, marked or displayed. Those stay with the

--- a/src/games/race/useRaceClock.ts
+++ b/src/games/race/useRaceClock.ts
@@ -76,10 +76,9 @@ export function useRaceClock({
 
   /**
    * The four below touch nothing but refs, so they're pinned with an empty
-   * dependency list. That isn't a micro-optimisation: `submit` in RaceTrack
-   * must keep a stable identity or the per-card timer effect would tear down
-   * and restart on every one of the ~16 renders a second the ticker causes,
-   * and never fire. Handing it unstable callbacks would break that from here.
+   * dependency list — for the reason above, one level up: `submit` in
+   * `RaceTrack` must keep a stable identity, and handing it unstable callbacks
+   * from here would break that.
    */
   const onCard = useCallback(() => performance.now() - cardStart.current, []);
 

--- a/src/games/race/useRaceFinish.ts
+++ b/src/games/race/useRaceFinish.ts
@@ -52,21 +52,13 @@ export function useRaceFinish({
   resultsPath: string;
   onSaving: () => void;
   /**
-   * What a finished run sounds like. `sfx.finish` unless a game says
-   * otherwise, which is every race: reaching the end of a deck is good news
-   * whatever the time on the clock.
-   *
-   * Hailstorm is the one that says otherwise, because it is the one run that
-   * can end by being LOST — a wave gets through the shield and the storm
-   * stops there. A major triad over a broken shield is the game congratulating
-   * a child for dying, so the storm passes a fanfare that does nothing and
-   * announces its own ending from the frame that stamped it, where the
-   * difference between clearing the wave and being breached is still in hand
-   * (`stormSounds.ts`).
+   * What a finished run sounds like. `sfx.finish` for every race; Hailstorm
+   * passes one that does nothing and announces its own ending instead, because
+   * a storm can end by being lost (docs/typing.md §8.12).
    *
    * It is here and not at the call site of `complete()` because this hook owns
-   * the once-per-run guard: a sound played beside a call that may be refused
-   * is a sound that can play twice.
+   * the once-per-run guard: a sound played beside a call that may be refused is
+   * a sound that can play twice.
    */
   fanfare?: () => void;
 }) {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -162,12 +162,9 @@ const ogImage = new URL(image, Astro.site).href;
        *
        * `google_tag_for_age_treatment = 1` is child-restricted treatment, and
        * it is a bare global rather than a property on the queue — that is the
-       * form AdSense documents (answer/3248194). It REPLACES
-       * `tagForChildDirectedTreatment`, which sat here for a while doing
-       * nothing at all: a captured production ad request carried `npa=1` but
-       * no `tfcd` of any spelling. Treat this one as unproven too until a live
-       * request is captured showing `tfat=1`; the declaration that is known to
-       * work is the site-level one in Search Console.
+       * form AdSense documents (answer/3248194). Treat it as unproven until a
+       * live request is captured showing `tfat=1`; the declaration known to
+       * work is the site-level one in Search Console (`components/site/ads.ts`).
        *
        * `is:inline` on both: Astro would otherwise bundle and hoist them, which
        * breaks that ordering and rewrites the loader's URL.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -81,21 +81,16 @@ const verse = passage("the-plans-of-the-diligent");
     </p>
     {
       /*
-       * The button goes down the page, not into a game.
+       * The button goes down the page, not into a game. The map is the
+       * thesis, and a child who came to practise spellings shouldn't have to
+       * back out of a multiplication race to find it — so the primary action
+       * is "choose", and the map is one scroll away.
        *
-       * It used to open /flash-cards, which quietly said the times tables were
-       * the site and the other three worlds were extras. They aren't — the map
-       * is the thesis, and a child who came to practise spellings shouldn't
-       * have to back out of a multiplication race to find it. So the primary
-       * action is "choose", and the map is one scroll away rather than one
-       * navigation away.
-       *
-       * Both buttons are in-page jumps now, so both carry `data-scroll`. The
-       * arrow is only on this one: it is the button that used to leave the
-       * page, and it is the one whose destination is off screen, so it is the
-       * one that has to say it goes downwards rather than away. See the script
-       * at the foot of this page for why the scroll is animated in JavaScript
-       * rather than by `scroll-behavior: smooth`.
+       * Both buttons are in-page jumps, so both carry `data-scroll`. The arrow
+       * is only on this one, whose destination is the one off screen: it has
+       * to say it goes downwards rather than away. See the script at the foot
+       * of this page for why the scroll is animated in JavaScript rather than
+       * by `scroll-behavior: smooth`.
        */
     }
     <div class="hero__actions">

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,41 +1,37 @@
 /**
  * Counting what happens, without learning who it happened to.
  *
- * The site's privacy page makes an unusually strong claim — no analytics
- * script, no cookies, no third-party requests, nothing that follows a child
- * anywhere — and that claim is a feature, not an accident. So measurement here
- * is built the only way that keeps every sentence of it true: as ordinary
+ * The privacy page promises parents no analytics script, no cookies, no
+ * third-party requests and nothing that follows a child anywhere. Measurement
+ * here is the only kind that keeps every sentence of that true: ordinary
  * requests to our own CDN, read back out of the access logs it already writes.
+ * `docs/analytics.md` covers reading them, and points back here for the rest.
  *
  * ── Why a GIF and not a real analytics call ─────────────────────────────────
- * There is no origin server. `dist/` is HTML on S3 with CloudFront in front,
- * which is what makes this site cost about a pound a month and have nothing
- * that can be down. Nothing here accepts a POST, so `navigator.sendBeacon` —
- * which only sends POST — has nowhere to go. What CloudFront *does* do,
- * unavoidably and for every request, is write a log line containing the path
- * and the query string.
- *
- * So an event is a GET for a 43-byte transparent GIF with the event in its
- * query string. No JavaScript from anyone else, no cookie, no identifier, no
- * response worth reading. The measurement is a side effect of a request the
- * CDN was going to log anyway.
+ * There is no origin server, and nothing here accepts a POST — so
+ * `navigator.sendBeacon`, which only sends POST, has nowhere to go. What
+ * CloudFront *does* do for every request is write a log line containing the
+ * path and the query string. So an event is a GET for a 43-byte transparent
+ * GIF with the event in its query string: no JavaScript from anyone else, no
+ * cookie, no identifier, no response worth reading, and the measurement is a
+ * side effect of a request the CDN was going to log anyway.
  *
  * ── What is deliberately NOT here ───────────────────────────────────────────
- * There is no visitor id, no session id and no first-seen timestamp, because
- * inventing one would be the exact thing the privacy page says we don't do:
- * under COPPA a persistent identifier IS personal information collected from a
- * child. "Unique visitors" therefore comes from the logs' own IP column, in
- * aggregate, at query time — approximate on purpose. A household behind one
- * router counts once; a phone that changes network counts twice. That is the
- * right trade for a site whose audience is children.
+ * No visitor id, no session id and no first-seen timestamp. Under COPPA a
+ * persistent identifier IS personal information collected from a child, so
+ * inventing one is the exact thing the privacy page says we don't do. "Unique
+ * visitors" therefore comes from the logs' own IP column, in aggregate, at
+ * query time — approximate on purpose. A household behind one router counts
+ * once; a phone that changes network counts twice. That is the right trade for
+ * a site whose audience is children.
  *
  * ── The event type is the safety mechanism ──────────────────────────────────
  * `Beacon` is a closed union rather than `track(name, props)`. Every field is
  * named here, so a future change cannot casually attach a profile name, an
  * age, a spelling word or a custom deck's id — the last of which is generated
- * per household and would be a tracking identifier in all but name. If a new
- * event needs a new property, it gets added to this file, where the reviewer
- * looking for exactly that mistake will see it.
+ * per household and would be a tracking identifier in all but name. A new
+ * event's new property gets added to this file, where the reviewer looking for
+ * exactly that mistake will see it.
  */
 
 import { OPERATION_ORDER } from "@/engine/decks/flashcards";
@@ -80,17 +76,14 @@ export type Beacon =
  * collapses to "custom", because a generated id that recurs in a log across
  * weeks is a tracking identifier however innocently it arrived.
  *
- * Built FROM the shipped registries rather than written out here. The first
- * version was a hand-maintained regex and it was wrong on the day it was
- * written: it listed the six graded Dolch lists and not the nouns list, so a
- * real shipped deck was being reported as somebody's private one. A list that
- * has to be kept in step with another list won't be.
+ * Built FROM the shipped registries rather than written out here: a list that
+ * has to be kept in step with another list won't be, and the failure is silent
+ * — a shipped deck reported as somebody's private one.
  *
- * `SHIPPED_LISTS` and not `WORD_LISTS`, for the same reason: `WORD_LISTS` is
+ * `SHIPPED_LISTS` and not `WORD_LISTS`, for the same reason. `WORD_LISTS` is
  * Dolch alone — the typing pools, the age lookup and the spelling shelf all
  * legitimately mean that — while the shelf a child can actually pick from is
- * the whole of it, Bible lists included. Reading the narrower one here would
- * log a public list as somebody's private one all over again.
+ * the whole of it, Bible lists included.
  */
 const SHIPPED: ReadonlySet<string> = new Set<string>([
   ...OPERATION_ORDER,

--- a/src/services/profiles.ts
+++ b/src/services/profiles.ts
@@ -3,12 +3,12 @@ import type { KeyboardMode, Profile } from "@/engine/types";
 import * as store from "./storage/db";
 
 /**
- * Profile CRUD, and the validation that used to live in the Express handlers.
+ * Profile CRUD, and the validation of it.
  *
- * Moving validation to the client doesn't make it weaker here: there is no
- * server left to protect, and the only person who can send bad input is the
- * person whose own data it is. What it still buys is a single place that turns
- * a typo into a readable message instead of a corrupt record.
+ * Validating on the client is not the weaker half of a pair here: there is no
+ * server to protect, and the only person who can send bad input is the person
+ * whose own data it is. What it buys is a single place that turns a typo into
+ * a readable message instead of a corrupt record.
  */
 
 export type NewProfile = Pick<Profile, "name" | "emoji" | "color" | "age">;

--- a/src/services/sound.ts
+++ b/src/services/sound.ts
@@ -215,39 +215,22 @@ export const sfx = {
 
   /* ── Hailstorm ───────────────────────────────────────────────────────────
    *
-   * Six sounds for one screen, and what makes them a set rather than six
-   * effects is that they have to stay apart from each other while three or
-   * four of them happen a second (docs/typing.md §8.12).
-   *
-   * They are laid out along two axes a five-year-old can hear without being
-   * taught either. **Pitch says whose it is**: the gun and the stones are
-   * bright and short, the shield is low and long, so "I did something" and
-   * "something happened to me" never have to be told apart by timbre alone.
-   * **Length says how much it cost**: 50ms for a shot, 90 for a stone, 160
-   * for armour absorbing a letter, 340 for the last point of a zone, and
-   * three quarters of a second for the run ending. Nothing else on the
-   * screen is allowed to be the longest sound in it.
-   *
-   * Gains are deliberately below the rest of the kit. A race plays a handful
-   * of sounds a minute; a storm plays one per keystroke, and a mixer summing
-   * six of those into a limiter is a mush that teaches nothing.
+   * Six sounds for one screen, kept apart from each other by pitch and by
+   * length while three or four of them happen a second (docs/typing.md §8.12).
+   * The lengths there are the contract; the comments below are how each one is
+   * built to hit it.
    */
 
   /**
-   * The trigger, on every stroke the gun takes — the hit and the miss are
-   * layered over the top of it rather than replacing it.
+   * The trigger, on every stroke the gun takes, with the hit or the miss
+   * layered over it (§8.12).
    *
-   * That layering is the point. A child who presses a key gets an answer
-   * within a frame whatever else is true, so the sound never has to wait on
-   * whether the shot landed, and the quietest, shortest thing on the screen
-   * is the one that happens most often.
-   *
-   * Two parts, because a single glide read as a blip rather than as a shot.
+   * Two parts, because a single glide reads as a blip rather than as a shot.
    * The click is what makes it one — a 20ms burst of high noise is the report,
    * and the ear places it as a *release* rather than as a note. The glide
    * under it is the shot leaving: fast, an octave and a half, and over before
-   * the next key can be pressed. Deliberately not dramatic — it fires several
-   * times a second and anything with a tail would be a drone.
+   * the next key can be pressed. Nothing with a tail, because it fires several
+   * times a second and a tail is a drone.
    */
   shoot: () => {
     noise({ dur: 0.02, gain: 0.16, sweepFrom: 7000, sweepTo: 4200 });
@@ -257,11 +240,10 @@ export const sfx = {
   /**
    * A hailstone shot out of the sky: a bright tone and a glassy noise burst.
    *
-   * The pitch climbs with the streak exactly as `correct` does, and for the
-   * same reason — it is the same streak, and the multiplier it is paying at
-   * is the number the HUD is already showing (§8.6). Capped at an octave, so
-   * a long run stops climbing rather than ending up somewhere only a dog can
-   * hear it.
+   * The pitch climbs with the streak exactly as `correct` does, because it is
+   * the same streak and the same multiplier the HUD is showing (§8.6). Capped
+   * at an octave, so a long run stops climbing rather than ending up somewhere
+   * only a dog can hear it.
    */
   shatter: (streak = 1) => {
     const step = Math.min(streak - 1, 11);
@@ -278,22 +260,17 @@ export const sfx = {
    * A stroke that hit nothing — the wrong key, or any key at an empty sky
    * (§8.6).
    *
-   * **A shot going past**, and the shape is the whole of how it reads that
-   * way. A thing that passes you gets brighter as it comes and darker as it
-   * goes, so this is two noise sweeps back to back — up through the near
-   * field, then down and away, the second longer than the first because that
+   * **A shot going past.** A thing that passes you gets brighter as it comes
+   * and darker as it goes, so this is two noise sweeps back to back — up
+   * through the near field, then down and away, the second longer because that
    * is what receding sounds like. Nothing else in the set moves in two
    * directions, which is what makes a miss unmistakable next to the shot that
-   * caused it.
+   * caused it. Under it a short low fall, because ten points off is not a
+   * neutral event.
    *
-   * Under it, a short low fall: the sound has to *cost* something as well as
-   * describe something, and ten points off is not a neutral event. Quiet
-   * enough not to be the thing you hear, present enough that a run of misses
-   * sags.
-   *
-   * `wrong`'s 260ms sawtooth would be both the wrong length and the wrong
-   * feeling. A child losing a storm mashes, and eight harsh buzzes a second is
-   * a drone; a flurry of whizzes is a flurry.
+   * `wrong`'s 260ms sawtooth is the wrong length and the wrong feeling. A child
+   * losing a storm mashes, and eight harsh buzzes a second is a drone; a flurry
+   * of whizzes is a flurry.
    */
   misfire: () => {
     noise({ dur: 0.05, gain: 0.13, sweepFrom: 800, sweepTo: 2800 });
@@ -316,11 +293,10 @@ export const sfx = {
   /**
    * …and that was the zone's last point: there is a hole under one finger now.
    *
-   * The loudest thing that is not the end of the run, because it is the
-   * moment a child can still do something about — the next letter on that
-   * finger ends the storm, and every clean hit from here is a chance to mend
-   * it (§8.5). A sound that were merely a bigger crunch would leave the one
-   * turning point in a run indistinguishable from the four hits before it.
+   * The loudest thing that is not the end of the run, because it is the last
+   * moment a child can still do something about (§8.5). A merely bigger crunch
+   * would leave the one turning point in a run sounding like the four hits
+   * before it.
    */
   shieldBreak: () => {
     tone({ freq: 300, dur: 0.34, wave: "sawtooth", gain: 0.26, glideTo: 88 });
@@ -330,11 +306,9 @@ export const sfx = {
   /**
    * A stone came through the hole. The run is over.
    *
-   * A falling minor figure under a long collapse of noise, and it is the one
-   * sound on this screen that is allowed to be sad. It is also why the storm
-   * does not play `finish`: a race ends by being finished and a storm can end
-   * by being lost, and a major triad over a broken shield would be the game
-   * congratulating a child for dying (`useRaceFinish`'s `fanfare`).
+   * A falling minor figure under a long collapse of noise — the one sound on
+   * this screen allowed to be sad, and what a lost storm plays instead of
+   * `finish` (§8.12).
    */
   breach: () => {
     noise({ dur: 0.75, gain: 0.24, sweepFrom: 4800, sweepTo: 110 });
@@ -353,33 +327,15 @@ export const sfx = {
   /* ── Typewriter ──────────────────────────────────────────────────────────
    *
    * The board's own voice: what a key sounds like going down, played whenever
-   * the keyboard is on screen (docs/typing.md §4.8).
+   * the keyboard is on screen (docs/typing.md §4.8). Quietest in the kit and
+   * pitchless, because at eight strokes a second it has to sit under `correct`
+   * and `wrong` without arguing with either.
    *
-   * These are the most frequent sounds on the site by an order of magnitude —
-   * a race plays a handful a minute, a storm one per stroke, and this one plays
-   * eight a second under a child who has got good. Two consequences run through
-   * every number below.
-   *
-   * **They are the quietest things in the kit**, quieter even than the storm's
-   * gun. Anything that could be noticed once is a headache after a passage.
-   *
-   * **They carry no pitch.** Every other sound here means something — the
-   * streak chime climbs, the miss falls, the bell rings. A clack means only
-   * "that key went down", which is a fact and not a verdict, and it has to keep
-   * saying that eight times a second underneath `correct` and `wrong` without
-   * arguing with either. So a strike is three noise bursts and no oscillator:
-   * a typewriter is percussion, and percussion is the one thing that can sit
-   * under a melody without being part of it. It is also why the clack does not
-   * change when a key is wrong — the board already flares `--flare` for that
-   * and the run plays `wrong` at the word, so a keyboard that scolded a child
-   * on the way down would be a third opinion, arriving before either of the
-   * other two knew the answer (`keySounds.ts`).
-   *
-   * `noise` is the right generator for a second reason: its envelope starts at
-   * full gain and decays, where `tone` ramps up over 12ms. Twelve milliseconds
-   * of attack on a forty-millisecond sound is a blip; percussion has no attack
-   * at all, and that difference is the whole distance between a click and a
-   * boop.
+   * `noise` and no oscillator, which is what pitchless costs — and it buys the
+   * envelope as well: `noise` starts at full gain and decays, where `tone`
+   * ramps up over 12ms. Twelve milliseconds of attack on a forty-millisecond
+   * sound is a blip; percussion has no attack at all, and that difference is
+   * the whole distance between a click and a boop.
    */
 
   /**
@@ -408,12 +364,10 @@ export const sfx = {
   /**
    * The space bar, which is a bigger lever and sounds like one.
    *
-   * The same three layers, moved down and lengthened. This is not decoration:
-   * space is the key that commits a word (`TypingTrack`), so it is the one
-   * stroke in a passage that is also a beat, and a child hearing the run tick
-   * over word by word is hearing something true about where they are. Making
-   * it deeper rather than louder is what keeps that from becoming a metronome
-   * they type to.
+   * The same three layers, moved down and lengthened. Space commits a word
+   * (`TypingTrack`), so it is the one stroke in a passage that is also a beat.
+   * Deeper rather than louder, so that beat does not become a metronome a child
+   * types to.
    */
   keySpace: () => {
     noise({ dur: 0.022, gain: 0.11, sweepFrom: 2600, sweepTo: 1100 });
@@ -430,22 +384,20 @@ export const sfx = {
   /**
    * Return: the bell, and the carriage going back.
    *
-   * The one sound in this block that is allowed a pitch, because a bell is a
-   * bell — two sine partials a fifth and a bit apart, which is what stops it
-   * reading as a beep. On the real machine the bell rings a few characters
-   * BEFORE the margin, as a warning, and the carriage is thrown afterwards by
-   * hand; putting both on one key merges a warning and an action that a child
-   * has never had to tell apart. What they get is the sound everybody means by
-   * "typewriter", on the key that ends the passage.
+   * The one sound in this block allowed a pitch (§4.8) — two sine partials a
+   * fifth and a bit apart, which is what stops it reading as a beep. On the
+   * real machine the bell warns a few characters before the margin and the
+   * carriage is thrown afterwards by hand; both on one key merges a warning
+   * and an action a child has never had to tell apart, and what they get is
+   * the sound everybody means by "typewriter".
    *
-   * Under the bell, the return itself: a rising sweep as the carriage flies
-   * left, and a low knock as it hits the stop. Rising, because nothing else in
-   * the kit does — `misfire` goes up and then down and is the only near
-   * neighbour, and it lives on a screen that has no keyboard on it.
+   * Under it, the return: a rising sweep as the carriage flies left, and a low
+   * knock as it hits the stop. Rising, because nothing else in the kit is —
+   * `misfire` is the only near neighbour and lives on a screen with no keyboard
+   * on it.
    *
-   * It is quiet for its length, and deliberately quieter than `finish`: Enter
-   * commits the last word of a passage, so this and the fanfare land together
-   * and the bell must not be the thing that wins.
+   * Quieter than `finish`, because Enter commits the last word of a passage, so
+   * the two land together and the bell must not be the one that wins.
    */
   keyReturn: () => {
     tone({ freq: 2093, dur: 0.4, wave: "sine", gain: 0.13 });

--- a/src/services/speech.ts
+++ b/src/services/speech.ts
@@ -46,12 +46,11 @@ const CLEAR = /\((?:premium|enhanced|natural)\)|\bneural\b|^google /i;
 /**
  * The English locale this device is set to, or null if it isn't set to one.
  *
- * The rule this replaces hard-coded a preference for en-GB, and the reasoning
- * behind it was right: a mismatched accent is a genuine obstacle when the whole
- * exercise is mapping a sound onto letters. What was wrong was assuming the
- * house. The device's own language is the only evidence we have about which
- * accent a child hears all day, and on a device set to something other than
- * English we have none — so we express no preference and let clarity decide.
+ * A mismatched accent is a genuine obstacle when the whole exercise is mapping
+ * a sound onto letters, so the accent a child hears all day is worth
+ * preferring — and the device's own language is the only evidence of it we
+ * have. A device set to something other than English gives us none, so we
+ * express no preference there and let clarity decide.
  */
 function deviceEnglish(): string | null {
   const tag =
@@ -80,8 +79,7 @@ const rank = (v: SpeechSynthesisVoice, want: string | null): number =>
  * better on Chrome and cost a spelling word leaving the house — see the header
  * — so the filter is a hard gate rather than a preference. The one exception is
  * a device with no local English voice at all, which falls through to whatever
- * English exists: at that point the alternative is silence, and the same
- * fallback was already here.
+ * English exists: at that point the alternative is silence.
  *
  * Sort is stable, so voices we rate equally stay in the order the platform
  * offered them — which is the platform's own preference, and a better
@@ -155,8 +153,8 @@ const stopWatching = () => {
  *
  * `onFail` is how a caller learns the word did NOT get said. The return value
  * can't carry that: everything interesting happens after `speak()` has already
- * returned true. Call it at most once, and only for a genuine failure — see
- * the error triage below, which is subtler than it looks.
+ * returned true. Call it at most once, and only for a genuine failure — see the
+ * error triage below.
  */
 export function say(text: string, onFail?: () => void): boolean {
   const engine = synth();

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -55,10 +55,7 @@
 }
 
 /* ── Five more, for paper ──────────────────────────────────────────────────
-   The Print Shop's faces. Same argument as above and then some: a worksheet is
-   the one thing here a parent is asked to look at for a minute before they
-   print it, so a face that arrives from Google's CDN would be a request with a
-   child's IP in it on the page that exists to make something for that child.
+   The Print Shop's faces, self-hosted for the same reason as the three above.
 
    They cost every other page nothing. A `@font-face` is a declaration, not a
    download — a browser fetches the file only when it has a glyph to draw in
@@ -72,18 +69,11 @@
                    sits nearer the midline of primary ruled paper than a text
                    face's does. The default, because a worksheet is set in
                    print unless somebody says otherwise.
-     Playwrite     Cursive, and three of them rather than one. TypeTogether's
-     US Trad       superfamily covers the handwriting models actually taught in
-     US Modern     forty-odd countries, built on the Primarium research, and
-     GB J          they are genuinely different models rather than three
-                   flavours of one: US Trad loops its ascenders and joins out
-                   of every letter, US Modern draws the same letters unlooped
-                   and lifts the pencil after `b f g j p q s y`, and GB J is
-                   the
-                   fully joined hand a British primary school teaches. Which
-                   letters join to which is in each file's `calt` table, so the
-                   model decides a join and this repo never does — see §6 and
-                   `engine/sheets/writing/joins.ts`. Their capitals and
+     Playwrite     Cursive, and three of them because the three handwriting
+     US Trad       models are genuinely different rather than flavours of one
+     US Modern     (§6). Which letters join to which is in each file's `calt`
+     GB J          table, so the model decides a join and this repo never does
+                   — `engine/sheets/writing/joins.ts`. Their capitals and
                    ascenders stand nearly a whole em tall, because the faces
                    are drawn to a ruling rather than to a paragraph, which is
                    why the tracing arithmetic in `faces.ts` comes out exact for

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -2226,10 +2226,11 @@ label.segmented__btn {
      far, so the distance is whatever sky there is, which is the whole viewport
      (decision 64). A 900ms fall crosses about 640px on a 1512×850 laptop and
      about 1100px on a 27-inch monitor, so without a ceiling the same level is a
-     different game depending on what a child opens it on. Nine stone heights a second is a shade above what the
-     tallest ordinary screen asks for, so on anything a child is likely to be
-     sitting at the stone uses the full sky and this changes nothing; on a
-     display taller than that it starts lower and falls at the ceiling.
+     different game depending on what a child opens it on. Nine stone heights a
+     second is a shade above what the tallest ordinary screen asks for, so on
+     anything a child is likely to be sitting at the stone uses the full sky and
+     this changes nothing; on a display taller than that it starts lower and
+     falls at the ceiling.
 
      Stone heights and not pixels, because what smears a moving glyph is how
      far it travels against its own size — a cap written in pixels would mean

--- a/src/styles/game.css
+++ b/src/styles/game.css
@@ -1880,26 +1880,12 @@ label.segmented__btn {
    one number sets the scale of all of it, floored so it stays legible on a
    narrow phone.
 
-   **The cap is the real thing's measurement, not a taste.** Key pitch on
-   every full-size keyboard a child will ever meet is 19.05mm — three quarters
-   of an inch, which CSS defines as exactly 72px, which is 4.5rem. That is the
-   number, and it is written in rem rather than in `mm` (identical lengths,
-   since CSS pins an inch to 96px) so that a child who has turned their text
-   up gets a board that grew with everything else.
-
-   Why life-size rather than merely large, on the screen that draws a board:
-   it is not an illustration of a keyboard, it is a map a child glances at
-   while their hands are on the actual one. A map at half scale asks them to
-   do the scaling — to see that the gap between `f` and `j` on screen is the
-   gap their two index fingers are already holding — and that translation is
-   exactly the work looking down at their hands would have saved them. At
-   pitch, the picture and the plastic are the same shape, so the glance costs
-   nothing and the reach it teaches is the reach they make.
-
-   And on the screen that draws no board, the cap is doing the same job for
-   the same reason. Hailstorm has lanes rather than keycaps now (decision 64),
-   but a lane still claims to be where that key IS — so a field wider than a
-   keyboard would be teaching a reach nobody's hand makes.
+   **The 4.5rem cap is a measurement, not a taste** (§4.7): key pitch on every
+   full-size keyboard a child will meet is 19.05mm, which CSS makes exactly
+   72px. In rem rather than mm — identical lengths — so a child who turned
+   their text up gets a board that grew with them. Hailstorm draws lanes rather
+   than keycaps and keeps the same ceiling, because a lane claims to be where
+   that key is.
 
    ── What this value is, and what overrides it ──────────────────────────────
    THIS one is the storm's: the lanes, the hailstones and the eight shield
@@ -1911,13 +1897,13 @@ label.segmented__btn {
    big enough that there is no sky left to read it against.
 
    The passage screen overrides it below, because that screen draws five rows
-   of keycaps under a HUD, three bars and a line of words. It lived on
-   `.keyboard` until Hailstorm and could not stay there — a custom property
-   inherits downwards only, so a value declared on the board is a value the
-   sky above it cannot read (docs/typing.md §8.2, decision 37). At the root
-   both screens can reach it and each is one value, which is the property that
-   matters: within a screen a lane and the segment it lands on are never free
-   to disagree about how wide a key is.
+   of keycaps under a HUD, three bars and a line of words. The declaration is
+   at the ROOT and not on `.keyboard`, because a custom property inherits
+   downwards only: a value declared on the board is a value the sky above it
+   cannot read (docs/typing.md §8.2, decision 37). At the root both screens
+   reach it and each sees one value, which is the property that matters —
+   within a screen a lane and the segment it lands on are never free to
+   disagree about how wide a key is.
 
    `--key-gap` is here for the same reason and one more: it is the inset that
    turns a key's slot into the keycap drawn inside it, so it is also what the
@@ -1931,30 +1917,18 @@ label.segmented__btn {
 
 /* …and one extra term on the passage screen: what is left after the words.
 
-   `9dvh` is a FRACTION of the viewport, and what the board is competing with
-   here is not a fraction. The HUD, the pass bars or the ghost lane, the line
-   you type on, four grid gaps and the race's own padding come to about 365px
-   at every height — they are type and borders, and none of them grows with
-   the window — and two lines of passage left to read is another 60. A dvh
-   coefficient that clears 425px of that at an 850px viewport does not clear
-   it at 700, which is how the board could grow the PAGE: `.race` is
-   `min-height`, so a grid whose rows stop fitting simply gets taller, and a
-   race that scrolls under a child's thumb mid-word is the exact thing that
-   `min-height` is there to prevent. At half pitch the ceiling hid this —
-   a 2.4rem board fitted anywhere, so the dvh term was never the governor it
-   looked like.
-
-   So the height term is a subtraction, not a proportion: take the constant
-   off the viewport and divide by the board's own height in key units — five
-   rows and the four gaps between them, `5 + 4 × 0.09`. The board is handed
-   what is actually left rather than a guess at it.
+   The height term is a subtraction rather than a proportion — the constant
+   this screen's chrome costs, taken off the viewport and divided by the
+   board's own height in key units, `5 + 4 × 0.09` (§4.7 does the arithmetic).
+   A dvh fraction cannot do it: `.race` is `min-height`, so a board that stops
+   fitting grows the PAGE, and a race that scrolls under a child's thumb
+   mid-word is the exact thing `min-height` is there to prevent.
 
    This is a second declaration of `--key`, which the note above rules out —
-   and it is not the one it rules out. What the storm may never do is let a
-   falling letter's lane and the cap it names come from two numbers. The
-   passage screen has no lanes: the board is the only thing on it that reads
-   `--key` at all, and a screen only ever sees one of these two values. There
-   is nothing here left to disagree.                                       */
+   and it is not the one it rules out. What may never happen is a falling
+   letter's lane and the cap it names coming from two numbers. The passage
+   screen has no lanes: the board is the only thing on it that reads `--key`,
+   and a screen only ever sees one of these two values.                    */
 .race.typing {
   --key: clamp(
     1.05rem,
@@ -2249,11 +2223,10 @@ label.segmented__btn {
      this only has to stop the one case that beat cannot cover.
 
      That case is real. A wave says how LONG a letter falls for and never how
-     far, so the distance is whatever sky there is — and since #197 took the
-     keyboard off the screen, that is the whole viewport. A 900ms fall crosses
-     about 640px on a 1512×850 laptop and about 1100px on a 27-inch monitor, so
-     without a ceiling the same level is a different game depending on what a
-     child opens it on. Nine stone heights a second is a shade above what the
+     far, so the distance is whatever sky there is, which is the whole viewport
+     (decision 64). A 900ms fall crosses about 640px on a 1512×850 laptop and
+     about 1100px on a 27-inch monitor, so without a ceiling the same level is a
+     different game depending on what a child opens it on. Nine stone heights a second is a shade above what the
      tallest ordinary screen asks for, so on anything a child is likely to be
      sitting at the stone uses the full sky and this changes nothing; on a
      display taller than that it starts lower and falls at the ceiling.
@@ -2285,11 +2258,9 @@ label.segmented__btn {
      there is an ending to show — nothing before that, so an `auto` track with
      no child in it is zero and the sky has the whole screen.
 
-     There was a board in that track until #197 and it was taking about 45% of
-     the height (decision 64). What it was taking it from is the fall, which is
-     the only thing on this screen that gives a child time to read a letter and
-     find its key — so the sky roughly doubled when it went, and the row it
-     left behind is the one the ending was already using. */
+     Nothing but the ending may go in that second track. Height taken there
+     comes out of the fall, which is the only thing on this screen that gives a
+     child time to read a letter and find its key (decision 64). */
   grid-template-rows: minmax(0, 1fr) auto;
   gap: clamp(0.35rem, 1.5vh, 1rem);
   padding: clamp(0.4rem, 1.5vh, 1rem) clamp(0.5rem, 2vw, 1rem);
@@ -2315,9 +2286,8 @@ label.segmented__btn {
    width of the field.
 
    The line the letters land on is the shield, at the bottom of this box and
-   inside it (below). It replaced a `border-bottom` here, and had to: a border
-   is one line where the thing a child has to read is eight, and the eight
-   have to be able to break one at a time. */
+   inside it (below) — eight elements rather than a `border-bottom`, because
+   the eight have to be able to break one at a time. */
 .storm__sky {
   position: relative;
   width: calc(15 * var(--key));
@@ -2334,7 +2304,7 @@ label.segmented__btn {
 
   /* Nothing in here is an interface. A drag should not select a hailstorm,
      and a tap should not land on a letter — the only thing that fires in this
-     game is a key (§8.8). */
+     game is a key (§8.11). */
   pointer-events: none;
   user-select: none;
 }
@@ -2427,12 +2397,12 @@ label.segmented__btn {
 
   border: 1px solid color-mix(in oklab, var(--accent) 42%, transparent);
   border-radius: calc(var(--key) * 0.3);
-  /* Opaque, where it used to be 88% of the ink. The only thing a stone ever
-     crosses is the HUD (see below), and the glyph inside it is the one thing
-     on this screen that has to be read at a glance while it is moving — a
-     score showing faintly through the `l` a child is trying to tell from an
-     `i` is a contrast cost for no gain. The HUD is still legible: what it is
-     drawn in is `--chalk-dim`, and what passes over it is one stone. */
+  /* Opaque rather than translucent. The only thing a stone ever crosses is the
+     HUD (see below), and the glyph inside it is the one thing on this screen
+     that has to be read at a glance while it is moving — a score showing
+     faintly through the `l` a child is trying to tell from an `i` is a contrast
+     cost for no gain. The HUD is still legible: what it is drawn in is
+     `--chalk-dim`, and what passes over it is one stone. */
   background: var(--ink-800);
   box-shadow: 0 0 calc(var(--key) * 0.45)
     color-mix(in oklab, var(--accent) 18%, transparent);
@@ -2563,18 +2533,11 @@ label.segmented__btn {
   color: var(--lime);
 }
 
-/* The way out, mid-run (docs/typing.md §8.8, decision 54).
+/* The way out, mid-run (docs/typing.md §8.11, decision 54).
 
-   A storm is a whole viewport with no site chrome over it, so this is the only
-   exit a child has until the run ends — and on a tablet, where the game cannot
-   be played at all, it is the only thing on the screen that does anything.
-   `Escape` is the same door for a child at a keyboard (`QUIT_KEY`), which this
-   one cannot be: `Tab` is a key the gun swallows while it is live.
-
-   `pointer-events` are handed back here and nowhere else in the sky. The sky
-   refuses them so a drag cannot select a hailstorm and a tap cannot land on a
-   letter, and this is the single exception — the one thing in there a finger
-   is meant to hit.
+   `pointer-events` are handed back here and nowhere else in the sky — the one
+   thing in there a finger is meant to hit, and on a tablet the only thing on
+   the screen that does anything at all (§8.8).
 
    Drawn like the race's quit and dimmer than the numbers beside it: it is the
    least urgent thing in the sky, and the letters have to stay the loudest. */
@@ -2860,19 +2823,15 @@ label.segmented__btn {
    motion to reach. That is the same reason `.fuse__fill` scales rather than
    animating: a clock a player asked less motion of still has to run.
 
-   **What comes off is decoration, and there is less of it here than the
-   design feared.** §8.10 asks for no screen shake, no parallax and no
-   particles under this setting, and the honest answer is that Hailstorm has
-   never had any of the three: nothing translates but the stones, the sky is
-   one flat box rather than layers at different speeds, and the only thing on
-   the screen resembling a particle is a hailstone, which is the game. The
-   guarantee is kept by not having built them, and it is measured rather than
-   promised — `e2e/smoke.mjs` runs the same twelve-landing wave twice and
-   counts `animationstart` over the whole of each: twelve under normal motion
-   (one per letter that lands), and zero under this setting. Both censuses
-   filter on `animationName` starting `storm-`, so what they can catch is a
-   new animation named into this family; one added under any other prefix is
-   invisible to them and needs its own check.
+   **What comes off is decoration, and there is almost none of it.** Nothing
+   translates but the stones, the sky is one flat box rather than layers at
+   different speeds, and the only thing resembling a particle is a hailstone,
+   which is the game — so §8.10's guarantee is kept by not having built any of
+   it. It is measured rather than promised: `e2e/smoke.mjs` runs the same
+   twelve-landing wave twice and counts `animationstart` over the whole of
+   each, twelve under normal motion and zero under this setting. Both censuses
+   filter on `animationName` starting `storm-`, so an animation added under any
+   other prefix is invisible to them and needs its own check.
 
    What is left is the three tints, and they are switched off rather than
    left to the blanket clamp. Under the clamp they still start and still fire
@@ -3008,7 +2967,7 @@ label.segmented__btn {
 /* The same eight hues the keycaps carry, on the same closed set of fingers —
    see the board's block above, and tokens.css for why none of them is one of
    the telemetry five. There is no thumb segment: nothing falls on the space
-   bar (§8.3).
+   bar (§8.5).
 
    The ending panel is on this list because it NAMES one of the eight, and the
    name has to be the colour of the block that broke and of the keys under it:

--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -197,8 +197,7 @@
 /* The viewport step is 2.6vw rather than the 3.4vw three columns could afford:
    a fourth column takes a quarter off every card, and at the narrow end of the
    four-across range a display face sized for a third of the row breaks "Word
-   Jungle" across two lines. Both ends of the clamp are unchanged, so a phone
-   and a wide desktop see exactly what they saw before. */
+   Jungle" across two lines. */
 .world__name {
   font-family: var(--font-display);
   font-weight: 400;

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -1,13 +1,11 @@
 /* ── What happens when somebody presses ⌘P ──────────────────────────────────
-   Print only. There is no PDF library here and there never will be: it would
-   cost ~600KB and a second rendering path that drifts from the first, and the
-   browser's own "Save as PDF" is already the download path (§10, decided).
+   Print only, and no PDF library (§10, decided) — so the print dialog is the
+   *whole* of the output path.
 
-   That makes the print dialog the *whole* of the output. Everything in this
-   file is therefore load-bearing rather than cosmetic — a masthead that
-   survives onto paper is a masthead a parent pays for in toner, and a page box
-   that disagrees with the sheet on it prints across two pages or gets silently
-   scaled to fit.
+   That is why everything in this file is load-bearing rather than cosmetic — a
+   masthead that survives onto paper is a masthead a parent pays for in toner,
+   and a page box that disagrees with the sheet on it prints across two pages or
+   gets silently scaled to fit.
 
    This file is imported by the sheet renderer rather than by a layout, so it
    lands on exactly the pages that have a sheet on them, and nowhere else. That

--- a/src/styles/screens.css
+++ b/src/styles/screens.css
@@ -239,11 +239,9 @@
 
 /* ── Modal ──────────────────────────────────────────────────────────────────
    The panel behind the player editor, the deck editor and the quit
-   confirmation. It was `.sheet` until The Print Shop arrived, and the rename is
-   recorded in the header of sheet.css: `/printables/make` is an island that
-   loads this file *and* the sheet renderer's, and two `.sheet` rules meeting
-   means an 8.5-inch-wide `position: fixed` modal. In a codebase with a print
-   shop in it, a sheet is a piece of paper.                                   */
+   confirmation. Not `.sheet`: `/printables/make` is an island that loads this
+   file *and* the sheet renderer's, and two `.sheet` rules meeting there is an
+   8.5-inch-wide `position: fixed` modal.                                     */
 
 .modal {
   position: fixed;

--- a/src/styles/sheet.css
+++ b/src/styles/sheet.css
@@ -11,21 +11,10 @@
    and every length in here is an inch, a point, or an em of a size that was
    itself set in points.
 
-   ── One name collision, settled ─────────────────────────────────────────────
-   `screens.css` used to have a `.sheet` of its own: the modal panel behind the
-   player editor and the quit confirmation. The two never met while this file
-   arrived with the renderer and that one with `index.css` on the game islands —
-   but `/printables/make` is an island that loads both, and on that day an
-   8.5in-wide `position: fixed` modal is what happened. So the modal was renamed
-   to `.modal` when the builder landed, which is the right way round: in a
-   codebase with a print shop in it, a sheet is a piece of paper.
-
    ── The ink ────────────────────────────────────────────────────────────────
-   Black on white with no fills, by default and on purpose. A parent printing
-   thirty pages a week is paying for this in toner, so ink-saving is a feature
-   rather than an accident (§5) — and it composes with the fact that browsers
-   drop background paint when printing anyway. Everything a child writes on is
-   a stroke or a border, both of which are foreground and always print.       */
+   Black on white with no fills (§5). Everything a child writes on is a stroke
+   or a border — foreground paint, which prints even when a browser drops
+   background graphics.                                                       */
 
 .sheet {
   --ui-scale: 1;
@@ -243,28 +232,23 @@
 }
 
 /* ── The five faces (§6) ────────────────────────────────────────────────────
-   Files now, self-hosted beside the site's own three — see `fonts.css` for
-   which face does which job and why none of them is a request to a CDN. What
-   is left in here is the part that belongs in a stylesheet: the stack, and the
-   fallback each id lands on while its woff2 is in flight or on a page that
-   never loaded `fonts.css`.
+   Self-hosted beside the site's own three — see `fonts.css` for which face
+   does which job and why none of them is a request to a CDN. What belongs in a
+   stylesheet is here: the stack, and the fallback each id lands on while its
+   woff2 is in flight or on a page that never loaded `fonts.css`.
 
-   The `Sheet` carries the id and never the stack. That is what let three of
-   these be system fonts for two stories and files today without a single saved
-   sheet changing its mind about which face it wanted.
+   The `Sheet` carries the id and never the stack, so a stack can change
+   without a saved sheet changing its mind about which face it wanted.
 
    The engine has measured proportions for all five (`faces.ts`) and sizes
    traced letterforms off them, so **the family named here and the family named
    there have to be the same font**. Changing one alone prints letters through
    the top rule.
 
-   Three of them are cursive, because there is no such thing as cursive: the
-   looped hand an American school teaches, the unlooped one that lifts the
-   pencil after `b f g j p q s y`, and the fully joined hand a British one
-   teaches
-   are three different models, and picking one would be calling the other two
-   wrong. `cursive` stays unqualified because it is the id saved sheets already
-   carry (§6).
+   Three of them are cursive, because the three handwriting models taught are
+   genuinely different and picking one would be calling the other two wrong
+   (§6). `cursive` stays unqualified because it is the id saved sheets already
+   carry.
 
    Their system fallbacks are a courtesy and nothing more. A script face a
    reader happens to have installed joins where it likes, which on a sheet of

--- a/src/styles/worlds.css
+++ b/src/styles/worlds.css
@@ -9,9 +9,8 @@
    properties instead of a second stylesheet — and why re-skinning a screen
    cannot move a box on it.
 
-   What a world may NOT touch is the telemetry five in tokens.css. Wrong is the
-   same red everywhere. A child should not have to re-learn the signal because
-   the background changed.
+   What a world may NOT touch is the telemetry five — see `tokens.css`, where
+   they are declared and the rule is written down.
 
    The blocks are scoped to `[data-world]` rather than `:root[data-world]` so
    the same declarations can dress a single element. That is what lets the


### PR DESCRIPTION
## What this does

The comment sweep after the two big subtrees. `engine/` outside `sheets/` and
`typing/`, `services/`, `components/` outside `sheet/`, `games/race/`,
`games/flashcards/` and `src/styles/` are read against the DEBT01 standard, and
what `docs/` already owns is cut rather than restated.

Closes #208. (The epic's issue titles are copy-paste mismatched with their
bodies — #208's body is this sweep, not the sheets/printables consolidation its
title names.)

## Before / after

```
comment lines (src/)   26,522 → 26,282   (ratio 0.378 → 0.375)
  engine/ (outside sheets, typing)  1,939 → 1,836   (0.401 → 0.380)
  services/                         1,070 → 1,013   (0.536 → 0.507)
  components/ (outside sheet)         792 →   751   (0.275 → 0.261)
  games/race/                         208 →   192   (0.314 → 0.290)
  games/flashcards/                   372 →   357   (0.182 → 0.175)
  src/styles/ (not in the audit)    1,705 → 1,639   (0.307 → 0.295)
verbatim eight-word phrases shared with docs/   1,234 → 1,003
blocks of 20+ comment lines                       109 → 101

engine/types.ts        192 → 162   quoting docs/  40 → 17
engine/progress.ts     143 →  80   quoting docs/ 116 →  6
services/sound.ts      168 → 120   quoting docs/  86 →  4
components/site/ads.ts 103 →  84
services/analytics.ts   93 →  86
services/speech.ts     114 → 112
engine/combo.ts         27 →  23
```

Code lines under `src/` are 70,144 at both `develop` and `HEAD` — no code was
added or removed.

## The largest overlaps

`engine/progress.ts` was the biggest left outside the two big subtrees: 116
phrases shared word for word with `docs/typing.md`. The three badge blocks were
§6.7 in different words, down to the express lane and the derived-rule
alternative; `stormXp`'s header was §8.6. What stays is what the doc does not
carry — the `max(0, …)` no test can reach, the run handed over beside the
history because it is not saved yet, and `correct > 0` being redundant on
purpose.

`engine/types.ts` is `TypingConfig`'s three optional fields, each carrying a
page of prose that §4.2, §5.4, §8.7 and §10 already own. What stays sits on the
field it constrains.

`services/sound.ts` keeps how each sound is **built** — two noise sweeps back to
back for a shot going past, the typebar/body/escapement layering, `noise`
starting at full gain where `tone` ramps over 12 ms — and drops the design story
§8.12 and §4.8 tell better.

## The fact written three times

`docs/typing.md §8.6` is now the owner of "the storm may not import
`progress.ts`". `engine/combo.ts`'s header is cut to the constraint plus that
citation, and `eslint.config.mjs`'s prose above `CORPUS_BAN` points at §5.3
instead of retelling it. The `CORPUS_BAN` string itself is untouched: it is
executable code, and it is what a developer sees at the moment of the violation
with no doc to hand.

## Historical narrative

Sixteen sites, in and out of the named subtrees — "There was a board in that
track until #197", "used to be 88% of the ink", "It used to open /flash-cards"
(twice), "It was false for exactly that reason once already", "Ported from
monilibrium_2", "the guard that retired itself". Each is replaced by the
constraint it was carrying, in the present tense, or deleted where git already
holds it. The two survivors are `sheet.css`'s "inherited from `base.css`" (CSS
inheritance, not history) and the 222 KB measurement inside `CORPUS_BAN`.

## Three § that named the wrong section

`src/styles/game.css` cited §8.8 twice for the sky's `pointer-events` and the
quit control — both are §8.11, which carries decision 54 — and cited §8.3 for
"nothing falls on the space bar", which is §8.5's sentence. All fixed, plus both
siblings of the first. Every other § in `src/styles/` was opened and checked.

## The one code change

`comboMultiplier` hard-coded its divisor as 10 beside a `MAX_COMBO_STEPS = 10`
it also read, so retuning the constant would silently move the ×2 ceiling the
comment promises. The divisor is now the constant, which makes the ceiling
structural — the cap over itself is 1 whatever the cap is. Identical output at
10.

## Behaviour preservation

Verified by parsing every changed `.ts` / `.tsx` / `.mjs` / `.astro` / `.css`
file at both refs and comparing comment-stripped output: all byte-identical
except the intended `engine/combo.ts` constant change. `describe` / `it` counts
are unchanged in all three changed test files, and `scripts/section-guard.mjs`
is clean across 1,364 citations — every one a section that exists.

## Validation

`type-check`, `lint`, `build`, `format:check`, `section-guard.mjs`, 2,231 unit
tests and the browser smoke suite (console errors: none) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
