### PR TITLE
Put a test behind the front doors every island reads through

### DIFF
--- a/src/engine/decks/index.test.ts
+++ b/src/engine/decks/index.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+
+import { LESSONS } from "@/engine/typing/lessons";
+import type { RaceConfig } from "@/engine/types";
+import type { World } from "@/engine/worlds";
+
+import { OPERATIONS } from "./flashcards";
+import { TYPING_LEVELS, typingMode } from "./typing";
+import { SHIPPED_LISTS } from "./wordlists";
+import { wordMode } from "./words";
+import { UNKNOWN_DECK } from "./spec";
+import { deckSpec, modeOf } from "./index";
+
+/**
+ * `deckSpec(mode)` answers for everything, because sessions outlive their decks.
+ *
+ * Each family's own suite spot-checks its routing; this is the sweep. Every mode
+ * this build can file a run under is read out of the registry that owns it —
+ * every operation, every shipped word list, every typing level and every lesson
+ * — so a list, a level or a lesson added tomorrow is covered the day it lands
+ * rather than the day somebody remembers to add it here.
+ *
+ * The other half is the modes that resolve to nothing: a list a parent deleted,
+ * a level a build retired, a mode from no family at all. A record book is
+ * rendered for every run a child has ever done, so one unresolvable mode is not
+ * one missing row — it is the whole screen, and the runs behind it are the only
+ * copy there is.
+ */
+
+type Family = {
+  name: string;
+  /** Where a run of this family opens. `DeckSpec.world`, keyed off the mode. */
+  world: World;
+  /** Every mode of this family, from the registry that owns them. */
+  modes: string[];
+  /** A run of this family, to prove those modes are what one is filed under. */
+  config: RaceConfig;
+};
+
+/*
+ * The `?? ""` on the ids below is deliberate: a registry that came back empty
+ * should trip the named guard in the first test rather than fail the whole file
+ * on `undefined.id`, which reads as a broken test rather than as a missing deck.
+ */
+const FAMILIES: Family[] = [
+  {
+    name: "arithmetic",
+    world: "grid",
+    modes: Object.keys(OPERATIONS),
+    config: {
+      operation: "multiply",
+      tables: [7],
+      others: [8],
+      cardCount: 1,
+      inputMode: "type",
+    },
+  },
+  {
+    name: "words",
+    world: "jungle",
+    modes: SHIPPED_LISTS.map((list) => wordMode(list.id)),
+    config: {
+      kind: "words",
+      listId: SHIPPED_LISTS[0]?.id ?? "",
+      cardCount: 1,
+      inputMode: "type",
+    },
+  },
+  {
+    name: "typing",
+    world: "ice",
+    // Two namespaces behind one prefix: a run files itself under its lesson
+    // where it has one and under its level otherwise, and both have to resolve.
+    modes: [
+      ...TYPING_LEVELS.map((level) => typingMode(level.id)),
+      ...LESSONS.map((lesson) => typingMode(lesson.id)),
+    ],
+    config: {
+      kind: "typing",
+      levelId: TYPING_LEVELS[0]?.id ?? "",
+      wordCount: 1,
+    },
+  },
+];
+
+/**
+ * Fact ids a spec has to survive being handed.
+ *
+ * Half of them are ordinary and half are what a record book two years old
+ * actually holds: `""` is what a card saved before fact ids existed migrates to
+ * (`engine/migrate.ts`), and the rest are the shapes a restored backup can
+ * carry, since a backup is put back exactly as it was written.
+ */
+const FACT_IDS = [
+  "",
+  "7:8",
+  "12:12",
+  "because",
+  "Because",
+  "The",
+  "🙂",
+  "constructor",
+  "x".repeat(200),
+];
+
+describe("the modes this build can file a run under", () => {
+  it.each(FAMILIES)(
+    "$name has some, and they are what runs carry",
+    (family) => {
+      // Without this the sweep below could quietly loop zero times — a registry
+      // that failed to load, or a family whose ids moved, would report green.
+      expect(
+        family.modes.length,
+        `no ${family.name} modes were found, so the sweep below checked nothing`,
+      ).toBeGreaterThan(0);
+
+      // And they are the same strings `Session.mode` holds, not a parallel set
+      // assembled for the test: `modeOf` is what writes one, so a family whose
+      // ids were read the wrong way round would land here rather than in a
+      // record book that has lost a year of runs.
+      expect(family.modes).toContain(modeOf(family.config));
+    },
+  );
+});
+
+describe.each(FAMILIES)("a $name mode", ({ world, modes }) => {
+  it.each(modes)("%s resolves to a deck that can name itself", (mode) => {
+    const spec = deckSpec(mode);
+
+    // `id` is what a saved run matches itself back to, so it has to be the mode
+    // it was asked about rather than the family's own idea of an id.
+    expect(spec.id).toBe(mode);
+    expect(spec.label.length).toBeGreaterThan(0);
+    // The one judgement that decides which mount a run belongs to: a race is on
+    // this island only if `deckSpec(mode).world` is the island's world, so a
+    // mode landing in the wrong world hides a child's runs from the game they
+    // played them in.
+    expect(spec.world).toBe(world);
+  });
+
+  it.each(modes)("%s marks and folds whatever fact id it is handed", (mode) => {
+    const spec = deckSpec(mode);
+    for (const factId of FACT_IDS) {
+      const where = `${mode} on fact id ${JSON.stringify(factId)}`;
+      // Total, all four. The mastery grid, the trouble list and the practice
+      // deck are built by mapping these over fact ids stored years ago — an
+      // empty one is what `readCard` writes for a card saved before fact ids
+      // existed — and one throw takes the whole screen with it.
+      expect(typeof spec.masteryKey(factId), where).toBe("string");
+      expect(typeof spec.drillKey(factId), where).toBe("string");
+      expect(typeof spec.factLabel(factId), where).toBe("string");
+
+      // Fact ids are stored already normalised, so folding one again must land
+      // on the same square a fresh card folds onto. A rule that changed its
+      // answer on the second pass would split a child's mastery of a word
+      // across two cells, one of which nothing can ever fill again.
+      const once = spec.normalise(factId);
+      expect(spec.normalise(once), where).toBe(once);
+      expect(spec.masteryKey(spec.masteryKey(factId)), where).toBe(
+        spec.masteryKey(factId),
+      );
+    }
+  });
+});
+
+describe("a mode this build has no deck for", () => {
+  it.each([
+    ["nothing at all", ""],
+    ["a word this build never shipped", "nonsense"],
+    ["an operation with the wrong case", "MULTIPLY"],
+    ["an operation with a stray space", "multiply "],
+    // The prefixes without their separator: neither routes, and both are one
+    // typo away from a mode that does.
+    ["a bare words prefix", "words"],
+    ["a bare typing prefix", "typing"],
+    // A backup file is restored exactly as it was written, deliberately and
+    // without validation (`importAll`), so any string at all can reach here.
+    // These are the ones a plain object answers for: `OPERATIONS.constructor`
+    // is a function, and handing one back as a deck crashes the record book on
+    // the first `masteryKey` rather than at the lookup.
+    ["a key every object has", "constructor"],
+    ["another", "toString"],
+    ["the prototype itself", "__proto__"],
+  ])("%s reads as a retired deck", (_why, mode) => {
+    expect(deckSpec(mode)).toBe(UNKNOWN_DECK);
+  });
+
+  it("keeps a run on a deleted list in its own world", () => {
+    // A parent deletes this week's spellings; the races played on them stay in
+    // the record book, keep their times, and still open in the jungle. The name
+    // is what's lost, not the record.
+    const spec = deckSpec(wordMode("week-12-gone"));
+    expect(spec.world).toBe("jungle");
+    expect(spec.label).toBe("Words");
+    expect(spec.masteryKey("Because")).toBe("because");
+  });
+
+  it("keeps a run on a retired level in its own world", () => {
+    const spec = deckSpec(typingMode("retired-level"));
+    expect(spec.world).toBe("ice");
+    expect(spec.label).toBe("Typing");
+  });
+
+  it.each(["words:", "typing:"])(
+    "answers for %s with nothing after it",
+    (mode) => {
+      // The prefix routes, and then there is no id to look up. It must still
+      // come back as a deck of that family rather than reaching for a list
+      // called "".
+      expect(() => deckSpec(mode)).not.toThrow();
+      expect(deckSpec(mode).label.length).toBeGreaterThan(0);
+    },
+  );
+});

--- a/src/engine/decks/index.ts
+++ b/src/engine/decks/index.ts
@@ -75,7 +75,13 @@ export function modeOf(config: RaceConfig): string {
 export function deckSpec(mode: string): DeckSpec {
   if (mode.startsWith(WORD_MODE_PREFIX)) return wordDeckSpec(mode);
   if (mode.startsWith(TYPING_MODE_PREFIX)) return typingDeckSpec(mode);
-  return OPERATIONS[mode as keyof typeof OPERATIONS] ?? UNKNOWN_DECK;
+  // `hasOwn` rather than `?? UNKNOWN_DECK`: a mode is any string a restored
+  // backup happens to carry, and `OPERATIONS.constructor` is a function — which
+  // is not nullish, so it would be handed back as a deck and crash the record
+  // book on the first `masteryKey` instead of reading as a retired one.
+  return Object.hasOwn(OPERATIONS, mode)
+    ? OPERATIONS[mode as keyof typeof OPERATIONS]
+    : UNKNOWN_DECK;
 }
 
 export function buildDeck(config: RaceConfig, seed: number): Card[] {

--- a/src/engine/decks/spec.test.ts
+++ b/src/engine/decks/spec.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { THEME_COLOUR } from "@/engine/worlds";
+
+import { UNKNOWN_DECK } from "./spec";
+
+/**
+ * The stand-in for a deck that isn't in the registry.
+ *
+ * `DeckSpec` is otherwise a type, and the type checker holds the families to
+ * it. The one value in this file is the one a family never wrote: what the
+ * record book gets when a parent deletes the spelling list from three months
+ * ago and every race played on it is still there.
+ *
+ * Its whole job is to be uneventful. Each expectation below is really "and it
+ * does nothing", because the alternative to nothing is a screen that reshapes a
+ * child's history on the way out of storage — folding two facts together, or
+ * renaming one — with no deck left to say whether that was right.
+ */
+
+describe("a retired deck", () => {
+  it("hands facts back exactly as they were stored", () => {
+    // No folding, in either key. Whether 7×8 and 8×7 are one fact is a
+    // judgement only the family that built them can make, and it is gone.
+    for (const factId of ["7:8", "8:7", "because", "The", ""]) {
+      expect(UNKNOWN_DECK.masteryKey(factId)).toBe(factId);
+      expect(UNKNOWN_DECK.drillKey(factId)).toBe(factId);
+      expect(UNKNOWN_DECK.factLabel(factId)).toBe(factId);
+    }
+  });
+
+  it("forgives nothing but the spaces round an answer", () => {
+    // Case is not forgiven here, though the jungle forgives it: "Because" was
+    // marked by a deck whose rule this is not, and quietly re-marking a run
+    // that has already been scored would rewrite history rather than read it.
+    expect(UNKNOWN_DECK.normalise("  56 ")).toBe("56");
+    expect(UNKNOWN_DECK.normalise("Because")).toBe("Because");
+  });
+
+  it("says what it is, in the words a record book can print", () => {
+    // The label is rendered next to a real run with a real time on it, so it
+    // has to read as an explanation rather than as a missing value.
+    expect(UNKNOWN_DECK.label).toBe("Retired deck");
+  });
+
+  it("has a world the site actually themes", () => {
+    // A deck from no family has no scenery of its own, and a record-book row is
+    // not the place for a child to find that out. Checked against the registry
+    // rather than written twice: a world id nothing themes leaves the page on
+    // whatever the last one set.
+    expect(Object.keys(THEME_COLOUR)).toContain(UNKNOWN_DECK.world);
+  });
+});

--- a/src/engine/run.test.ts
+++ b/src/engine/run.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CardResult, FlashConfig, Ghost, Profile, Session } from "./types";
 
+import { levelFromXp } from "./progress";
 import { summariseRun, type RunTally } from "./run";
 
 /**
@@ -214,6 +215,20 @@ describe("summarising a run", () => {
   });
 });
 
+/**
+ * The XP a player is holding the moment they reach level 10, asked of the
+ * curve rather than transcribed: `levelFromXp` owns the formula, and a test
+ * that copied the number would go on passing after the curve moved.
+ *
+ * `toNext` is the gap to the next level's floor, so adding it lands exactly on
+ * that floor — nine steps from zero to the level-10 line.
+ */
+const LEVEL_10_XP = (() => {
+  let xp = 0;
+  while (levelFromXp(xp).level < 10) xp += levelFromXp(xp).toNext;
+  return xp;
+})();
+
 describe("the badges a run earns", () => {
   it("tells the player what is new to them, and the service what they hold", () => {
     const { earnedBadges, newBadges } = summarise();
@@ -255,6 +270,27 @@ describe("the badges a run earns", () => {
       summarise({ ghost: rival, tally: tally({ maxDeficitMs: 500 }) })
         .earnedBadges,
     ).not.toContain("comeback");
+  });
+
+  it("judges the level badge on the XP the player leaves with", () => {
+    // `xpAfter` is the only thing "Double Digits" is decided on, and the
+    // profile handed in still holds the XP from *before* this race. A summary
+    // that passed `profile.xp` straight through would hold the badge back
+    // until the next race — a level-up the child watched happen, paid late.
+    const cardXp = 120;
+    const onTheLine = { ...ada, xp: LEVEL_10_XP - cardXp };
+
+    expect(
+      summarise({ profile: onTheLine, tally: tally({ cardXp }) }).earnedBadges,
+    ).toContain("level-10");
+    // And one XP short of the line is still short of it, so the case above is
+    // pinning the crossing rather than a threshold that is always met.
+    expect(
+      summarise({
+        profile: { ...onTheLine, xp: onTheLine.xp - 1 },
+        tally: tally({ cardXp }),
+      }).earnedBadges,
+    ).not.toContain("level-10");
   });
 
   it("counts the cards a player had answered before this race", () => {

--- a/src/engine/run.test.ts
+++ b/src/engine/run.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardResult, FlashConfig, Ghost, Profile, Session } from "./types";
+
+import { summariseRun, type RunTally } from "./run";
+
+/**
+ * What a finished race is worth, decided away from the render tree.
+ *
+ * This was inline in `RaceTrack`, and the reason it moved is the reason it is
+ * worth testing: the results screen, the record book and the badge shelf all
+ * read the same summary, so a rule that only exists inside a component is a
+ * rule three screens can disagree about.
+ *
+ * `compareRuns` and `evaluateBadges` have their own suites and are not re-tested
+ * here. What is tested is the wiring: which numbers this hands them, and what it
+ * does with the answers — a summary that judged badges on the XP a player had
+ * *before* the race, or that read "no previous best" as "beat your best", would
+ * satisfy both of those suites and still pay a seven-year-old for nothing.
+ */
+
+const ada: Profile = {
+  id: "kid-1",
+  name: "Ada",
+  emoji: "🚀",
+  color: "#7c3aed",
+  age: 7,
+  soundOn: true,
+  xp: 340,
+  badges: ["green-light"],
+  createdAt: "2026-03-01T09:00:00.000Z",
+};
+
+const config: FlashConfig = {
+  operation: "multiply",
+  tables: [7],
+  others: [8],
+  cardCount: 3,
+  inputMode: "type",
+};
+
+/** The key that config has always produced — transcribed, not computed. */
+const CONFIG_KEY = "multiply|7|8|3|type";
+
+const card = (ms: number, ok: boolean): CardResult => ({
+  prompt: "7 × 8",
+  answer: "56",
+  given: ok ? "56" : "54",
+  ok,
+  ms,
+  factId: "7:8",
+});
+
+/** Two right and one wrong, 3.7 seconds of clock between them. */
+const tally = (over: Partial<RunTally> = {}): RunTally => ({
+  cards: [card(1000, true), card(1200, true), card(1500, false)],
+  cardXp: 120,
+  bestStreak: 2,
+  maxDeficitMs: 0,
+  ...over,
+});
+
+/** A run already in the book, at whatever pace the case needs. */
+const past = (over: Partial<Session> = {}): Session => ({
+  id: "s_old",
+  profileId: ada.id,
+  game: "flashcards",
+  mode: "multiply",
+  configKey: CONFIG_KEY,
+  config,
+  seed: 1,
+  finishedAt: "2026-03-01T09:00:00.000Z",
+  durationMs: 9000,
+  correct: 3,
+  incorrect: 0,
+  bestStreak: 3,
+  xpEarned: 100,
+  ghostSessionId: null,
+  beatGhost: null,
+  cards: [],
+  ...over,
+});
+
+const ghostOf = (session: Session): Ghost => ({
+  session,
+  profile: ada,
+  isSelf: true,
+});
+
+/** A solo, untimed, unremarkable race, with the case's own details laid over. */
+const summarise = (over: Partial<Parameters<typeof summariseRun>[0]> = {}) =>
+  summariseRun({
+    profile: ada,
+    config,
+    seed: 42,
+    ghost: null,
+    history: [],
+    previousBest: null,
+    tally: tally(),
+    ...over,
+  });
+
+describe("summarising a run", () => {
+  it("hands the session service a draft it can save as it stands", () => {
+    const { draft } = summarise();
+
+    expect(draft).toMatchObject({
+      profileId: ada.id,
+      game: "flashcards",
+      mode: "multiply",
+      configKey: CONFIG_KEY,
+      config,
+      seed: 42,
+    });
+    // The clock is the cards added up, not a wall-clock reading: a race paused
+    // for lunch is still the time it took to answer.
+    expect(draft.durationMs).toBe(3700);
+    // Counted off the cards rather than off `cardCount`, which is what was
+    // asked for and not what was answered — a quit run has fewer.
+    expect(draft.correct).toBe(2);
+    expect(draft.incorrect).toBe(1);
+    expect(draft.cards).toHaveLength(3);
+    expect(draft.bestStreak).toBe(2);
+  });
+
+  it("pays the XP the cards earned when nothing else was won", () => {
+    const { draft, bonuses } = summarise();
+    expect(bonuses).toEqual([]);
+    expect(draft.xpEarned).toBe(120);
+  });
+
+  it("doesn't call a player's first run at a setting a record", () => {
+    // There is nothing to have beaten. Reading "no previous best" as a record
+    // would pay 150 XP and a badge for every first race a child ever ran.
+    const { personalRecord, bonuses, draft } = summarise({
+      previousBest: null,
+    });
+    expect(personalRecord).toBe(false);
+    expect(bonuses).toEqual([]);
+    expect(draft.xpEarned).toBe(120);
+  });
+
+  it("pays for a personal best, and adds it to the XP", () => {
+    const { personalRecord, bonuses, draft } = summarise({
+      // 3.7s plus one 3s penalty beats nine seconds.
+      previousBest: past({ durationMs: 9000 }),
+    });
+    expect(personalRecord).toBe(true);
+    expect(bonuses).toEqual([{ label: "Personal best", xp: 150 }]);
+    expect(draft.xpEarned).toBe(120 + 150);
+  });
+
+  it("doesn't pay for a slower run than the one on record", () => {
+    const { personalRecord, bonuses } = summarise({
+      previousBest: past({ durationMs: 5000 }),
+    });
+    expect(personalRecord).toBe(false);
+    expect(bonuses).toEqual([]);
+  });
+
+  it("ranks a timed run on cards beaten, not on the clock", () => {
+    // Under a per-card clock the total time can't run away, so the run that
+    // beat the clock more often wins — `compareRuns` owns that rule, and this
+    // is the case that says a summary asks it rather than comparing times
+    // itself. Twice as fast, one card fewer: still not a record.
+    const timed = { ...config, timeLimitMs: 5000 };
+    const { personalRecord } = summarise({
+      config: timed,
+      previousBest: past({
+        config: timed,
+        durationMs: 20_000,
+        correct: 3,
+        incorrect: 0,
+      }),
+    });
+    expect(personalRecord).toBe(false);
+  });
+
+  it("says there was nobody to race, rather than that they lost", () => {
+    // `null`, not `false`. The record book renders the two differently, and a
+    // solo run recorded as a loss is a rival a child never had.
+    const { beatGhost, draft } = summarise({ ghost: null });
+    expect(beatGhost).toBeNull();
+    expect(draft.beatGhost).toBeNull();
+    expect(draft.ghostSessionId).toBeNull();
+  });
+
+  it("records which run was raced, and whether it was beaten", () => {
+    const rival = past({ id: "s_rival", durationMs: 9000 });
+    const { beatGhost, bonuses, draft } = summarise({
+      ghost: ghostOf(rival),
+    });
+
+    expect(beatGhost).toBe(true);
+    // The id is kept so the results screen can name the run that was raced,
+    // years later and after the rival's own best has moved on.
+    expect(draft.ghostSessionId).toBe("s_rival");
+    expect(bonuses).toEqual([{ label: "Beat your rival", xp: 100 }]);
+  });
+
+  it("pays for a clean sheet by the size of the deck", () => {
+    const { bonuses, draft } = summarise({
+      tally: tally({ cards: [card(900, true), card(800, true)] }),
+    });
+    expect(bonuses).toEqual([{ label: "No mistakes", xp: 50 + 2 * 5 }]);
+    expect(draft.xpEarned).toBe(120 + 60);
+  });
+
+  it("doesn't call a race with no cards in it perfect", () => {
+    // A run quit on the first card has no mistakes in it either. Paying it a
+    // clean sheet would make quitting the cheapest XP in the game.
+    const { bonuses } = summarise({ tally: tally({ cards: [] }) });
+    expect(bonuses).toEqual([]);
+  });
+});
+
+describe("the badges a run earns", () => {
+  it("tells the player what is new to them, and the service what they hold", () => {
+    const { earnedBadges, newBadges } = summarise();
+    // Ada already has "green-light", so it stays in what gets saved and drops
+    // out of what the results screen crows about. Awarding it again would pop
+    // a "new badge!" for something she earned months ago.
+    expect(earnedBadges).toContain("green-light");
+    expect(newBadges).not.toContain("green-light");
+  });
+
+  it("hands the personal best it just decided to the badge rules", () => {
+    const history = [past({ id: "s_1" })];
+    const beaten = past({ durationMs: 9000 });
+
+    // "Record Setter" needs both halves: a best that was beaten, and an
+    // earlier run at these exact settings to have beaten. Only this function
+    // knows the first, so a summary that judged badges without passing it in
+    // would silently stop awarding the badge.
+    expect(summarise({ previousBest: beaten, history }).earnedBadges).toContain(
+      "record-setter",
+    );
+    expect(
+      summarise({ previousBest: past({ durationMs: 1000 }), history })
+        .earnedBadges,
+    ).not.toContain("record-setter");
+  });
+
+  it("hands over how far behind the player ever fell", () => {
+    const rival = ghostOf(past({ id: "s_rival", durationMs: 9000 }));
+
+    // "Comeback" is a badge about the shape of a race rather than its result,
+    // and the shape is only known to the loop that counted it — nothing in the
+    // saved session records the deficit.
+    expect(
+      summarise({ ghost: rival, tally: tally({ maxDeficitMs: 4000 }) })
+        .earnedBadges,
+    ).toContain("comeback");
+    expect(
+      summarise({ ghost: rival, tally: tally({ maxDeficitMs: 500 }) })
+        .earnedBadges,
+    ).not.toContain("comeback");
+  });
+
+  it("counts the cards a player had answered before this race", () => {
+    // The history is snapshotted before this run exists, so the lifetime count
+    // has to add this race to it. Ninety-nine cards behind them and three in
+    // front: the hundredth is in this race.
+    const history = [
+      past({
+        id: "s_1",
+        cards: Array.from({ length: 99 }, () => card(900, true)),
+      }),
+    ];
+    expect(summarise({ history }).earnedBadges).toContain("century");
+    expect(summarise({ history: [] }).earnedBadges).not.toContain("century");
+  });
+});

--- a/src/engine/worlds.test.ts
+++ b/src/engine/worlds.test.ts
@@ -99,15 +99,29 @@ const LINKS = WORLDS.flatMap((world) => [
 
 describe("the worlds", () => {
   it("are the ones the type says exist", () => {
-    // Without this the two comparisons below could both hold over an empty
-    // list: a regex that stopped matching would report every world fine.
+    // Both guards live here rather than inside the sweeps they protect, because
+    // a guard that runs once per case doesn't run at all when there are no
+    // cases. Over an empty list every comparison below holds: a regex that
+    // stopped matching, or a registry that emptied, would report every world
+    // fine and check nothing.
     expect(
       DECLARED.length,
       "no worlds were parsed out of the World union — the check below would pass over an empty list",
     ).toBeGreaterThan(1);
+    expect(
+      LINKS.length,
+      "no world links were found, so the sweep below checked nothing",
+    ).toBeGreaterThan(1);
 
     expect(Object.keys(THEME_COLOUR).sort()).toEqual([...DECLARED].sort());
-    expect(WORLDS.every((world) => DECLARED.includes(world.id))).toBe(true);
+    // Named rather than counted: `every(...)` reports "expected false to be
+    // true" and leaves you to work out which world it meant.
+    expect(
+      WORLDS.filter((world) => !DECLARED.includes(world.id)).map(
+        (world) => world.id,
+      ),
+      "these worlds carry an id the World union doesn't declare",
+    ).toEqual([]);
   });
 
   it.each(DECLARED)(

--- a/src/engine/worlds.test.ts
+++ b/src/engine/worlds.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { THEME_COLOUR, WORLDS, type World } from "./worlds";
+
+/**
+ * The registry both halves of the site read, held to the two things it can't
+ * type-check about itself.
+ *
+ * `THEME_COLOUR` is `Record<World, string>`, so a missing entry is already a
+ * type error — what a type cannot say is whether the colour in it is the one
+ * `worlds.css` paints. Those two are the only duplication in the world system,
+ * and they are duplicated for a reason that isn't going away: `<meta
+ * name="theme-color">` is markup, and markup cannot read a custom property. A
+ * world whose chrome is a shade off its own page is the sort of thing nobody
+ * files a bug about and everybody sees.
+ *
+ * The links are the other half. A world's `href` is what the map, the masthead
+ * and the footer point at, and its `island` is what `astro.config.mjs` keeps
+ * out of the sitemap — a string that no longer matches a page doesn't fail
+ * anything at build time: it just quietly becomes a 404 on the map, or stops
+ * excluding the game route it was there to exclude.
+ *
+ * Both ends are read out of the tree rather than written down here, so a world
+ * added tomorrow is checked tomorrow.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(HERE, "..");
+
+/**
+ * The `World` union, read out of the type rather than off `THEME_COLOUR`.
+ *
+ * Taking the list from the record under test would agree with any record at
+ * all. The type is what the rest of the codebase narrows against, so it is the
+ * side that decides which worlds exist.
+ */
+function declaredWorlds(): string[] {
+  const source = readFileSync(join(SRC, "engine/worlds.ts"), "utf8");
+  const union = /export type World\s*=([\s\S]*?);/.exec(source);
+  return [...(union?.[1] ?? "").matchAll(/"([a-z]+)"/g)].map(
+    (match) => match[1],
+  );
+}
+
+/** What `worlds.css` paints as the darkest ink of each world it dresses. */
+function styledWorlds(): Map<string, string> {
+  const source = readFileSync(join(SRC, "styles/worlds.css"), "utf8");
+  const blocks = source.matchAll(/\[data-world="([a-z]+)"\]\s*\{([^}]*)\}/g);
+  const found = new Map<string, string>();
+  for (const [, world, body] of blocks) {
+    const ink = /--ink-900:\s*(#[0-9a-f]{3,8})/i.exec(body);
+    if (ink) found.set(world, ink[1].toLowerCase());
+  }
+  return found;
+}
+
+/**
+ * Every route this build emits as a page of its own.
+ *
+ * Read off `src/pages/`, which is where Astro decides routes, and not off
+ * `dist/` — the suite has to say the same thing whether or not somebody has
+ * built the site since their last edit, and a check that quietly passes when
+ * `dist/` is missing is worse than none.
+ *
+ * Static routes only: a `[slug]` page emits whatever its `getStaticPaths`
+ * returns, which is a question for the catalog guards. No world has ever
+ * pointed at one, and one that did would fail here rather than be waved
+ * through — which is the right way round for a link on the map.
+ */
+function staticRoutes(dir = join(SRC, "pages"), prefix = ""): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    // `_name.ts` is a helper Astro never routes; `[slug]` is a dynamic one.
+    if (entry.name.startsWith("_") || entry.name.includes("[")) return [];
+    if (entry.isDirectory()) {
+      return staticRoutes(join(dir, entry.name), `${prefix}/${entry.name}`);
+    }
+    if (!entry.name.endsWith(".astro")) return [];
+    const name = entry.name.replace(/\.astro$/, "");
+    return [name === "index" ? prefix || "/" : `${prefix}/${name}`];
+  });
+}
+
+const DECLARED = declaredWorlds();
+const STYLED = styledWorlds();
+const ROUTES = staticRoutes();
+
+/** Every link a world hands out, and what to call it when one is wrong. */
+const LINKS = WORLDS.flatMap((world) => [
+  [`${world.name}'s front door`, world.href] as const,
+  [`${world.name}'s island`, world.island] as const,
+  ...(world.guide
+    ? [[`${world.name}'s guide`, world.guide.href] as const]
+    : []),
+]);
+
+describe("the worlds", () => {
+  it("are the ones the type says exist", () => {
+    // Without this the two comparisons below could both hold over an empty
+    // list: a regex that stopped matching would report every world fine.
+    expect(
+      DECLARED.length,
+      "no worlds were parsed out of the World union — the check below would pass over an empty list",
+    ).toBeGreaterThan(1);
+
+    expect(Object.keys(THEME_COLOUR).sort()).toEqual([...DECLARED].sort());
+    expect(WORLDS.every((world) => DECLARED.includes(world.id))).toBe(true);
+  });
+
+  it.each(DECLARED)(
+    "%s is themed the same colour in the chrome as on the page",
+    (world) => {
+      expect(
+        STYLED.size,
+        "no [data-world] blocks were found in worlds.css",
+      ).toBeGreaterThan(1);
+
+      // The browser chrome joins the page rather than framing it in whatever
+      // the previous world left behind. `THEME_COLOUR` is the only copy of
+      // these seven values outside the stylesheet, and this is the line that
+      // keeps them in step.
+      expect(
+        THEME_COLOUR[world as World],
+        `theme-color for "${world}" and its --ink-900 in worlds.css have drifted apart`,
+      ).toBe(STYLED.get(world));
+    },
+  );
+
+  it.each(LINKS)("%s (%s) is a page this build emits", (what, href) => {
+    // A guard against the walk, not against the worlds: an empty route list
+    // would fail every case below with the same unhelpful message.
+    expect(
+      ROUTES.length,
+      "no pages were found under src/pages/",
+    ).toBeGreaterThan(1);
+
+    expect(
+      ROUTES.includes(href),
+      `${what} points at ${href}, and no page in src/pages/ builds that route. The routes this build emits are:\n  ${[...ROUTES].sort().join("\n  ")}`,
+    ).toBe(true);
+  });
+});

--- a/src/services/hub.test.ts
+++ b/src/services/hub.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  CustomDeck,
+  LegacySession,
+  Profile,
+  Session,
+} from "@/engine/types";
+
+import { freshIndexedDB, loadDb, openVersion2 } from "./storage/fakedb";
+
+/**
+ * The one call every island makes before it can draw anything.
+ *
+ * `loadHub` is three reads and two sorts, which sounds like nothing to test —
+ * except that the whole app is downstream of it. The order it returns decides
+ * the order of the player picker and the record book; the deck read has to go
+ * through the deck *service* rather than the store, because loading is also
+ * what fills the engine's custom-list mirror; and a failure has to arrive as a
+ * message a parent can act on, since `HubContext` renders `err.message` as the
+ * whole of the boot error screen.
+ */
+
+const profile = (id: string, name: string, createdAt: string): Profile => ({
+  id,
+  name,
+  emoji: "🚀",
+  color: "#7c3aed",
+  age: 7,
+  soundOn: true,
+  xp: 0,
+  badges: [],
+  createdAt,
+});
+
+const run = (id: string, finishedAt: string): Session => ({
+  id,
+  profileId: "kid-1",
+  game: "flashcards",
+  mode: "multiply",
+  configKey: "multiply|7|1-12|20|type",
+  config: {
+    operation: "multiply",
+    tables: [7],
+    others: [8],
+    cardCount: 1,
+    inputMode: "type",
+  },
+  seed: 42,
+  finishedAt,
+  durationMs: 1900,
+  correct: 1,
+  incorrect: 0,
+  bestStreak: 1,
+  xpEarned: 55,
+  ghostSessionId: null,
+  beatGhost: null,
+  cards: [
+    {
+      prompt: "7 × 8",
+      answer: "56",
+      given: "56",
+      ok: true,
+      ms: 1900,
+      factId: "7:8",
+    },
+  ],
+});
+
+const deck: CustomDeck = {
+  id: "custom-abc",
+  name: "Week 4 spellings",
+  emoji: "📝",
+  words: ["because", "thought"],
+  createdAt: "2026-03-01T09:00:00.000Z",
+  updatedAt: "2026-03-01T09:00:00.000Z",
+};
+
+/** The hub service and the store under it, on a device with nothing saved. */
+async function fresh() {
+  freshIndexedDB();
+  const store = await loadDb();
+  const hub = await import("./hub");
+  return { hub, store };
+}
+
+describe("loading the hub", () => {
+  it("hands back everything at boot, in the order the screens read it", async () => {
+    const { hub, store } = await fresh();
+    // Written newest-first, and with ids that sort the opposite way to the
+    // dates on them. `getAll` hands records back in key order, so an id that
+    // happened to agree with the date would let a sort on the wrong field —
+    // or no sort at all — look exactly like this one.
+    await store.putProfile(profile("p_a", "Bob", "2026-03-02T09:00:00.000Z"));
+    await store.putProfile(profile("p_z", "Ada", "2026-03-01T09:00:00.000Z"));
+    await store.putSession(run("s_a", "2026-03-05T09:00:00.000Z"));
+    await store.putSession(run("s_z", "2026-03-04T09:00:00.000Z"));
+    await store.putDeck(deck);
+
+    const state = await hub.loadHub();
+
+    // Oldest first, both times. The picker shows players in the order they
+    // joined, and every "your last run" in the app is the end of this list.
+    expect(state.profiles.map((p) => p.name)).toEqual(["Ada", "Bob"]);
+    expect(state.sessions.map((s) => s.id)).toEqual(["s_z", "s_a"]);
+    expect(state.decks).toEqual([deck]);
+  });
+
+  it("reads a run saved before answers became text", async () => {
+    const { hub, store } = await fresh();
+    // Cards from before the widening, put in as they sit on disk today. The
+    // hub is what the record book reads through, so a load that skipped the
+    // migration would hand every screen a numeric answer it no longer types.
+    const legacy: LegacySession = {
+      ...run("s_old", "2026-03-04T09:00:00.000Z"),
+      cards: [
+        {
+          prompt: "7 × 8",
+          answer: 56,
+          given: 56,
+          ok: true,
+          ms: 1900,
+          facts: [7, 8],
+        },
+      ],
+    };
+    await store.putSession(legacy as unknown as Session);
+
+    const [read] = (await hub.loadHub()).sessions;
+    expect(read.cards[0]).toMatchObject({
+      answer: "56",
+      given: "56",
+      factId: "7:8",
+    });
+  });
+
+  it("mirrors a parent's lists into the engine before anything can name one", async () => {
+    const { hub, store } = await fresh();
+    await store.putDeck(deck);
+    const { deckSpec } = await import("@/engine/decks");
+    const { wordMode } = await import("@/engine/decks/words");
+
+    // Before the load the engine has never heard of the list, so a run played
+    // on it reads as the generic "Words" — this is the state the assertion
+    // below has to move away from, and asserting it is what stops that
+    // assertion from being true for some other reason.
+    expect(deckSpec(wordMode(deck.id)).label).toBe("Words");
+
+    await hub.loadHub();
+
+    // The reason `loadHub` calls the deck service rather than the store: the
+    // record book can name a run on a parent's list without the engine ever
+    // learning that storage exists.
+    expect(deckSpec(wordMode(deck.id)).label).toBe("Week 4 spellings");
+  });
+
+  it("gives a device with nothing on it three empty lists", async () => {
+    const { hub } = await fresh();
+    // The first-ever page load. An empty database is the normal state, not an
+    // error state — the app opens on "add a player" from here.
+    expect(await hub.loadHub()).toEqual({
+      profiles: [],
+      sessions: [],
+      decks: [],
+    });
+  });
+
+  it("says why when the database can't be opened", async () => {
+    const { hub } = await fresh();
+    // A tab left open from before this deploy, holding the old version. The
+    // upgrade cannot start while it is there, and the sentence below is the
+    // whole of what a parent sees on the boot screen.
+    const stale = await openVersion2();
+
+    // Rejecting, not resolving empty. A hub that swallowed this would show a
+    // parent an empty player picker over a record book that is still there —
+    // and the obvious next move from that screen is to make a new profile.
+    await expect(hub.loadHub()).rejects.toThrow(/another tab/i);
+    stale.close();
+  });
+});

--- a/src/services/profiles.test.ts
+++ b/src/services/profiles.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { NewProfile } from "./profiles";
+import { freshIndexedDB, loadDb } from "./storage/fakedb";
+
+/**
+ * Profile CRUD, against a real (fake) IndexedDB rather than a mocked store.
+ *
+ * The validation could be exercised as pure functions, but half of what this
+ * service does is only true of the write: a name clash is a question about what
+ * is already in the database, `update` reads the record back before patching
+ * it, and deleting a player has to take their races with them. Mocking the
+ * store would leave every one of those asserting against the mock.
+ *
+ * There is no server to defend, so none of this is a security boundary — it is
+ * the one place a typo becomes a readable sentence instead of a corrupt record,
+ * and the messages are asserted because a parent reads them.
+ */
+
+/** A player as the "add a player" form would hand them over. */
+const ada: NewProfile = {
+  name: "Ada",
+  emoji: "🚀",
+  color: "#7c3aed",
+  age: 7,
+};
+
+// Only the persistence cases stub `navigator`, and a stub that outlived a
+// failing one would silently answer for the rest of the file.
+afterEach(() => vi.unstubAllGlobals());
+
+/** The service and the store under it, on a device with nothing saved. */
+async function fresh() {
+  freshIndexedDB();
+  const store = await loadDb();
+  const profiles = await import("./profiles");
+  return { profiles, store };
+}
+
+describe("creating a player", () => {
+  it("writes a player who starts at nothing", async () => {
+    const { profiles, store } = await fresh();
+
+    const created = await profiles.create(ada);
+    expect(created).toMatchObject({ name: "Ada", emoji: "🚀", age: 7 });
+    // The starting state, which nothing else sets: a new player has no XP, no
+    // badges and their sound on. A missing default here is a child who opens
+    // the game to a silent screen or a level counter that never moves.
+    expect(created).toMatchObject({ xp: 0, badges: [], soundOn: true });
+    expect(created.id.startsWith("p_")).toBe(true);
+    expect(Date.parse(created.createdAt)).not.toBeNaN();
+
+    // Read back from storage rather than trusted from the return value — the
+    // whole point of the service is that the record landed.
+    expect(await store.allProfiles()).toEqual([created]);
+  });
+
+  it("trims what was typed", async () => {
+    const { profiles } = await fresh();
+    const created = await profiles.create({ ...ada, name: "  Ada  " });
+    // Leading space is invisible on the picker and would make "Ada" and " Ada"
+    // two players — and the clash check below would never see it coming.
+    expect(created.name).toBe("Ada");
+  });
+
+  it.each([
+    [{ name: "" }, /empty/i],
+    [{ name: "   " }, /empty/i],
+    [{ name: "x".repeat(25) }, /24 characters/],
+    [{ name: 42 as unknown as string }, /must be text/],
+    [{ emoji: "" }, /empty/i],
+    [{ color: "purple" }, /hex/i],
+    [{ color: "#7c3ae" }, /hex/i],
+    [{ age: 2 }, /between 3 and 18/],
+    [{ age: 19 }, /between 3 and 18/],
+    [{ age: 7.5 }, /whole number/],
+    [{ age: "seven" as unknown as number }, /whole number/],
+  ])("refuses %o", async (bad, message) => {
+    const { profiles, store } = await fresh();
+
+    const refusal = await profiles
+      .create({ ...ada, ...bad })
+      .catch((err: unknown) => err);
+    // The class, because the form catches it to decide whether the message is
+    // showable; and the message, because a parent reads it.
+    expect(refusal).toBeInstanceOf(profiles.InvalidInput);
+    expect((refusal as Error).message).toMatch(message);
+
+    // And nothing was written on the way to the refusal. A half-made profile
+    // would show up on the picker as a player who cannot be raced.
+    expect(await store.allProfiles()).toEqual([]);
+  });
+
+  it("won't let two players share a name, however it is capitalised", async () => {
+    const { profiles } = await fresh();
+    await profiles.create(ada);
+
+    // The name is the only thing on the picker, so two of them is two children
+    // tapping the same-looking card and one of them losing their record book.
+    await expect(profiles.create({ ...ada, name: "ada" })).rejects.toThrow(
+      /already a player called Ada/,
+    );
+    // Named, not just refused: "there's already a player called Ada" is what
+    // tells a parent which card on the picker is the one they meant.
+    expect(await profiles.create({ ...ada, name: "Ada B" })).toMatchObject({
+      name: "Ada B",
+    });
+  });
+
+  it("asks to keep the data only once there is data to keep", async () => {
+    const { profiles } = await fresh();
+    const persist = vi.fn().mockResolvedValue(true);
+    // Chrome grants persistence silently, Firefox prompts. Asking on page load
+    // would be a prompt about nothing; asking here is asking at the moment a
+    // child's progress starts to exist.
+    vi.stubGlobal("navigator", {
+      storage: { persist, persisted: () => Promise.resolve(false) },
+    });
+
+    const created = await profiles.create(ada);
+    await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(1));
+
+    // Editing one isn't the moment — the ask already happened.
+    await profiles.update(created.id, { name: "Ada B" });
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the player when the browser refuses to keep the data", async () => {
+    const { profiles, store } = await fresh();
+    // Safari effectively ignores the request and applies its 7-day cap anyway.
+    // Whatever the answer, it is advisory — a profile that failed to save
+    // because a permission was declined would be a bug about nothing.
+    vi.stubGlobal("navigator", {
+      storage: {
+        persisted: () => Promise.reject(new Error("no")),
+        persist: () => Promise.reject(new Error("no")),
+      },
+    });
+
+    const created = await profiles.create(ada);
+    expect(await store.allProfiles()).toEqual([created]);
+  });
+});
+
+describe("editing a player", () => {
+  it("patches the field it was given and leaves the rest alone", async () => {
+    const { profiles, store } = await fresh();
+    const created = await profiles.create(ada);
+
+    const grown = await profiles.update(created.id, { age: 8 });
+    expect(grown).toEqual({ ...created, age: 8 });
+    expect(await store.allProfiles()).toEqual([grown]);
+  });
+
+  it("still validates the fields the patch does carry", async () => {
+    const { profiles } = await fresh();
+    const created = await profiles.create(ada);
+
+    // Partial means "the absent fields are not being changed", not "the rules
+    // are off" — a patch is the only way a bad value could reach the record.
+    await expect(profiles.update(created.id, { age: 99 })).rejects.toThrow(
+      /between 3 and 18/,
+    );
+    await expect(
+      profiles.update(created.id, { color: "nope" }),
+    ).rejects.toThrow(/hex/i);
+  });
+
+  it("lets a player keep their own name", async () => {
+    const { profiles } = await fresh();
+    const created = await profiles.create(ada);
+    // Saving the editor without touching the name resubmits it, so a clash
+    // check that didn't exclude the player being edited would make every
+    // profile uneditable the moment it was saved once.
+    expect(await profiles.update(created.id, { name: "Ada" })).toMatchObject({
+      name: "Ada",
+    });
+  });
+
+  it("won't rename a player onto another player's name", async () => {
+    const { profiles } = await fresh();
+    await profiles.create(ada);
+    const bob = await profiles.create({ ...ada, name: "Bob" });
+
+    await expect(profiles.update(bob.id, { name: "ADA" })).rejects.toThrow(
+      /already a player called Ada/,
+    );
+  });
+
+  it("refuses a player who isn't there", async () => {
+    const { profiles } = await fresh();
+    // Two tabs, one holding the editor for a profile the other just deleted.
+    await expect(profiles.update("p_gone", { age: 8 })).rejects.toThrow(
+      /No player with that id/,
+    );
+  });
+
+  it("takes settings as settings, not as text", async () => {
+    const { profiles } = await fresh();
+    const created = await profiles.create(ada);
+
+    // `soundOn` is a toggle: whatever the control sent, what lands is a boolean.
+    expect(
+      await profiles.update(created.id, {
+        soundOn: 0 as unknown as boolean,
+      }),
+    ).toMatchObject({ soundOn: false });
+
+    expect(
+      await profiles.update(created.id, { keyboard: "keys" }),
+    ).toMatchObject({ keyboard: "keys" });
+    // Only the three modes are written. Anything else leaves the profile on
+    // whatever it was on, rather than parking a value in storage that the
+    // typing game would have to resolve every time it reads it.
+    expect(
+      await profiles.update(created.id, {
+        keyboard: "sideways" as unknown as "keys",
+      }),
+    ).toMatchObject({ keyboard: "keys" });
+  });
+});
+
+describe("deleting a player", () => {
+  it("takes their races with them", async () => {
+    const { profiles, store } = await fresh();
+    const created = await profiles.create(ada);
+    const other = await profiles.create({ ...ada, name: "Bob" });
+    const run = (id: string, profileId: string) => ({
+      id,
+      profileId,
+      game: "flashcards" as const,
+      mode: "multiply",
+      configKey: "multiply|7|1-12|20|type",
+      config: {
+        operation: "multiply" as const,
+        tables: [7],
+        others: [8],
+        cardCount: 1,
+        inputMode: "type" as const,
+      },
+      seed: 1,
+      finishedAt: "2026-03-02T09:00:00.000Z",
+      durationMs: 1000,
+      correct: 1,
+      incorrect: 0,
+      bestStreak: 1,
+      xpEarned: 10,
+      ghostSessionId: null,
+      beatGhost: null,
+      cards: [],
+    });
+    await store.putSession(run("s_1", created.id));
+    await store.putSession(run("s_2", other.id));
+
+    await profiles.remove(created.id);
+
+    expect(await store.allProfiles()).toEqual([other]);
+    // Their runs go, and only theirs. A session left pointing at a profile id
+    // that no longer resolves renders as a ghost player in every screen that
+    // groups by profile.
+    expect((await store.allSessions()).map((s) => s.id)).toEqual(["s_2"]);
+  });
+});

--- a/src/services/sessions.test.ts
+++ b/src/services/sessions.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { CardResult, Profile, Session } from "@/engine/types";
+
+import type { SessionDraft } from "./sessions";
+import { freshIndexedDB, loadDb } from "./storage/fakedb";
+
+/**
+ * Banking a finished race.
+ *
+ * The one write that touches two records at once — the run, plus the XP and
+ * badges it earned on the player — so it is exercised against a real (fake)
+ * IndexedDB: what "atomic" means here is a property of the transaction, and a
+ * mocked store would only ever prove that two functions were called.
+ *
+ * `summariseRun` (engine/run.ts) decides what a run is worth; this decides what
+ * is kept. The split matters to the assertions below: everything derived is
+ * asserted there, and everything written is asserted here.
+ */
+
+const ada: Profile = {
+  id: "kid-1",
+  name: "Ada",
+  emoji: "🚀",
+  color: "#7c3aed",
+  age: 7,
+  soundOn: true,
+  xp: 340,
+  badges: ["green-light"],
+  createdAt: "2026-03-01T09:00:00.000Z",
+};
+
+const card: CardResult = {
+  prompt: "7 × 8",
+  answer: "56",
+  given: "56",
+  ok: true,
+  ms: 1900,
+  factId: "7:8",
+};
+
+const run: Omit<Session, "id" | "finishedAt"> = {
+  profileId: ada.id,
+  game: "flashcards",
+  mode: "multiply",
+  configKey: "multiply|7|1-12|20|type",
+  config: {
+    operation: "multiply",
+    tables: [7],
+    others: [8],
+    cardCount: 1,
+    inputMode: "type",
+  },
+  seed: 42,
+  durationMs: 1900,
+  correct: 1,
+  incorrect: 0,
+  bestStreak: 1,
+  xpEarned: 55,
+  ghostSessionId: null,
+  beatGhost: null,
+  cards: [card],
+};
+
+/** A run as `summariseRun` hands it over: no id, no finish time, badges named. */
+const draft = (over: Partial<SessionDraft> = {}): SessionDraft => ({
+  ...run,
+  earnedBadges: [],
+  ...over,
+});
+
+/** A run already in the record book, banked `at` milliseconds into 2026. */
+const stored = (
+  id: string,
+  at: number,
+  over: Partial<Session> = {},
+): Session => ({
+  ...run,
+  id,
+  finishedAt: new Date(Date.UTC(2026, 0, 1) + at).toISOString(),
+  ...over,
+});
+
+/** The service and the store under it, with Ada already on the picker. */
+async function fresh(profile: Profile = ada) {
+  freshIndexedDB();
+  const store = await loadDb();
+  await store.putProfile(profile);
+  const sessions = await import("./sessions");
+  return { sessions, store };
+}
+
+describe("recording a run", () => {
+  it("banks the run and the XP it earned together", async () => {
+    const { sessions, store } = await fresh();
+
+    const { session, profile } = await sessions.record(
+      draft({ earnedBadges: ["green-light", "clean-sheet"] }),
+    );
+
+    expect(session.id.startsWith("s_")).toBe(true);
+    // The service stamps the finish time, not the caller: a clock the race loop
+    // passed in would let a paused tab file a run under when it started.
+    expect(Date.parse(session.finishedAt)).not.toBeNaN();
+    expect(await store.allSessions()).toEqual([session]);
+
+    // XP adds up and badges are a set — "green-light" was already held, and a
+    // second copy would show as a duplicate on the badge shelf forever.
+    expect(profile.xp).toBe(340 + 55);
+    expect(profile.badges).toEqual(["green-light", "clean-sheet"]);
+    // Both halves landed. Splitting them would let a crash bank the run and
+    // lose the XP it paid for.
+    expect(await store.allProfiles()).toEqual([profile]);
+  });
+
+  it("starts a player who predates XP at zero rather than at NaN", async () => {
+    // A profile written before XP and badges existed has neither field. One
+    // `undefined + 55` here and a child's level reads NaN from then on.
+    const { sessions } = await fresh({
+      ...ada,
+      xp: undefined as unknown as number,
+      badges: undefined as unknown as string[],
+    });
+
+    const { profile } = await sessions.record(
+      draft({ earnedBadges: ["green-light"] }),
+    );
+    expect(profile.xp).toBe(55);
+    expect(profile.badges).toEqual(["green-light"]);
+  });
+
+  it("stores a whole number of milliseconds", async () => {
+    const { sessions } = await fresh();
+    // Times are summed from `performance.now()`, which is fractional. Every
+    // comparison the record book makes is on this number.
+    const { session } = await sessions.record(draft({ durationMs: 1900.6 }));
+    expect(session.durationMs).toBe(1901);
+  });
+
+  it("caps how much card history one run can carry", async () => {
+    const { sessions } = await fresh();
+    const { session } = await sessions.record(
+      draft({ cards: Array.from({ length: 600 }, () => card) }),
+    );
+    // A malformed deck must not be able to grow a single record without bound —
+    // this is the only copy of the record book there is, and it is all read at
+    // boot.
+    expect(session.cards).toHaveLength(500);
+  });
+
+  it("refuses a run for a player who is gone, and writes nothing", async () => {
+    const { sessions, store } = await fresh();
+    // Two tabs: one finishes a race for a player the other has just deleted.
+    await expect(
+      sessions.record(draft({ profileId: "p_gone" })),
+    ).rejects.toThrow(/no longer exists/i);
+    expect(await store.allSessions()).toEqual([]);
+    // And the run didn't pay its XP to somebody else on the way past.
+    expect(await store.allProfiles()).toEqual([ada]);
+  });
+
+  it("drops the oldest run when a player is at the cap, and only theirs", async () => {
+    const { sessions, store } = await fresh();
+    // Ada is filled to the cap exactly, so the run recorded below is the one
+    // that pushes her over. Seeded through the store rather than through
+    // `record`: what is being tested is the trim, not two thousand round trips.
+    for (let i = 0; i < store.MAX_SESSIONS_PER_PROFILE; i++) {
+      await store.putSession(stored(`s_ada${i}`, i * 1000));
+    }
+    await store.putProfile({ ...ada, id: "kid-2", name: "Bob" });
+    for (let i = 0; i < 3; i++) {
+      await store.putSession(
+        stored(`s_bob${i}`, i * 1000, {
+          profileId: "kid-2",
+        }),
+      );
+    }
+
+    const { session } = await sessions.record(draft());
+
+    // Trimming happens after the commit rather than inside it, so the run is
+    // already safe by the time this settles — hence the wait. Ada being back at
+    // the cap is also what says the trim has run at all, which is what makes
+    // the assertion about Bob below a real one rather than a race won early.
+    await vi.waitFor(async () => {
+      const kept = await store.allSessions();
+      const mine = kept.filter((s) => s.profileId === ada.id);
+      expect(mine).toHaveLength(store.MAX_SESSIONS_PER_PROFILE);
+      const ids = mine.map((s) => s.id);
+      // The oldest went and the new one stayed. Trimming the wrong end would
+      // quietly delete a run a child had just finished.
+      expect(ids).not.toContain("s_ada0");
+      expect(ids).toContain("s_ada1");
+      expect(ids).toContain(session.id);
+
+      // The cap is per player. A sibling filling their own record book must not
+      // cost this one a single race, in either direction.
+      expect(
+        kept.filter((s) => s.profileId === "kid-2").map((s) => s.id),
+      ).toEqual(["s_bob0", "s_bob1", "s_bob2"]);
+    });
+  });
+});

--- a/src/services/storage/db.test.ts
+++ b/src/services/storage/db.test.ts
@@ -1,39 +1,30 @@
-import {
-  IDBCursor,
-  IDBDatabase,
-  IDBFactory,
-  IDBIndex,
-  IDBKeyRange,
-  IDBObjectStore,
-  IDBRequest,
-  IDBTransaction,
-} from "fake-indexeddb";
 import { openDB, type IDBPDatabase } from "idb";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { DEFAULT_FONT_PT, DEFAULT_PAPER } from "@/engine/sheets/paper";
 import type { SavedInventory } from "@/engine/sheets/phonics";
 import type { SavedSheet } from "@/engine/sheets/types";
 import type { CustomDeck, Profile, Session } from "@/engine/types";
 
+import { freshIndexedDB, loadDb, openVersion2 } from "./fakedb";
+
 /**
  * The store itself, against a fake IndexedDB.
  *
- * The one file in the suite that opens a database, and it exists because this
- * layer holds the only copy of a child's record book there is. An upgrade that
- * dropped a store, an index that came back missing, or a backup that restored
- * four of five collections cannot be caught by reading the diff — the failure
- * is in what the browser did with the data, not in what the code says.
+ * The only suite that opens one at a version this build no longer writes, and
+ * it exists because this layer holds the only copy of a child's record book
+ * there is. An upgrade that dropped a store, an index that came back missing,
+ * or a backup that restored four of five collections cannot be caught by
+ * reading the diff — the failure is in what the browser did with the data, not
+ * in what the code says.
  *
  * `fake-indexeddb` rather than the browser suite: the interesting case is a
  * database that already has data in it *at the old version*, which means
  * building version 2 by hand before the app ever opens it. There is no way to
  * arrange that from a page that has already booted.
  *
- * Every case starts from a brand-new `IDBFactory` and a fresh module registry,
- * because `db.ts` memoises its connection and exports no way to drop it — which
- * is right for the app and means a test that reused it could only ever see
- * whatever version the first case happened to open.
+ * Every case starts from a brand-new database and a fresh module registry —
+ * see `fakedb.ts`, which is where that is arranged and why.
  */
 
 const profile: Profile = {
@@ -118,51 +109,11 @@ const inventory: SavedInventory = {
 const EXPORTED_AT = "2026-03-03T09:00:00.000Z";
 
 /**
- * Node has no IndexedDB at all, so the whole family goes on the global object
- * rather than only the factory: `idb` unwraps what a request hands back by
- * asking `instanceof IDBDatabase`, `instanceof IDBCursor` and so on, and a fake
- * factory whose results fail every one of those checks is worse than none.
- */
-Object.assign(globalThis, {
-  IDBCursor,
-  IDBDatabase,
-  IDBFactory,
-  IDBIndex,
-  IDBKeyRange,
-  IDBObjectStore,
-  IDBRequest,
-  IDBTransaction,
-});
-
-/** A device nobody has ever run School Skills on. */
-function freshIndexedDB(): void {
-  globalThis.indexedDB = new IDBFactory();
-}
-
-/** `db.ts` as the browser would load it on that device. */
-async function loadDb() {
-  vi.resetModules();
-  return import("./db");
-}
-
-/**
- * The database exactly as version 2 shipped it, with a kid's data already in
- * it — written by hand rather than by an older copy of `db.ts`, because the
- * point is to upgrade *from what is on disk*, not from what this build would
- * have created. The connection is left open for the caller to close: a tab
- * that never lets go is one of the cases below.
+ * Version 2 with a kid's data already in it. The connection is left open for
+ * the caller to close: a tab that never lets go is one of the cases below.
  */
 async function seedVersion2(): Promise<IDBPDatabase> {
-  const old = await openDB("schoolskills", 2, {
-    upgrade(database) {
-      database.createObjectStore("profiles", { keyPath: "id" });
-      const sessions = database.createObjectStore("sessions", {
-        keyPath: "id",
-      });
-      sessions.createIndex("byProfile", "profileId");
-      database.createObjectStore("decks", { keyPath: "id" });
-    },
-  });
+  const old = await openVersion2();
   await old.put("profiles", profile);
   await old.put("sessions", session);
   await old.put("decks", deck);

--- a/src/services/storage/fakedb.ts
+++ b/src/services/storage/fakedb.ts
@@ -1,0 +1,80 @@
+import {
+  IDBCursor,
+  IDBDatabase,
+  IDBFactory,
+  IDBIndex,
+  IDBKeyRange,
+  IDBObjectStore,
+  IDBRequest,
+  IDBTransaction,
+} from "fake-indexeddb";
+import { openDB, type IDBPDatabase } from "idb";
+import { vi } from "vitest";
+
+/**
+ * A browser's IndexedDB, for the suites that have to write to one.
+ *
+ * Test-only, and never in a bundle — nothing outside a `.test.ts` imports it.
+ * Not named `.test.ts` because it holds no tests, and vitest fails a test file
+ * that defines none. It lives in `storage/` rather than beside the suites
+ * because what it fakes is this directory's dependency: `db.ts` is the only
+ * module allowed to open a database, so it is the only module that needs one
+ * faked out from under it.
+ *
+ * Node has no IndexedDB at all, so the whole family goes on the global object
+ * rather than only the factory: `idb` unwraps what a request hands back by
+ * asking `instanceof IDBDatabase`, `instanceof IDBCursor` and so on, and a fake
+ * factory whose results fail every one of those checks is worse than none.
+ */
+Object.assign(globalThis, {
+  IDBCursor,
+  IDBDatabase,
+  IDBFactory,
+  IDBIndex,
+  IDBKeyRange,
+  IDBObjectStore,
+  IDBRequest,
+  IDBTransaction,
+});
+
+/** A device nobody has ever run School Skills on. */
+export function freshIndexedDB(): void {
+  globalThis.indexedDB = new IDBFactory();
+}
+
+/**
+ * `db.ts` as the browser would load it on that device.
+ *
+ * The module registry is dropped first because `db.ts` memoises its connection
+ * and exports no way to let go of it — which is right for the app, and means a
+ * suite that reused the module could only ever see whatever database the first
+ * case happened to open. Anything imported *after* this resolves binds to the
+ * fresh copy, which is how a service above the store is exercised against it:
+ * `freshIndexedDB(); await loadDb(); const profiles = await import("../profiles")`.
+ */
+export async function loadDb(): Promise<typeof import("./db")> {
+  vi.resetModules();
+  return import("./db");
+}
+
+/**
+ * The database exactly as version 2 shipped it, and nothing in it.
+ *
+ * The schema is written out by hand rather than built by an older copy of
+ * `db.ts`, because what an upgrade has to survive is what is *on disk* — not
+ * what this build would have created. Version 2 is the shape every existing
+ * browser is upgrading from, so it is also the stale tab: a connection at the
+ * old version blocks the new one, and the caller decides when to let go.
+ */
+export async function openVersion2(): Promise<IDBPDatabase> {
+  return openDB("schoolskills", 2, {
+    upgrade(database) {
+      database.createObjectStore("profiles", { keyPath: "id" });
+      const sessions = database.createObjectStore("sessions", {
+        keyPath: "id",
+      });
+      sessions.createIndex("byProfile", "profileId");
+      database.createObjectStore("decks", { keyPath: "id" });
+    },
+  });
+}


### PR DESCRIPTION
## What this does

Puts a test behind the seven load-bearing modules that had no colocated test: the three services that own a child's records (`profiles`, `sessions`, `hub`), the deck front door (`decks/index.ts`) and the `DeckSpec` contract behind it, run construction, and the world registry.

Closes #215.

> Note: issue #215's title is copy-pasted from another card in the epic — its body is the untested front doors, which is what this PR delivers.

## The sweeps are derived, and each one is guarded against checking nothing

`deckSpec` is checked against every mode this build can file a run under, read out of `OPERATIONS`, `SHIPPED_LISTS`, `TYPING_LEVELS` and `LESSONS` — so a list or lesson added tomorrow is covered the day it lands. The worlds are read out of the `World` union and `src/pages/`.

A derived sweep that loops zero times reports green while checking nothing, so **each one carries a named guard that runs outside the sweep**:

- Emptying `SHIPPED_LISTS` reports "no words modes were found, so the sweep below checked nothing".
- Making the `World` union unparseable reports "no worlds were parsed out of the World union".
- Emptying `WORLDS` reports "no world links were found, so the sweep below checked nothing: expected 0 to be greater than 1".

The `FAMILIES` table in `decks/index.test.ts` is written out in the file rather than derived, so its per-family guard runs once per literal entry; deriving that table from the `RaceConfig` union is filed as a follow-up, not done here.

## Every new assertion was proven to fail

Not "should fail" — each was broken and the reported message recorded: the profile default that went missing (`soundOn: false` against `soundOn: true`), the case-insensitive name clash, the persistence request never made ("expected vi.fn() to be called 1 times, but got 0 times"), the rounding, the 500-card cap, the badge set that grew a duplicate, the trim that took `s_ada0` from the wrong end, the hub swallowing a stale-tab failure ("promise resolved instead of rejecting"), a word deck moved to the wrong world (12 modes named), a normalise that stopped being idempotent (105 cases named), the first run counted as a personal best, a solo run recorded as a loss, a theme colour drifted from its `--ink-900`, and a world linking at a page that does not exist — which prints the routes the build does emit.

## Review found a suite claiming coverage it did not have

Worth calling out on its own. `run.test.ts`'s header claimed the suite would catch a summary that judged badges on the XP a player had *before* the race. **It would not.** Changing `xpAfter: profile.xp + xpEarned` to `xpAfter: profile.xp` passed all 2,809 tests.

`xpAfter` is the only input to the "Double Digits" badge, so that bug pays a child their level-10 badge one race late, in silence. Rather than delete the claim, this PR adds the two-sided coverage for it — matching the record-setter and comeback cases: a profile one race short of the level-10 line earns it, and the same profile one XP further back does not. Under the mutation the new case reports "expected [ 'green-light' ] to include 'level-10'". The threshold is asked of `levelFromXp` rather than transcribed, so the case follows the XP curve if it ever moves.

## One source change

It is the invariant the story names. `deckSpec` did not in fact answer for every mode: `OPERATIONS[mode] ?? UNKNOWN_DECK` hands back `Object.prototype.constructor` for `mode === "constructor"` — not nullish, so not treated as a retired deck, and a crash on the first `masteryKey` rather than a readable row. A backup file is restored exactly as written and never validated, so any string can reach there. Now `Object.hasOwn`.

## Notes

The service suites run against `fake-indexeddb` rather than a mocked store, because what is being tested is what landed: the atomic commit of a run and the XP it paid, the per-player session cap, the cascade that takes a deleted player's races with them. The harness `db.test.ts` had inline is now `storage/fakedb.ts`, shared by four suites.

## Validation

`type-check`, `lint`, `test:unit`, `build`, `format:check`, `section-guard`, the bundle budget guard from #212, and the browser smoke test all pass locally.

**2,810 tests in 2.7s, up from 2,484.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
