### PR TITLE
Say what the profile editor, the site chrome and the record book are for (#209)

### DIFF
--- a/src/components/PlayerEditor.tsx
+++ b/src/components/PlayerEditor.tsx
@@ -4,6 +4,13 @@ import { sfx } from "@/services/sound";
 import type { Profile } from "@/engine/types";
 import { Button, Field, FieldSet, Input, Scrim } from "@/components/ui/kit";
 
+/**
+ * The faces on offer, and the order a new player's default is taken from.
+ *
+ * The default rotates on how many players already exist, so the second child
+ * in a house isn't handed the first child's fox. On the picker the face and
+ * the colour are the whole of how a five-year-old finds their own card.
+ */
 export const AVATARS = [
   "🦊",
   "🐼",
@@ -31,6 +38,11 @@ export const AVATARS = [
   "🐉",
 ];
 
+/**
+ * Rotated the same way, and not only a swatch: `usePlayer` writes the chosen
+ * one to `--accent`, so it becomes the colour of the whole app while that
+ * player is in it.
+ */
 export const COLORS = [
   "#4cc4ff",
   "#c8ff41",
@@ -43,11 +55,33 @@ export const COLORS = [
 ];
 
 type Props = {
+  /**
+   * The player being edited, or `null` for a new one. Callers hold a third
+   * state — `undefined`, meaning no dialog at all — which is why this is
+   * `Profile | null` rather than optional.
+   */
   profile: Profile | null;
   onClose: () => void;
   onDeleted?: () => void;
 };
 
+/**
+ * Add or edit a player, in one dialog.
+ *
+ * **The form pre-empts two of the three name rules and cannot pre-empt the
+ * third.** `services/profiles.ts` wants a name that is non-empty once trimmed,
+ * no longer than 24 characters, and not already taken by someone else in the
+ * house (compared without case). The first two are held here — Save stays
+ * disabled on an empty box, `maxLength` stops the 25th character — so a child
+ * never meets an error for them. A clash can only be answered by reading
+ * storage, so it arrives as a thrown `InvalidInput` and `save` shows that
+ * message verbatim: the service names who already has the name, where a
+ * generic "Could not save" would leave a child guessing.
+ *
+ * The age stepper's 3 to 18 is the same range that service validates. Widen
+ * one and the other has to move with it, or − and + start offering a value the
+ * save then rejects.
+ */
 export default function PlayerEditor({ profile, onClose, onDeleted }: Props) {
   const { createProfile, updateProfile, deleteProfile, profiles, notify } =
     useHub();
@@ -56,6 +90,10 @@ export default function PlayerEditor({ profile, onClose, onDeleted }: Props) {
   const [emoji, setEmoji] = useState(
     profile?.emoji ?? AVATARS[profiles.length % AVATARS.length],
   );
+  // Previewed live: the form below carries its own `--accent`, so the Save
+  // button and the focus rings take this colour before it is saved. The root
+  // holds the saved one (`usePlayer`), which is what makes closing without
+  // saving leave nothing behind.
   const [color, setColor] = useState(
     profile?.color ?? COLORS[profiles.length % COLORS.length],
   );
@@ -100,10 +138,17 @@ export default function PlayerEditor({ profile, onClose, onDeleted }: Props) {
       onClose();
     } catch (err) {
       notify(err instanceof Error ? err.message : "Could not save", "bad");
+      // Cleared only on the way that stays on screen. A save that worked has
+      // already closed the dialog, so there is nothing left to hand the
+      // buttons back to; a save that failed has to, because the name that
+      // caused it is still in the box waiting to be fixed.
       setSaving(false);
     }
   }
 
+  // `deleteProfile` cascades: the races go with the player, and IndexedDB
+  // holds the only copy of them. That is what the confirmation below is
+  // naming, rather than asking "are you sure?" about something unstated.
   async function remove() {
     if (!profile) return;
     setSaving(true);

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -11,6 +11,23 @@ type Props = {
   children?: React.ReactNode;
 };
 
+/**
+ * The chrome around a game: who is playing, how far along they are, and the
+ * ways out.
+ *
+ * **It must never sit over a running race.** Every screen either side of one
+ * has it — the hub, the setup screen, the results, the record book — and the
+ * track itself puts `race/Hud` there instead: quit, clock, count, nothing
+ * else. A map link or a sound toggle a thumb's width from the answer field is
+ * a run thrown away by accident, and the single way out of a live run goes
+ * through `QuitSheet`, which pauses the clock and says what abandoning it
+ * costs. So don't mount this on a track, and don't add anything to it that
+ * would be unsafe to press at any moment.
+ *
+ * `children` renders before the map and sound icons, which is what keeps those
+ * two together at the end of the row on every screen while a screen adds its
+ * own beside them.
+ */
 export default function TopBar({
   profile,
   back = { to: "/", label: "Players" },
@@ -18,8 +35,16 @@ export default function TopBar({
 }: Props) {
   const { updateProfile, notify } = useHub();
   const { level, intoLevel, levelSpan, progress } = levelFromXp(profile.xp);
+  // Missing reads as on. The type says every profile carries `soundOn`, but a
+  // backup is restored into the store whole, so that is a promise about the
+  // records this build wrote rather than about every record in the store.
   const soundOn = profile.soundOn !== false;
 
+  // The sound service is flipped before the write rather than after it: a
+  // child taps the speaker because they want the next sound gone now, and
+  // waiting on IndexedDB first would let one more through. A failed write puts
+  // the service back, so what is heard on this page always matches what the
+  // profile will say on the next one.
   async function toggleSound() {
     const next = !soundOn;
     setSoundEnabled(next);

--- a/src/components/screens/PlayerHub.tsx
+++ b/src/components/screens/PlayerHub.tsx
@@ -17,6 +17,17 @@ import { BADGES_BY_ID } from "@/engine/progress";
 import { WORLDS } from "@/engine/worlds";
 import { sfx } from "@/services/sound";
 
+/**
+ * A player's home on the card island: what they have done, and the way into
+ * the next race.
+ *
+ * Subject-agnostic on purpose. The eyebrow, the title and the blurb all come
+ * from `useSubject()`, so this one screen is The Grid at `/flash-cards` and
+ * Word Jungle at `/spelling/play`, and nothing in it names a deck family.
+ *
+ * The typing island has no equivalent: with one game there is nothing to
+ * choose between, so `/typing#/p/:id` is its setup screen instead.
+ */
 export default function PlayerHub() {
   const { profileId } = useParams();
   const { sessions } = useHub();
@@ -28,8 +39,14 @@ export default function PlayerHub() {
 
   const mine = sessionsFor(sessions, profile.id);
   const stats = lifetimeStats(mine);
+  // `loadHub` sorts sessions oldest-first and every write appends to the end,
+  // so the newest four are a reverse and a slice rather than a sort.
   const recent = [...mine].reverse().slice(0, 4);
   const flagship = bestRun(mine);
+  // A badge id outlives the table it was earned from: `Profile.badges` is the
+  // only copy there is, so an id this build no longer ships simply doesn't
+  // resolve (`engine/progress.ts`). Dropping the miss is what keeps an older
+  // profile rendering at all — and is why the `!`s below are safe.
   const badges = profile.badges
     .map((id) => BADGES_BY_ID.get(id))
     .filter(Boolean);
@@ -42,6 +59,9 @@ export default function PlayerHub() {
     mine.map((s) => s.mode),
     profile.age,
   );
+  // Six at most, and the button below is offered from three up. `buildDrill`
+  // runs two passes at each fact and never builds fewer than six cards, so a
+  // shorter list would only come round again.
   const trouble = troubleFacts(mine, drillMode, 6);
   // Everywhere else you could be. The world you're standing in isn't offered.
   const elsewhere = WORLDS.filter((w) => w.id !== subject.world);

--- a/src/components/screens/PlayerHub.tsx
+++ b/src/components/screens/PlayerHub.tsx
@@ -23,7 +23,9 @@ import { sfx } from "@/services/sound";
  *
  * Subject-agnostic on purpose. The eyebrow, the title and the blurb all come
  * from `useSubject()`, so this one screen is The Grid at `/flash-cards` and
- * Word Jungle at `/spelling/play`, and nothing in it names a deck family.
+ * Word Jungle at `/spelling/play`, and nothing in it branches on a deck
+ * family. (`timeLimitForAge` is imported from the flash-card module, but it
+ * only turns an age into a clock and is shared by every deck.)
  *
  * The typing island has no equivalent: with one game there is nothing to
  * choose between, so `/typing#/p/:id` is its setup screen instead.

--- a/src/components/screens/PlayerSelect.tsx
+++ b/src/components/screens/PlayerSelect.tsx
@@ -10,9 +10,26 @@ import { percent } from "@/engine/format";
 import { sfx } from "@/services/sound";
 import type { Profile } from "@/engine/types";
 
+/**
+ * Who's racing — the entry screen, and the only screen the racing islands
+ * share.
+ *
+ * `/flash-cards`, `/spelling/play` and `/typing` all mount it at their `/`,
+ * which is why it lives here rather than inside a game and why it names no
+ * subject: choosing a player comes before choosing what to practise, and all
+ * three mounts read one profile list because a game is a path and not a
+ * subdomain (CLAUDE.md).
+ *
+ * The line under the title counts the household — every player's races added
+ * up — while each card counts only its own player. A shared device is the
+ * assumption everywhere in this app, and this is the screen where it shows.
+ */
 export default function PlayerSelect() {
   const { profiles, sessions } = useHub();
   const navigate = useNavigate();
+  // Three states rather than two: `undefined` is no dialog, `null` is adding
+  // someone new, and a profile is editing that one. `PlayerEditor` sees only
+  // the last two.
   const [editing, setEditing] = useState<Profile | null | undefined>(undefined);
 
   const totals = lifetimeStats(sessions);

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -41,9 +41,15 @@ import { duration, percent } from "@/engine/format";
  * The record book — one screen for everything this player has ever raced.
  *
  * It is mounted on the card island, but it is not that island's screen. The
- * typing results link into it by URL (`/flash-cards#/p/:id/progress`), and the
- * stats, the badges and the records below cover every world a player has been
- * in. Only the fact map and the trouble spots are per-deck, chosen by `mode`.
+ * typing results link into it by URL (`/flash-cards#/p/:id/progress`), and it
+ * mixes two scopes deliberately. Races, cards, correct, time practising, the
+ * badges, the record book and the run list all count every world the player
+ * has been in. The fact map, the trouble spots, the table trophies and the
+ * "Facts mastered" stat follow the deck switcher, because each of them reads
+ * `grid` or `trouble`, and `factStats`/`troubleFacts` drop every session run
+ * on another `mode`. So switching decks moves one stat in a strip of
+ * lifetime totals — intended, and the reason that strip is not simply
+ * `lifetimeStats`.
  *
  * So it has to be able to show a deck this mount cannot play, and `ownsMode`
  * is what decides that: it is the difference between "Drill these" being a

--- a/src/components/screens/Progress.tsx
+++ b/src/components/screens/Progress.tsx
@@ -37,6 +37,19 @@ import { RecordBook, RunList } from "./progress/RecordBook";
 import { TroubleSpots } from "./progress/TroubleSpots";
 import { duration, percent } from "@/engine/format";
 
+/**
+ * The record book — one screen for everything this player has ever raced.
+ *
+ * It is mounted on the card island, but it is not that island's screen. The
+ * typing results link into it by URL (`/flash-cards#/p/:id/progress`), and the
+ * stats, the badges and the records below cover every world a player has been
+ * in. Only the fact map and the trouble spots are per-deck, chosen by `mode`.
+ *
+ * So it has to be able to show a deck this mount cannot play, and `ownsMode`
+ * is what decides that: it is the difference between "Drill these" being a
+ * button here and being a link into the world that does own the deck
+ * (`TroubleSpots`).
+ */
 export default function Progress() {
   const { profileId } = useParams();
   const { profiles, sessions } = useHub();
@@ -132,9 +145,9 @@ export default function Progress() {
   /** Which world this deck is played in — and so where a drill of it starts. */
   const owner = WORLDS.find((w) => w.id === spec.world);
   /**
-   * The same facts as a worksheet, or null where this build has no sheet for
-   * them — a typing passage is not a page of problems (docs/printables.md
-   * §14).
+   * The same facts as a worksheet: the record book's second door, beside the
+   * drill (docs/printables.md §14). Null where this build has no sheet family
+   * for them — `practiceSheet` is where that call is made, and why.
    */
   const printable = practiceSheet(
     mode,

--- a/src/engine/format.ts
+++ b/src/engine/format.ts
@@ -1,4 +1,23 @@
-/** 74210 → "1:14.21" · 9840 → "9.84" */
+/**
+ * Numbers, as text a person reads.
+ *
+ * One way only. Nothing here parses text back into a number, and nothing it
+ * returns is safe to compare, sort or store: the values are rounded, clamped,
+ * and — for a date — in whatever locale the browser is set to.
+ *
+ * The one string this app really does compare never comes through here. A
+ * card's `answer` is already text in the engine ("56", not 56), and judging
+ * what was typed against it is `DeckSpec.normalise`'s job. So no answer,
+ * `factId` or `configKey` is formatted below, and changing how something here
+ * reads can never change whether a card was marked right.
+ */
+
+/**
+ * 74210 → "1:14.21" · 9840 → "9.84"
+ *
+ * Never negative: a clock that has run backwards is a bug upstream, and
+ * "-0.03" on the HUD hands it to the child to worry about instead.
+ */
 export function clock(ms: number, { withMinutes = true } = {}) {
   const safe = Math.max(0, ms);
   const totalSeconds = safe / 1000;
@@ -10,13 +29,22 @@ export function clock(ms: number, { withMinutes = true } = {}) {
   return totalSeconds.toFixed(2);
 }
 
-/** Signed split, rally style: "-1.42" when you're ahead. */
+/**
+ * Signed split, rally style: "−1.42" when you're ahead. A real minus (U+2212)
+ * and not a hyphen, so + and − are the same width down a mono column, and "±"
+ * for dead level, which "+0.00" would make look like behind by a rounding
+ * error.
+ */
 export function delta(ms: number) {
   const sign = ms > 0 ? "+" : ms < 0 ? "−" : "±";
   return `${sign}${(Math.abs(ms) / 1000).toFixed(2)}`;
 }
 
-/** Coarse duration for totals: "45s", "12m", "3h 20m". */
+/**
+ * Coarse duration for totals: "45s", "12m", "3h 20m". Rounded to one unit, so
+ * two of these must never be compared or subtracted — 61 seconds and 89
+ * seconds are both "1m". `clock` is the one for a time that means something.
+ */
 export function duration(ms: number) {
   const seconds = Math.round(ms / 1000);
   if (seconds < 60) return `${seconds}s`;
@@ -33,6 +61,12 @@ export function plural(count: number, one: string, many = `${one}s`) {
   return `${count} ${count === 1 ? one : many}`;
 }
 
+/**
+ * Month and day, in the reader's own locale. An unreadable date gives "—"
+ * rather than "Invalid Date", so a record from an older build, or one
+ * hand-edited into a backup, still draws its row in the record book instead of
+ * shouting about itself in the middle of a list.
+ */
 export function shortDate(iso: string) {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "—";


### PR DESCRIPTION
Closes #209.

The comment standard runs both ways. DEBT01 cut the files that said too much; this is the other end of it — the profile editor, the site chrome and the record book, which had almost nothing to say about themselves. A 245-line form carrying three comment lines, a top bar whose one real rule was written nowhere, and six formatting helpers whose contract is the whole of what they are.

## What is now written down

- **`components/PlayerEditor.tsx`** — the form pre-empts two of the three name rules from `services/profiles.ts` (trimmed and non-empty, 24 characters) and cannot pre-empt the third, because a clash with a sibling can only be answered by reading storage. That is why the catch shows `InvalidInput.message` verbatim rather than a generic "Could not save". The age stepper's 3–18 is that service's range. `saving` is cleared only on failure, because success has already unmounted the dialog. `deleteProfile` cascades, which is what the confirmation names.
- **`components/TopBar.tsx`** — the invariant the issue asks for: it must never sit over a running race. A track puts `race/Hud` there instead, and the way out of a live run goes through `QuitSheet`, which pauses the clock and says what abandoning it costs. Also why `soundOn` is read as `!== false`, and why the sound service is flipped before the write.
- **`components/screens/PlayerSelect.tsx`** — the only screen the racing islands share, mounted at `/` by all three; the tri-state `editing` (`undefined` closed, `null` new).
- **`components/screens/PlayerHub.tsx`** — subject-agnostic by construction; the typing island has no hub; a badge id outlives the badge table; three facts is the drill floor because `buildDrill` never builds fewer than six cards.
- **`components/screens/Progress.tsx`** — the record book is one screen for the whole site, linked into from typing by URL, which is why it must be able to show a deck this mount cannot play (`ownsMode`). The header now names **both** halves of the screen rather than claiming a split the file does not hold: races, cards, correct, time practising, the badges, the record book and the run list count every world; the fact map, the trouble spots, the table trophies and "Facts mastered" follow the deck switcher, because each reads `grid` or `trouble` and both are mode-filtered. A reader trusting the earlier word "only" would have believed the stats strip was lifetime totals, and the first deck switch would have contradicted them.
- **`engine/format.ts`** — the guarantee the issue asks for: everything here runs one way, and the one string the app compares never comes through it. A card's `answer` is already text in the engine (`"56"`, not `56`) and is judged by `DeckSpec.normalise`, so changing a format here can never change whether a card was marked right. Plus the clamp in `clock`, the U+2212 in `delta`, "never subtract two of these" on `duration`, and the "—" in `shortDate`.

`components/screens/progress/**` is deliberately left alone: those six files already carry headers, and adding to them is the over-correction the story warns about.

## Not over-corrected

Measured with `node scripts/comment-audit.mjs --json`, over the story's files:

|              | comment lines | code lines | ratio |
| ------------ | ------------- | ---------- | ----- |
| before       | 144           | 1343       | 0.107 |
| after        | 297           | 1343       | 0.221 |

| File | Before | After |
| --- | --- | --- |
| `PlayerEditor.tsx` | 3 | 48 |
| `TopBar.tsx` | 6 | 31 |
| `engine/format.ts` | 3 | 36 |
| `PlayerHub.tsx` | 10 | 30 |
| `PlayerSelect.tsx` | 6 | 23 |
| `Progress.tsx` | 35 | 48 |

Still well under the `src` average of 0.377, so nothing here lands over-commented in the other direction. `format.ts` sits at 1.13 deliberately — 32 lines of code, six public helpers, and the contract is the point. No new run of 20+ consecutive comment lines, no new phrase quoted from `docs/` (1003 unchanged), no new `§` reference (1281 unchanged). Every addition is an invariant, a constraint or a consequence — nothing restates a line of code.

## Also in here

One `§14` citation on `printable` in `Progress.tsx` was retargeted. §14 owns the door ("the progress screen … the same list, either raced or printed"); it does not own the null case, whose reasoning lives on `practiceSheet`. The citation now sits on the claim the section actually makes.

## Safety

Comments only — no executable code changed. Verified by parsing every touched file with the TypeScript compiler API and diffing the comment-stripped emit against `develop`: all identical.

## Validation

`type-check`, `lint`, `test:unit` (2231 passing), `build`, `format:check`, `node scripts/section-guard.mjs`, and the browser smoke test (all checks passed, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
