### PR TITLE
Say once what every sheet family promises, and check nobody skips it

### DIFF
--- a/src/engine/sheets/contract.test.ts
+++ b/src/engine/sheets/contract.test.ts
@@ -39,9 +39,10 @@ function suitesIn(dir: string): string[] {
 /**
  * The kind each suite runs the contract on, and which suite runs it.
  *
- * This file is left out of the walk deliberately: the messages below quote the
- * call a suite is missing, and a guard that read its own error text would report
- * every family as covered.
+ * This file is left out of the walk deliberately: the failure message below
+ * quotes the call a suite is missing, `${id}` and all, so a scan that read this
+ * file would take that literal `${id}` for a covered kind, and the stray-kind
+ * test would fail on it.
  */
 function covered(): Map<string, string> {
   const found = new Map<string, string>();
@@ -65,7 +66,7 @@ describe("the sheet-family contract", () => {
     (id: string) => {
       expect(
         COVERED.get(id) ?? null,
-        `no suite calls describeSheetFamily("${id}", …). Add it to that family's test file — the eight assertions in contract.ts are what every other family is held to, and a family added to families.ts without them is checked by nothing they cover.`,
+        `no suite calls describeSheetFamily("${id}", …). Add it to that family's test file — the nine clauses in contract.ts are what every other family is held to, and a family added to families.ts without them is checked by nothing they cover.`,
       ).not.toBeNull();
     },
   );

--- a/src/engine/sheets/contract.test.ts
+++ b/src/engine/sheets/contract.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { SHEET_FAMILIES } from "./families";
+
+/**
+ * Every family in the registry is held to the contract (§20).
+ *
+ * `contract.ts` is only worth having if a family cannot quietly skip it, and a
+ * shared helper is exactly the kind of thing an author of the twenty-eighth
+ * family never hears about: their suite passes, the catalog builds, and the
+ * assertions the other twenty-seven keep are simply never made about theirs.
+ *
+ * So the list comes out of `families.ts` rather than being written here. A
+ * hard-coded twenty-seven names would stop covering a family the day somebody
+ * added one, which is the day it matters. Same reason the import-graph guard in
+ * `src/components/sheet/blocks/` reads the registry rather than a list of its
+ * own.
+ *
+ * A source scan and not a registration hook: vitest gives each test file its own
+ * module graph, so a set filled in by `describeSheetFamily` at import time would
+ * only ever hold the one family whose suite happened to be running.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Every suite under the sheet layer, this guard excepted — see `covered`. */
+function suitesIn(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return suitesIn(path);
+    return /\.test\.ts$/.test(entry.name) ? [path] : [];
+  });
+}
+
+/**
+ * The kind each suite runs the contract on, and which suite runs it.
+ *
+ * This file is left out of the walk deliberately: the messages below quote the
+ * call a suite is missing, and a guard that read its own error text would report
+ * every family as covered.
+ */
+function covered(): Map<string, string> {
+  const found = new Map<string, string>();
+  for (const path of suitesIn(HERE)) {
+    if (path === fileURLToPath(import.meta.url)) continue;
+    const source = readFileSync(path, "utf8");
+    for (const [, kind] of source.matchAll(
+      /describeSheetFamily\(\s*"([^"]+)"/g,
+    )) {
+      found.set(kind, relative(HERE, path));
+    }
+  }
+  return found;
+}
+
+const COVERED = covered();
+
+describe("the sheet-family contract", () => {
+  it.each(SHEET_FAMILIES.map((family) => [family.id]))(
+    "is kept by the %s family",
+    (id: string) => {
+      expect(
+        COVERED.get(id) ?? null,
+        `no suite calls describeSheetFamily("${id}", …). Add it to that family's test file — the eight assertions in contract.ts are what every other family is held to, and a family added to families.ts without them is checked by nothing they cover.`,
+      ).not.toBeNull();
+    },
+  );
+
+  it("is not run against a kind this build does not make", () => {
+    // A mistyped kind would otherwise fail as "sheetSpec is UNKNOWN_SHEET",
+    // which reads like a broken loader rather than like a typo in a test.
+    const registry = new Set(SHEET_FAMILIES.map((family) => family.id));
+    const strays = [...COVERED].filter(([kind]) => !registry.has(kind));
+    expect(
+      strays.map(([kind, suite]) => `"${kind}" in ${suite}`),
+      "a suite runs the contract on a kind families.ts has never heard of",
+    ).toEqual([]);
+  });
+});

--- a/src/engine/sheets/contract.ts
+++ b/src/engine/sheets/contract.ts
@@ -100,6 +100,20 @@ export function describeSheetFamily<C extends SheetConfig>(
   const where = (one: C) => `${kind}: ${describeSheet(one)}`;
 
   describe(`the ${kind} family keeps the contract`, () => {
+    it("is swept over at least one shape and one seed", () => {
+      // This clause is about the suite rather than the family: every clause
+      // below is a loop over these two, so emptying either would report the
+      // family as keeping the whole contract while nothing below it ran.
+      expect(
+        configs.length,
+        `${kind}: shapes is empty, so every clause below loops zero times and asserts nothing — pass the shapes this family builds, or leave shapes off to sweep its defaults`,
+      ).toBeGreaterThan(0);
+      expect(
+        seeds.length,
+        `${kind}: seeds is empty, so every clause that builds at a seed asserts nothing — pass the seeds to sweep, or leave seeds off for the defaults`,
+      ).toBeGreaterThan(0);
+    });
+
     it("is in the registry under the kind its config carries", () => {
       expect(
         sheetSpec(kind),

--- a/src/engine/sheets/contract.ts
+++ b/src/engine/sheets/contract.ts
@@ -1,0 +1,226 @@
+/**
+ * The promises every sheet family makes, asserted in one place (§20).
+ *
+ * They are the whole of what `SheetSpec` means beyond its types: a family is in
+ * the registry under the kind its config carries, draws the same sheet from the
+ * same seed, prints on the paper it was handed, and hands back a key that is the
+ * sheet it belongs to with the answers switched on (§7). Copied into each
+ * family's suite by hand — as they were — a family keeps as much of the contract
+ * as its author happened to remember, and the twenty-eighth keeps whatever its
+ * author noticed the other twenty-seven doing.
+ *
+ * A family that keeps all of it can still be wrong, and nothing here would know:
+ * whether the sums add up is the one bug a worksheet site cannot ship, and that
+ * is checked in the family's own suite, against a path the family does not use.
+ * This is the floor, not the ceiling.
+ *
+ * Test-only, and never in a bundle — it reaches `index.ts`, which awaits every
+ * family at load. Not named `.test.ts` because it defines a suite rather than
+ * being one, and vitest fails a test file that holds no tests.
+ * `contract.test.ts` next door is the other half: the guard that every family in
+ * the registry actually calls this.
+ */
+import { describe, expect, it } from "vitest";
+
+import { answerKey, buildSheet, describeSheet, sheetSpec } from "./index";
+import { sheetFamily } from "./families";
+import { SHEET_CREDIT, SHEET_URL, type SheetSpec } from "./spec";
+import type { SheetConfig } from "./types";
+
+/**
+ * What a key says at the foot of the page.
+ *
+ * Every family writes this literal for itself, so here is where they are held to
+ * the same word: a parent printing sheet and key from two families should not
+ * find two different things at the bottom of the two pages.
+ */
+const KEY_NOTE = "Answer key";
+
+/** The seeds a family is swept over when its suite names none of its own. */
+const SEEDS = [0, 1, 4242];
+
+/**
+ * A second stock and a second type size, laid over every shape.
+ *
+ * Here rather than in the shapes a suite passes, because almost none of them
+ * vary the paper — and a family that ignored `config.paper` outright would
+ * satisfy a check made only against the Letter default that produced it.
+ */
+const OTHER_STOCK = {
+  paper: { size: "a4", orientation: "landscape", margin: "wide" },
+  fontPt: 18,
+} as const;
+
+export type SheetFamilyContract<C extends SheetConfig> = {
+  /** How the picker names it — the string in families.ts. */
+  label: string;
+  spec: SheetSpec<C>;
+  /** The suite's own config factory: defaults, with the shape laid over. */
+  config: (over?: Partial<C>) => C;
+  /**
+   * Every shape of sheet worth sweeping. Whole configs are as welcome as
+   * partial ones — a suite that already keeps a list of them can hand it
+   * straight over. Left out, the contract holds the family to its defaults.
+   */
+  shapes?: Array<Partial<C>>;
+  seeds?: number[];
+  /**
+   * Whether this config withholds something a key would reveal — the family's
+   * own `formKeyed`/`chartKeyed`/`phonicsKeyed` where it has one.
+   *
+   * The default says yes, so a family that has an answer key and forgets to say
+   * so is still held to printing one. The families it is passed for are the
+   * blank ones: paper, cards, calendars. A key of one of those is the same page
+   * again (§11), and a page that claimed to be revealing something would be
+   * telling a parent to look for what isn't there.
+   */
+  keyed?: (config: C) => boolean;
+};
+
+/**
+ * Assert the contract for one family. Called from the family's own suite, which
+ * keeps the family-specific half of the file next to the generic half, and calls
+ * the contract with the shapes that suite already sweeps.
+ */
+export function describeSheetFamily<C extends SheetConfig>(
+  kind: string,
+  contract: SheetFamilyContract<C>,
+): void {
+  const {
+    label,
+    spec,
+    config,
+    shapes = [{}],
+    seeds = SEEDS,
+    keyed = () => true,
+  } = contract;
+
+  const configs = shapes.map((shape) => config(shape));
+  /** Which sheet a failure is about: the family, and the line it prints under. */
+  const where = (one: C) => `${kind}: ${describeSheet(one)}`;
+
+  describe(`the ${kind} family keeps the contract`, () => {
+    it("is in the registry under the kind its config carries", () => {
+      expect(
+        sheetSpec(kind),
+        `${kind}: sheetSpec("${kind}") is not this family's own spec — check the loader in families.ts points at the module that exports it`,
+      ).toBe(spec);
+      expect(
+        sheetFamily(kind)?.label,
+        `${kind}: the name the picker offers it under`,
+      ).toBe(label);
+    });
+
+    it("builds the same sheet twice", () => {
+      for (const one of configs) {
+        for (const seed of seeds) {
+          const once = buildSheet(one, seed);
+          const twice = buildSheet(one, seed);
+          // Two builds, not one handed back twice — otherwise a family that
+          // cached a sheet would satisfy the comparison below by identity.
+          expect(once, `${where(one)} at seed ${seed}`).not.toBe(twice);
+          expect(
+            once,
+            `${where(one)} at seed ${seed}: not a pure function of (config, seed), so a parent cannot have the same sheet again and the key may not match the page`,
+          ).toEqual(twice);
+        }
+      }
+    });
+
+    it("prints on the paper it was handed, in the type it was asked for", () => {
+      // A renderer is given a `Sheet` and nothing else, so a family that read
+      // the config and then printed on its own default would be invisible until
+      // a parent held the printout against A4 (§4, §17).
+      for (const one of configs) {
+        for (const asked of [one, { ...one, ...OTHER_STOCK }]) {
+          const sheet = buildSheet(asked, 3);
+          const on = `${where(one)} on ${asked.paper.size} at ${asked.fontPt}pt`;
+          expect(sheet.paper, `${on}: the paper it printed on`) //
+            .toEqual(asked.paper);
+          expect(sheet.fontPt, `${on}: the type size it set`) //
+            .toBe(asked.fontPt);
+        }
+      }
+    });
+
+    it("carries the seed and the credit into the footer", () => {
+      // The seed is what makes the same sheet printable again next week (§7);
+      // the credit and the link back to the games are on every sheet there is
+      // (§16, §19).
+      for (const one of configs) {
+        for (const seed of seeds) {
+          const { footer } = buildSheet(one, seed);
+          expect(footer.seed, `${where(one)}: the seed printed at the foot`) //
+            .toBe(seed);
+          expect(footer.credit, `${where(one)}: the credit`).toBe(SHEET_CREDIT);
+          expect(footer.url ?? "", `${where(one)}: the way back to the games`) //
+            .toContain(SHEET_URL);
+        }
+      }
+    });
+
+    it("names in one line what it prints", () => {
+      // The catalog and the record of what a parent printed are both this
+      // string, and both have one line to put it on.
+      for (const one of configs) {
+        const line = describeSheet(one);
+        expect(line.trim(), `${kind}: describe() gave this config no name`) //
+          .not.toBe("");
+        expect(line, `${kind}: "${line}" is more than one line`) //
+          .not.toContain("\n");
+      }
+    });
+
+    it("prints the answers only when the sheet is a key", () => {
+      for (const one of configs) {
+        for (const seed of seeds) {
+          expect(
+            buildSheet(one, seed).answers,
+            `${where(one)} at seed ${seed}: the sheet a child is given has the answers printed on it`,
+          ).toBe(false);
+        }
+        if (!keyed(one)) continue;
+        const key = answerKey(one, 5);
+        expect(
+          key.answers,
+          `${where(one)}: this config withholds something, but its key does not print it`,
+        ).toBe(true);
+        expect(key.footer.note, `${where(one)}: what the key says it is`) //
+          .toBe(KEY_NOTE);
+      }
+    });
+
+    it("is the same sheet keyed, never a second generation", () => {
+      // The key is the build, told to print what it already worked out — never
+      // a second draw from the seed, which could answer a question the page
+      // never asked (§7). So the two differ in the answers switch and in the
+      // note at the foot, and in nothing else.
+      for (const one of configs) {
+        const sheet = buildSheet(one, 11);
+        const key = answerKey(one, 11);
+        expect(
+          { ...key.footer, note: sheet.footer.note },
+          `${where(one)}: the key changed the footer for more than to say what it is — the source credit belongs to the words on the page and prints on both`,
+        ).toEqual(sheet.footer);
+        expect(
+          { ...key, answers: sheet.answers, footer: sheet.footer },
+          `${where(one)}: the key is not the sheet it belongs to`,
+        ).toEqual(sheet);
+      }
+    });
+
+    it("marks a sheet out of a whole number, or does not mark it at all", () => {
+      // "___ / 0" is what a score box counted from something nobody checked
+      // looks like on paper. How many it should say is the family's business.
+      for (const one of configs) {
+        const score = buildSheet(one, 3).header.score;
+        if (score === undefined) continue;
+        expect(score.outOf, `${where(one)}: the score box`).toBeGreaterThan(0);
+        expect(
+          Number.isInteger(score.outOf),
+          `${where(one)}: the score box says "/ ${score.outOf}"`,
+        ).toBe(true);
+      }
+    });
+  });
+}

--- a/src/engine/sheets/grammar/grammar.test.ts
+++ b/src/engine/sheets/grammar/grammar.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import type { Block, GrammarConfig, GrammarStyle, Paper } from "../types";
 
 import { END_MARK, KINDS, PARTS, SENTENCES, type Tagged } from "./bank";
@@ -183,12 +183,14 @@ describe("the sentence bank", () => {
 
 /* ── The family ────────────────────────────────────────────────────────── */
 
-describe("the grammar family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("grammar")).toBe(GRAMMAR_SHEET);
-    expect(sheetFamily("grammar")?.label).toBe("Grammar");
-  });
+describeSheetFamily("grammar", {
+  label: "Grammar",
+  spec: GRAMMAR_SHEET,
+  config,
+  shapes: EVERY_SHEET,
+});
 
+describe("the grammar family", () => {
   it("prints a titled, marked page for every topic and style", () => {
     for (const one of EVERY_SHEET) {
       const sheet = buildSheet(one, 1);
@@ -423,21 +425,6 @@ describe("circling one of a closed list", () => {
         expect(chosen, question.prompt) //
           .toBe(topic === "parts" ? entry.focus?.part : entry.kind);
       }
-    }
-  });
-});
-
-/* ── The key ───────────────────────────────────────────────────────────── */
-
-describe("the answer key", () => {
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const one of EVERY_SHEET) {
-      const sheet = buildSheet(one, 7);
-      const key = answerKey(one, 7);
-      expect(key.answers, where(one)).toBe(true);
-      expect(key.footer.note, where(one)).toBe("Answer key");
-      expect({ ...key, answers: false, footer: sheet.footer }, where(one)) //
-        .toEqual(sheet);
     }
   });
 });

--- a/src/engine/sheets/index.test.ts
+++ b/src/engine/sheets/index.test.ts
@@ -1,17 +1,37 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet, sheetSpec } from "./index";
+import { BLANK_SHEET } from "./blank";
+import { describeSheetFamily } from "./contract";
 import { SHEET_FAMILIES, sheetFamily } from "./families";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, UNKNOWN_SHEET } from "./spec";
 import { DEFAULT_PAPER } from "./paper";
 import type { BlankConfig, SheetConfig } from "./types";
 
-const config = (over: Partial<BlankConfig> = {}): SheetConfig => ({
+const config = (over: Partial<BlankConfig> = {}): BlankConfig => ({
   kind: "blank",
   paper: DEFAULT_PAPER,
   fontPt: 12,
   fields: ["name", "date"],
   ...over,
+});
+
+/** Everything a page with nothing on it can still be asked for. */
+const EVERY_SHAPE: Array<Partial<BlankConfig>> = [
+  {},
+  { paper: { size: "a4", orientation: "landscape", margin: "wide" } },
+  { title: "Story paper", instructions: "Write about your week." },
+  { fields: [] },
+];
+
+// Blank paper has no suite of its own — this file is it, because the family is
+// the front door's worked example everywhere else on the page.
+describeSheetFamily("blank", {
+  label: "Blank page",
+  spec: BLANK_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  keyed: () => false,
 });
 
 describe("the registry", () => {
@@ -71,37 +91,6 @@ describe("the registry", () => {
 });
 
 describe("buildSheet", () => {
-  it("is a pure function of its config and seed", () => {
-    // Three features rest on this, not one (§7): the answer key is the same
-    // build, "another sheet like this one" is seed + 1, and a shared URL
-    // reproduces a sheet because the seed travels in it.
-    for (const seed of [0, 1, 4242]) {
-      const once = buildSheet(config(), seed);
-      const twice = buildSheet(config(), seed);
-      expect(once).not.toBe(twice);
-      expect(once).toEqual(twice);
-    }
-  });
-
-  it("stays deterministic across papers, margins and options", () => {
-    const variants: SheetConfig[] = [
-      config(),
-      config({
-        paper: { size: "a4", orientation: "landscape", margin: "wide" },
-      }),
-      config({ title: "Story paper", instructions: "Write about your week." }),
-      config({ fields: [] }),
-    ];
-    for (const variant of variants) {
-      expect(buildSheet(variant, 9)).toEqual(buildSheet(variant, 9));
-    }
-  });
-
-  it("carries the seed into the footer, which is what makes it repeatable", () => {
-    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
-    expect(buildSheet(config(), 12_346).footer.seed).toBe(12_346);
-  });
-
   it("prints the name line blank, because it has nothing to fill it with", () => {
     const sheet = buildSheet(config(), 1);
     // A `HeaderField` is a marker, not a value: a config has nowhere to put a

--- a/src/engine/sheets/maths/arithmetic.test.ts
+++ b/src/engine/sheets/maths/arithmetic.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { answerKey, buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP } from "../layout";
 import { LINE_INSET, labelRoom, ticks } from "../numberline";
 import { inches } from "../paper";
@@ -89,6 +89,14 @@ const EVERY_SHAPE: Array<Partial<ArithmeticConfig>> = [
 ];
 
 const SEEDS = [0, 1, 2, 7, 4242];
+
+describeSheetFamily("arithmetic", {
+  label: "Addition and subtraction",
+  spec: ARITHMETIC_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
 
 /** Every column count the family will lay out — `MAX_COLUMNS` is six. */
 const COLUMN_COUNTS = [1, 2, 3, 4, 5, 6];
@@ -205,11 +213,6 @@ function factOf(sentence: string): string {
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the arithmetic family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("arithmetic")).toBe(ARITHMETIC_SHEET);
-    expect(sheetFamily("arithmetic")?.label).toBe("Addition and subtraction");
-  });
-
   it("names what it prints, in the terms a parent chose it by", () => {
     expect(describeSheet(config())).toBe("Addition to 20");
     expect(describeSheet(config({ form: "vertical" }))).toBe(
@@ -263,25 +266,6 @@ describe("the answer key", () => {
           }
         }
       }
-    }
-  });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    // The key is not built again from the seed — it is the build, told to
-    // print what it already worked out. So the problems on the two are the
-    // same objects, and a key cannot disagree with the sheet it belongs to.
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
     }
   });
 
@@ -428,21 +412,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
-  it("carries the seed into the footer, so the same sheet can be had again", () => {
-    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     // Building twice in one process only proves the draw is a function of
     // `(config, seed)`. The promise the footer makes is bigger than that: the

--- a/src/engine/sheets/maths/decimals.test.ts
+++ b/src/engine/sheets/maths/decimals.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP } from "../layout";
 import type {
   DecimalConfig,
@@ -96,6 +96,14 @@ const EVERY_SHAPE: Array<Partial<DecimalConfig>> = [
 ];
 
 const SEEDS = [0, 1, 2, 7, 4242];
+
+describeSheetFamily("decimals", {
+  label: "Decimals and percents",
+  spec: DECIMALS_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
 
 /** The one block a decimals sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<DecimalConfig>, seed: number): Problem[] {
@@ -228,11 +236,6 @@ function decimalsOn(problem: Problem): string[] {
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the decimals family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("decimals")).toBe(DECIMALS_SHEET);
-    expect(sheetFamily("decimals")?.label).toBe("Decimals and percents");
-  });
-
   it("names what it prints, in the terms a parent chose it by", () => {
     expect(describeSheet(config())).toBe("Adding decimals — hundredths");
     expect(describeSheet(config({ places: 1 }))).toBe(
@@ -389,22 +392,6 @@ describe("the answer key", () => {
     }
   });
 
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
-    }
-  });
-
   it("leaves exactly one number that would fit a conversion blank", () => {
     // Searched over the hundredths rather than over the whole numbers, because
     // that is the alphabet the answer is written in: two failures caught at
@@ -538,21 +525,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
-  it("carries the seed into the footer, so the same sheet can be had again", () => {
-    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     // The promise the footer makes: the seed is printed on the paper so a
     // parent can have the same sheet again next week, across a deploy. Nothing

--- a/src/engine/sheets/maths/fractions.test.ts
+++ b/src/engine/sheets/maths/fractions.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP } from "../layout";
 import type {
   FractionConfig,
@@ -100,6 +100,14 @@ const EVERY_SHAPE: Array<Partial<FractionConfig>> = [
 ];
 
 const SEEDS = [0, 1, 2, 7, 4242];
+
+describeSheetFamily("fractions", {
+  label: "Fractions",
+  spec: FRACTIONS_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
 
 /** The one block a fraction sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<FractionConfig>, seed: number): Problem[] {
@@ -209,11 +217,6 @@ function holds(sentence: string): boolean {
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the fractions family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("fractions")).toBe(FRACTIONS_SHEET);
-    expect(sheetFamily("fractions")?.label).toBe("Fractions");
-  });
-
   it("names what it prints, in the terms a parent chose it by", () => {
     expect(describeSheet(config())).toBe(
       "Adding fractions — denominators to 12",
@@ -302,26 +305,6 @@ describe("the answer key", () => {
           ).toBe(true);
         }
       }
-    }
-  });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    // The key is not built again from the seed — it is the build, told to print
-    // what it already worked out. So the blocks on the two are equal, and a key
-    // cannot disagree with the sheet it belongs to. The picture on a naming
-    // sheet is part of that: it is the question, so it is on both.
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
     }
   });
 
@@ -571,21 +554,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
-  it("carries the seed into the footer, so the same sheet can be had again", () => {
-    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     // Building twice in one process only proves the draw is a function of
     // `(config, seed)`. The promise the footer makes is bigger than that: the

--- a/src/engine/sheets/maths/geometry.test.ts
+++ b/src/engine/sheets/maths/geometry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { figureBox, figureRow } from "../figure";
 import { BLOCK_GAP, PROBLEM_GAP } from "../layout";
 import type {
@@ -82,6 +82,14 @@ const EVERY_SHAPE: Array<Partial<GeometryConfig>> = [
 ];
 
 const SEEDS = [0, 1, 2, 7, 4242];
+
+describeSheetFamily("geometry", {
+  label: "Shape and space",
+  spec: GEOMETRY_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
 
 /** The problems of a sheet, whichever block they landed in. */
 function problemsOf(over: Partial<GeometryConfig>, seed: number): Problem[] {
@@ -215,11 +223,6 @@ const question = (problem: Problem): string => {
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the geometry family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("geometry")).toBe(GEOMETRY_SHEET);
-    expect(sheetFamily("geometry")?.label).toBe("Shape and space");
-  });
-
   it("names the sheet in the words a parent chose it by", () => {
     expect(describeSheet(config())).toBe(
       "Area of rectangles and triangles — sides to 12 — in cm and m",
@@ -435,22 +438,6 @@ describe("the answer key", () => {
       }
     }
   });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
-    }
-  });
 });
 
 /** A printed total, split into its number and the unit it is counted in. */
@@ -644,17 +631,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     // The promise the footer makes: the seed is printed on the paper so a
     // parent can have the same sheet again next week, across a deploy.

--- a/src/engine/sheets/maths/integers.test.ts
+++ b/src/engine/sheets/maths/integers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP } from "../layout";
 import type {
   IntegerConfig,
@@ -247,6 +247,14 @@ const EVERY_SHAPE: Array<Partial<IntegerConfig>> = [
 
 const SEEDS = [0, 1, 2, 7, 4242];
 
+describeSheetFamily("integers", {
+  label: "Integers and powers",
+  spec: INTEGERS_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
+
 /** The one block an integer sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<IntegerConfig>, seed: number): Problem[] {
   const block = buildSheet(config(over), seed).blocks[0];
@@ -270,11 +278,6 @@ const everyProblem = function* (
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the integers family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("integers")).toBe(INTEGERS_SHEET);
-    expect(sheetFamily("integers")?.label).toBe("Integers and powers");
-  });
-
   it("names the sheet in the words a parent chose it by", () => {
     expect(describeSheet(config({ operation: "multiply" }))).toBe(
       "Multiplying integers — positive and negative — numbers to 12",
@@ -402,22 +405,6 @@ describe("the answer key", () => {
       { style: "powers", range: { min: 2, max: 12 } },
     ])) {
       expect(problem.prompt, problem.prompt).not.toMatch(/√\s*−/);
-    }
-  });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
     }
   });
 });
@@ -575,17 +562,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     // The promise the footer makes: the seed is printed on the paper so a
     // parent can have the same sheet again next week, across a deploy.

--- a/src/engine/sheets/maths/measure.test.ts
+++ b/src/engine/sheets/maths/measure.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP } from "../layout";
 import type {
   MarginSize,
@@ -148,6 +148,14 @@ const EVERY_SHAPE: Array<Partial<MeasureConfig>> = [
 
 const SEEDS = [0, 1, 2, 7, 4242];
 
+describeSheetFamily("measure", {
+  label: "Measurement",
+  spec: MEASURE_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
+
 /** The one block a measurement sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<MeasureConfig>, seed: number): Problem[] {
   const block = buildSheet(config(over), seed).blocks[0];
@@ -190,11 +198,6 @@ const sentence = (problem: Problem): string =>
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the measurement family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("measure")).toBe(MEASURE_SHEET);
-    expect(sheetFamily("measure")?.label).toBe("Measurement");
-  });
-
   it("names the sheet in the words the system it is for uses", () => {
     // Metric weighs mass and imperial weighs weight. It is one word, and it is
     // the word a parent types into a search box.
@@ -293,22 +296,6 @@ describe("the answer key", () => {
           }
         }
       }
-    }
-  });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
     }
   });
 });
@@ -414,17 +401,6 @@ const howBig = (amount: Amount): number =>
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
   it("draws the same numbers whichever system they are printed in", () => {
     // The system is a set of units and a title, and nothing else. Two sheets
     // that drew different questions would be two sheets, and "the same

--- a/src/engine/sheets/maths/money.test.ts
+++ b/src/engine/sheets/maths/money.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP } from "../layout";
 import type {
   Currency,
@@ -83,6 +83,14 @@ const EVERY_SHAPE: Array<Partial<MoneyConfig>> = [
 
 const SEEDS = [0, 1, 2, 7, 4242];
 
+describeSheetFamily("money", {
+  label: "Money",
+  spec: MONEY_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
+
 /** The one block a money sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<MoneyConfig>, seed: number): Problem[] {
   const block = buildSheet(config(over), seed).blocks[0];
@@ -154,11 +162,6 @@ function amountsOn(problem: Problem): string[] {
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the money family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("money")).toBe(MONEY_SHEET);
-    expect(sheetFamily("money")?.label).toBe("Money");
-  });
-
   it("names the sheet in the words the country it is for uses", () => {
     // Not decoration: "adding pounds and pence" and "adding dollars and cents"
     // are two different searches, and a parent types the one their child says.
@@ -263,22 +266,6 @@ describe("the answer key", () => {
       }
     }
   });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
-    }
-  });
 });
 
 /* ── Bounds (§20) ──────────────────────────────────────────────────────── */
@@ -363,17 +350,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
   it("draws the same amounts whatever currency they are printed in", () => {
     // The currency is a symbol and a title, and nothing else. Three sheets that
     // drew different sums would be three sheets, and "the same worksheet in

--- a/src/engine/sheets/maths/multiplication.test.ts
+++ b/src/engine/sheets/maths/multiplication.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { answerKey, buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP, answerLine } from "../layout";
 import { points } from "../paper";
 import type {
@@ -124,6 +124,14 @@ const EVERY_SHAPE: Array<Partial<MultiplicationConfig>> = [
 ];
 
 const SEEDS = [0, 1, 2, 7, 4242];
+
+describeSheetFamily("multiplication", {
+  label: "Multiplication and division",
+  spec: MULTIPLICATION_SHEET,
+  config,
+  shapes: [...EVERY_SHAPE, { style: "grid" as const }],
+  seeds: SEEDS,
+});
 
 /** Every column count the family will lay out — `MAX_COLUMNS` is six. */
 const COLUMN_COUNTS = [1, 2, 3, 4, 5, 6];
@@ -249,13 +257,6 @@ function factOf(sentence: string, folds: boolean): string {
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the multiplication family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("multiplication")).toBe(MULTIPLICATION_SHEET);
-    expect(sheetFamily("multiplication")?.label).toBe(
-      "Multiplication and division",
-    );
-  });
-
   it("names what it prints, in the terms a parent chose it by", () => {
     expect(describeSheet(config())).toBe("Multiplication to 12");
     expect(describeSheet(config({ tables: [7] }))).toBe("The 7 times table");
@@ -328,25 +329,6 @@ describe("the answer key", () => {
           }
         }
       }
-    }
-  });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    // The key is not built again from the seed — it is the build, told to
-    // print what it already worked out. So the blocks on the two are equal,
-    // and a key cannot disagree with the sheet it belongs to.
-    for (const shape of [...EVERY_SHAPE, { style: "grid" as const }]) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
     }
   });
 
@@ -706,21 +688,6 @@ describe("the multiplication grid", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of [...EVERY_SHAPE, { style: "grid" as const }]) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
-  it("carries the seed into the footer, so the same sheet can be had again", () => {
-    expect(buildSheet(config(), 12_345).footer.seed).toBe(12_345);
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     // Building twice in one process only proves the draw is a function of
     // `(config, seed)`. The promise the footer makes is bigger than that: the

--- a/src/engine/sheets/maths/prealgebra.test.ts
+++ b/src/engine/sheets/maths/prealgebra.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { BLOCK_GAP, PROBLEM_GAP } from "../layout";
 import type {
   GridMark,
@@ -206,6 +206,14 @@ const EVERY_SHAPE: Array<Partial<PreAlgebraConfig>> = [
 
 const SEEDS = [0, 1, 2, 7, 4242];
 
+describeSheetFamily("prealgebra", {
+  label: "Pre-algebra",
+  spec: PREALGEBRA_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
+
 /** The problems block, which is the last one whatever else is on the sheet. */
 function problemsOf(over: Partial<PreAlgebraConfig>, seed: number): Problem[] {
   const blocks = buildSheet(config(over), seed).blocks;
@@ -241,11 +249,6 @@ const shapesOf = (style: string): Array<Partial<PreAlgebraConfig>> =>
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the pre-algebra family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("prealgebra")).toBe(PREALGEBRA_SHEET);
-    expect(sheetFamily("prealgebra")?.label).toBe("Pre-algebra");
-  });
-
   it("names the sheet in the words a parent chose it by", () => {
     expect(describeSheet(config({ style: "equation", steps: 2 }))).toBe(
       "Two-step equations — positive and negative — numbers to 12",
@@ -391,22 +394,6 @@ describe("the answer key", () => {
           expectSlope(problem.answer, from, to, problem.prompt);
         }
       }
-    }
-  });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
     }
   });
 });
@@ -568,17 +555,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     expect(problemsOf({ style: "equation", steps: 2, count: 3 }, 7).map(said)) //
       .toEqual(GOLDEN.equation);

--- a/src/engine/sheets/maths/ratio.test.ts
+++ b/src/engine/sheets/maths/ratio.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP } from "../layout";
 import type {
   MarginSize,
@@ -93,6 +93,14 @@ const EVERY_SHAPE: Array<Partial<RatioConfig>> = [
 
 const SEEDS = [0, 1, 2, 7, 4242];
 
+describeSheetFamily("ratio", {
+  label: "Ratio and rate",
+  spec: RATIO_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
+
 /** The one block a ratio sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<RatioConfig>, seed: number): Problem[] {
   const block = buildSheet(config(over), seed).blocks[0];
@@ -119,11 +127,6 @@ const shapesOf = (style: string): Array<Partial<RatioConfig>> =>
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the ratio family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("ratio")).toBe(RATIO_SHEET);
-    expect(sheetFamily("ratio")?.label).toBe("Ratio and rate");
-  });
-
   it("names the sheet in the words a parent chose it by", () => {
     expect(describeSheet(config())).toBe("Simplifying ratios — numbers to 12");
     expect(describeSheet(config({ style: "rate" }))).toBe(
@@ -196,22 +199,6 @@ describe("the answer key", () => {
       expect(said?.[2], problem.prompt).toBe(`${said?.[4]}s`);
     }
   });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
-    }
-  });
 });
 
 /* ── Bounds (§20) ──────────────────────────────────────────────────────── */
@@ -272,17 +259,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     expect(problemsOf({ count: 3 }, 7).map(said)).toEqual(GOLDEN.simplify);
     expect(problemsOf({ style: "rate", count: 3 }, 7).map(said)).toEqual(

--- a/src/engine/sheets/maths/statistics.test.ts
+++ b/src/engine/sheets/maths/statistics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP, answerLine } from "../layout";
 import type {
   MarginSize,
@@ -136,6 +136,14 @@ const EVERY_SHAPE: Array<Partial<StatisticsConfig>> = [
 
 const SEEDS = [0, 1, 2, 7, 4242];
 
+describeSheetFamily("statistics", {
+  label: "Mean, median and mode",
+  spec: STATISTICS_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
+
 /** The one block a statistics sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<StatisticsConfig>, seed: number): Problem[] {
   const block = buildSheet(config(over), seed).blocks[0];
@@ -162,11 +170,6 @@ const shapesOf = (style: string): Array<Partial<StatisticsConfig>> =>
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the statistics family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("statistics")).toBe(STATISTICS_SHEET);
-    expect(sheetFamily("statistics")?.label).toBe("Mean, median and mode");
-  });
-
   it("names the sheet in the words a parent chose it by", () => {
     expect(describeSheet(config())).toBe(
       "Finding the mean — sets of 5 — numbers to 20",
@@ -263,22 +266,6 @@ describe("the answer key", () => {
       const order = ordered(values);
       expect(Number(written.range), said).toBe(
         order[order.length - 1] - order[0],
-      );
-    }
-  });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
       );
     }
   });
@@ -413,17 +400,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     expect(problemsOf({ count: 3 }, 7).map(said)).toEqual(GOLDEN.mean);
     expect(

--- a/src/engine/sheets/maths/time.test.ts
+++ b/src/engine/sheets/maths/time.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { DIAL, MINUTES_A_TURN } from "../clockface";
 import { PROBLEM_GAP } from "../layout";
 import type {
@@ -78,6 +78,14 @@ const EVERY_SHAPE: Array<Partial<TimeConfig>> = [
 
 const SEEDS = [0, 1, 2, 7, 4242];
 
+describeSheetFamily("time", {
+  label: "Telling the time",
+  spec: TIME_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
+
 /** The one block a time sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<TimeConfig>, seed: number): Problem[] {
   const block = buildSheet(config(over), seed).blocks[0];
@@ -148,11 +156,6 @@ function faceOf(problem: Problem): ClockFace {
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the time family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("time")).toBe(TIME_SHEET);
-    expect(sheetFamily("time")?.label).toBe("Telling the time");
-  });
-
   it("names the sheet by how precise it is, which is what makes it hard", () => {
     expect(describeSheet(config({ step: 60 }))).toBe(
       "Telling the time to the hour",
@@ -262,22 +265,6 @@ describe("the answer key", () => {
       expect(faceOf(problem).hands).toBe(false);
       // The time to draw has to be on the page, or there is nothing to draw.
       expect(problem.prompt).toBe(problem.answer);
-    }
-  });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
     }
   });
 });
@@ -400,17 +387,6 @@ describe("what may be on the page", () => {
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
   it("draws the same times whether they are read or drawn", () => {
     // The two sheets are one question asked from either end, so a parent who
     // prints both for the same seed gets the same twelve times — and a child who

--- a/src/engine/sheets/maths/wordproblems.test.ts
+++ b/src/engine/sheets/maths/wordproblems.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { PROBLEM_GAP } from "../layout";
 import type {
   MarginSize,
@@ -164,6 +164,14 @@ const EVERY_SHAPE: Array<Partial<WordProblemConfig>> = [
 
 const SEEDS = [0, 1, 2, 7, 4242];
 
+describeSheetFamily("word-problems", {
+  label: "Word problems",
+  spec: WORD_PROBLEMS_SHEET,
+  config,
+  shapes: EVERY_SHAPE,
+  seeds: SEEDS,
+});
+
 /** The one block a word-problem sheet has, narrowed for the reader. */
 function problemsOf(over: Partial<WordProblemConfig>, seed: number): Problem[] {
   const block = buildSheet(config(over), seed).blocks[0];
@@ -187,11 +195,6 @@ const everyStory = function* (
 /* ── The registry ──────────────────────────────────────────────────────── */
 
 describe("the word-problem family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("word-problems")).toBe(WORD_PROBLEMS_SHEET);
-    expect(sheetFamily("word-problems")?.label).toBe("Word problems");
-  });
-
   it("names the sheet after its topic, and a mixed sheet after none", () => {
     expect(describeSheet(config({ topics: ["percent"] }))).toBe(
       "Word problems: percentages",
@@ -240,22 +243,6 @@ describe("the answer key", () => {
   it("prints a story's answer as a number and nothing else", () => {
     for (const story of everyStory()) {
       expect(story.answer, story.text).toMatch(/^−?\d+$/);
-    }
-  });
-
-  it("prints the answers only when the sheet is a key", () => {
-    const sheet = buildSheet(config(), 5);
-    const key = answerKey(config(), 5);
-    expect(sheet.answers).toBe(false);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const shape of EVERY_SHAPE) {
-      expect(answerKey(config(shape), 11).blocks).toEqual(
-        buildSheet(config(shape), 11).blocks,
-      );
     }
   });
 });
@@ -381,17 +368,6 @@ const everyProblem = function* (
 /* ── Determinism, and the three features it buys (§7) ──────────────────── */
 
 describe("(config, seed)", () => {
-  it("builds the same sheet twice", () => {
-    for (const shape of EVERY_SHAPE) {
-      for (const seed of SEEDS) {
-        const once = buildSheet(config(shape), seed);
-        const twice = buildSheet(config(shape), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
-  });
-
   it("draws the same problems for a seed as it did the day it shipped", () => {
     expect(
       wordStories(config({ count: 3 }), 7).map((story) => [

--- a/src/engine/sheets/phonics/sheets.test.ts
+++ b/src/engine/sheets/phonics/sheets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet } from "@/engine/sheets";
+import { describeSheetFamily } from "@/engine/sheets/contract";
 import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "@/engine/sheets/paper";
 import type {
   Block,
@@ -16,9 +17,11 @@ import { markWord, markedText } from "./cards";
 import { allSounds, readInventory, type Inventory } from "./inventory";
 import { SENTENCES, sentenceText, sentenceWords } from "./sentences";
 import {
+  PHONICS_SHEET,
   PHONICS_STYLES,
   familiesOf,
   phonicsColumns,
+  phonicsKeyed,
   phonicsLayout,
   phonicsSupply,
 } from "./sheets";
@@ -127,6 +130,14 @@ const config = (
   count: 16,
   columns: 2,
   ...extra,
+});
+
+describeSheetFamily("phonics", {
+  label: "Phonics",
+  spec: PHONICS_SHEET,
+  config: (over = {}) => config("blending", EVERYTHING, over),
+  shapes: PHONICS_STYLES.map((style) => ({ style })),
+  keyed: (one) => phonicsKeyed(one.style),
 });
 
 /* ── Reading the page back ─────────────────────────────────────────────── */

--- a/src/engine/sheets/templates/cards.test.ts
+++ b/src/engine/sheets/templates/cards.test.ts
@@ -11,8 +11,16 @@ import type {
   Sheet,
 } from "../types";
 import { buildSheet, describeSheet, sheetSpec } from "../index";
+import { describeSheetFamily } from "../contract";
 
-import { CARD_STEP, canFold, cardsKeyed, inchLabel, layoutsFor } from "./cards";
+import {
+  CARDS_SHEET,
+  CARD_STEP,
+  canFold,
+  cardsKeyed,
+  inchLabel,
+  layoutsFor,
+} from "./cards";
 
 /**
  * The one shelf whose geometry is checked with a pair of scissors.
@@ -349,6 +357,18 @@ describe("what a card carries", () => {
 
 /* ── The promises every family makes ───────────────────────────────────── */
 
+describeSheetFamily("cards", {
+  label: "Cards, tags and bookmarks",
+  spec: CARDS_SHEET,
+  config,
+  shapes: STYLES.map((style) => ({
+    style,
+    passage: "psalm-23",
+    words: ["a", "b"],
+  })),
+  keyed: cardsKeyed,
+});
+
 describe("the cards family", () => {
   it("names the size it actually printed", () => {
     // The catalog quotes this line, so it is a claim about the paper rather
@@ -364,15 +384,6 @@ describe("the cards family", () => {
     expect(describeSheet(config({ style: "certificate", up: 1 }))).toContain(
       "1 to a page",
     );
-  });
-
-  it("is deterministic in (config, seed)", () => {
-    for (const style of STYLES) {
-      const built = config({ style, passage: "psalm-23", words: ["a", "b"] });
-      expect(JSON.stringify(buildSheet(built, 9))).toBe(
-        JSON.stringify(buildSheet(built, 9)),
-      );
-    }
   });
 
   it("withholds nothing, and says so where a page can ask", () => {

--- a/src/engine/sheets/templates/charts.test.ts
+++ b/src/engine/sheets/templates/charts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { answerKey, buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { printedBlockBox, sheetBlockBox } from "../chrome";
 import { ticks } from "../numberline";
 import { MARGINS, PAPERS, toInches } from "../paper";
@@ -13,6 +14,8 @@ import type {
   PaperSize,
   Sheet,
 } from "../types";
+
+import { CHART_SHEET, chartKeyed } from "./charts";
 
 /**
  * The family where being one out is the whole of the bug.
@@ -376,6 +379,14 @@ const STYLES: ChartStyle[] = [
   "coordinate",
   "place-value",
 ];
+
+describeSheetFamily("chart", {
+  label: "Charts, number lines and grids",
+  spec: CHART_SHEET,
+  config,
+  shapes: STYLES.map((style) => ({ style })),
+  keyed: chartKeyed,
+});
 
 describe("every reference sheet", () => {
   it("is the same sheet on every build, and on every seed", () => {

--- a/src/engine/sheets/templates/forms.test.ts
+++ b/src/engine/sheets/templates/forms.test.ts
@@ -12,9 +12,10 @@ import type {
   Sheet,
 } from "../types";
 import { buildSheet, describeSheet, sheetSpec } from "../index";
+import { describeSheetFamily } from "../contract";
 
 import { WRITING_PROMPTS, promptAt } from "./prompts";
-import { MAX_FORM_ROWS, formKeyed } from "./forms";
+import { FORM_SHEET, MAX_FORM_ROWS, formKeyed } from "./forms";
 
 /**
  * The forms, and the one thing a blank form can get wrong.
@@ -344,16 +345,15 @@ describe("a writing prompt", () => {
 
 /* ── The promises every family makes ───────────────────────────────────── */
 
-describe("the forms family", () => {
-  it("is deterministic in (config, seed)", () => {
-    for (const style of STYLES) {
-      const built = config({ style });
-      expect(JSON.stringify(buildSheet(built, 9))).toBe(
-        JSON.stringify(buildSheet(built, 9)),
-      );
-    }
-  });
+describeSheetFamily("form", {
+  label: "Logs, reports and forms",
+  spec: FORM_SHEET,
+  config,
+  shapes: STYLES.map((style) => ({ style })),
+  keyed: formKeyed,
+});
 
+describe("the forms family", () => {
   it("withholds nothing, and says so where a page can ask", () => {
     // The whole of §11's third tier: these are supposed to be empty, so a key
     // is the same paper with a word in the footer. A page asks the family

--- a/src/engine/sheets/templates/nets.test.ts
+++ b/src/engine/sheets/templates/nets.test.ts
@@ -12,12 +12,14 @@ import type {
   Sheet,
 } from "../types";
 import { buildSheet, describeSheet, sheetSpec } from "../index";
+import { describeSheetFamily } from "../contract";
 
 import { CARD_STEP } from "./cards";
 import {
   DICE_PAIR,
   DICE_TABS,
   JOINS,
+  NET_SHEET,
   OPPOSITE,
   SECTORS,
   cubeEdge,
@@ -426,16 +428,18 @@ describe("a spinner", () => {
 
 /* ── The promises every family makes ───────────────────────────────────── */
 
-describe("the nets family", () => {
-  it("is deterministic in (config, seed)", () => {
-    for (const style of ["dice", "spinner"] as NetStyle[]) {
-      const built = config({ style, labels: ["a", "b"] });
-      expect(JSON.stringify(buildSheet(built, 9))).toBe(
-        JSON.stringify(buildSheet(built, 9)),
-      );
-    }
-  });
+describeSheetFamily("net", {
+  label: "Dice and spinners",
+  spec: NET_SHEET,
+  config,
+  shapes: (["dice", "spinner"] as NetStyle[]).map((style) => ({
+    style,
+    labels: ["a", "b"],
+  })),
+  keyed: netKeyed,
+});
 
+describe("the nets family", () => {
   it("withholds nothing, and says so where a page can ask", () => {
     expect(netKeyed()).toBe(false);
     const sheet = buildSheet(config(), 1);

--- a/src/engine/sheets/templates/paper.test.ts
+++ b/src/engine/sheets/templates/paper.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import { sheetBlockBox } from "../chrome";
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { answerKey, buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { contentBox, ruledLines } from "../layout";
 import { RULINGS, inches, rulePitch } from "../paper";
 import type {
@@ -57,12 +57,15 @@ const RULED = STYLES.filter((style) => RULINGS[style].pitch > 0);
 const SIZES: PaperSize[] = ["letter", "a4", "legal"];
 const MARGINS: MarginSize[] = ["none", "narrow", "normal", "wide"];
 
-describe("the paper family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("paper")).toBe(PAPER_SHEET);
-    expect(sheetFamily("paper")?.label).toBe("Lined and graph paper");
-  });
+describeSheetFamily("paper", {
+  label: "Lined and graph paper",
+  spec: PAPER_SHEET,
+  config,
+  shapes: STYLES.map((style) => ({ rule: { style } })),
+  keyed: () => false,
+});
 
+describe("the paper family", () => {
   it("rules a sheet in every ruling of §5", () => {
     for (const style of RULED) {
       const block = rulesOf({ rule: { style } });
@@ -74,12 +77,6 @@ describe("the paper family", () => {
   it("draws nothing on blank paper, rather than a zero-height box", () => {
     // Blank is a ruling with no pitch. Nought repeats is the honest answer.
     expect(rulesOf({ rule: { style: "blank" } }).lines).toBe(0);
-  });
-
-  it("is a pure function of its config, like every other family", () => {
-    for (const seed of [0, 1, 4242]) {
-      expect(buildSheet(config(), seed)).toEqual(buildSheet(config(), seed));
-    }
   });
 
   it("has nothing to answer, so its key is the sheet itself", () => {

--- a/src/engine/sheets/templates/planner.test.ts
+++ b/src/engine/sheets/templates/planner.test.ts
@@ -14,10 +14,12 @@ import type {
   Sheet,
 } from "../types";
 import { buildSheet, describeSheet, sheetSpec } from "../index";
+import { describeSheetFamily } from "../contract";
 
 import {
   MONTH_NAMES,
   PLANNER_ROWS,
+  PLANNER_SHEET,
   daysInMonth,
   isLeapYear,
   monthGrid,
@@ -371,6 +373,14 @@ describe("a verse of the week", () => {
 
 /* ── The promises every family makes ───────────────────────────────────── */
 
+describeSheetFamily("planner", {
+  label: "Calendars, planners and charts",
+  spec: PLANNER_SHEET,
+  config,
+  shapes: STYLES.map((style) => ({ style, passage: "psalm-23" })),
+  keyed: plannerKeyed,
+});
+
 describe("the planner family", () => {
   /**
    * Every combination the page panel actually offers: three stocks, four
@@ -460,15 +470,6 @@ describe("the planner family", () => {
         table.columns.reduce((total, column) => total + column.width, 0),
         style,
       ).toBe(printedBlockBox(sheet).width);
-    }
-  });
-
-  it("is deterministic in (config, seed)", () => {
-    for (const style of STYLES) {
-      const built = config({ style, passage: "psalm-23" });
-      expect(JSON.stringify(buildSheet(built, 9))).toBe(
-        JSON.stringify(buildSheet(built, 9)),
-      );
     }
   });
 

--- a/src/engine/sheets/words/puzzles.test.ts
+++ b/src/engine/sheets/words/puzzles.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { WORD_LISTS, listWords } from "@/engine/decks/wordlists";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import type { Block, Paper, PuzzleConfig } from "../types";
 
 import { SEARCH_CELL, searchCell } from "./metrics";
@@ -55,6 +55,8 @@ const config = (over: Partial<PuzzleConfig> = {}): PuzzleConfig => ({
   ...over,
 });
 
+const STYLES: PuzzleConfig["style"][] = ["search", "crossword", "scramble"];
+
 function blockOf<K extends Block["kind"]>(
   kind: K,
   over: Partial<PuzzleConfig>,
@@ -66,12 +68,14 @@ function blockOf<K extends Block["kind"]>(
   return block as Extract<Block, { kind: K }>;
 }
 
-describe("the family", () => {
-  it("is in the registry, under the kind a saved sheet carries", () => {
-    expect(sheetSpec("puzzle")).toBe(PUZZLE_SHEET);
-    expect(sheetFamily("puzzle")?.label).toBe("Word puzzle");
-  });
+describeSheetFamily("puzzle", {
+  label: "Word puzzle",
+  spec: PUZZLE_SHEET,
+  config,
+  shapes: STYLES.map((style) => ({ style })),
+});
 
+describe("the family", () => {
   it("makes one block, whichever puzzle it is", () => {
     expect(blockOf("wordsearch", {}).kind).toBe("wordsearch");
     expect(blockOf("crossword", { style: "crossword" }).kind).toBe("crossword");
@@ -82,17 +86,6 @@ describe("the family", () => {
     // A sheet saved in March opens in June, the same promise `sheetSpec` makes.
     const stale = { style: "acrostic" as PuzzleConfig["style"] };
     expect(buildSheet(config(stale), 1).blocks[0].kind).toBe("wordsearch");
-  });
-
-  it("is a pure function of its config and seed", () => {
-    for (const style of ["search", "crossword", "scramble"] as const) {
-      for (const seed of [0, 1, 4242]) {
-        const once = buildSheet(config({ style }), seed);
-        const twice = buildSheet(config({ style }), seed);
-        expect(once).not.toBe(twice);
-        expect(once).toEqual(twice);
-      }
-    }
   });
 
   it("stays deterministic across papers and type sizes", () => {
@@ -419,19 +412,6 @@ describe("a crossword's clues", () => {
 });
 
 describe("the answer key", () => {
-  it("is the same sheet with the answers turned on", () => {
-    for (const style of ["search", "crossword", "scramble"] as const) {
-      const sheet = buildSheet(config({ style }), 3);
-      const key = answerKey(config({ style }), 3);
-      // The blocks are identical — the answers were decided when the sheet was
-      // built, so there is no second generation to disagree with the first.
-      expect(key.blocks).toEqual(sheet.blocks);
-      expect(sheet.answers).toBe(false);
-      expect(key.answers).toBe(true);
-      expect(key.footer.note).toBe("Answer key");
-    }
-  });
-
   it("carries a stroke for every word on the list and no others", () => {
     const block = blockOf("wordsearch", {});
     expect(block.solution?.map((found) => found.word)).toEqual(block.find);
@@ -446,7 +426,7 @@ describe("a list nothing can be done with", () => {
       { length: 20 },
       (_, at) => `zzzzzzz${String.fromCharCode(97 + at)}`,
     );
-    for (const style of ["search", "crossword", "scramble"] as const) {
+    for (const style of STYLES) {
       const sheet = buildSheet(
         config({
           style,
@@ -463,7 +443,7 @@ describe("a list nothing can be done with", () => {
   });
 
   it("still produces a sheet when there is no list at all", () => {
-    for (const style of ["search", "crossword", "scramble"] as const) {
+    for (const style of STYLES) {
       const sheet = buildSheet(config({ style, words: [], count: 0 }), 1);
       expect(sheet.blocks).toHaveLength(1);
       expect(sheet.header.score).toEqual({ outOf: 0 });

--- a/src/engine/sheets/words/spelling.test.ts
+++ b/src/engine/sheets/words/spelling.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import { answerLine } from "../layout";
 import type {
   Blank,
   Choice,
   Paper,
   Problem,
+  WordSheetStyle,
   WordShape,
   WordsConfig,
 } from "../types";
@@ -97,12 +98,24 @@ function refilled(blank: Blank): string {
 
 /* ── The registry ──────────────────────────────────────────────────────── */
 
-describe("the spelling family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("words")).toBe(WORDS_SHEET);
-    expect(sheetFamily("words")?.label).toBe("Spelling list");
-  });
+const STYLES: WordSheetStyle[] = [
+  "copy",
+  "missing",
+  "test",
+  "abc",
+  "shapes",
+  "sentence",
+  "find",
+];
 
+describeSheetFamily("words", {
+  label: "Spelling list",
+  spec: WORDS_SHEET,
+  config,
+  shapes: STYLES.map((style) => ({ style })),
+});
+
+describe("the spelling family", () => {
   it("names what it prints, in the terms it was chosen by", () => {
     expect(describeSheet(config())) //
       .toBe("Spelling practice — 5 words — written 3 times");
@@ -353,25 +366,6 @@ describe("finding the word", () => {
   });
 });
 
-/* ── The key ───────────────────────────────────────────────────────────── */
-
-describe("the answer key", () => {
-  it("prints the answers only when the sheet is a key", () => {
-    expect(buildSheet(config(), 3).answers).toBe(false);
-    const key = answerKey(config(), 3);
-    expect(key.answers).toBe(true);
-    expect(key.footer.note).toBe("Answer key");
-  });
-
-  it("is the same sheet keyed, never a second generation", () => {
-    // The gaps are drawn from the seed, so a key that regenerated them would
-    // ask for one letter and answer with another.
-    const sheet = buildSheet(config({ style: "missing" }), 7);
-    const key = answerKey(config({ style: "missing" }), 7);
-    expect({ ...key, answers: false, footer: sheet.footer }).toEqual(sheet);
-  });
-});
-
 /* ── The list ──────────────────────────────────────────────────────────── */
 
 describe("the list itself", () => {
@@ -388,12 +382,6 @@ describe("the list itself", () => {
     // A spelling list is often taught in order, and a list of missed words
     // arrives ranked worst-first. Neither is ours to shuffle.
     expect(wordsOf(config())).toEqual(WORDS);
-  });
-
-  it("builds the same sheet twice", () => {
-    expect(buildSheet(config({ style: "missing" }), 12)).toEqual(
-      buildSheet(config({ style: "missing" }), 12),
-    );
   });
 
   it("never prints more words than the paper holds", () => {

--- a/src/engine/sheets/words/study.test.ts
+++ b/src/engine/sheets/words/study.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { answerKey, buildSheet, describeSheet, sheetSpec } from "../index";
-import { sheetFamily } from "../families";
+import { buildSheet, describeSheet } from "../index";
+import { describeSheetFamily } from "../contract";
 import type { Block, Paper, WordStudyConfig, WordStudyStyle } from "../types";
 
 import {
@@ -153,12 +153,14 @@ describe("the word bank", () => {
 
 /* ── The family ────────────────────────────────────────────────────────── */
 
-describe("the word-study family", () => {
-  it("is in the registry under the kind its config carries", () => {
-    expect(sheetSpec("word-study")).toBe(WORD_STUDY_SHEET);
-    expect(sheetFamily("word-study")?.label).toBe("Word study");
-  });
+describeSheetFamily("word-study", {
+  label: "Word study",
+  spec: WORD_STUDY_SHEET,
+  config,
+  shapes: EVERY_SHEET,
+});
 
+describe("the word-study family", () => {
   it("prints a titled, marked page for every topic and style", () => {
     for (const one of EVERY_SHEET) {
       const sheet = buildSheet(one, 1);
@@ -299,21 +301,6 @@ describe("joining two columns", () => {
       block.left.forEach((cue, at) => {
         expect(block.right[block.answer[at]], cue).toBe(bank.get(cue));
       });
-    }
-  });
-});
-
-/* ── The key ───────────────────────────────────────────────────────────── */
-
-describe("the answer key", () => {
-  it("is the same sheet keyed, never a second generation", () => {
-    for (const one of EVERY_SHEET) {
-      const sheet = buildSheet(one, 7);
-      const key = answerKey(one, 7);
-      expect(key.answers, where(one)).toBe(true);
-      expect(key.footer.note, where(one)).toBe("Answer key");
-      expect({ ...key, answers: false, footer: sheet.footer }, where(one)) //
-        .toEqual(sheet);
     }
   });
 });

--- a/src/engine/sheets/writing/handwriting.test.ts
+++ b/src/engine/sheets/writing/handwriting.test.ts
@@ -7,6 +7,7 @@ import {
   glyphEm,
   isCursive,
 } from "../faces";
+import { describeSheetFamily } from "../contract";
 import { ruleCapacity, ruledLines } from "../layout";
 import { RULINGS, inches, rulePitch, toInches, writingSpace } from "../paper";
 import {
@@ -85,6 +86,20 @@ const written = (rows: TraceRow[]): string[] => [
     ),
   ),
 ];
+
+describeSheetFamily("handwriting", {
+  label: "Handwriting practice",
+  spec: HANDWRITING_SHEET,
+  config,
+  shapes: [
+    {},
+    { style: "numbers" },
+    { style: "joins", font: "cursive" },
+    { style: "words", words: ["cat", "dog"] },
+    { style: "passage", text: "One line." },
+  ],
+  keyed: () => false,
+});
 
 describe("what goes on a handwriting sheet", () => {
   it("writes the whole alphabet, upper and lower, on one page", () => {
@@ -745,16 +760,6 @@ describe("copywork out of the passage library", () => {
 /* ── The sheet itself ──────────────────────────────────────────────────── */
 
 describe("the sheet", () => {
-  it("is the same page on every build", () => {
-    // §7, and what lets a catalog page be prerendered: a parent who printed
-    // this in March prints the identical sheet in June.
-    for (const seed of [0, 1, 4242]) {
-      expect(JSON.stringify(HANDWRITING_SHEET.build(config(), seed))).toBe(
-        JSON.stringify(HANDWRITING_SHEET.build(config(), seed)),
-      );
-    }
-  });
-
   it("has nothing to mark and no key to disagree with it", () => {
     const sheet = HANDWRITING_SHEET.build(config(), 1);
     // No score box: a handwriting sheet is not marked out of anything, and a

--- a/src/engine/sheets/writing/memory.test.ts
+++ b/src/engine/sheets/writing/memory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { chromeHeight, sheetBlockBox, type FootLine } from "../chrome";
+import { describeSheetFamily } from "../contract";
 import { faceOf } from "../faces";
 import { contentBox } from "../layout";
 import { DEFAULT_FONT_PT, DEFAULT_PAPER, points } from "../paper";
@@ -73,6 +74,18 @@ function filled(round: Blank): string {
     .map((word) => (word === "_" ? round.answers[at++] : word))
     .join(" ");
 }
+
+describeSheetFamily("memory", {
+  label: "Memory verse",
+  spec: MEMORY_SHEET,
+  config,
+  shapes: [
+    {},
+    { rounds: 1 },
+    { passage: "bed-in-summer" },
+    { passage: undefined, text: "Mine." },
+  ],
+});
 
 describe("what goes on a memory sheet", () => {
   it("writes the passage out whole first, and empty last", () => {


### PR DESCRIPTION
Closes #214.

(The issue's title is copy-pasted from another card in the epic — its body, acceptance criteria and family list are the sheet-family contract, which is what this is.)

## What this does

Seventeen suites under `src/engine/sheets/` had hand-copied the same ten assertions, so a family kept as much of the contract as its author remembered. `describeSheetFamily(kind, …)` in `src/engine/sheets/contract.ts` now says once what is true of every family:

- it is in the registry under the kind its config carries, and under the name the picker offers
- it builds the same sheet twice
- it prints on the paper and in the type it was handed
- it carries the seed and the credit into the footer
- it names itself in one line
- the answers are on the key and nowhere else
- the key is that build keyed, not a second generation
- a score box is a whole number over nought
- it is swept over at least one shape and one seed

**All twenty-seven families call it, not the seventeen.** A contract only some families keep is one the next family can skip without noticing.

## The family list is derived, not hard-coded

`contract.test.ts` walks the suites for `describeSheetFamily("…")` calls and fails per family that has none — with the list read out of **`src/engine/sheets/families.ts`**, the same way the import-graph guard in `src/components/sheet/blocks/` reads it. Nothing here writes the family names down a second time, so **a new family added to the registry is covered automatically**: it appears in the check the moment it appears in `families.ts`, and lands red until its suite calls the contract. A second clause catches the mirror-image mistake — a suite running the contract on a kind `families.ts` has never heard of.

## The contract was verified to actually reject violations

A guard that has never been seen to fail is a guard nobody has tested. Each of these was broken deliberately, observed failing with the named message, then reverted:

- **ratio** — key note `"Answer key"` → `"Answers"` reported `the ratio family keeps the contract > prints the answers only when the sheet is a key`, and `ratio: Simplifying ratios — numbers to 12: what the key says it is: expected 'Answers' to be 'Answer key'`.
- **geometry** — a build ignoring `config.paper` reported `prints on the paper it was handed, in the type it was asked for`, naming the sheet and diffing a4/landscape/wide against letter/portrait/normal. That break passed the *first* draft of the clause, which only ever checked the default stock — which is why `OTHER_STOCK` exists.
- **a new family** — a `"copywork"` entry added to `families.ts` with no suite reported `the sheet-family contract > is kept by the copywork family` and named the call to add.

### The empty-sweep guard, added during review

Seven of the original eight clauses are a loop over `configs` and `seeds`. A suite that passed `shapes: []` — the obvious reach of an author whose shape would not build — ran those loops **zero times**, and vitest reported eight green tests with nothing asserted behind them, while the source scan still counted the family as covered. So a ninth clause holds the *suite* rather than the family. Seen to fail both ways on money:

- `shapes: []` → `money: shapes is empty, so every clause below loops zero times and asserts nothing — pass the shapes this family builds, or leave shapes off to sweep its defaults: expected 0 to be greater than 0`
- `seeds: []` → `money: seeds is empty, so every clause that builds at a seed asserts nothing — pass the seeds to sweep, or leave seeds off for the defaults`

Both took the run from 55 passed to 1 failed. Before this clause, the same `shapes: []` left it at 54 passed **with a deliberate paper-ignoring break in `money.ts` going unseen** — which is the failure the contract exists to close, arrived at from the other side.

## Acceptance criteria

- [x] A shared helper asserts the contract every family must satisfy
- [x] All existing suites use it, family-specific tests intact (nothing here can tell whether the sums add up — that is still checked against a path the family does not use)
- [x] Adding a family to the registry without the contract test **fails** — verified with `copywork`
- [x] Total test count does not drop — 2,290 → 2,484
- [x] The suite stays fast — 2.58s → 2.60s

## Validation

`type-check`, `lint`, `format:check`, `build` (static, bundle budgets clear — tightest is /typing with 10,240 B to spare), `test:unit` (2,484 passed / 111 files, 2.60s), `section-guard`, and the browser smoke test against the built site — all green, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
