### PR TITLE
Weigh what an island fetches, and fail the build when it grows

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import { catalogAudit } from "./src/pages/printables/_search";
 import { pathOf, sitemapGuard } from "./scripts/sitemap-guard.mjs";
 import { searchIndexGuard } from "./scripts/search-index-guard.mjs";
 import { sectionGuard } from "./scripts/section-guard.mjs";
+import { bundleGuard } from "./scripts/bundle-guard.mjs";
 
 /**
  * Static output, deliberately.
@@ -67,6 +68,14 @@ export default defineConfig({
      * the start and a wrong citation costs seconds rather than a full build.
      */
     sectionGuard(),
+    /*
+     * And the fourth, over what each island weighs. It reads dist/ like the
+     * first two, and for the same reason they do: what an island costs is
+     * decided by the chunks that shipped, not by anything the source can be
+     * asked. See scripts/bundle-guard.mjs for why the budget is the whole
+     * static import closure and not the entry chunk.
+     */
+    bundleGuard(),
   ],
   // Emit `/about/index.html` rather than `/about.html` so CloudFront can serve
   // clean URLs from S3 without a rewrite function.

--- a/docs/printables.md
+++ b/docs/printables.md
@@ -140,8 +140,9 @@ chunk fell much further, 431,805 B to 66,315 B, but most of that is code that
 moved into siblings the entry still imports statically; a budget set on the
 entry alone would sit at 66 KB and never notice 300 KB of new siblings beside
 it. Two thirds of what remains is React (184,057 B, the same file on both
-sides): the sheet code itself is 512,021 B → 156,446 B. Whatever enforces a
-budget here has to walk the closure for the same reason (DEBT12).
+sides): the sheet code itself is 512,021 B → 156,446 B. `scripts/bundle-guard.mjs`
+enforces a budget on that figure after every build, for the same reason it is
+the figure quoted here.
 
 The closure is also the only thing that can say whether a family is _actually_
 lazy. A block renderer that reaches into a family module for one pure helper
@@ -1573,3 +1574,9 @@ The engine is pure, so most of this is cheap and worth having:
   sheet family or a corpus by a static import, so a helper borrowed from a
   family module fails the suite instead of quietly re-fattening the builder
   (§3).
+- **The island's weight.** `scripts/bundle-guard.mjs` weighs every island's
+  closure against a recorded baseline after each build — the React runtime
+  budgeted separately, because every island pays for it — and fails on a step
+  change in either direction. The closure and not the entry chunk, for the
+  reason in §3. It is the half that catches a leak the import graph above
+  can't see, because the module that grew was somewhere else.

--- a/scripts/bundle-guard.mjs
+++ b/scripts/bundle-guard.mjs
@@ -1,0 +1,335 @@
+// @ts-check
+import { readFile, readdir } from "node:fs/promises";
+
+/**
+ * The build-time check that an island still downloads what it downloaded
+ * yesterday.
+ *
+ * `CORPUS_BAN` in `eslint.config.mjs` exists because one import of the passage
+ * library took the shared chunk from 46 KB to 222 KB. That rule bans one known
+ * path, which is all a lint rule can do — it cannot name the module nobody has
+ * written yet. Meanwhile the Print Shop reached 696 KB with nothing failing.
+ * So this is the other half: not "don't import that", but "whatever you do
+ * import, the island stays about this size".
+ *
+ * **Measured as the transitive static import closure from
+ * `dist/<route>/index.html`, never the entry chunk.** That distinction is the
+ * whole design. Lazy-loading the sheet families (#211) took the Print Shop's
+ * entry file from 431,805 B to 66,315 B, an 84.7% fall that was mostly code
+ * moving sideways into sibling chunks the entry still imports statically; the
+ * closure — what the browser actually fetches before the island renders — went
+ * 696,078 B to 340,503 B. A budget on the entry alone would have sat at 66 KB
+ * passing while 300 KB grew beside it (docs/printables.md §3).
+ *
+ * The source-graph twin of this is `src/components/sheet/blocks/index.test.ts`,
+ * which walks `src/` and names the import chain that reaches a corpus. Both are
+ * wanted: that one says what to do about it, this one catches the byte count
+ * however it got there.
+ */
+
+/**
+ * The React client runtime, given a budget of its own because every island pays
+ * for it — 192 KB of the 340 KB the Print Shop fetches, and the same bytes in
+ * all of them.
+ *
+ * It stays inside each island's closure as well, deliberately: what an island
+ * costs a parent on a slow connection is what it fetches, not what it fetches
+ * minus the parts it shares with a page they haven't opened. This line is what
+ * tells you which of the two moved when every figure rises at once.
+ *
+ * Not a route, so it cannot collide with one — every other key here starts "/".
+ */
+export const RUNTIME = "react-runtime";
+
+/**
+ * How far above the recorded baseline an island may drift before the build
+ * fails.
+ *
+ * Flat rather than a percentage, and this size for a reason at each end. Below
+ * it: a feature is a few KB of components, and a guard that fires on those is
+ * one people learn to re-record without reading. Above it: what this is here to
+ * catch is a data module becoming statically reachable, and the chunks those
+ * arrive in start around 10 KB — the word-puzzle family — and run to 173 KB for
+ * the passage library. Nothing that matters hides underneath 10 KB.
+ */
+export const HEADROOM = 10 * 1024;
+
+/**
+ * What each island's closure measured when it was last recorded, in bytes.
+ *
+ * Written down rather than derived, because there is nothing to derive it
+ * from: the size an island *ought* to be is a judgement, and this is where the
+ * judgement is kept. Re-record a line in the same commit that moves it, and say
+ * in the message why the new number is one worth defending.
+ *
+ * Measured on b44d52d, the commit that lazy-loaded the sheet families. Two
+ * thirds of every figure below is `react-runtime`, which is the same bytes in
+ * all of them.
+ *
+ * @type {Record<string, number>}
+ */
+export const BASELINE = {
+  "/flash-cards": 389_189,
+  "/printables": 203_902,
+  "/printables/make": 340_503,
+  "/spelling/play": 389_189,
+  "/typing": 410_445,
+  [RUNTIME]: 192_242,
+};
+
+/** Where a route's HTML lands, with `build.format: "directory"`. */
+const PAGE = "index.html";
+
+const bytes = (/** @type {number} */ size) =>
+  `${size.toLocaleString("en-US")} B`;
+
+/**
+ * The chunks a page hands the browser as its islands: `component-url` is the
+ * island itself, `renderer-url` the framework runtime that hydrates it. Astro
+ * writes both onto the `<astro-island>` element, so the page that shipped is
+ * the thing being read — no manifest, no build metadata, no second opinion.
+ *
+ * @param {string} html
+ * @returns {{ islands: string[], renderers: string[] }} dist-relative URLs
+ */
+export function islandEntries(html) {
+  const urls = (/** @type {string} */ attribute) => [
+    ...new Set(
+      [...html.matchAll(new RegExp(`${attribute}="([^"]+)"`, "g"))].map(
+        (match) => match[1],
+      ),
+    ),
+  ];
+  return { islands: urls("component-url"), renderers: urls("renderer-url") };
+}
+
+/**
+ * The chunks a built chunk pulls in eagerly.
+ *
+ * Everything here turns on `import(...)` NOT matching. A dynamic import is an
+ * expression — `import` followed by a paren — where every static form puts a
+ * binding, a `from`, or the quote itself next, so a pattern that demands a
+ * quoted specifier after an optional binding clause never reaches past the
+ * paren. Vite's own `__vite__mapDeps` table lists its lazy chunks as bare
+ * strings (`"_astro/x.js"`) with no `import` in front, and falls out the same
+ * way.
+ *
+ * Line-anchored the way the source walker in
+ * `src/components/sheet/blocks/index.test.ts` is, this would find a third of
+ * them: Rollup writes one import per line in an entry chunk and packs them onto
+ * one line elsewhere. Minified output has no statement layout to lean on.
+ *
+ * @param {string} source
+ * @returns {string[]} specifiers, as written
+ */
+export function staticImports(source) {
+  const star = String.raw`\*\s*(?:as\s+[\w$]+)?`;
+  const binding = String.raw`\{[^}]*\}|${star}|[\w$]+(?:\s*,\s*(?:\{[^}]*\}|${star}))?`;
+  const statements = new RegExp(
+    String.raw`(?:^|[;}\s])(?:import|export)\s*(?:${binding})?\s*(?:from\s*)?"([^"]+)"`,
+    "g",
+  );
+  return [...source.matchAll(statements)].map((match) => match[1]);
+}
+
+/**
+ * A relative specifier as a dist-relative URL, `..` segments resolved.
+ *
+ * @param {string} from the importer, as a dist-relative URL
+ * @param {string} spec
+ * @returns {string}
+ */
+function resolveChunk(from, spec) {
+  const segments = `${from.slice(0, from.lastIndexOf("/"))}/${spec}`.split("/");
+  /** @type {string[]} */
+  const resolved = [];
+  for (const segment of segments) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") resolved.pop();
+    else resolved.push(segment);
+  }
+  return `/${resolved.join("/")}`;
+}
+
+/**
+ * Every chunk reachable from a set of entries by static import, and what they
+ * weigh together — the download an island costs before it can render.
+ *
+ * A chunk two entries share is counted once, which is what makes this a closure
+ * rather than a sum: the runtime is in every island's, and adding the islands
+ * up would charge for it four times over.
+ *
+ * `missing` is a specifier that resolved to no chunk. It should always be
+ * empty; it is reported rather than skipped because the way a walker like this
+ * rots is by quietly following fewer edges than it thinks.
+ *
+ * @param {string[]} entries dist-relative URLs
+ * @param {Map<string, string>} chunks dist-relative URL → source
+ * @returns {{ bytes: number, chunks: [string, number][], missing: string[] }}
+ */
+export function closure(entries, chunks) {
+  const seen = new Set();
+  const queue = [...entries];
+  /** @type {[string, number][]} */
+  const found = [];
+  /** @type {string[]} */
+  const missing = [];
+
+  // Indexed rather than a shift, because the loop appends to what it reads.
+  for (let at = 0; at < queue.length; at++) {
+    const url = queue[at];
+    if (seen.has(url)) continue;
+    seen.add(url);
+
+    const source = chunks.get(url);
+    if (source === undefined) {
+      missing.push(url);
+      continue;
+    }
+    found.push([url, Buffer.byteLength(source)]);
+
+    for (const spec of staticImports(source)) {
+      if (spec.startsWith(".")) queue.push(resolveChunk(url, spec));
+    }
+  }
+
+  found.sort((a, b) => b[1] - a[1]);
+  return {
+    bytes: found.reduce((sum, [, size]) => sum + size, 0),
+    chunks: found,
+    missing,
+  };
+}
+
+/**
+ * Every way the islands that shipped and the budgets recorded for them can
+ * disagree, as lines a human can act on. An empty array is the passing case.
+ *
+ * It fails in both directions, deliberately. Over budget is the regression
+ * everyone expects. Under the baseline by more than the headroom is a win
+ * nobody wrote down, and a baseline sitting 40 KB above what the island ships
+ * is a budget that has quietly stopped guarding 40 KB.
+ *
+ * @param {Map<string, ReturnType<typeof closure>>} measured
+ * @param {Record<string, number>} baseline
+ * @param {number} headroom
+ * @returns {string[]}
+ */
+export function auditBundles(measured, baseline, headroom) {
+  if (measured.size === 0) {
+    return [
+      "No islands were found in dist/ at all, so there is nothing to weigh. Either the pages stopped mounting one or this guard is reading the wrong directory.",
+    ];
+  }
+
+  /** @type {string[]} */
+  const problems = [];
+
+  for (const [name, { bytes: size, chunks, missing }] of measured) {
+    if (missing.length > 0) {
+      problems.push(
+        `${name} imports ${missing.join(", ")} and no such chunk was built, so this walk followed fewer edges than the browser will and every figure for it is an undercount.`,
+      );
+    }
+
+    const recorded = baseline[name];
+    if (recorded === undefined) {
+      problems.push(
+        `${name} is an island with no budget recorded. It fetches ${bytes(size)} today — put that in BASELINE in scripts/bundle-guard.mjs, once satisfied it is a number worth defending.`,
+      );
+      continue;
+    }
+
+    const budget = recorded + headroom;
+    if (size > budget) {
+      const largest = chunks
+        .slice(0, 3)
+        .map(([url, chunk]) => `${url.split("/").pop()} ${bytes(chunk)}`)
+        .join(", ");
+      problems.push(
+        `${name} fetches ${bytes(size)} before it renders — ${bytes(size - budget)} over its budget of ${bytes(budget)} (${bytes(recorded)} recorded, ${bytes(headroom)} headroom). Its closure is ${chunks.length} chunks; the largest are ${largest}.`,
+      );
+    } else if (size < recorded - headroom) {
+      problems.push(
+        `${name} fetches ${bytes(size)}, which is ${bytes(recorded - size)} under the ${bytes(recorded)} recorded for it. Record the win — until you do, the budget above it is that much looser than it reads.`,
+      );
+    }
+  }
+
+  for (const name of Object.keys(baseline)) {
+    if (!measured.has(name)) {
+      problems.push(
+        `${name} has a budget recorded and nothing was measured against it — no island was built at that route, so the line guards nothing.`,
+      );
+    }
+  }
+
+  return problems.sort();
+}
+
+/**
+ * Wired into `astro.config.mjs` after the other two `astro:build:done` guards,
+ * for the reason they go where they go: there is nothing to weigh until the
+ * build has written it.
+ *
+ * @returns {import("astro").AstroIntegration}
+ */
+export function bundleGuard() {
+  return {
+    name: "bundle-guard",
+    hooks: {
+      "astro:build:done": async ({ dir, logger }) => {
+        const files = await readdir(dir, { recursive: true });
+        const read = (/** @type {string} */ file) =>
+          readFile(new URL(file, dir), "utf8");
+
+        /** @type {Map<string, string>} */
+        const chunks = new Map();
+        await Promise.all(
+          files
+            .filter((file) => file.endsWith(".js"))
+            .map(async (file) => {
+              chunks.set(`/${file}`, await read(file));
+            }),
+        );
+
+        /** @type {Map<string, ReturnType<typeof closure>>} */
+        const measured = new Map();
+        /** @type {Set<string>} */
+        const renderers = new Set();
+        for (const file of files.filter((file) => file.endsWith(PAGE))) {
+          const { islands, renderers: used } = islandEntries(await read(file));
+          if (islands.length === 0) continue;
+          measured.set(
+            `/${file.slice(0, -(PAGE.length + 1))}`,
+            closure([...islands, ...used], chunks),
+          );
+          for (const url of used) renderers.add(url);
+        }
+        if (renderers.size > 0) {
+          measured.set(RUNTIME, closure([...renderers], chunks));
+        }
+
+        const problems = auditBundles(measured, BASELINE, HEADROOM);
+        if (problems.length > 0) {
+          throw new Error(
+            [
+              "Island bundle budgets and dist/ disagree:",
+              ...problems.map((line) => `  · ${line}`),
+              "",
+              "Every figure is the transitive STATIC import closure from dist/<route>/index.html — each chunk the browser fetches before the island renders, not the entry file. A step change is almost always a data module that has become statically reachable: a sheet family or a corpus pulled in by a component, whose `() => import(...)` then resolves out of memory instead of fetching. src/components/sheet/blocks/index.test.ts names the import chain when the leak starts under src/components/sheet/ (docs/printables.md §3).",
+            ].join("\n"),
+          );
+        }
+
+        const spare = (
+          /** @type {[string, ReturnType<typeof closure>]} */ [name, walked],
+        ) => BASELINE[name] + HEADROOM - walked.bytes;
+        const tightest = [...measured].sort((a, b) => spare(a) - spare(b))[0];
+        logger.info(
+          `bundle budgets checked — ${measured.size - 1} islands and the runtime, tightest is ${tightest[0]} with ${bytes(spare(tightest))} to spare`,
+        );
+      },
+    },
+  };
+}

--- a/scripts/bundle-guard.test.mjs
+++ b/scripts/bundle-guard.test.mjs
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  auditBundles,
+  closure,
+  islandEntries,
+  staticImports,
+} from "./bundle-guard.mjs";
+
+/**
+ * A budget nobody has watched fail is a budget nobody knows works, and this one
+ * has two ways to be wrong that both look exactly like passing: reading the
+ * entry chunk instead of the closure, and counting a lazy chunk as though it
+ * were eager. So the walker is exercised on output shaped like Rollup's, and
+ * the audit is made to fire once per way an island and its budget can part.
+ *
+ * The build-time half runs against the chunks that actually shipped; this half
+ * proves that what it reads it also adds up correctly.
+ */
+
+/** One island, one runtime, on the element Astro writes. */
+const HTML = `<astro-island uid="a1" component-url="/_astro/App.aaa.js"
+  component-export="default" renderer-url="/_astro/client.bbb.js"
+  props="{}" ssr client="only"></astro-island>`;
+
+const chunk = (bytes) => "x".repeat(bytes);
+
+describe("reading the entries off a page", () => {
+  it("takes the island and its renderer", () => {
+    expect(islandEntries(HTML)).toEqual({
+      islands: ["/_astro/App.aaa.js"],
+      renderers: ["/_astro/client.bbb.js"],
+    });
+  });
+
+  it("counts a chunk once when two islands share it", () => {
+    expect(islandEntries(HTML + HTML).renderers).toEqual([
+      "/_astro/client.bbb.js",
+    ]);
+  });
+
+  it("finds nothing on a page that mounts nothing", () => {
+    expect(islandEntries("<p>A worksheet, prerendered.</p>")).toEqual({
+      islands: [],
+      renderers: [],
+    });
+  });
+});
+
+describe("telling a static import from a lazy one", () => {
+  it("takes every static form Rollup writes", () => {
+    // All on one line, as a minified chunk has them: the statement layout an
+    // anchored pattern would need is only there in an entry chunk.
+    const source =
+      'import{a as b,c}from"./records.aaa.js";import"./side-effect.bbb.js";' +
+      'export*from"./words.ccc.js";export{d}from"./kit.ddd.js";' +
+      'import e,{f}from"./react.eee.js";import*as g from"./paper.fff.js"';
+    expect(staticImports(source)).toEqual([
+      "./records.aaa.js",
+      "./side-effect.bbb.js",
+      "./words.ccc.js",
+      "./kit.ddd.js",
+      "./react.eee.js",
+      "./paper.fff.js",
+    ]);
+  });
+
+  it("leaves a dynamic import out, and Vite's table of them with it", () => {
+    // The whole point of the guard: `() => import(...)` is a fetch the browser
+    // makes later, if ever. Counting it would put all twenty-seven sheet
+    // families back in the Print Shop's budget and hide the regression the
+    // budget exists to catch.
+    const source =
+      'const __vite__mapDeps=(i,m=m.f||(m.f=["_astro/copywork.aaa.js"]))=>i.map(i=>m.f[i]);' +
+      'import{p}from"./real.bbb.js";' +
+      'const load=()=>__vitePreload(()=>import("./copywork.aaa.js"),__vite__mapDeps([0]))';
+    expect(staticImports(source)).toEqual(["./real.bbb.js"]);
+  });
+});
+
+describe("walking the closure", () => {
+  const CHUNKS = new Map([
+    ["/_astro/App.aaa.js", `import{a}from"./shared.ccc.js";${chunk(1_000)}`],
+    ["/_astro/client.bbb.js", `import"./shared.ccc.js";${chunk(2_000)}`],
+    ["/_astro/shared.ccc.js", `import"../vendor/deep.ddd.js";${chunk(500)}`],
+    ["/vendor/deep.ddd.js", chunk(300)],
+    ["/_astro/lazy.eee.js", chunk(9_000)],
+  ]);
+
+  it("sums every chunk reachable from the entries, each one once", () => {
+    const walked = closure(
+      ["/_astro/App.aaa.js", "/_astro/client.bbb.js"],
+      CHUNKS,
+    );
+    // 1,000 + 2,000 + 500 + 300, plus the import statements' own bytes. The
+    // shared chunk is in both entries' graphs and is paid for once.
+    expect(walked.chunks).toHaveLength(4);
+    expect(walked.bytes).toBe(
+      [...CHUNKS]
+        .filter(([url]) => url !== "/_astro/lazy.eee.js")
+        .reduce((sum, [, source]) => sum + source.length, 0),
+    );
+    expect(walked.missing).toEqual([]);
+  });
+
+  it("puts the largest chunk first, since that is the one to look at", () => {
+    const walked = closure(["/_astro/App.aaa.js"], CHUNKS);
+    expect(walked.chunks[0][0]).toBe("/_astro/App.aaa.js");
+  });
+
+  it("reports a specifier that resolves to no chunk rather than skipping it", () => {
+    // How a walker like this rots: it follows fewer edges than the browser
+    // does, and every number it reports is quietly an undercount.
+    expect(closure(["/_astro/App.aaa.js"], new Map()).missing).toEqual([
+      "/_astro/App.aaa.js",
+    ]);
+  });
+});
+
+describe("auditing the closures against the budgets", () => {
+  const HEADROOM = 10_240;
+  const BASELINE = { "/typing": 400_000, "react-runtime": 190_000 };
+  const weigh = (bytes, chunks) => ({
+    bytes,
+    chunks: chunks ?? [["/_astro/App.aaa.js", bytes]],
+    missing: [],
+  });
+  const shipped = (bytes, chunks) =>
+    new Map([
+      ["/typing", weigh(bytes, chunks)],
+      ["react-runtime", weigh(190_000)],
+    ]);
+
+  it("passes an island sitting on its baseline", () => {
+    expect(auditBundles(shipped(400_000), BASELINE, HEADROOM)).toEqual([]);
+  });
+
+  it("passes a drift inside the headroom", () => {
+    expect(auditBundles(shipped(410_240), BASELINE, HEADROOM)).toEqual([]);
+  });
+
+  it("names the island, the budget, the size and the chunks over budget", () => {
+    const problems = auditBundles(
+      shipped(584_000, [
+        ["/_astro/copywork.aaa.js", 173_202],
+        ["/_astro/App.aaa.js", 79_359],
+      ]),
+      BASELINE,
+      HEADROOM,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("/typing");
+    expect(problems[0]).toContain("584,000 B"); // what it ships
+    expect(problems[0]).toContain("410,240 B"); // what it may ship
+    expect(problems[0]).toContain("173,760 B"); // by how much it is over
+    expect(problems[0]).toContain("copywork.aaa.js 173,202 B"); // the likely cause
+  });
+
+  it("fails a win nobody recorded, so the budget cannot go slack", () => {
+    const problems = auditBundles(shipped(300_000), BASELINE, HEADROOM);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("100,000 B under");
+  });
+
+  it("fails an island with no budget written down", () => {
+    const problems = auditBundles(
+      new Map([...shipped(400_000), ["/new-game", weigh(500_000)]]),
+      BASELINE,
+      HEADROOM,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("/new-game");
+    expect(problems[0]).toContain("no budget recorded");
+  });
+
+  it("fails a budget with no island left under it", () => {
+    // The stale half: a route moves, its line stays, and it guards nothing
+    // while still reading like a guard.
+    const problems = auditBundles(
+      new Map([["react-runtime", weigh(190_000)]]),
+      BASELINE,
+      HEADROOM,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("/typing");
+    expect(problems[0]).toContain("guards nothing");
+  });
+
+  it("reports an undercount rather than judging one", () => {
+    const problems = auditBundles(
+      new Map([
+        ["/typing", { bytes: 400_000, chunks: [], missing: ["/_astro/x.js"] }],
+        ["react-runtime", weigh(190_000)],
+      ]),
+      BASELINE,
+      HEADROOM,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("undercount");
+  });
+
+  it("says so rather than passing when there is nothing to weigh", () => {
+    // The way a directory check rots: a moved output path finds no islands,
+    // and an empty loop reports no problems.
+    const problems = auditBundles(new Map(), BASELINE, HEADROOM);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("nothing to weigh");
+  });
+});

--- a/src/components/sheet/blocks/index.test.ts
+++ b/src/components/sheet/blocks/index.test.ts
@@ -24,9 +24,10 @@ import { describe, expect, it } from "vitest";
  * Type-only imports are erased before the bundler sees them, so they cost
  * nothing and are skipped here.
  *
- * A source graph, not the built one: it names the offending import, where a
- * budget over `dist/` (DEBT12) catches the byte count however it got there.
- * Both are wanted, and this is the half that can say what to do about it.
+ * A source graph, not the built one: it names the offending import, where
+ * `scripts/bundle-guard.mjs` catches the byte count in `dist/` however it got
+ * there. Both are wanted, and this is the half that can say what to do about
+ * it.
  */
 
 const HERE = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Closes #212.

`CORPUS_BAN` bans one known import path, which is all a lint rule can do — it cannot name the module nobody has written yet, and `/printables/make` reached 696 KB with nothing failing. `scripts/bundle-guard.mjs` is the other half: a fourth `astro:build:done` guard beside the sitemap and search-index ones, over what each island actually costs.

## What is measured, and why it isn't the entry chunk

**Budgets are measured against the transitive static import closure from `dist/<route>/index.html`, never the entry chunk.** The guard reads `component-url` and `renderer-url` off the `<astro-island>` element and walks the built chunks' static imports transitively, counting each shared chunk once.

That is the design, and it comes directly from the review of DEBT10/#211. There, the entry file fell 431,805 → 66,315 B (-84.7%) while roughly 316 KB merely moved into sibling chunks the island still imports statically. The honest figure was 696,078 → 340,503 B. **A budget on the entry chunk would have sat at 66 KB passing while 300 KB grew beside it** — code moving into a statically-imported sibling is invisible to an entry-chunk measurement, and that is exactly what happened before review caught it.

`() => import(...)` and Vite's `__vite__mapDeps` table are excluded, which is the whole point — counting them would put all twenty-seven sheet families back in the Print Shop's figure and hide the regression the budget exists to catch.

## Budgets

Baselines, measured on b44d52d and identical to the numbers that commit recorded:

| Island | Baseline |
| --- | --- |
| `/flash-cards` | 389,189 B |
| `/spelling/play` | 389,189 B |
| `/printables` | 203,902 B (the catalog's search box) |
| `/printables/make` | 340,503 B |
| `/typing` | 410,445 B |
| react-runtime | 192,242 B (client + the JSX shim, in all five) |

The React runtime gets its own line because every island pays for it — 192 KB of the Print Shop's 340 KB — and it stays inside each island's closure too, so the separate line is what says which of the two moved when every figure rises at once.

## Headroom

Headroom is a flat **10 KB over each baseline**, not a percentage. Below it, a feature is a few KB of components and a guard that fires on those is one people learn to re-record without reading; 8% of `/typing` would have been 32 KB, wide enough for a whole word bank to walk through. Above it, the chunks a leaked data module arrives in start around 10 KB (the word-puzzle family) and run to 173 KB (the passage library), so nothing that matters hides underneath.

## It fails in both directions

Over budget is the expected regression. Under the baseline by more than the headroom is a win nobody wrote down, and a baseline left sitting above what an island ships is a budget that has quietly stopped guarding the difference. A route with no baseline, a baseline with no route, a specifier resolving to no chunk, and finding no islands at all each fail too — a check that always passes is indistinguishable from one that works.

## Proved it fails

A static `import { SCRIPTURE } from ".../passages/scripture"` added to `games/printshop/App.tsx` made the build exit 1 with:

```
/printables/make fetches 425,519 B before it renders — 74,776 B over its
budget of 350,743 B (340,503 B recorded, 10,240 B headroom). Its closure is
20 chunks; the largest are client.DnJUoW7W.js 184,057 B,
scripture.1mU5NEVj.js 84,861 B, App.DnyP7puX.js 66,470 B.
```

The entry chunk moved 66,315 → 66,470 B under that same import, **+155 B: an entry-chunk budget would have passed it.** Reverted after measuring.

The unit test beside `sitemap-guard.test.mjs` and `search-index-guard.test.mjs` makes the audit fire once per way an island and its budget can part, and makes the walker prove it drops a dynamic import and keeps every static form Rollup writes.

Also: pointed the sheet-renderer import-graph test at the guard that now exists, rather than at "DEBT12" — which turned out to be a different story.

## Validation

`npm run type-check`, `npm run lint`, `npm run test:unit`, `npm run build` (bundle guard included), `npm run format:check`, `node scripts/section-guard.mjs`, and the browser smoke test all pass.
