### PR TITLE
Fetch a sheet family when it is chosen, not when the Print Shop opens (#211)

### DIFF
--- a/docs/printables.md
+++ b/docs/printables.md
@@ -62,8 +62,11 @@ written before there were any worksheets. It is still the right shape.
 
 ```
 src/engine/sheets/
-  spec.ts          SheetSpec — what every family of sheets must say about itself
-  index.ts         the front door: sheetSpec(kind), buildSheet(config, seed)
+  spec.ts          SheetSpec — how a family builds, keys and describes a sheet
+  families.ts      the family table: which kinds there are, what each is
+                   called, and the import() that fetches one
+  index.ts         the front door for Node: every family awaited, then
+                   sheetSpec(kind), buildSheet(config, seed)
   types.ts         SheetConfig union, Sheet, Block
   paper.ts         page sizes, margins, ruling geometry — all in real units
   layout.ts        how many problems fit on a page (pure arithmetic, no DOM)
@@ -106,9 +109,6 @@ problem, so it gets the same shape of answer:
 
 ```ts
 export type SheetSpec = {
-  /** Matches SheetConfig.kind, so a saved sheet finds its way back here. */
-  id: string;
-  label: string;
   /** Which world it prints in — always "paper", but stated, not assumed. */
   world: World;
   /** Build the sheet. Deterministic in (config, seed). */
@@ -123,6 +123,29 @@ export type SheetSpec = {
 `sheetSpec(kind)` never throws, for the same reason `deckSpec(mode)` never
 throws: a sheet saved six months ago must still open after its family is
 renamed. Return an `UNKNOWN_SHEET` that renders a blank page and says so.
+
+### One table, two doors
+
+Behaviour is all a spec carries. Which `kind` reaches a family and what it is
+called are in `families.ts`, beside a `() => import(...)` for the module itself,
+because a family reached by a static import is a family in every bundle that can
+see the registry — and several carry a corpus. Eagerly, the builder shipped
+421.7 KB against 48–78 KB for every other island, the passage library alone
+being 174 KB of text: a parent choosing a times-table sheet downloaded the King
+James Bible to do it.
+
+So the table is read two ways:
+
+- **`index.ts` awaits all of it**, once, at module load. The catalog build and
+  the tests keep an ordinary synchronous `buildSheet`, and nothing that ships
+  to a browser imports this module.
+- **The builder island loads one at a time**, through `loadSheet(kind)`, and
+  renders no paper until the family that draws it has landed. The picker still
+  names all twenty-seven, because naming them is what the table is for.
+
+The option panels split on the same seam (`games/printshop/options/index.tsx`),
+which is the half that matters for the passage picker: it reads the whole
+library to list it.
 
 ### `Sheet` is plain data
 

--- a/docs/printables.md
+++ b/docs/printables.md
@@ -129,10 +129,27 @@ renamed. Return an `UNKNOWN_SHEET` that renders a blank page and says so.
 Behaviour is all a spec carries. Which `kind` reaches a family and what it is
 called are in `families.ts`, beside a `() => import(...)` for the module itself,
 because a family reached by a static import is a family in every bundle that can
-see the registry — and several carry a corpus. Eagerly, the builder shipped
-421.7 KB against 48–78 KB for every other island, the passage library alone
-being 174 KB of text: a parent choosing a times-table sheet downloaded the King
-James Bible to do it.
+see the registry — and several carry a corpus. Eagerly, opening the builder
+fetched **696,078 B** of JavaScript, the passage library alone being 174 KB of
+text: a parent choosing a times-table sheet downloaded the King James Bible to
+do it. It now fetches **340,503 B**, and the rest arrives a family at a time.
+
+**Both numbers are the whole static import closure, walked from
+`dist/printables/make/index.html` — not the island's entry chunk.** The entry
+chunk fell much further, 431,805 B to 66,315 B, but most of that is code that
+moved into siblings the entry still imports statically; a budget set on the
+entry alone would sit at 66 KB and never notice 300 KB of new siblings beside
+it. Two thirds of what remains is React (184,057 B, the same file on both
+sides): the sheet code itself is 512,021 B → 156,446 B. Whatever enforces a
+budget here has to walk the closure for the same reason (DEBT12).
+
+The closure is also the only thing that can say whether a family is _actually_
+lazy. A block renderer that reaches into a family module for one pure helper
+puts that whole family in the closure, and its `() => import(...)` then resolves
+from memory — lazy in the registry, eager in the browser. That is what
+`phonics/metrics.ts` and `words/metrics.ts` exist to prevent, and
+`components/sheet/blocks/index.test.ts` is the guard that fails when a renderer
+reaches past them.
 
 So the table is read two ways:
 
@@ -1552,3 +1569,7 @@ The engine is pure, so most of this is cheap and worth having:
   catalog page's sheet.
 - **Sitemap.** `/printables` and every catalog slug are in it; `/printables/make`
   is not.
+- **The island's import graph.** Nothing under `src/components/sheet/` reaches a
+  sheet family or a corpus by a static import, so a helper borrowed from a
+  family module fails the suite instead of quietly re-fattening the builder
+  (§3).

--- a/src/components/sheet/blocks/Cards.tsx
+++ b/src/components/sheet/blocks/Cards.tsx
@@ -5,7 +5,7 @@ import {
   CARD_PAD_EMS,
   CARD_SMALL_EMS,
   CARD_SMALL_LEADING,
-} from "@/engine/sheets/phonics/cards";
+} from "@/engine/sheets/phonics/metrics";
 import type { MarkedWord } from "@/engine/sheets/types";
 
 import type { BlockProps } from "./block";
@@ -18,11 +18,13 @@ import type { BlockProps } from "./block";
  * say /sh/" needs to be.
  *
  * **Nothing here decides a size.** Every proportion comes out of
- * `phonics/cards.ts` — the big line's size travels on the block, because a
+ * `phonics/metrics.ts` — the big line's size travels on the block, because a
  * flash card and a sentence strip are this block at two very different sizes,
  * and the leading and the small line are the constants the family reserved the
  * page against. A second set of numbers in this file would be a card
- * overhanging the one beneath it, and the failure is silent on screen.
+ * overhanging the one beneath it, and the failure is silent on screen. From the
+ * leaf rather than from `phonics/cards.ts`, so that four constants cost this
+ * island four constants and not the phonics word bank (§3).
  *
  * The border is a real border rather than a tint (§5), so a page of cards to
  * cut out does not come out as words floating on nothing.

--- a/src/components/sheet/blocks/Crossword.tsx
+++ b/src/components/sheet/blocks/Crossword.tsx
@@ -10,7 +10,7 @@
  * The clues are real HTML under it, so they are selectable, they wrap, and a
  * crawler reads them as the text they are.
  */
-import { searchCell } from "@/engine/sheets/words/search";
+import { searchCell } from "@/engine/sheets/words/metrics";
 import type { CrosswordEntry } from "@/engine/sheets/types";
 
 import { HAIRLINE, inch } from "../units";

--- a/src/components/sheet/blocks/Omitted.tsx
+++ b/src/components/sheet/blocks/Omitted.tsx
@@ -12,7 +12,7 @@
  * printed at another is the last line of a sheet on a second sheet of paper.
  * `more` is what the reservation could not name — see `Block.omittedMore`.
  */
-import { missingTokens } from "@/engine/sheets/words/puzzles";
+import { missingTokens } from "@/engine/sheets/words/metrics";
 
 export function Omitted({ words, more }: { words?: string[]; more?: number }) {
   const named = words ?? [];

--- a/src/components/sheet/blocks/WordSearch.tsx
+++ b/src/components/sheet/blocks/WordSearch.tsx
@@ -1,4 +1,4 @@
-import { searchCell } from "@/engine/sheets/words/search";
+import { searchCell } from "@/engine/sheets/words/metrics";
 
 import { HEAVY, inch } from "../units";
 import type { BlockProps } from "./block";

--- a/src/components/sheet/blocks/index.test.ts
+++ b/src/components/sheet/blocks/index.test.ts
@@ -1,0 +1,144 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The block renderers draw a block. They never reach the family that made one.
+ *
+ * `Sheet.tsx` and its blocks ship inside the Print Shop's first download, and
+ * `families.ts` keeps twenty-seven corpora out of that download only while
+ * nothing static points at them (§3). A renderer that imports one helper from
+ * `words/puzzles.ts` puts the whole puzzle generator back in the island, and
+ * the family's `() => import(...)` then "fetches" a module the browser already
+ * had — a regression that is invisible in review, because the import reads like
+ * any other and the loader still looks lazy from the registry's side.
+ *
+ * So this walks the static import graph out of `src/components/sheet/` and
+ * fails if it reaches a family module or a corpus, naming the chain that got
+ * there. The cure is always the same one MF1 and MF2 took: put the pure helper
+ * in a leaf of its own — `phonics/metrics.ts`, `words/metrics.ts` — and import
+ * that instead.
+ *
+ * Type-only imports are erased before the bundler sees them, so they cost
+ * nothing and are skipped here.
+ *
+ * A source graph, not the built one: it names the offending import, where a
+ * budget over `dist/` (DEBT12) catches the byte count however it got there.
+ * Both are wanted, and this is the half that can say what to do about it.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "../../..");
+const SHEETS = join(SRC, "engine/sheets");
+
+/** Every source file under a directory, tests excluded — they don't ship. */
+function sourcesIn(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourcesIn(path);
+    if (!/\.tsx?$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name))
+      return [];
+    return [path];
+  });
+}
+
+/**
+ * The specifiers a module pulls in eagerly.
+ *
+ * Statements only, which is what makes `import(...)` fall out for free: a
+ * dynamic import is an expression, and never starts a line with `import` or
+ * `export`. `import type` goes the same way, deliberately.
+ */
+function staticImports(source: string): string[] {
+  const statements = source.matchAll(
+    /^(?:import|export)\b[^"';]*?from\s*["']([^"']+)["']|^import\s*["']([^"']+)["']/gm,
+  );
+  return [...statements]
+    .filter((match) => !/^(?:import|export)\s+type\b/.test(match[0]))
+    .map((match) => match[1] ?? match[2]);
+}
+
+/** Where a specifier lands on disk, or null for a package we don't own. */
+function resolveImport(from: string, spec: string): string | null {
+  const base = spec.startsWith("@/")
+    ? join(SRC, spec.slice(2))
+    : spec.startsWith(".")
+      ? resolve(dirname(from), spec)
+      : null;
+  if (base === null) return null;
+  const tries = [base, `${base}.ts`, `${base}.tsx`, join(base, "index.ts")];
+  return tries.find((path) => /\.tsx?$/.test(path) && exists(path)) ?? null;
+}
+
+const exists = (path: string): boolean => {
+  try {
+    readFileSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** The twenty-seven, read out of the registry so the list can't drift. */
+function familyModules(): string[] {
+  const registry = readFileSync(join(SHEETS, "families.ts"), "utf8");
+  return [...registry.matchAll(/import\("\.\/([^"]+)"\)/g)].map((match) =>
+    join(SHEETS, `${match[1]}.ts`),
+  );
+}
+
+const BANNED = new Map<string, string>([
+  // The eager door: it awaits every family at module load, for the catalog
+  // build and the tests. Nothing that reaches a browser may import it.
+  [join(SHEETS, "index.ts"), "awaits every family at module load"],
+  ...familyModules().map(
+    (path) =>
+      [path, "a sheet family — it must stay behind its loader"] as const,
+  ),
+  // The corpora the issue named. A family module is the usual way in, but
+  // `phonics/cards.ts` was the way MF1 got there, and it is not a family.
+  ...(
+    [
+      "passages/scripture.ts",
+      "passages/kjv.ts",
+      "phonics/bank.ts",
+      "grammar/bank.ts",
+      "words/bank.ts",
+    ] as const
+  ).map((path) => [join(SHEETS, path), "a corpus"] as const),
+]);
+
+/** The chain from a renderer to something banned, or null if there is none. */
+function chainToBanned(root: string): string[] | null {
+  const seen = new Set([root]);
+  const queue: string[][] = [[root]];
+  while (queue.length > 0) {
+    const chain = queue.shift() as string[];
+    const at = chain[chain.length - 1];
+    if (BANNED.has(at)) return chain;
+    for (const spec of staticImports(readFileSync(at, "utf8"))) {
+      const next = resolveImport(at, spec);
+      if (next === null || seen.has(next)) continue;
+      seen.add(next);
+      queue.push([...chain, next]);
+    }
+  }
+  return null;
+}
+
+describe("the sheet view's import graph", () => {
+  it.each(
+    sourcesIn(join(SRC, "components/sheet")).map((path) => [
+      relative(SRC, path),
+    ]),
+  )("%s reaches no sheet family and no corpus", (root: string) => {
+    const chain = chainToBanned(join(SRC, root));
+    const why = chain ? BANNED.get(chain[chain.length - 1]) : "";
+    expect(
+      chain?.map((path) => relative(SRC, path)).join("\n  → ") ?? null,
+      `that last module is ${why}`,
+    ).toBeNull();
+  });
+});

--- a/src/engine/sheets/blank.ts
+++ b/src/engine/sheets/blank.ts
@@ -53,8 +53,6 @@ export function buildBlankSheet(config: BlankConfig, seed: number): Sheet {
 }
 
 export const BLANK_SHEET: SheetSpec<BlankConfig> = {
-  id: "blank",
-  label: "Blank page",
   world: SHEET_WORLD,
   build: buildBlankSheet,
   // Nothing to fill in. Returned as-is rather than with `answers: true`,

--- a/src/engine/sheets/families.test.ts
+++ b/src/engine/sheets/families.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SHEET_FAMILIES,
+  loadSheet,
+  loadedSheet,
+  sheetFamily,
+} from "./families";
+import { UNKNOWN_SHEET } from "./spec";
+
+/**
+ * The family table: what the picker reads before anything has loaded, and the
+ * loader the bench reaches a family through.
+ *
+ * `index.ts` is tested separately and awaits every entry here, so a loader
+ * pointing at a module that doesn't export what it says fails over there. What
+ * this file covers is the half `index.ts` never uses: what a kind from outside
+ * this build gets back, and that a family is fetched once.
+ */
+
+describe("the family table", () => {
+  it("names every family exactly once", () => {
+    const ids = SHEET_FAMILIES.map((family) => family.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const labels = SHEET_FAMILIES.map((family) => family.label);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it("is not fooled by a kind that names something on Object.prototype", () => {
+    // Same untrusted `kind` the registry guards against, and the reason the
+    // table is a Map: `{}["toString"]` is a function, truthy, and not a family.
+    for (const kind of ["toString", "constructor", "valueOf"]) {
+      expect(sheetFamily(kind)).toBeUndefined();
+    }
+    expect(sheetFamily("blank")?.label).toBe("Blank page");
+  });
+});
+
+describe("fetching one", () => {
+  it("answers a kind this build has never heard of, rather than rejecting", async () => {
+    // A shared link bookmarked in March, opened in June, after its family was
+    // renamed. Same promise `sheetSpec` makes.
+    await expect(loadSheet("long-division-2027")).resolves.toBe(UNKNOWN_SHEET);
+  });
+
+  it("is nothing until it is here, and then the same module every time", async () => {
+    expect(loadedSheet("memory")).toBeUndefined();
+
+    const spec = await loadSheet("memory");
+    expect(loadedSheet("memory")).toBe(spec);
+    // One module, however many times it is asked for — the second ask is not a
+    // second copy of the passage library.
+    expect(await loadSheet("memory")).toBe(spec);
+  });
+});

--- a/src/engine/sheets/families.ts
+++ b/src/engine/sheets/families.ts
@@ -1,0 +1,225 @@
+/**
+ * Which families of sheet this build makes, what each is called, and how to
+ * fetch the one being printed (§3).
+ *
+ * The table below is the only place a family's identity is written down.
+ * `SheetSpec` says how a family behaves and no longer says what it is called,
+ * because the picker has to name all twenty-seven while loading none of them.
+ *
+ * **The loaders are dynamic deliberately.** A family reached by a static import
+ * is a family in the bundle, and several carry a corpus: the passage library is
+ * 174 KB of text on its own, so a parent choosing a times-table sheet was
+ * downloading the King James Bible to do it. `() => import(...)` puts each
+ * family in a chunk of its own, fetched when it is chosen and not before.
+ *
+ * `index.ts` is the other half of the trade. It awaits every entry here once,
+ * so the catalog build and the tests keep an ordinary synchronous `buildSheet`
+ * — one table of loaders, two doors onto it, and nothing to keep in step.
+ */
+import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
+
+export type SheetFamily = {
+  /** Matches `SheetConfig.kind`, so a saved sheet finds its way back here. */
+  id: string;
+  /** How it reads in the picker — the one thing known before it loads. */
+  label: string;
+  load: () => Promise<SheetSpec>;
+};
+
+/**
+ * Everything this build can make, in the order the picker offers it: blank
+ * paper, then the stationery, then the subjects roughly by age.
+ */
+export const SHEET_FAMILIES: readonly SheetFamily[] = [
+  {
+    id: "blank",
+    label: "Blank page",
+    load: () => import("./blank").then((m) => m.BLANK_SHEET),
+  },
+  {
+    id: "paper",
+    label: "Lined and graph paper",
+    load: () => import("./templates/paper").then((m) => m.PAPER_SHEET),
+  },
+  {
+    id: "chart",
+    label: "Charts, number lines and grids",
+    load: () => import("./templates/charts").then((m) => m.CHART_SHEET),
+  },
+  {
+    id: "form",
+    label: "Logs, reports and forms",
+    load: () => import("./templates/forms").then((m) => m.FORM_SHEET),
+  },
+  {
+    id: "planner",
+    label: "Calendars, planners and charts",
+    load: () => import("./templates/planner").then((m) => m.PLANNER_SHEET),
+  },
+  {
+    id: "cards",
+    label: "Cards, tags and bookmarks",
+    load: () => import("./templates/cards").then((m) => m.CARDS_SHEET),
+  },
+  {
+    id: "net",
+    label: "Dice and spinners",
+    load: () => import("./templates/nets").then((m) => m.NET_SHEET),
+  },
+  {
+    id: "arithmetic",
+    label: "Addition and subtraction",
+    load: () => import("./maths/arithmetic").then((m) => m.ARITHMETIC_SHEET),
+  },
+  {
+    id: "multiplication",
+    label: "Multiplication and division",
+    load: () =>
+      import("./maths/multiplication").then((m) => m.MULTIPLICATION_SHEET),
+  },
+  {
+    id: "fractions",
+    label: "Fractions",
+    load: () => import("./maths/fractions").then((m) => m.FRACTIONS_SHEET),
+  },
+  {
+    id: "decimals",
+    label: "Decimals and percents",
+    load: () => import("./maths/decimals").then((m) => m.DECIMALS_SHEET),
+  },
+  {
+    id: "money",
+    label: "Money",
+    load: () => import("./maths/money").then((m) => m.MONEY_SHEET),
+  },
+  {
+    id: "time",
+    label: "Telling the time",
+    load: () => import("./maths/time").then((m) => m.TIME_SHEET),
+  },
+  {
+    id: "measure",
+    label: "Measurement",
+    load: () => import("./maths/measure").then((m) => m.MEASURE_SHEET),
+  },
+  {
+    id: "geometry",
+    label: "Shape and space",
+    load: () => import("./maths/geometry").then((m) => m.GEOMETRY_SHEET),
+  },
+  {
+    id: "integers",
+    label: "Integers and powers",
+    load: () => import("./maths/integers").then((m) => m.INTEGERS_SHEET),
+  },
+  {
+    id: "prealgebra",
+    label: "Pre-algebra",
+    load: () => import("./maths/prealgebra").then((m) => m.PREALGEBRA_SHEET),
+  },
+  {
+    id: "ratio",
+    label: "Ratio and rate",
+    load: () => import("./maths/ratio").then((m) => m.RATIO_SHEET),
+  },
+  {
+    id: "statistics",
+    label: "Mean, median and mode",
+    load: () => import("./maths/statistics").then((m) => m.STATISTICS_SHEET),
+  },
+  {
+    id: "word-problems",
+    label: "Word problems",
+    load: () =>
+      import("./maths/wordproblems").then((m) => m.WORD_PROBLEMS_SHEET),
+  },
+  {
+    id: "words",
+    label: "Spelling list",
+    load: () => import("./words/spelling").then((m) => m.WORDS_SHEET),
+  },
+  {
+    id: "word-study",
+    label: "Word study",
+    load: () => import("./words/study").then((m) => m.WORD_STUDY_SHEET),
+  },
+  {
+    id: "puzzle",
+    label: "Word puzzle",
+    load: () => import("./words/puzzles").then((m) => m.PUZZLE_SHEET),
+  },
+  {
+    id: "grammar",
+    label: "Grammar",
+    load: () => import("./grammar/grammar").then((m) => m.GRAMMAR_SHEET),
+  },
+  {
+    id: "phonics",
+    label: "Phonics",
+    load: () => import("./phonics/sheets").then((m) => m.PHONICS_SHEET),
+  },
+  {
+    id: "handwriting",
+    label: "Handwriting practice",
+    load: () =>
+      import("./writing/handwriting").then((m) => m.HANDWRITING_SHEET),
+  },
+  {
+    id: "memory",
+    label: "Memory verse",
+    load: () => import("./writing/memory").then((m) => m.MEMORY_SHEET),
+  },
+];
+
+/*
+   A `Map` rather than a keyed object, for the reason `sheetSpec` gives at
+   length: a kind arrives from a saved sheet or a URL somebody typed, and
+   `.get("toString")` is nothing where an index would find a function.        */
+
+const BY_ID = new Map(SHEET_FAMILIES.map((family) => [family.id, family]));
+
+/** The family a kind names, or nothing if this build doesn't make one. */
+export const sheetFamily = (kind: string): SheetFamily | undefined =>
+  BY_ID.get(kind);
+
+const FETCHING = new Map<string, Promise<SheetSpec>>();
+const HERE = new Map<string, SheetSpec>();
+
+/**
+ * A family's module, fetched once and then kept.
+ *
+ * Never rejects, for the reason `sheetSpec` never throws: a kind out of a saved
+ * sheet or a shared link may name a family this build has retired, and that has
+ * to print `UNKNOWN_SHEET` rather than fail.
+ *
+ * A module that fails to arrive lands there too. It is the wrong sentence for a
+ * dropped connection — nothing is retired — but the alternative is a promise
+ * nobody settles and a bench that never draws, and a page that says something is
+ * better than a page that says nothing. A reload starts the fetch over.
+ */
+export function loadSheet(kind: string): Promise<SheetSpec> {
+  const already = FETCHING.get(kind);
+  if (already) return already;
+
+  const family = BY_ID.get(kind);
+  const fetching = (family ? family.load() : Promise.resolve(UNKNOWN_SHEET))
+    .catch(() => UNKNOWN_SHEET)
+    .then((spec) => {
+      HERE.set(kind, spec);
+      return spec;
+    });
+  FETCHING.set(kind, fetching);
+  return fetching;
+}
+
+/**
+ * The same, for a caller that cannot wait: the family if its module is already
+ * here, and nothing if it isn't.
+ *
+ * What lets the builder render from a plain value rather than a promise — and
+ * what makes "the wrong family's spec" unrepresentable, because the answer is
+ * looked up by the kind being asked about rather than remembered from the last
+ * one that arrived.
+ */
+export const loadedSheet = (kind: string): SheetSpec | undefined =>
+  HERE.get(kind);

--- a/src/engine/sheets/grammar/grammar.test.ts
+++ b/src/engine/sheets/grammar/grammar.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import type { Block, GrammarConfig, GrammarStyle, Paper } from "../types";
 
 import { END_MARK, KINDS, PARTS, SENTENCES, type Tagged } from "./bank";
@@ -185,7 +186,7 @@ describe("the sentence bank", () => {
 describe("the grammar family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("grammar")).toBe(GRAMMAR_SHEET);
-    expect(sheetSpec("grammar").label).toBe("Grammar");
+    expect(sheetFamily("grammar")?.label).toBe("Grammar");
   });
 
   it("prints a titled, marked page for every topic and style", () => {

--- a/src/engine/sheets/grammar/grammar.ts
+++ b/src/engine/sheets/grammar/grammar.ts
@@ -558,8 +558,6 @@ export function buildGrammarSheet(config: GrammarConfig, seed: number): Sheet {
 }
 
 export const GRAMMAR_SHEET: SheetSpec<GrammarConfig> = {
-  id: "grammar",
-  label: "Grammar",
   world: SHEET_WORLD,
   build: buildGrammarSheet,
   // Every answer was decided when the sheet was built — which sentences were

--- a/src/engine/sheets/index.test.ts
+++ b/src/engine/sheets/index.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  answerKey,
-  buildSheet,
-  describeSheet,
-  listSheets,
-  sheetSpec,
-} from "./index";
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "./index";
+import { SHEET_FAMILIES, sheetFamily } from "./families";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, UNKNOWN_SHEET } from "./spec";
 import { DEFAULT_PAPER } from "./paper";
 import type { BlankConfig, SheetConfig } from "./types";
@@ -21,7 +16,7 @@ const config = (over: Partial<BlankConfig> = {}): SheetConfig => ({
 
 describe("the registry", () => {
   it("routes a kind to its family", () => {
-    expect(sheetSpec("blank").label).toBe("Blank page");
+    expect(sheetFamily("blank")?.label).toBe("Blank page");
     expect(describeSheet(config())).toBe("A blank page");
   });
 
@@ -53,14 +48,25 @@ describe("the registry", () => {
     expect(UNKNOWN_SHEET.build(stale, 7).paper).toEqual(DEFAULT_PAPER);
   });
 
+  it("has a module behind every family it offers", () => {
+    // The picker names all twenty-seven before any of them has loaded, so a
+    // loader pointing at a path that no longer exports what it says would stay
+    // invisible until a parent picked that family. This door has awaited every
+    // one of them by the time the suite runs.
+    for (const { id } of SHEET_FAMILIES) {
+      expect(sheetSpec(id), id).not.toBe(UNKNOWN_SHEET);
+    }
+  });
+
   it("prints in the world every sheet prints in", () => {
-    for (const spec of [...listSheets(), UNKNOWN_SHEET]) {
+    const specs = SHEET_FAMILIES.map((family) => sheetSpec(family.id));
+    for (const spec of [...specs, UNKNOWN_SHEET]) {
       expect(spec.world).toBe(SHEET_WORLD);
     }
   });
 
   it("lists what this build can make", () => {
-    expect(listSheets().map((spec) => spec.id)).toContain("blank");
+    expect(SHEET_FAMILIES.map((family) => family.id)).toContain("blank");
   });
 });
 

--- a/src/engine/sheets/index.ts
+++ b/src/engine/sheets/index.ts
@@ -1,73 +1,31 @@
 /**
- * The sheet layer's front door (§3).
+ * The sheet layer's front door, with every family already in hand (§3).
  *
  * The `SheetConfig` union is narrowed in exactly one place: the registry lookup
  * in `sheetSpec`. A spec is keyed by the same string its config carries as
  * `kind`, so looking one up *is* the narrowing — there is no `if (isLined)`
- * chain to keep in step with the union, and adding a family is an entry in the
- * table below plus a `kind` in types.ts. See the note on `SheetSpec` for the one
- * thing that makes that typecheck.
+ * chain to keep in step with the union, and adding a family is an entry in
+ * families.ts plus a `kind` in types.ts. See the note on `SheetSpec` for the
+ * one thing that makes that typecheck.
+ *
+ * **This door assembles the whole press, so only Node ever opens it.** The
+ * top-level `await` below runs every loader in families.ts, which is what lets
+ * the catalog build and the tests call a plain synchronous `buildSheet` while
+ * the builder island fetches a family at a time. Import it from anything that
+ * ships to a browser and the split stops working: the island's route is
+ * `loadSheet(kind)`.
  */
+import { SHEET_FAMILIES } from "./families";
+import { UNKNOWN_SHEET, buildWith, keyWith, type SheetSpec } from "./spec";
 import type { Sheet, SheetConfig } from "./types";
 
-import { BLANK_SHEET } from "./blank";
-import { GRAMMAR_SHEET } from "./grammar/grammar";
-import { ARITHMETIC_SHEET } from "./maths/arithmetic";
-import { DECIMALS_SHEET } from "./maths/decimals";
-import { FRACTIONS_SHEET } from "./maths/fractions";
-import { GEOMETRY_SHEET } from "./maths/geometry";
-import { INTEGERS_SHEET } from "./maths/integers";
-import { MEASURE_SHEET } from "./maths/measure";
-import { MONEY_SHEET } from "./maths/money";
-import { MULTIPLICATION_SHEET } from "./maths/multiplication";
-import { PREALGEBRA_SHEET } from "./maths/prealgebra";
-import { RATIO_SHEET } from "./maths/ratio";
-import { STATISTICS_SHEET } from "./maths/statistics";
-import { TIME_SHEET } from "./maths/time";
-import { WORD_PROBLEMS_SHEET } from "./maths/wordproblems";
-import { PHONICS_SHEET } from "./phonics/sheets";
-import { UNKNOWN_SHEET, type SheetSpec } from "./spec";
-import { CARDS_SHEET } from "./templates/cards";
-import { CHART_SHEET } from "./templates/charts";
-import { FORM_SHEET } from "./templates/forms";
-import { NET_SHEET } from "./templates/nets";
-import { PAPER_SHEET } from "./templates/paper";
-import { PLANNER_SHEET } from "./templates/planner";
-import { HANDWRITING_SHEET } from "./writing/handwriting";
-import { MEMORY_SHEET } from "./writing/memory";
-import { PUZZLE_SHEET } from "./words/puzzles";
-import { WORDS_SHEET } from "./words/spelling";
-import { WORD_STUDY_SHEET } from "./words/study";
-
-const SHEETS: Record<string, SheetSpec> = {
-  [BLANK_SHEET.id]: BLANK_SHEET,
-  [PAPER_SHEET.id]: PAPER_SHEET,
-  [CHART_SHEET.id]: CHART_SHEET,
-  [FORM_SHEET.id]: FORM_SHEET,
-  [PLANNER_SHEET.id]: PLANNER_SHEET,
-  [CARDS_SHEET.id]: CARDS_SHEET,
-  [NET_SHEET.id]: NET_SHEET,
-  [ARITHMETIC_SHEET.id]: ARITHMETIC_SHEET,
-  [MULTIPLICATION_SHEET.id]: MULTIPLICATION_SHEET,
-  [FRACTIONS_SHEET.id]: FRACTIONS_SHEET,
-  [DECIMALS_SHEET.id]: DECIMALS_SHEET,
-  [MONEY_SHEET.id]: MONEY_SHEET,
-  [TIME_SHEET.id]: TIME_SHEET,
-  [MEASURE_SHEET.id]: MEASURE_SHEET,
-  [GEOMETRY_SHEET.id]: GEOMETRY_SHEET,
-  [INTEGERS_SHEET.id]: INTEGERS_SHEET,
-  [PREALGEBRA_SHEET.id]: PREALGEBRA_SHEET,
-  [RATIO_SHEET.id]: RATIO_SHEET,
-  [STATISTICS_SHEET.id]: STATISTICS_SHEET,
-  [WORD_PROBLEMS_SHEET.id]: WORD_PROBLEMS_SHEET,
-  [WORDS_SHEET.id]: WORDS_SHEET,
-  [WORD_STUDY_SHEET.id]: WORD_STUDY_SHEET,
-  [PUZZLE_SHEET.id]: PUZZLE_SHEET,
-  [GRAMMAR_SHEET.id]: GRAMMAR_SHEET,
-  [PHONICS_SHEET.id]: PHONICS_SHEET,
-  [HANDWRITING_SHEET.id]: HANDWRITING_SHEET,
-  [MEMORY_SHEET.id]: MEMORY_SHEET,
-};
+const SHEETS: Record<string, SheetSpec> = Object.fromEntries(
+  await Promise.all(
+    SHEET_FAMILIES.map(
+      async (family) => [family.id, await family.load()] as const,
+    ),
+  ),
+);
 
 /**
  * Resolves a sheet family. Never throws — see `UNKNOWN_SHEET` for why a kind
@@ -82,59 +40,17 @@ export function sheetSpec(kind: string): SheetSpec {
   return Object.hasOwn(SHEETS, kind) ? SHEETS[kind] : UNKNOWN_SHEET;
 }
 
-/** Everything this build can make, for the catalog and the builder's picker. */
-export function listSheets(): SheetSpec[] {
-  return Object.values(SHEETS);
-}
-
-/**
- * The presentation half of `SheetOptions`, copied onto what a family built.
- *
- * Here rather than in every `build` function: every family would otherwise write
- * the same three lines, and the next one added would be the one that forgot. It
- * is safe to do after the fact because none of the three changes a length — the
- * face is set in points, a bordered slot is the same line box as a ruled one,
- * and the cut guides are drawn over the paper rather than in the flow — so
- * nothing here can make a sheet the layout arithmetic already fitted stop
- * fitting.
- *
- * A family that has already said something wins, which is what keeps this a
- * default rather than an override: `UNKNOWN_SHEET` sets nothing and gets the
- * parent's choices, and a family that one day sets its own is not quietly
- * undone from out here.
- */
-function present(config: SheetConfig, sheet: Sheet): Sheet {
-  return {
-    ...sheet,
-    font: sheet.font ?? config.font,
-    answerBox: sheet.answerBox ?? config.answerBox,
-    cutLines: sheet.cutLines ?? config.cutLines,
-  };
-}
-
-/**
- * Build a sheet. Deterministic in `(config, seed)`, which is the mechanism
- * behind three of the features in §7 rather than one: an answer key is the
- * same build, "another sheet like this one" is `seed + 1`, and a sheet is
- * reproducible from a shared URL because the seed is in it.
- */
+/** Build a sheet. Deterministic in `(config, seed)` — see `buildWith`. */
 export function buildSheet(config: SheetConfig, seed: number): Sheet {
-  return present(config, sheetSpec(config.kind).build(config, seed));
+  return buildWith(sheetSpec(config.kind), config, seed);
 }
 
-/**
- * The same sheet with the answers drawn in.
- *
- * A second build from the same seed, not a second generation of the answers:
- * they were computed when the sheet was built and `key` only decides to print
- * them, so a key cannot disagree with the sheet it belongs to.
- */
+/** The same sheet with the answers drawn in — see `keyWith`. */
 export function answerKey(config: SheetConfig, seed: number): Sheet {
-  const spec = sheetSpec(config.kind);
-  return present(config, spec.key(spec.build(config, seed)));
+  return keyWith(sheetSpec(config.kind), config, seed);
 }
 
-/** One line naming what a config prints, for the catalog and the record. */
+/** One line naming what a config prints, for the catalog and its tests. */
 export function describeSheet(config: SheetConfig): string {
   return sheetSpec(config.kind).describe(config);
 }

--- a/src/engine/sheets/maths/arithmetic.test.ts
+++ b/src/engine/sheets/maths/arithmetic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP } from "../layout";
 import { LINE_INSET, labelRoom, ticks } from "../numberline";
 import { inches } from "../paper";
@@ -206,7 +207,7 @@ function factOf(sentence: string): string {
 describe("the arithmetic family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("arithmetic")).toBe(ARITHMETIC_SHEET);
-    expect(sheetSpec("arithmetic").label).toBe("Addition and subtraction");
+    expect(sheetFamily("arithmetic")?.label).toBe("Addition and subtraction");
   });
 
   it("names what it prints, in the terms a parent chose it by", () => {

--- a/src/engine/sheets/maths/arithmetic.ts
+++ b/src/engine/sheets/maths/arithmetic.ts
@@ -588,8 +588,6 @@ export function buildArithmeticSheet(
 }
 
 export const ARITHMETIC_SHEET: SheetSpec<ArithmeticConfig> = {
-  id: "arithmetic",
-  label: "Addition and subtraction",
   world: SHEET_WORLD,
   build: buildArithmeticSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/decimals.test.ts
+++ b/src/engine/sheets/maths/decimals.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP } from "../layout";
 import type {
   DecimalConfig,
@@ -229,7 +230,7 @@ function decimalsOn(problem: Problem): string[] {
 describe("the decimals family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("decimals")).toBe(DECIMALS_SHEET);
-    expect(sheetSpec("decimals").label).toBe("Decimals and percents");
+    expect(sheetFamily("decimals")?.label).toBe("Decimals and percents");
   });
 
   it("names what it prints, in the terms a parent chose it by", () => {

--- a/src/engine/sheets/maths/decimals.ts
+++ b/src/engine/sheets/maths/decimals.ts
@@ -511,8 +511,6 @@ export function buildDecimalSheet(config: DecimalConfig, seed: number): Sheet {
 }
 
 export const DECIMALS_SHEET: SheetSpec<DecimalConfig> = {
-  id: "decimals",
-  label: "Decimals and percents",
   world: SHEET_WORLD,
   build: buildDecimalSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/fractions.test.ts
+++ b/src/engine/sheets/maths/fractions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP } from "../layout";
 import type {
   FractionConfig,
@@ -210,7 +211,7 @@ function holds(sentence: string): boolean {
 describe("the fractions family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("fractions")).toBe(FRACTIONS_SHEET);
-    expect(sheetSpec("fractions").label).toBe("Fractions");
+    expect(sheetFamily("fractions")?.label).toBe("Fractions");
   });
 
   it("names what it prints, in the terms a parent chose it by", () => {

--- a/src/engine/sheets/maths/fractions.ts
+++ b/src/engine/sheets/maths/fractions.ts
@@ -556,8 +556,6 @@ export function buildFractionSheet(
 }
 
 export const FRACTIONS_SHEET: SheetSpec<FractionConfig> = {
-  id: "fractions",
-  label: "Fractions",
   world: SHEET_WORLD,
   build: buildFractionSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/geometry.test.ts
+++ b/src/engine/sheets/maths/geometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { figureBox, figureRow } from "../figure";
 import { BLOCK_GAP, PROBLEM_GAP } from "../layout";
 import type {
@@ -216,7 +217,7 @@ const question = (problem: Problem): string => {
 describe("the geometry family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("geometry")).toBe(GEOMETRY_SHEET);
-    expect(sheetSpec("geometry").label).toBe("Shape and space");
+    expect(sheetFamily("geometry")?.label).toBe("Shape and space");
   });
 
   it("names the sheet in the words a parent chose it by", () => {

--- a/src/engine/sheets/maths/geometry.ts
+++ b/src/engine/sheets/maths/geometry.ts
@@ -582,8 +582,6 @@ export function buildGeometrySheet(
 }
 
 export const GEOMETRY_SHEET: SheetSpec<GeometryConfig> = {
-  id: "geometry",
-  label: "Shape and space",
   world: SHEET_WORLD,
   build: buildGeometrySheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/integers.test.ts
+++ b/src/engine/sheets/maths/integers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP } from "../layout";
 import type {
   IntegerConfig,
@@ -271,7 +272,7 @@ const everyProblem = function* (
 describe("the integers family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("integers")).toBe(INTEGERS_SHEET);
-    expect(sheetSpec("integers").label).toBe("Integers and powers");
+    expect(sheetFamily("integers")?.label).toBe("Integers and powers");
   });
 
   it("names the sheet in the words a parent chose it by", () => {

--- a/src/engine/sheets/maths/integers.ts
+++ b/src/engine/sheets/maths/integers.ts
@@ -681,8 +681,6 @@ export function buildIntegerSheet(config: IntegerConfig, seed: number): Sheet {
 }
 
 export const INTEGERS_SHEET: SheetSpec<IntegerConfig> = {
-  id: "integers",
-  label: "Integers and powers",
   world: SHEET_WORLD,
   build: buildIntegerSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/measure.test.ts
+++ b/src/engine/sheets/maths/measure.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP } from "../layout";
 import type {
   MarginSize,
@@ -191,7 +192,7 @@ const sentence = (problem: Problem): string =>
 describe("the measurement family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("measure")).toBe(MEASURE_SHEET);
-    expect(sheetSpec("measure").label).toBe("Measurement");
+    expect(sheetFamily("measure")?.label).toBe("Measurement");
   });
 
   it("names the sheet in the words the system it is for uses", () => {

--- a/src/engine/sheets/maths/measure.ts
+++ b/src/engine/sheets/maths/measure.ts
@@ -358,8 +358,6 @@ export function buildMeasureSheet(config: MeasureConfig, seed: number): Sheet {
 }
 
 export const MEASURE_SHEET: SheetSpec<MeasureConfig> = {
-  id: "measure",
-  label: "Measurement",
   world: SHEET_WORLD,
   build: buildMeasureSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/money.test.ts
+++ b/src/engine/sheets/maths/money.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP } from "../layout";
 import type {
   Currency,
@@ -155,7 +156,7 @@ function amountsOn(problem: Problem): string[] {
 describe("the money family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("money")).toBe(MONEY_SHEET);
-    expect(sheetSpec("money").label).toBe("Money");
+    expect(sheetFamily("money")?.label).toBe("Money");
   });
 
   it("names the sheet in the words the country it is for uses", () => {

--- a/src/engine/sheets/maths/money.ts
+++ b/src/engine/sheets/maths/money.ts
@@ -387,8 +387,6 @@ export function buildMoneySheet(config: MoneyConfig, seed: number): Sheet {
 }
 
 export const MONEY_SHEET: SheetSpec<MoneyConfig> = {
-  id: "money",
-  label: "Money",
   world: SHEET_WORLD,
   build: buildMoneySheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/multiplication.test.ts
+++ b/src/engine/sheets/maths/multiplication.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP, answerLine } from "../layout";
 import { points } from "../paper";
 import type {
@@ -250,7 +251,7 @@ function factOf(sentence: string, folds: boolean): string {
 describe("the multiplication family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("multiplication")).toBe(MULTIPLICATION_SHEET);
-    expect(sheetSpec("multiplication").label).toBe(
+    expect(sheetFamily("multiplication")?.label).toBe(
       "Multiplication and division",
     );
   });

--- a/src/engine/sheets/maths/multiplication.ts
+++ b/src/engine/sheets/maths/multiplication.ts
@@ -660,8 +660,6 @@ export function buildMultiplicationSheet(
 }
 
 export const MULTIPLICATION_SHEET: SheetSpec<MultiplicationConfig> = {
-  id: "multiplication",
-  label: "Multiplication and division",
   world: SHEET_WORLD,
   build: buildMultiplicationSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/prealgebra.test.ts
+++ b/src/engine/sheets/maths/prealgebra.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { BLOCK_GAP, PROBLEM_GAP } from "../layout";
 import type {
   GridMark,
@@ -242,7 +243,7 @@ const shapesOf = (style: string): Array<Partial<PreAlgebraConfig>> =>
 describe("the pre-algebra family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("prealgebra")).toBe(PREALGEBRA_SHEET);
-    expect(sheetSpec("prealgebra").label).toBe("Pre-algebra");
+    expect(sheetFamily("prealgebra")?.label).toBe("Pre-algebra");
   });
 
   it("names the sheet in the words a parent chose it by", () => {

--- a/src/engine/sheets/maths/prealgebra.ts
+++ b/src/engine/sheets/maths/prealgebra.ts
@@ -767,8 +767,6 @@ export function buildPreAlgebraSheet(
 }
 
 export const PREALGEBRA_SHEET: SheetSpec<PreAlgebraConfig> = {
-  id: "prealgebra",
-  label: "Pre-algebra",
   world: SHEET_WORLD,
   build: buildPreAlgebraSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/ratio.test.ts
+++ b/src/engine/sheets/maths/ratio.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP } from "../layout";
 import type {
   MarginSize,
@@ -120,7 +121,7 @@ const shapesOf = (style: string): Array<Partial<RatioConfig>> =>
 describe("the ratio family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("ratio")).toBe(RATIO_SHEET);
-    expect(sheetSpec("ratio").label).toBe("Ratio and rate");
+    expect(sheetFamily("ratio")?.label).toBe("Ratio and rate");
   });
 
   it("names the sheet in the words a parent chose it by", () => {

--- a/src/engine/sheets/maths/ratio.ts
+++ b/src/engine/sheets/maths/ratio.ts
@@ -324,8 +324,6 @@ export function buildRatioSheet(config: RatioConfig, seed: number): Sheet {
 }
 
 export const RATIO_SHEET: SheetSpec<RatioConfig> = {
-  id: "ratio",
-  label: "Ratio and rate",
   world: SHEET_WORLD,
   build: buildRatioSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/statistics.test.ts
+++ b/src/engine/sheets/maths/statistics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP, answerLine } from "../layout";
 import type {
   MarginSize,
@@ -163,7 +164,7 @@ const shapesOf = (style: string): Array<Partial<StatisticsConfig>> =>
 describe("the statistics family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("statistics")).toBe(STATISTICS_SHEET);
-    expect(sheetSpec("statistics").label).toBe("Mean, median and mode");
+    expect(sheetFamily("statistics")?.label).toBe("Mean, median and mode");
   });
 
   it("names the sheet in the words a parent chose it by", () => {

--- a/src/engine/sheets/maths/statistics.ts
+++ b/src/engine/sheets/maths/statistics.ts
@@ -443,8 +443,6 @@ export function buildStatisticsSheet(
 }
 
 export const STATISTICS_SHEET: SheetSpec<StatisticsConfig> = {
-  id: "statistics",
-  label: "Mean, median and mode",
   world: SHEET_WORLD,
   build: buildStatisticsSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/maths/time.test.ts
+++ b/src/engine/sheets/maths/time.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { DIAL, MINUTES_A_TURN } from "../clockface";
 import { PROBLEM_GAP } from "../layout";
 import type {
@@ -149,7 +150,7 @@ function faceOf(problem: Problem): ClockFace {
 describe("the time family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("time")).toBe(TIME_SHEET);
-    expect(sheetSpec("time").label).toBe("Telling the time");
+    expect(sheetFamily("time")?.label).toBe("Telling the time");
   });
 
   it("names the sheet by how precise it is, which is what makes it hard", () => {

--- a/src/engine/sheets/maths/time.ts
+++ b/src/engine/sheets/maths/time.ts
@@ -363,8 +363,6 @@ export function buildTimeSheet(config: TimeConfig, seed: number): Sheet {
 }
 
 export const TIME_SHEET: SheetSpec<TimeConfig> = {
-  id: "time",
-  label: "Telling the time",
   world: SHEET_WORLD,
   build: buildTimeSheet,
   // On a drawing sheet the key is the same faces with their hands put on, which

--- a/src/engine/sheets/maths/wordproblems.test.ts
+++ b/src/engine/sheets/maths/wordproblems.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { PROBLEM_GAP } from "../layout";
 import type {
   MarginSize,
@@ -188,7 +189,7 @@ const everyStory = function* (
 describe("the word-problem family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("word-problems")).toBe(WORD_PROBLEMS_SHEET);
-    expect(sheetSpec("word-problems").label).toBe("Word problems");
+    expect(sheetFamily("word-problems")?.label).toBe("Word problems");
   });
 
   it("names the sheet after its topic, and a mixed sheet after none", () => {

--- a/src/engine/sheets/maths/wordproblems.ts
+++ b/src/engine/sheets/maths/wordproblems.ts
@@ -725,8 +725,6 @@ export function buildWordProblemSheet(
 }
 
 export const WORD_PROBLEMS_SHEET: SheetSpec<WordProblemConfig> = {
-  id: "word-problems",
-  label: "Word problems",
   world: SHEET_WORLD,
   build: buildWordProblemSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/phonics/cards.ts
+++ b/src/engine/sheets/phonics/cards.ts
@@ -1,11 +1,11 @@
 /**
  * A word as it is *printed*: cut into its spellings, and marked.
  *
- * Two jobs that are one idea, which is why they are one module. The marking
- * pass turns a word into the pieces a sheet sets it in, and the proportions
- * below are how tall that lands on the page — a family reserves the page
- * against them and `Cards.tsx` draws against them, so a second copy in either
- * place would be a card overhanging the one beneath it.
+ * The marking pass turns a word into the pieces a sheet sets it in. How tall
+ * that lands on the page is the other half of the same idea, and it lives next
+ * door in `metrics.ts`: `Cards.tsx` draws against those proportions and has no
+ * use for the word bank this module reads, so the numbers are a module of their
+ * own and this one imports them like everybody else.
  *
  * The three marks are independent switches, derived from `sounds.ts` rather
  * than authored, so there is nowhere here for a programme's own spelling of a
@@ -27,46 +27,6 @@ import {
   graphemeText,
   type Correspondence,
 } from "./sounds";
-
-/* ── How big a card is ────────────────────────────────────────────────────
-   Declared, not measured (§4), and in ems of the body size — so a parent who
-   wants cards twice the size raises the type size and the whole card grows
-   with it, which is also how one block prints both a flash card an inch high
-   and a sentence strip a child reads across a room.                         */
-
-/** The spelling on a sound card, and on the wall chart. */
-export const CARD_BIG_EMS = 3.2;
-
-/** A sentence strip: a whole sentence, so a great deal smaller than a card. */
-export const STRIP_BIG_EMS = 1.6;
-
-/** The example word under the spelling. */
-export const CARD_SMALL_EMS = 0.95;
-
-/** The leading each of the two lines is set on. */
-export const CARD_BIG_LEADING = 1.1;
-export const CARD_SMALL_LEADING = 1.35;
-
-/** The air inside a card's box, top and bottom each. */
-export const CARD_PAD_EMS = 0.42;
-
-/**
- * How tall one card stands, in ems of the body size.
- *
- * Written here and read by both the family that reserves the page and the
- * renderer that draws the box, for the reason `answerLine` gives: the failure
- * is silent on screen and is the last row of cards on a second sheet of paper.
- *
- * `rows` is how many lines the big line wraps onto — one for a spelling, and
- * however many the longest sentence needs for a strip.
- */
-export function cardRowEms(big: number, rows: number, small: boolean): number {
-  return (
-    rows * big * CARD_BIG_LEADING +
-    (small ? CARD_SMALL_EMS * CARD_SMALL_LEADING : 0) +
-    CARD_PAD_EMS * 2
-  );
-}
 
 /* ── The marks ──────────────────────────────────────────────────────────── */
 

--- a/src/engine/sheets/phonics/index.ts
+++ b/src/engine/sheets/phonics/index.ts
@@ -34,6 +34,14 @@ export {
 } from "./bank";
 
 export {
+  markGrapheme,
+  markSentence,
+  markSpelling,
+  markWord,
+  markedText,
+} from "./cards";
+
+export {
   CARD_BIG_EMS,
   CARD_BIG_LEADING,
   CARD_PAD_EMS,
@@ -41,12 +49,7 @@ export {
   CARD_SMALL_LEADING,
   STRIP_BIG_EMS,
   cardRowEms,
-  markGrapheme,
-  markSentence,
-  markSpelling,
-  markWord,
-  markedText,
-} from "./cards";
+} from "./metrics";
 
 export {
   SENTENCES,

--- a/src/engine/sheets/phonics/metrics.ts
+++ b/src/engine/sheets/phonics/metrics.ts
@@ -1,0 +1,51 @@
+/**
+ * How big a card is, and nothing else — which is the whole point of the module.
+ *
+ * Declared, not measured (§4), and in ems of the body size, so a parent who
+ * wants cards twice the size raises the type size and the whole card grows with
+ * it. It is also how one block prints both a flash card an inch high and a
+ * sentence strip a child reads across a room.
+ *
+ * **These numbers sit apart from `cards.ts` because two very different callers
+ * read them:** the family, which reserves the page against them, and
+ * `blocks/Cards.tsx`, which draws the box. A renderer reaching them through
+ * `cards.ts` would drag `bank.ts` — 27 KB of word corpus — into the Print
+ * Shop's first download for four numbers, and the phonics family's
+ * `() => import(...)` in `families.ts` would then be fetching a module the
+ * browser already had (§3). So this file imports nothing at all, and the rule
+ * that keeps it that way is `blocks/index.test.ts`.
+ */
+
+/** The spelling on a sound card, and on the wall chart. */
+export const CARD_BIG_EMS = 3.2;
+
+/** A sentence strip: a whole sentence, so a great deal smaller than a card. */
+export const STRIP_BIG_EMS = 1.6;
+
+/** The example word under the spelling. */
+export const CARD_SMALL_EMS = 0.95;
+
+/** The leading each of the two lines is set on. */
+export const CARD_BIG_LEADING = 1.1;
+export const CARD_SMALL_LEADING = 1.35;
+
+/** The air inside a card's box, top and bottom each. */
+export const CARD_PAD_EMS = 0.42;
+
+/**
+ * How tall one card stands, in ems of the body size.
+ *
+ * Read by both the family that reserves the page and the renderer that draws
+ * the box, for the reason `answerLine` gives: the failure is silent on screen
+ * and is the last row of cards on a second sheet of paper.
+ *
+ * `rows` is how many lines the big line wraps onto — one for a spelling, and
+ * however many the longest sentence needs for a strip.
+ */
+export function cardRowEms(big: number, rows: number, small: boolean): number {
+  return (
+    rows * big * CARD_BIG_LEADING +
+    (small ? CARD_SMALL_EMS * CARD_SMALL_LEADING : 0) +
+    CARD_PAD_EMS * 2
+  );
+}

--- a/src/engine/sheets/phonics/sheets.ts
+++ b/src/engine/sheets/phonics/sheets.ts
@@ -39,15 +39,8 @@ import { points } from "../paper";
 import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
 
 import { WORDS, WORD_BY_SPELLING, type Word } from "./bank";
-import {
-  CARD_BIG_EMS,
-  STRIP_BIG_EMS,
-  cardRowEms,
-  markGrapheme,
-  markSentence,
-  markWord,
-  sentenceLength,
-} from "./cards";
+import { markGrapheme, markSentence, markWord, sentenceLength } from "./cards";
+import { CARD_BIG_EMS, STRIP_BIG_EMS, cardRowEms } from "./metrics";
 import {
   pickWords,
   readInventory,

--- a/src/engine/sheets/phonics/sheets.ts
+++ b/src/engine/sheets/phonics/sheets.ts
@@ -705,8 +705,6 @@ export function buildPhonicsSheet(config: PhonicsConfig, seed: number): Sheet {
 }
 
 export const PHONICS_SHEET: SheetSpec<PhonicsConfig> = {
-  id: "phonics",
-  label: "Phonics",
   world: SHEET_WORLD,
   build: buildPhonicsSheet,
   // Every answer was decided when the sheet was built — which words were drawn,

--- a/src/engine/sheets/search.test.ts
+++ b/src/engine/sheets/search.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { listSheets } from "./index";
+import { SHEET_FAMILIES } from "./families";
 import {
   EMPTY_QUERY,
   SHEET_TYPES,
@@ -77,8 +77,8 @@ describe("what kind of page a family makes", () => {
     // A `Record` over the config union, so this is really a compile-time check
     // — the runtime half is that the registry and the union agree, which is
     // what would rot if a family were registered under a different id.
-    for (const spec of listSheets()) {
-      expect(TYPE_OF[spec.id as keyof typeof TYPE_OF], spec.id).toBeDefined();
+    for (const { id } of SHEET_FAMILIES) {
+      expect(TYPE_OF[id as keyof typeof TYPE_OF], id).toBeDefined();
     }
   });
 

--- a/src/engine/sheets/spec.ts
+++ b/src/engine/sheets/spec.ts
@@ -52,7 +52,7 @@ export const LONGEST_SHEET_URL: string = WORLDS.map((world) =>
 );
 
 /**
- * `C` is the family's own config, and the registry in index.ts is what ties it
+ * `C` is the family's own config, and the table in families.ts is what ties it
  * back to the union: a spec is only ever handed the config whose `kind` looked
  * it up. Declaring `build` and `describe` as methods rather than as arrow
  * properties is load-bearing — TypeScript checks method parameters
@@ -60,11 +60,11 @@ export const LONGEST_SHEET_URL: string = WORLDS.map((world) =>
  * of `SheetSpec<SheetConfig>` without a cast at every entry. Rewrite either as
  * `build: (config: C, seed: number) => Sheet` and the registry stops
  * compiling.
+ *
+ * Behaviour only: what a family is called and which `kind` reaches it are in
+ * `SheetFamily`, because the picker names every family without loading one.
  */
 export type SheetSpec<C extends SheetConfig = SheetConfig> = {
-  /** Matches `SheetConfig.kind`, so a saved sheet finds its way back here. */
-  id: string;
-  label: string;
   world: World;
   /** Build the sheet. Deterministic in (config, seed) — see §7. */
   build(config: C, seed: number): Sheet;
@@ -78,7 +78,7 @@ export type SheetSpec<C extends SheetConfig = SheetConfig> = {
 };
 
 /**
- * Stands in for a sheet family that isn't in the registry.
+ * Stands in for a sheet family that isn't in the table.
  *
  * Saved sheets outlive the families they were made on, the same way sessions
  * outlive their decks: a config from a URL somebody bookmarked in March must
@@ -87,8 +87,6 @@ export type SheetSpec<C extends SheetConfig = SheetConfig> = {
  * inside a build that would otherwise have shipped a catalog (§3).
  */
 export const UNKNOWN_SHEET: SheetSpec = {
-  id: "unknown",
-  label: "Retired sheet",
   world: SHEET_WORLD,
   build: (config, seed) => ({
     // The one place a config is treated as untrusted rather than as its type.
@@ -108,3 +106,62 @@ export const UNKNOWN_SHEET: SheetSpec = {
   key: (sheet) => sheet,
   describe: () => "A sheet this build no longer makes",
 };
+
+/**
+ * The presentation half of `SheetOptions`, copied onto what a family built.
+ *
+ * Here rather than in every `build` function: every family would otherwise write
+ * the same three lines, and the next one added would be the one that forgot. It
+ * is safe to do after the fact because none of the three changes a length — the
+ * face is set in points, a bordered slot is the same line box as a ruled one,
+ * and the cut guides are drawn over the paper rather than in the flow — so
+ * nothing here can make a sheet the layout arithmetic already fitted stop
+ * fitting.
+ *
+ * A family that has already said something wins, which is what keeps this a
+ * default rather than an override: `UNKNOWN_SHEET` sets nothing and gets the
+ * parent's choices, and a family that one day sets its own is not quietly
+ * undone from out here.
+ */
+function present(config: SheetConfig, sheet: Sheet): Sheet {
+  return {
+    ...sheet,
+    font: sheet.font ?? config.font,
+    answerBox: sheet.answerBox ?? config.answerBox,
+    cutLines: sheet.cutLines ?? config.cutLines,
+  };
+}
+
+/**
+ * Build a sheet from a family already in hand. Deterministic in
+ * `(config, seed)`, which is the mechanism behind three of the features in §7
+ * rather than one: an answer key is the same build, "another sheet like this
+ * one" is `seed + 1`, and a sheet is reproducible from a shared URL because the
+ * seed is in it.
+ *
+ * Takes the spec rather than looking one up, because there are two ways to
+ * reach a family — the whole press at once in index.ts, one at a time through
+ * `loadSheet` — and only one of them may decide what "built" means.
+ */
+export function buildWith(
+  spec: SheetSpec,
+  config: SheetConfig,
+  seed: number,
+): Sheet {
+  return present(config, spec.build(config, seed));
+}
+
+/**
+ * The same sheet with the answers drawn in.
+ *
+ * A second build from the same seed, not a second generation of the answers:
+ * they were computed when the sheet was built and `key` only decides to print
+ * them, so a key cannot disagree with the sheet it belongs to.
+ */
+export function keyWith(
+  spec: SheetSpec,
+  config: SheetConfig,
+  seed: number,
+): Sheet {
+  return present(config, spec.key(spec.build(config, seed)));
+}

--- a/src/engine/sheets/templates/cards.ts
+++ b/src/engine/sheets/templates/cards.ts
@@ -402,8 +402,6 @@ export function describeCards(config: CardsConfig): string {
 }
 
 export const CARDS_SHEET: SheetSpec<CardsConfig> = {
-  id: "cards",
-  label: "Cards, tags and bookmarks",
   world: SHEET_WORLD,
   build: buildCardsSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/templates/charts.ts
+++ b/src/engine/sheets/templates/charts.ts
@@ -476,8 +476,6 @@ export function describeChart(config: ChartConfig): string {
 }
 
 export const CHART_SHEET: SheetSpec<ChartConfig> = {
-  id: "chart",
-  label: "Charts, number lines and grids",
   world: SHEET_WORLD,
   build: buildChartSheet,
   // The filled chart, on the one sheet that has an answer at all. On the other

--- a/src/engine/sheets/templates/forms.ts
+++ b/src/engine/sheets/templates/forms.ts
@@ -504,8 +504,6 @@ export function describeForm(config: FormConfig, seed = 0): string {
 }
 
 export const FORM_SHEET: SheetSpec<FormConfig> = {
-  id: "form",
-  label: "Logs, reports and forms",
   world: SHEET_WORLD,
   build: buildFormSheet,
   // Nothing to reveal, ever — see `formKeyed`. A key of one of these is the

--- a/src/engine/sheets/templates/nets.ts
+++ b/src/engine/sheets/templates/nets.ts
@@ -314,8 +314,6 @@ export function describeNet(config: NetConfig): string {
 }
 
 export const NET_SHEET: SheetSpec<NetConfig> = {
-  id: "net",
-  label: "Dice and spinners",
   world: SHEET_WORLD,
   build: buildNetSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/templates/paper.test.ts
+++ b/src/engine/sheets/templates/paper.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { sheetBlockBox } from "../chrome";
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { contentBox, ruledLines } from "../layout";
 import { RULINGS, inches, rulePitch } from "../paper";
 import type {
@@ -59,7 +60,7 @@ const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
 describe("the paper family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("paper")).toBe(PAPER_SHEET);
-    expect(sheetSpec("paper").label).toBe("Lined and graph paper");
+    expect(sheetFamily("paper")?.label).toBe("Lined and graph paper");
   });
 
   it("rules a sheet in every ruling of §5", () => {

--- a/src/engine/sheets/templates/paper.ts
+++ b/src/engine/sheets/templates/paper.ts
@@ -66,8 +66,6 @@ export function describePaper(config: PaperConfig): string {
 }
 
 export const PAPER_SHEET: SheetSpec<PaperConfig> = {
-  id: "paper",
-  label: "Lined and graph paper",
   world: SHEET_WORLD,
   build: buildPaperSheet,
   // Blank paper is the answer. Returned as-is rather than with `answers: true`,

--- a/src/engine/sheets/templates/planner.test.ts
+++ b/src/engine/sheets/templates/planner.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { declaredWidth, printedBlockBox } from "../chrome";
 import { BLOCK_GAP } from "../layout";
 import { MARGINS } from "../paper";
-import { cardRowEms } from "../phonics/cards";
+import { cardRowEms } from "../phonics/metrics";
 import { SCRIPTURE_CREDIT } from "../passages";
 import type {
   Block,

--- a/src/engine/sheets/templates/planner.ts
+++ b/src/engine/sheets/templates/planner.ts
@@ -17,7 +17,7 @@
 import { declaredWidth, sheetBlockBox } from "../chrome";
 import { BLOCK_GAP, type Box } from "../layout";
 import { own, points, whole } from "../paper";
-import { cardRowEms } from "../phonics/cards";
+import { cardRowEms } from "../phonics/metrics";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
 import type {
   Block,

--- a/src/engine/sheets/templates/planner.ts
+++ b/src/engine/sheets/templates/planner.ts
@@ -682,8 +682,6 @@ export function describePlanner(config: PlannerConfig): string {
 }
 
 export const PLANNER_SHEET: SheetSpec<PlannerConfig> = {
-  id: "planner",
-  label: "Calendars, planners and charts",
   world: SHEET_WORLD,
   build: buildPlannerSheet,
   key: (sheet) => ({

--- a/src/engine/sheets/words/metrics.ts
+++ b/src/engine/sheets/words/metrics.ts
@@ -1,0 +1,51 @@
+/**
+ * What a word puzzle reserves the page against, and what the renderer draws
+ * against — the handful of things both halves have to agree on exactly.
+ *
+ * A grid a hair wider than the space kept for it, or a "not in the grid" line
+ * measured at one length and printed at another, looks right on screen and
+ * comes out on a second sheet of paper. So there is one copy of each, here.
+ *
+ * **Here rather than in `search.ts` or `puzzles.ts` for the reason
+ * `phonics/metrics.ts` gives:** three block renderers need these, and reaching
+ * them through a family module would put the puzzle generators in the Print
+ * Shop's first download — leaving the `puzzle` and `words` entries in
+ * `families.ts` fetching modules the browser already had (§3). Nothing here
+ * generates anything: two numbers and a list of tokens, over `paper.ts`, which
+ * every sheet already needs.
+ */
+import type { Mil } from "../types";
+
+import { inches } from "../paper";
+
+/**
+ * A letter big enough for a five-year-old to find, and small enough that a
+ * ten-by-ten puzzle doesn't take the whole page.
+ */
+export const SEARCH_CELL: Mil = inches(0.34);
+
+/** How wide one cell comes out at, given the room and the number of them. */
+export const searchCell = (width: Mil, size: number): Mil =>
+  size <= 0 ? 0 : Math.min(SEARCH_CELL, Math.floor(width / size));
+
+/** What `<Omitted>` puts in front of the list. */
+const MISSING_HEAD = "Not in the grid:";
+
+/**
+ * The missing line, as the words it is set from.
+ *
+ * Tokens rather than a sentence because both halves need it in this shape: the
+ * renderer joins them with a space, and the reservation packs them by whole
+ * words, greedily, exactly as `packRows` does for the wrapping rows in the
+ * chrome. A copy of the sentence in `Omitted.tsx` would be a paragraph measured
+ * at one length and printed at another.
+ */
+export function missingTokens(words: string[], more: number): string[] {
+  return [
+    MISSING_HEAD,
+    // The last word takes no comma, the tail included: "CAT, DOG … and 3 more"
+    // is a list that ran out, and "DOG, … and 3 more" is a typo.
+    ...words.map((word, at) => (at === words.length - 1 ? word : `${word},`)),
+    ...(more > 0 ? [`… and ${more} more`] : []),
+  ];
+}

--- a/src/engine/sheets/words/puzzles.test.ts
+++ b/src/engine/sheets/words/puzzles.test.ts
@@ -6,7 +6,8 @@ import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
 import { sheetFamily } from "../families";
 import type { Block, Paper, PuzzleConfig } from "../types";
 
-import { SEARCH_CELL, findWord, searchCell, searchSteps } from "./search";
+import { SEARCH_CELL, searchCell } from "./metrics";
+import { findWord, searchSteps } from "./search";
 import {
   MAX_GRID,
   MIN_GRID,

--- a/src/engine/sheets/words/puzzles.test.ts
+++ b/src/engine/sheets/words/puzzles.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it } from "vitest";
 import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import type { Block, Paper, PuzzleConfig } from "../types";
 
 import { SEARCH_CELL, findWord, searchCell, searchSteps } from "./search";
 import {
   MAX_GRID,
   MIN_GRID,
+  PUZZLE_SHEET,
   crosswordClue,
   crosswordLayout,
   letterHint,
@@ -65,8 +67,8 @@ function blockOf<K extends Block["kind"]>(
 
 describe("the family", () => {
   it("is in the registry, under the kind a saved sheet carries", () => {
-    expect(sheetSpec("puzzle").id).toBe("puzzle");
-    expect(sheetSpec("puzzle").label).toBe("Word puzzle");
+    expect(sheetSpec("puzzle")).toBe(PUZZLE_SHEET);
+    expect(sheetFamily("puzzle")?.label).toBe("Word puzzle");
   });
 
   it("makes one block, whichever puzzle it is", () => {

--- a/src/engine/sheets/words/puzzles.ts
+++ b/src/engine/sheets/words/puzzles.ts
@@ -750,8 +750,6 @@ export function buildPuzzleSheet(config: PuzzleConfig, seed: number): Sheet {
 }
 
 export const PUZZLE_SHEET: SheetSpec<PuzzleConfig> = {
-  id: "puzzle",
-  label: "Word puzzle",
   world: SHEET_WORLD,
   build: buildPuzzleSheet,
   // Every answer here was decided when the sheet was built — which is to say,

--- a/src/engine/sheets/words/puzzles.ts
+++ b/src/engine/sheets/words/puzzles.ts
@@ -25,13 +25,8 @@ import { PROBLEM_GAP, columnWidth, fitAcross, type Box } from "../layout";
 import { inches, points } from "../paper";
 import { SHEET_CREDIT, SHEET_WORLD, gameUrl, type SheetSpec } from "../spec";
 import { buildCrossword, type Clued } from "./crossword";
-import {
-  SEARCH_CELL,
-  buildSearch,
-  gridForm,
-  searchCell,
-  searchSteps,
-} from "./search";
+import { SEARCH_CELL, missingTokens, searchCell } from "./metrics";
+import { buildSearch, gridForm, searchSteps } from "./search";
 import { wordsOf } from "./spelling";
 
 /* ── What a puzzle takes on the page ──────────────────────────────────────
@@ -248,32 +243,12 @@ function listHeight(words: string[], head: SheetOptions, width: Mil): Mil {
    shrunk to exactly the room available, and the trimming is what creates the
    list it prints — so it is guaranteed to be there precisely when there is
    nothing left to put it in. What the arithmetic measures and what the renderer
-   sets are therefore the same tokens, out of the same function.              */
-
-/** What `<Omitted>` puts in front of the list. */
-const MISSING_HEAD = "Not in the grid:";
+   sets are therefore the same tokens, out of the same function — `missingTokens`,
+   which is in `metrics.ts` so that reading it costs `Omitted.tsx` a leaf rather
+   than this whole family (§3).                                               */
 
 /** As much of the list as the page can hold, and a count of the rest. */
 type Missing = { words: string[]; more: number };
-
-/**
- * The missing line, as the words it is set from.
- *
- * Tokens rather than a sentence because both halves need it in this shape: the
- * renderer joins them with a space, and the reservation packs them by whole
- * words, greedily, exactly as `packRows` does for the wrapping rows in the
- * chrome. A copy of the sentence in `Omitted.tsx` would be a paragraph measured
- * at one length and printed at another.
- */
-export function missingTokens(words: string[], more: number): string[] {
-  return [
-    MISSING_HEAD,
-    // The last word takes no comma, the tail included: "CAT, DOG … and 3 more"
-    // is a list that ran out, and "DOG, … and 3 more" is a typo.
-    ...words.map((word, at) => (at === words.length - 1 ? word : `${word},`)),
-    ...(more > 0 ? [`… and ${more} more`] : []),
-  ];
-}
 
 /** How many rows those tokens wrap onto, in the room they are given. */
 function missingRowsOf(

--- a/src/engine/sheets/words/search.test.ts
+++ b/src/engine/sheets/words/search.test.ts
@@ -4,12 +4,11 @@ import { mulberry32 } from "@/engine/random";
 
 import type { Found } from "../types";
 
+import { SEARCH_CELL, searchCell } from "./metrics";
 import {
-  SEARCH_CELL,
   buildSearch,
   findWord,
   gridForm,
-  searchCell,
   searchSteps,
   type Step,
 } from "./search";

--- a/src/engine/sheets/words/search.ts
+++ b/src/engine/sheets/words/search.ts
@@ -14,28 +14,10 @@
  */
 import { shuffled } from "@/engine/random";
 
-import type { Found, Mil, SearchDirections } from "../types";
-
-import { inches } from "../paper";
+import type { Found, SearchDirections } from "../types";
 
 /** One step along a word, per letter. `(1, 0)` reads left to right. */
 export type Step = { dx: number; dy: number };
-
-/**
- * A letter big enough for a five-year-old to find, and small enough that a
- * ten-by-ten puzzle doesn't take the whole page.
- *
- * Here rather than in `WordSearch.tsx` because both halves need it and they
- * have to agree: the family reserves the page against the height the grid will
- * take, and the renderer draws it. A copy in each would be a grid taller than
- * the space reserved for it — invisible on screen, and the word list on a
- * second sheet of paper.
- */
-export const SEARCH_CELL: Mil = inches(0.34);
-
-/** How wide one cell comes out at, given the room and the number of them. */
-export const searchCell = (width: Mil, size: number): Mil =>
-  size <= 0 ? 0 : Math.min(SEARCH_CELL, Math.floor(width / size));
 
 /**
  * The directions a word may run, before `reverse` is applied.

--- a/src/engine/sheets/words/spelling.test.ts
+++ b/src/engine/sheets/words/spelling.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import { answerLine } from "../layout";
 import type {
   Blank,
@@ -99,7 +100,7 @@ function refilled(blank: Blank): string {
 describe("the spelling family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("words")).toBe(WORDS_SHEET);
-    expect(sheetSpec("words").label).toBe("Spelling list");
+    expect(sheetFamily("words")?.label).toBe("Spelling list");
   });
 
   it("names what it prints, in the terms it was chosen by", () => {

--- a/src/engine/sheets/words/spelling.ts
+++ b/src/engine/sheets/words/spelling.ts
@@ -436,8 +436,6 @@ export function buildWordsSheet(config: WordsConfig, seed: number): Sheet {
 }
 
 export const WORDS_SHEET: SheetSpec<WordsConfig> = {
-  id: "words",
-  label: "Spelling list",
   world: SHEET_WORLD,
   build: buildWordsSheet,
   // Every answer was decided when the sheet was built — which letters came out,

--- a/src/engine/sheets/words/study.test.ts
+++ b/src/engine/sheets/words/study.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
+import { sheetFamily } from "../families";
 import type { Block, Paper, WordStudyConfig, WordStudyStyle } from "../types";
 
 import {
@@ -155,7 +156,7 @@ describe("the word bank", () => {
 describe("the word-study family", () => {
   it("is in the registry under the kind its config carries", () => {
     expect(sheetSpec("word-study")).toBe(WORD_STUDY_SHEET);
-    expect(sheetSpec("word-study").label).toBe("Word study");
+    expect(sheetFamily("word-study")?.label).toBe("Word study");
   });
 
   it("prints a titled, marked page for every topic and style", () => {

--- a/src/engine/sheets/words/study.ts
+++ b/src/engine/sheets/words/study.ts
@@ -562,8 +562,6 @@ export function buildStudySheet(config: WordStudyConfig, seed: number): Sheet {
 }
 
 export const WORD_STUDY_SHEET: SheetSpec<WordStudyConfig> = {
-  id: "word-study",
-  label: "Word study",
   world: SHEET_WORLD,
   build: buildStudySheet,
   // Every answer was decided when the sheet was built — which questions were

--- a/src/engine/sheets/writing/handwriting.ts
+++ b/src/engine/sheets/writing/handwriting.ts
@@ -569,8 +569,6 @@ export function buildHandwritingSheet(
 }
 
 export const HANDWRITING_SHEET: SheetSpec<HandwritingConfig> = {
-  id: "handwriting",
-  label: "Handwriting practice",
   world: SHEET_WORLD,
   build: buildHandwritingSheet,
   // Returned as-is rather than with `answers: true`, for the same reason blank

--- a/src/engine/sheets/writing/memory.ts
+++ b/src/engine/sheets/writing/memory.ts
@@ -286,8 +286,6 @@ export function buildMemorySheet(config: MemoryConfig, seed: number): Sheet {
 }
 
 export const MEMORY_SHEET: SheetSpec<MemoryConfig> = {
-  id: "memory",
-  label: "Memory verse",
   world: SHEET_WORLD,
   build: buildMemorySheet,
   // The passage whole, every gap filled from the words that were taken out when

--- a/src/games/printshop/App.tsx
+++ b/src/games/printshop/App.tsx
@@ -3,16 +3,16 @@
  *
  * Two columns and one idea. On the left, every option that changes the paper;
  * on the right, the paper. There is no preview button and no "apply", because
- * there is nothing to apply to: `buildSheet(config, seed)` is a pure function of
- * the state this island holds, so the sheet on the right is not a rendering of
- * the settings on the left, it *is* them.
+ * there is nothing to apply to: `buildWith(spec, config, seed)` is a pure
+ * function of the state this island holds, so the sheet on the right is not a
+ * rendering of the settings on the left, it *is* them.
  *
  * Why an island can keep the site's chrome around it here, where a race cannot,
  * is in make.astro.
  */
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
-import { answerKey, buildSheet } from "@/engine/sheets";
+import { buildWith, keyWith } from "@/engine/sheets/spec";
 import type { Sheet } from "@/engine/sheets/types";
 import "@/styles/printshop.css";
 
@@ -23,10 +23,32 @@ import { Picker } from "./Picker";
 import { Preview, PrintCopy } from "./Preview";
 import { PrintBar } from "./PrintBar";
 import { SavedSheets } from "./SavedSheets";
-import { useBuilder, useDebounced } from "./useBuilder";
+import { FIRST_SHEET } from "./defaults";
+import {
+  openingSheet,
+  useBuilder,
+  useDebounced,
+  type SharedSheet,
+} from "./useBuilder";
+import { useFamily } from "./useFamily";
 
+/**
+ * The wait for the family the bench opens on, and nothing else.
+ *
+ * A family is a chunk of its own now (§3), and the bench builds paper as it
+ * mounts — `useBuilder` test-builds whatever the fragment held before it trusts
+ * it — so there is nothing to render until that one module is here. Every
+ * family chosen afterwards is fetched underneath a bench that stays on screen.
+ */
 export default function PrintShopApp() {
-  const bench = useBuilder();
+  const [opening] = useState(openingSheet);
+  const first = useFamily(opening?.config.kind ?? FIRST_SHEET);
+
+  return first ? <Bench opening={opening} /> : null;
+}
+
+function Bench({ opening }: { opening: SharedSheet | null }) {
+  const bench = useBuilder(opening);
 
   // Memoised so the debounce below has something stable to hold. Without it
   // every render would make a new object, the timer would restart on the render
@@ -43,17 +65,26 @@ export default function PrintShopApp() {
 
   const settled = useDebounced(live);
 
+  // Two families, and the second is not a slip. The picker names the one being
+  // chosen and the press builds the one that has settled, which are the same
+  // family except in the moment after a switch — and that is exactly when the
+  // difference pays, because asking for the live one starts its download while
+  // the preview is still holding the old sheet.
+  const chosen = useFamily(bench.config.kind);
+  const printing = useFamily(settled.config.kind);
+
   const sheets = useMemo<Sheet[]>(() => {
+    if (!printing) return [];
     const pages: Sheet[] = [];
     for (let copy = 0; copy < settled.variants; copy++) {
       // Variants are `seed + n` and nothing more elaborate (§7), so each one is
       // reproducible from the number printed at the foot of the page.
       const seed = settled.seed + copy;
-      pages.push(buildSheet(settled.config, seed));
-      if (settled.answers) pages.push(answerKey(settled.config, seed));
+      pages.push(buildWith(printing, settled.config, seed));
+      if (settled.answers) pages.push(keyWith(printing, settled.config, seed));
     }
     return pages;
-  }, [settled]);
+  }, [printing, settled]);
 
   return (
     <div className="bench">
@@ -64,7 +95,11 @@ export default function PrintShopApp() {
             the bench — everything below stays in charge of it afterwards. */}
         <Bootstrap onOpen={bench.open} />
 
-        <Picker config={bench.config} onFamily={bench.setFamily} />
+        <Picker
+          config={bench.config}
+          spec={chosen}
+          onFamily={bench.setFamily}
+        />
 
         <section className="bench__group">
           <h2 className="bench__title u-display">What is on it</h2>

--- a/src/games/printshop/Picker.tsx
+++ b/src/games/printshop/Picker.tsx
@@ -1,26 +1,32 @@
 /**
  * Which kind of sheet is on the bench.
  *
- * Built from `listSheets()` rather than from a list here, so a family added to
- * the engine's registry appears in the picker without anybody remembering to
- * come and say so.
+ * Built from `SHEET_FAMILIES` rather than from a list here, so a family added
+ * to the engine's table appears in the picker without anybody remembering to
+ * come and say so — and appears without its module, which is the whole reason
+ * that table names a family rather than the family naming itself (§3).
  *
- * The line underneath is `describeSheet(config)`, which is also what a saved
- * sheet is named after when a parent doesn't name it — one sentence, written
- * once.
+ * The line underneath is the family's own `describe`, which is also what a
+ * saved sheet is named after when a parent doesn't name it — one sentence,
+ * written once. It is blank for as long as the chosen family is still on its
+ * way, which is the only thing on this control that waits for anything.
  */
-import { describeSheet, listSheets } from "@/engine/sheets";
+import { SHEET_FAMILIES } from "@/engine/sheets/families";
+import type { SheetSpec } from "@/engine/sheets/spec";
 import type { SheetConfig } from "@/engine/sheets/types";
 
 import { Choice, opt } from "./options/parts";
 
-const FAMILIES = listSheets().map((spec) => opt(spec.id, spec.label));
+const FAMILIES = SHEET_FAMILIES.map((family) => opt(family.id, family.label));
 
 export function Picker({
   config,
+  spec,
   onFamily,
 }: {
   config: SheetConfig;
+  /** The chosen family, once its module is here. */
+  spec: SheetSpec | undefined;
   onFamily: (kind: string) => void;
 }) {
   return (
@@ -31,7 +37,7 @@ export function Picker({
         onChange={onFamily}
         options={FAMILIES}
       />
-      <p className="picker__line">{describeSheet(config)}</p>
+      <p className="picker__line">{spec ? spec.describe(config) : ""}</p>
     </div>
   );
 }

--- a/src/games/printshop/options/index.tsx
+++ b/src/games/printshop/options/index.tsx
@@ -1,44 +1,22 @@
 /**
  * The option panels' front door.
  *
- * A registry keyed by `kind`, exactly as `engine/sheets/index.ts` is, and for
- * the same reason: looking a panel up *is* the narrowing, so there is no
- * `switch` over `SheetConfig` here to keep in step with the union. Adding a
- * family is a module beside this one and a line in the table.
+ * A registry keyed by `kind`, exactly as `engine/sheets/families.ts` is, and for
+ * the same two reasons: looking a panel up *is* the narrowing, so there is no
+ * `switch` over `SheetConfig` here to keep in step with the union — and each
+ * entry is a `import()` rather than an import, so a panel arrives with the
+ * family it belongs to instead of with the twenty-six it doesn't. Several of
+ * them are the expensive half: the passage picker under copywork reads the
+ * whole library, Scripture included. Adding a family is a module beside this
+ * one and a line in the table.
  */
-import type { ReactNode } from "react";
+import { Suspense, lazy, type ComponentType, type ReactNode } from "react";
 
 import type { SheetConfig } from "@/engine/sheets/types";
 
-import { ArithmeticPanel } from "./arithmetic";
-import { CardsPanel } from "./cards";
-import { ChartsPanel } from "./charts";
-import { DecimalsPanel } from "./decimals";
-import { FormsPanel } from "./forms";
-import { FractionsPanel } from "./fractions";
-import { GeometryPanel } from "./geometry";
-import { GrammarPanel } from "./grammar";
-import { HandwritingPanel } from "./handwriting";
-import { IntegersPanel } from "./integers";
-import { MeasurePanel } from "./measure";
-import { MemoryPanel } from "./memory";
-import { MoneyPanel } from "./money";
-import { MultiplicationPanel } from "./multiplication";
-import { NetsPanel } from "./nets";
-import { PaperPanel } from "./paper";
-import { PlannerPanel } from "./planner";
-import { PhonicsPanel } from "./phonics";
-import { PreAlgebraPanel } from "./prealgebra";
-import { PuzzlesPanel } from "./puzzles";
-import { RatioPanel } from "./ratio";
-import { StatisticsPanel } from "./statistics";
-import { TimePanel } from "./time";
-import { WordProblemsPanel } from "./wordproblems";
-import { WordsPanel } from "./words";
-import { WordStudyPanel } from "./wordstudy";
 import type { PanelProps } from "./parts";
 
-type FamilyPanel = (props: PanelProps) => ReactNode;
+type FamilyPanel = ComponentType<PanelProps>;
 
 /**
  * Files a family's panel under the union, which the lookup then honours — the
@@ -56,8 +34,9 @@ type FamilyPanel = (props: PanelProps) => ReactNode;
  * a `MoneyPanel` that reached for `regrouping` still fails to compile.
  */
 const panel = <C extends SheetConfig>(
-  Panel: (props: PanelProps<C>) => ReactNode,
-): FamilyPanel => Panel as unknown as FamilyPanel;
+  load: () => Promise<(props: PanelProps<C>) => ReactNode>,
+): FamilyPanel =>
+  lazy(async () => ({ default: await load() })) as unknown as FamilyPanel;
 
 /**
  * A family with nothing of its own to choose — blank paper, whose every option
@@ -69,32 +48,38 @@ const NO_OPTIONS: FamilyPanel = () => null;
 
 const PANELS: Record<string, FamilyPanel> = {
   blank: NO_OPTIONS,
-  paper: panel(PaperPanel),
-  chart: panel(ChartsPanel),
-  form: panel(FormsPanel),
-  planner: panel(PlannerPanel),
-  cards: panel(CardsPanel),
-  net: panel(NetsPanel),
-  arithmetic: panel(ArithmeticPanel),
-  multiplication: panel(MultiplicationPanel),
-  fractions: panel(FractionsPanel),
-  decimals: panel(DecimalsPanel),
-  money: panel(MoneyPanel),
-  time: panel(TimePanel),
-  measure: panel(MeasurePanel),
-  geometry: panel(GeometryPanel),
-  integers: panel(IntegersPanel),
-  prealgebra: panel(PreAlgebraPanel),
-  ratio: panel(RatioPanel),
-  statistics: panel(StatisticsPanel),
-  "word-problems": panel(WordProblemsPanel),
-  words: panel(WordsPanel),
-  "word-study": panel(WordStudyPanel),
-  puzzle: panel(PuzzlesPanel),
-  grammar: panel(GrammarPanel),
-  phonics: panel(PhonicsPanel),
-  handwriting: panel(HandwritingPanel),
-  memory: panel(MemoryPanel),
+  paper: panel(async () => (await import("./paper")).PaperPanel),
+  chart: panel(async () => (await import("./charts")).ChartsPanel),
+  form: panel(async () => (await import("./forms")).FormsPanel),
+  planner: panel(async () => (await import("./planner")).PlannerPanel),
+  cards: panel(async () => (await import("./cards")).CardsPanel),
+  net: panel(async () => (await import("./nets")).NetsPanel),
+  arithmetic: panel(async () => (await import("./arithmetic")).ArithmeticPanel),
+  multiplication: panel(
+    async () => (await import("./multiplication")).MultiplicationPanel,
+  ),
+  fractions: panel(async () => (await import("./fractions")).FractionsPanel),
+  decimals: panel(async () => (await import("./decimals")).DecimalsPanel),
+  money: panel(async () => (await import("./money")).MoneyPanel),
+  time: panel(async () => (await import("./time")).TimePanel),
+  measure: panel(async () => (await import("./measure")).MeasurePanel),
+  geometry: panel(async () => (await import("./geometry")).GeometryPanel),
+  integers: panel(async () => (await import("./integers")).IntegersPanel),
+  prealgebra: panel(async () => (await import("./prealgebra")).PreAlgebraPanel),
+  ratio: panel(async () => (await import("./ratio")).RatioPanel),
+  statistics: panel(async () => (await import("./statistics")).StatisticsPanel),
+  "word-problems": panel(
+    async () => (await import("./wordproblems")).WordProblemsPanel,
+  ),
+  words: panel(async () => (await import("./words")).WordsPanel),
+  "word-study": panel(async () => (await import("./wordstudy")).WordStudyPanel),
+  puzzle: panel(async () => (await import("./puzzles")).PuzzlesPanel),
+  grammar: panel(async () => (await import("./grammar")).GrammarPanel),
+  phonics: panel(async () => (await import("./phonics")).PhonicsPanel),
+  handwriting: panel(
+    async () => (await import("./handwriting")).HandwritingPanel,
+  ),
+  memory: panel(async () => (await import("./memory")).MemoryPanel),
 };
 
 /**
@@ -104,10 +89,19 @@ const PANELS: Record<string, FamilyPanel> = {
  * arrives from a URL somebody may have typed, and plain `PANELS[kind]` answers
  * `"toString"` with a function off `Object.prototype` — truthy, not a panel, and
  * rendered as a component one line later.
+ *
+ * Nothing while a panel is on its way, rather than a spinner: the heading above
+ * it stays put and the shared options below it never move, so what a parent sees
+ * is one group filling in — and the paper beside it is waiting on the same
+ * fetch anyway.
  */
 export function FamilyOptions({ config, set }: PanelProps) {
   const Panel = Object.hasOwn(PANELS, config.kind)
     ? PANELS[config.kind]
     : NO_OPTIONS;
-  return <Panel config={config} set={set} />;
+  return (
+    <Suspense fallback={null}>
+      <Panel config={config} set={set} />
+    </Suspense>
+  );
 }

--- a/src/games/printshop/useBuilder.ts
+++ b/src/games/printshop/useBuilder.ts
@@ -12,8 +12,9 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { buildSheet, describeSheet } from "@/engine/sheets";
+import { loadedSheet } from "@/engine/sheets/families";
 import { decodeSharedSheet, encodeSharedSheet } from "@/engine/sheets/share";
+import { buildWith } from "@/engine/sheets/spec";
 import type { SheetConfig } from "@/engine/sheets/types";
 
 import { defaultConfig, FIRST_SHEET } from "./defaults";
@@ -42,49 +43,59 @@ export type Builder = {
   setAnswers: (on: boolean) => void;
 };
 
+/** A whole sheet: a family tuned some way, and which draw of it (§7). */
+export type SharedSheet = { config: SheetConfig; seed: number };
+
 /**
  * What the fragment held when the page opened, if it held a sheet.
  *
- * Read once, on mount, and never again: the hook rewrites `#s=` on every change
- * from then on, so re-reading it would be reading its own handwriting.
- *
- * Test-built before it is trusted. `decodeSharedSheet` rebuilds the half of a
- * config every family shares and leaves each family's own fields alone, so this
- * is the belt to that pair of braces — and the one place §14's "fall back to
- * defaults rather than throwing" is actually kept.
+ * Read once, before the bench mounts, and never again: the hook rewrites `#s=`
+ * on every change from then on, so re-reading it would be reading its own
+ * handwriting. `App` is what reads it, because the family it names has to be
+ * fetched before there is anything to test-build.
  */
-function fromHash(): { config: SheetConfig; seed: number } | null {
+export function openingSheet(): SharedSheet | null {
   if (typeof window === "undefined") return null;
   const match = /^#s=(.*)$/.exec(window.location.hash);
-  if (!match) return null;
-
-  const shared = decodeSharedSheet(match[1]);
-  if (!shared) return null;
-
-  try {
-    // Both halves, because a family reaches into its own config twice: once to
-    // make the page and once to say in a line what is on it. A bench that built
-    // the paper and then threw on the caption is no better than one that threw
-    // on the paper.
-    buildSheet(shared.config, shared.seed);
-    describeSheet(shared.config);
-  } catch {
-    return null;
-  }
-  return shared;
+  return match ? decodeSharedSheet(match[1]) : null;
 }
 
-export function useBuilder(): Builder {
-  // Lazily, so the fragment is read once rather than on every render — and so
-  // the very first paint is already the shared sheet rather than the default
-  // one replaced a tick later.
-  const [state, setState] = useState(() => {
-    const shared = fromHash();
-    return {
-      config: shared?.config ?? defaultConfig(FIRST_SHEET),
-      seed: shared?.seed ?? 1,
-    };
-  });
+/**
+ * Whether a shared sheet survives being built.
+ *
+ * `decodeSharedSheet` rebuilds the half of a config every family shares and
+ * leaves each family's own fields alone, so this is the belt to that pair of
+ * braces — and the one place §14's "fall back to defaults rather than throwing"
+ * is actually kept.
+ *
+ * Both halves, because a family reaches into its own config twice: once to make
+ * the page and once to say in a line what is on it. A bench that built the paper
+ * and then threw on the caption is no better than one that threw on the paper.
+ *
+ * Synchronous, and entitled to be: `App` renders nothing until this family's
+ * module has landed, so there is always a spec in hand by the time the bench
+ * first mounts.
+ */
+function survivesBuilding({ config, seed }: SharedSheet): boolean {
+  const spec = loadedSheet(config.kind);
+  if (!spec) return false;
+  try {
+    buildWith(spec, config, seed);
+    spec.describe(config);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+export function useBuilder(opening: SharedSheet | null): Builder {
+  // Lazily, so the very first paint is already the shared sheet rather than the
+  // default one replaced a tick later.
+  const [state, setState] = useState<SharedSheet>(() =>
+    opening && survivesBuilding(opening)
+      ? opening
+      : { config: defaultConfig(FIRST_SHEET), seed: 1 },
+  );
   const [variants, setVariants] = useState(1);
   const [answers, setAnswers] = useState(false);
 

--- a/src/games/printshop/useFamily.ts
+++ b/src/games/printshop/useFamily.ts
@@ -1,0 +1,34 @@
+/**
+ * A sheet family, fetched the moment the bench needs it.
+ *
+ * Every family is a chunk of its own (`engine/sheets/families.ts`), so the
+ * builder holds a spec rather than importing one — and the answer is looked up
+ * by the kind being asked about rather than remembered from the last module
+ * that arrived, which is what makes "family A's spec over family B's config"
+ * unrepresentable rather than merely unlikely.
+ *
+ * Returns nothing until the module is here. That is a real state and the bench
+ * renders it: there is no paper to draw before the family that draws it lands.
+ */
+import { useEffect, useState } from "react";
+
+import { loadSheet, loadedSheet } from "@/engine/sheets/families";
+import type { SheetSpec } from "@/engine/sheets/spec";
+
+export function useFamily(kind: string): SheetSpec | undefined {
+  const [, redraw] = useState(0);
+  const spec = loadedSheet(kind);
+
+  useEffect(() => {
+    if (loadedSheet(kind)) return;
+    let live = true;
+    void loadSheet(kind).then(() => {
+      if (live) redraw((count) => count + 1);
+    });
+    return () => {
+      live = false;
+    };
+  }, [kind]);
+
+  return spec;
+}

--- a/src/services/sheets.test.ts
+++ b/src/services/sheets.test.ts
@@ -44,42 +44,44 @@ describe("sharing a sheet", () => {
     expect(Object.keys(toFile(sheet))).not.toContain("id");
   });
 
-  it("reads a good file into the same input the builder produces", () => {
-    expect(readSheetFile(toFile(sheet))).toEqual({
+  it("reads a good file into the same input the builder produces", async () => {
+    await expect(readSheetFile(toFile(sheet))).resolves.toEqual({
       name: "Monday handwriting",
       config,
       seed: 12,
     });
   });
 
-  it("keeps the seed, because it says which sheet this is", () => {
+  it("keeps the seed, because it says which sheet this is", async () => {
     // A config alone reproduces the same *kind* of sheet with different
     // problems. The seed is the difference between being sent a worksheet and
     // being sent a description of one.
-    expect(readSheetFile({ ...toFile(sheet), seed: 991 }).seed).toBe(991);
+    expect((await readSheetFile({ ...toFile(sheet), seed: 991 })).seed).toBe(
+      991,
+    );
   });
 
-  it("refuses a file that isn't ours", () => {
-    expect(() => readSheetFile({ kind: "schoolskills-deck" })).toThrow(
+  it("refuses a file that isn't ours", async () => {
+    await expect(readSheetFile({ kind: "schoolskills-deck" })).rejects.toThrow(
       InvalidSheet,
     );
-    expect(() => readSheetFile({ ...toFile(sheet), config: null })).toThrow(
-      InvalidSheet,
-    );
+    await expect(
+      readSheetFile({ ...toFile(sheet), config: null }),
+    ).rejects.toThrow(InvalidSheet);
     // A sheet with no seed can't be the sheet the sender printed.
-    expect(() => readSheetFile({ ...toFile(sheet), seed: undefined })).toThrow(
-      InvalidSheet,
-    );
-    expect(() => readSheetFile("a string")).toThrow(InvalidSheet);
-    expect(() => readSheetFile(null)).toThrow(InvalidSheet);
+    await expect(
+      readSheetFile({ ...toFile(sheet), seed: undefined }),
+    ).rejects.toThrow(InvalidSheet);
+    await expect(readSheetFile("a string")).rejects.toThrow(InvalidSheet);
+    await expect(readSheetFile(null)).rejects.toThrow(InvalidSheet);
   });
 
-  it("refuses a half-built config as InvalidSheet, not as a TypeError", () => {
+  it("refuses a half-built config as InvalidSheet, not as a TypeError", async () => {
     // The kind is one this build makes, so the spec check passes — and then the
     // family reads its own config to name the sheet, and `paper` has no rule to
     // read. Whatever comes out of this door has to be an `InvalidSheet`, or the
     // caller that catches one is left holding a crash instead of a message.
-    expect(() =>
+    await expect(
       readSheetFile({
         kind: "schoolskills-sheet",
         version: 1,
@@ -87,41 +89,41 @@ describe("sharing a sheet", () => {
         config: { kind: "paper" },
         seed: 1,
       }),
-    ).toThrow(InvalidSheet);
+    ).rejects.toThrow(InvalidSheet);
   });
 
-  it("refuses a sheet this build doesn't know how to make", () => {
+  it("refuses a sheet this build doesn't know how to make", async () => {
     // It would import perfectly and then print a page saying "sheet
     // unavailable". Somebody who was sent a worksheet is better told why.
-    expect(() =>
+    await expect(
       readSheetFile({
         ...toFile(sheet),
         config: { ...config, kind: "alchemy" },
       }),
-    ).toThrow(InvalidSheet);
+    ).rejects.toThrow(InvalidSheet);
   });
 });
 
 describe("what may be saved", () => {
-  it("names an unnamed sheet after what it prints", () => {
+  it("names an unnamed sheet after what it prints", async () => {
     // The engine already says in one line what a config makes, so a sheet with
     // no name typed on it gets that rather than "Untitled".
-    const read = readSheetFile({ ...toFile(sheet), name: "   " });
+    const read = await readSheetFile({ ...toFile(sheet), name: "   " });
     expect(read.name).toBe(describeSheet(config));
     expect(read.name.length).toBeGreaterThan(0);
   });
 
-  it("refuses a name past the cap", () => {
-    expect(() =>
+  it("refuses a name past the cap", async () => {
+    await expect(
       readSheetFile({ ...toFile(sheet), name: "x".repeat(MAX_NAME + 1) }),
-    ).toThrow(InvalidSheet);
+    ).rejects.toThrow(InvalidSheet);
   });
 
-  it("refuses a seed that isn't a whole number", () => {
+  it("refuses a seed that isn't a whole number", async () => {
     // Every one of these builds — `mulberry32` starts with `seed >>> 0` — and
     // every one builds a different sheet from the one being saved.
     for (const seed of [1.5, -1, Number.NaN, 2 ** 60]) {
-      expect(() => readSheetFile({ ...toFile(sheet), seed })).toThrow(
+      await expect(readSheetFile({ ...toFile(sheet), seed })).rejects.toThrow(
         InvalidSheet,
       );
     }

--- a/src/services/sheets.ts
+++ b/src/services/sheets.ts
@@ -1,5 +1,5 @@
-import { describeSheet, sheetSpec } from "@/engine/sheets";
-import { UNKNOWN_SHEET } from "@/engine/sheets/spec";
+import { loadSheet, sheetFamily } from "@/engine/sheets/families";
+import type { SheetSpec } from "@/engine/sheets/spec";
 import type { SavedSheet, SheetConfig } from "@/engine/sheets/types";
 
 import * as store from "./storage/db";
@@ -26,7 +26,7 @@ export class InvalidSheet extends Error {}
  * Long enough for the name the engine gives a sheet when a parent doesn't.
  *
  * Generous next to a word list's 40, because it is not only a thing somebody
- * types: `describeSheet` produces lines like "Multiplication — 3-digit by
+ * types: a family's own `describe` produces lines like "Multiplication — 3-digit by
  * 2-digit — worked in columns", and the default name has to fit inside its own
  * cap.
  */
@@ -43,7 +43,13 @@ const nextId = () =>
 /** What a caller hands over. The record's id and timestamps are ours to make. */
 export type SheetInput = { name: string; config: SheetConfig; seed: number };
 
-function validate(input: SheetInput): SheetInput {
+/**
+ * `spec` is passed in rather than looked up, because a family is a chunk of its
+ * own now (`engine/sheets/families.ts`) and only an `await` can produce one.
+ * Every door into this file is already async, so the wait costs nothing here —
+ * and keeping the rules themselves synchronous keeps them one function.
+ */
+function validate(input: SheetInput, spec: SheetSpec): SheetInput {
   // Guarded rather than trusted, because this is also the door a shared file
   // comes through. A config with no `kind` at all is not a sheet from a family
   // that retired — it is a record that can never start printing.
@@ -55,8 +61,9 @@ function validate(input: SheetInput): SheetInput {
     throw new InvalidSheet(`Name must be ${MAX_NAME} characters or fewer`);
 
   // A blank name is not an error here, unlike a blank word-list name: the
-  // engine can already say in one line what a config prints, and `describeSheet`
-  // is documented as the line for the catalog *and the record*. Clipped rather
+  // engine can already say in one line what a config prints, and
+  // `SheetSpec.describe` is documented as the line for the catalog *and the
+  // record*. Clipped rather
   // than checked against the cap, because a name the service chose for itself
   // must never be the thing that refuses the save.
   //
@@ -69,7 +76,7 @@ function validate(input: SheetInput): SheetInput {
   let name = typed;
   if (!name) {
     try {
-      name = describeSheet(input.config).slice(0, MAX_NAME);
+      name = spec.describe(input.config).slice(0, MAX_NAME);
     } catch {
       throw new InvalidSheet("That sheet has nothing to print");
     }
@@ -99,7 +106,7 @@ export async function all(): Promise<SavedSheet[]> {
 }
 
 export async function create(input: SheetInput): Promise<SavedSheet> {
-  const clean = validate(input);
+  const clean = validate(input, await loadSheet(input.config.kind));
   const now = new Date().toISOString();
   const sheet: SavedSheet = {
     id: nextId(),
@@ -119,7 +126,7 @@ export async function update(
   if (!existing) throw new InvalidSheet("That sheet no longer exists");
   const sheet: SavedSheet = {
     ...existing,
-    ...validate(input),
+    ...validate(input, await loadSheet(input.config.kind)),
     updatedAt: new Date().toISOString(),
   };
   await store.putSheet(sheet);
@@ -180,7 +187,7 @@ export const toFile = (sheet: SavedSheet): SheetFile => ({
  * Two families' copies are separate sheets, and keeping the id would silently
  * overwrite a sheet of the same origin that the reader had since re-tuned.
  */
-export function readSheetFile(parsed: unknown): SheetInput {
+export async function readSheetFile(parsed: unknown): Promise<SheetInput> {
   const file = parsed as Partial<SheetFile>;
   if (
     typeof parsed !== "object" ||
@@ -199,12 +206,19 @@ export function readSheetFile(parsed: unknown): SheetInput {
   // already in storage are never held to this — `UNKNOWN_SHEET` exists so a
   // sheet outlives the family it was made on, and renaming an old one must not
   // fail because that family has since retired.
-  if (sheetSpec(file.config.kind) === UNKNOWN_SHEET)
+  //
+  // Asked of the family table rather than of a loaded spec: whether this build
+  // makes that kind of sheet is a fact about the table, so it costs no download
+  // to answer and answers before one starts.
+  if (!sheetFamily(file.config.kind))
     throw new InvalidSheet("This version doesn't make that kind of sheet");
 
-  return validate({
-    name: typeof file.name === "string" ? file.name : "",
-    config: file.config,
-    seed: file.seed,
-  });
+  return validate(
+    {
+      name: typeof file.name === "string" ? file.name : "",
+      config: file.config,
+      seed: file.seed,
+    },
+    await loadSheet(file.config.kind),
+  );
 }


### PR DESCRIPTION
Closes #211.

> Issue #211's **title** belongs to a different story in the epic (the `SplitsTable` move); its **body** is this one — lazy-loading the Print Shop's sheet families. This PR implements the body.

## What changed

A sheet family's corpus is now fetched when a parent picks that family, not when `/printables/make` opens. `src/engine/sheets/families.ts` is a new registry of `() => import(...)` loaders; `useFamily.ts` in the Print Shop resolves one on selection. The build-time path is unchanged in behaviour — catalog pages still render every sheet at build time, they just `await` the same loader.

Two block renderers (`Cards.tsx`, `WordSearch.tsx`) reached into family modules for pure helpers, which would have dragged the corpora straight back into the island. Those helpers moved to leaves of their own — `phonics/metrics.ts` and `words/metrics.ts`.

## Bundle numbers — transitive static import closure, not the entry chunk

Measured as the **transitive static import closure reachable from `dist/<route>/index.html`** (follow every `/_astro/*.js` the page references, then every static import from those chunks; `import()` edges excluded, since those are the lazy ones).

**This framing matters and is the one #212 should budget against.** An entry-chunk-only measurement hides the statically-imported siblings that load alongside it — here roughly **316 KB** of them on the before side. A budget set on the entry chunk alone would go green while sibling chunks grew without limit.

| Route | Before (develop) | After | Δ |
|---|---:|---:|---:|
| `/printables/make` | **696,078 B** | **340,503 B** | **−355,575 B (−51.1%)** |
| `/printables/make`, excluding React runtime | 512,021 B | 156,446 B | −355,575 B (−69.4%) |
| `/typing` | 410,035 B | 410,445 B | +410 B |
| `/flash-cards` (and `/spelling/play`) | 388,602 B | 389,189 B | +587 B |

The React runtime is the same 184,057 B chunk on both sides — identical size and identical code, differing only in the minified import bindings it takes from its resized sibling. Excluding it from both sides is the fairer read of what this change actually moved: **−69.4%** of the app's own code on that route.

Secondary detail, deliberately *not* the headline: the island entry chunk went **431,805 B → 66,315 B**. Useful for orientation, but see the note above — a budget on this number alone would miss sibling growth entirely.

The `/typing` and `/flash-cards` deltas are the shared-chunk boundaries shifting slightly as a result of the split. Both are small enough to be noise against the route totals, and both are in the initial graph.

## What did not change

- **All 200 prerendered pages are byte-identical to `develop`** apart from asset hashes. Checked file by file with hashes normalised: 200/200 identical, 0 differing.
- **`sitemap-0.xml` (195 URLs) and `printables/search-index.json` (119 sheets, 18,232 B) are byte-identical** — literally, not modulo anything.
- **2,274 unit tests pass** across 109 files.

## New guard

`src/components/sheet/blocks/index.test.ts` walks the static import graph out of `src/components/sheet/` and fails if it reaches a family module or a corpus, naming the import chain that got there.

This is the regression that would otherwise be invisible in review: a block renderer importing one helper from `words/puzzles.ts` puts the whole generator back in the island, and the family's `() => import(...)` then "fetches" a module the browser already had. The loader still *looks* lazy from the registry's side. This is a source-graph guard, so it can name the offending import and the fix; a byte budget over `dist/` (#212) catches the size however it got there. Both are wanted.

## Validation

`type-check`, `lint`, `test:unit` (2,274), `build` (200 pages / 195 sitemap URLs / 119 sheets), `format:check`, `section-guard`, and the browser smoke test all pass, with no console errors.
