### PR TITLE
Let the registry be the only way in to a sheet builder

### DIFF
--- a/src/engine/sheets/blank.ts
+++ b/src/engine/sheets/blank.ts
@@ -26,7 +26,7 @@ import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "./spec";
 const HEADER_HEIGHT = inches(1);
 const FOOTER_HEIGHT = inches(0.25);
 
-export function buildBlankSheet(config: BlankConfig, seed: number): Sheet {
+function buildBlankSheet(config: BlankConfig, seed: number): Sheet {
   return {
     paper: config.paper,
     fontPt: config.fontPt,

--- a/src/engine/sheets/grammar/grammar.ts
+++ b/src/engine/sheets/grammar/grammar.ts
@@ -518,7 +518,7 @@ function headerOf(config: GrammarConfig): SheetOptions {
 }
 
 /** One line naming what the sheet holds, in the terms it was chosen by. */
-export function describeGrammar(config: GrammarConfig): string {
+function describeGrammar(config: GrammarConfig): string {
   const topic = topicOf(config.topic);
   // What the sheet will print rather than what was asked for, and by the same
   // arithmetic the build uses — a line that promised twenty over a page of
@@ -534,7 +534,7 @@ export function describeGrammar(config: GrammarConfig): string {
 
 /* ── The sheet ─────────────────────────────────────────────────────────── */
 
-export function buildGrammarSheet(config: GrammarConfig, seed: number): Sheet {
+function buildGrammarSheet(config: GrammarConfig, seed: number): Sheet {
   const head = headerOf(config);
   const { blocks, outOf } = bodyOf(config, seed);
 

--- a/src/engine/sheets/maths/arithmetic.ts
+++ b/src/engine/sheets/maths/arithmetic.ts
@@ -536,7 +536,7 @@ function headerOf(config: ArithmeticConfig): SheetOptions {
  * sheet matches the lesson: whether it carries, and whether the sum is written
  * along a line or worked in columns.
  */
-export function describeArithmetic(config: ArithmeticConfig): string {
+function describeArithmetic(config: ArithmeticConfig): string {
   const REGROUPING: Record<Regrouping, string | null> = {
     either: null,
     never: "no regrouping",
@@ -562,10 +562,7 @@ export function describeArithmetic(config: ArithmeticConfig): string {
     .join(" — ");
 }
 
-export function buildArithmeticSheet(
-  config: ArithmeticConfig,
-  seed: number,
-): Sheet {
+function buildArithmeticSheet(config: ArithmeticConfig, seed: number): Sheet {
   const items = arithmeticProblems(config, seed);
   const { columns } = arithmeticLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/decimals.ts
+++ b/src/engine/sheets/maths/decimals.ts
@@ -480,7 +480,7 @@ function headerOf(config: DecimalConfig): SheetOptions {
  * matches the lesson: how far past the point the numbers go, and whether the
  * sum is written along a line or worked in columns.
  */
-export function describeDecimals(config: DecimalConfig): string {
+function describeDecimals(config: DecimalConfig): string {
   return [
     titleOf(config),
     config.style === "percent" ? null : PLACE_NAME[placesOf(config)],
@@ -490,7 +490,7 @@ export function describeDecimals(config: DecimalConfig): string {
     .join(" — ");
 }
 
-export function buildDecimalSheet(config: DecimalConfig, seed: number): Sheet {
+function buildDecimalSheet(config: DecimalConfig, seed: number): Sheet {
   const items = decimalProblems(config, seed);
   const { columns } = decimalLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/fractions.ts
+++ b/src/engine/sheets/maths/fractions.ts
@@ -518,7 +518,7 @@ const MODEL_NAME = {
  * matches the lesson: which pictures a naming sheet draws, and how far up the
  * denominators go.
  */
-export function describeFractions(config: FractionConfig): string {
+function describeFractions(config: FractionConfig): string {
   const pool = denominatorsOf(config);
   return [
     titleOf(config),
@@ -532,10 +532,7 @@ export function describeFractions(config: FractionConfig): string {
     .join(" — ");
 }
 
-export function buildFractionSheet(
-  config: FractionConfig,
-  seed: number,
-): Sheet {
+function buildFractionSheet(config: FractionConfig, seed: number): Sheet {
   const items = fractionProblems(config, seed);
   const { columns } = fractionLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/geometry.ts
+++ b/src/engine/sheets/maths/geometry.ts
@@ -536,7 +536,7 @@ function headerOf(config: GeometryConfig): SheetOptions {
  * runs, which is the difference between a sheet a child does in their head and
  * one they need paper for.
  */
-export function describeGeometry(config: GeometryConfig): string {
+function describeGeometry(config: GeometryConfig): string {
   const title = titleOf(config);
   if (config.style === "coordinates") {
     return `${title} — ${Math.floor(config.quadrants ?? 1) === 4 ? "four quadrants" : "the first quadrant"}`;
@@ -550,10 +550,7 @@ export function describeGeometry(config: GeometryConfig): string {
   ].join(" — ");
 }
 
-export function buildGeometrySheet(
-  config: GeometryConfig,
-  seed: number,
-): Sheet {
+function buildGeometrySheet(config: GeometryConfig, seed: number): Sheet {
   const { items, marks } = geometryProblems(config, seed);
   const { columns, plane } = geometryLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/integers.ts
+++ b/src/engine/sheets/maths/integers.ts
@@ -648,7 +648,7 @@ function headerOf(config: IntegerConfig): SheetOptions {
  * What the title leaves off is the one thing that decides whether the sheet is
  * this term's work or last term's: whether there are minus signs on it at all.
  */
-export function describeIntegers(config: IntegerConfig): string {
+function describeIntegers(config: IntegerConfig): string {
   const { max } = bounds(config.range);
   return [
     titleOf(config),
@@ -660,7 +660,7 @@ export function describeIntegers(config: IntegerConfig): string {
     .join(" — ");
 }
 
-export function buildIntegerSheet(config: IntegerConfig, seed: number): Sheet {
+function buildIntegerSheet(config: IntegerConfig, seed: number): Sheet {
   const items = integerProblems(config, seed);
   const { columns } = integerLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/measure.ts
+++ b/src/engine/sheets/maths/measure.ts
@@ -324,7 +324,7 @@ function headerOf(config: MeasureConfig): SheetOptions {
  * the whole of whether a sheet matches the lesson: "metric units of length" is
  * millimetres one week and kilometres the next.
  */
-export function describeMeasure(config: MeasureConfig): string {
+function describeMeasure(config: MeasureConfig): string {
   const system = systemOf(config);
   const pool = quantitiesOf(config);
   if (pool.length === 0) return titleOf(config);
@@ -337,7 +337,7 @@ export function describeMeasure(config: MeasureConfig): string {
   return `${titleOf(config)} — ${said}`;
 }
 
-export function buildMeasureSheet(config: MeasureConfig, seed: number): Sheet {
+function buildMeasureSheet(config: MeasureConfig, seed: number): Sheet {
   const items = measureProblems(config, seed);
   const { columns } = measureLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/money.ts
+++ b/src/engine/sheets/maths/money.ts
@@ -354,7 +354,7 @@ function headerOf(config: MoneyConfig): SheetOptions {
  * they are stacked — which is the difference between a sheet a child adds in
  * their head and one they work in columns.
  */
-export function describeMoney(config: MoneyConfig): string {
+function describeMoney(config: MoneyConfig): string {
   const money = currencyOf(config);
   const { max } = bounds(config.range);
   return [
@@ -366,7 +366,7 @@ export function describeMoney(config: MoneyConfig): string {
     .join(" — ");
 }
 
-export function buildMoneySheet(config: MoneyConfig, seed: number): Sheet {
+function buildMoneySheet(config: MoneyConfig, seed: number): Sheet {
   const items = moneyProblems(config, seed);
   const { columns } = moneyLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/multiplication.ts
+++ b/src/engine/sheets/maths/multiplication.ts
@@ -587,7 +587,7 @@ function headerOf(config: MultiplicationConfig): SheetOptions {
  * sheet matches the lesson: how the problem is written down, and — for a long
  * form — how big the numbers are.
  */
-export function describeMultiplication(config: MultiplicationConfig): string {
+function describeMultiplication(config: MultiplicationConfig): string {
   const digits = longDigits(config);
   // "8 tricky facts" is the race's own phrase for the same list — see
   // `describeFlashConfig` — so a drill that was printed and one that was raced
@@ -637,7 +637,7 @@ function bodyOf(
   };
 }
 
-export function buildMultiplicationSheet(
+function buildMultiplicationSheet(
   config: MultiplicationConfig,
   seed: number,
 ): Sheet {

--- a/src/engine/sheets/maths/prealgebra.ts
+++ b/src/engine/sheets/maths/prealgebra.ts
@@ -716,7 +716,7 @@ function headerOf(config: PreAlgebraConfig): SheetOptions {
  * minus signs on it, which is the difference between this term's sheet and last
  * term's — and, on a graph, how much of the plane a child has to read.
  */
-export function describePreAlgebra(config: PreAlgebraConfig): string {
+function describePreAlgebra(config: PreAlgebraConfig): string {
   const title = titleOf(config);
   // A graph sheet takes neither of the other two: how far the plane runs is
   // what decides how hard it is, and `negatives` has nothing to say — a line
@@ -735,10 +735,7 @@ export function describePreAlgebra(config: PreAlgebraConfig): string {
   ].join(" — ");
 }
 
-export function buildPreAlgebraSheet(
-  config: PreAlgebraConfig,
-  seed: number,
-): Sheet {
+function buildPreAlgebraSheet(config: PreAlgebraConfig, seed: number): Sheet {
   const { items, marks } = preAlgebraProblems(config, seed);
   const { columns, plane } = preAlgebraLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/ratio.ts
+++ b/src/engine/sheets/maths/ratio.ts
@@ -299,11 +299,11 @@ function headerOf(config: RatioConfig): SheetOptions {
  * What the title leaves off is the size of the numbers, which on this family is
  * the difference between a sheet done in the head and one done on paper.
  */
-export function describeRatio(config: RatioConfig): string {
+function describeRatio(config: RatioConfig): string {
   return `${titleOf(config)} — numbers to ${bounds(config.range).max}`;
 }
 
-export function buildRatioSheet(config: RatioConfig, seed: number): Sheet {
+function buildRatioSheet(config: RatioConfig, seed: number): Sheet {
   const items = ratioProblems(config, seed);
   const { columns } = ratioLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/statistics.ts
+++ b/src/engine/sheets/maths/statistics.ts
@@ -409,7 +409,7 @@ function headerOf(config: StatisticsConfig): SheetOptions {
  * off — and, on an even-sized set, it is a different question rather than a
  * harder one: the median lands between two numbers rather than on one.
  */
-export function describeStatistics(config: StatisticsConfig): string {
+function describeStatistics(config: StatisticsConfig): string {
   return [
     titleOf(config),
     // What the sets on the page actually hold, which a narrow range can make
@@ -419,10 +419,7 @@ export function describeStatistics(config: StatisticsConfig): string {
   ].join(" — ");
 }
 
-export function buildStatisticsSheet(
-  config: StatisticsConfig,
-  seed: number,
-): Sheet {
+function buildStatisticsSheet(config: StatisticsConfig, seed: number): Sheet {
   const items = statisticsProblems(config, seed);
   const { columns } = statisticsLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/time.ts
+++ b/src/engine/sheets/maths/time.ts
@@ -336,13 +336,13 @@ function headerOf(config: TimeConfig): SheetOptions {
  * is the difference between a sheet a child counts on their fingers and one they
  * work out.
  */
-export function describeTime(config: TimeConfig): string {
+function describeTime(config: TimeConfig): string {
   if (config.style !== "elapsed") return titleOf(config);
   const { max } = spanOf(config, stepOf(config));
   return `${titleOf(config)} — up to ${durationText(max)}`;
 }
 
-export function buildTimeSheet(config: TimeConfig, seed: number): Sheet {
+function buildTimeSheet(config: TimeConfig, seed: number): Sheet {
   const items = timeProblems(config, seed);
   const { columns } = timeLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/maths/wordproblems.ts
+++ b/src/engine/sheets/maths/wordproblems.ts
@@ -695,16 +695,13 @@ function headerOf(config: WordProblemConfig): SheetOptions {
  * Which topics are on the page is the whole of whether a sheet matches the
  * lesson, and it is exactly what the title of a mixed sheet leaves off.
  */
-export function describeWordProblems(config: WordProblemConfig): string {
+function describeWordProblems(config: WordProblemConfig): string {
   const pool = topicsOf(config);
   if (pool.length <= 1) return titleOf(config);
   return `${titleOf(config)} — ${pool.map((topic) => TOPIC_NAME[topic]).join(", ")}`;
 }
 
-export function buildWordProblemSheet(
-  config: WordProblemConfig,
-  seed: number,
-): Sheet {
+function buildWordProblemSheet(config: WordProblemConfig, seed: number): Sheet {
   const items = wordProblems(config, seed);
   const { columns } = wordLayout(config);
   const head = headerOf(config);

--- a/src/engine/sheets/phonics/sheets.ts
+++ b/src/engine/sheets/phonics/sheets.ts
@@ -659,7 +659,7 @@ function headerOf(config: PhonicsConfig): SheetOptions {
 }
 
 /** One line naming what the sheet holds, in the terms it was chosen by. */
-export function describePhonics(config: PhonicsConfig): string {
+function describePhonics(config: PhonicsConfig): string {
   const style = styleOf(config);
   const [one, many] = THINGS[style];
   const asked = wantedOf(config);
@@ -673,7 +673,7 @@ export function describePhonics(config: PhonicsConfig): string {
 
 /* ── The sheet ─────────────────────────────────────────────────────────── */
 
-export function buildPhonicsSheet(config: PhonicsConfig, seed: number): Sheet {
+function buildPhonicsSheet(config: PhonicsConfig, seed: number): Sheet {
   const head = headerOf(config);
   const { blocks, outOf } = bodyOf(config, seed);
 

--- a/src/engine/sheets/spec.ts
+++ b/src/engine/sheets/spec.ts
@@ -63,6 +63,14 @@ export const LONGEST_SHEET_URL: string = WORLDS.map((world) =>
  *
  * Behaviour only: what a family is called and which `kind` reaches it are in
  * `SheetFamily`, because the picker names every family without loading one.
+ *
+ * **The functions a family fills these in with are its own — not exported.**
+ * The spec is the whole of what a family offers, and `index.ts` is how a caller
+ * reaches one. An exported `buildArithmeticSheet` would be a second door past
+ * the registry, and it would also hide drift: `noUnusedLocals` has nothing to
+ * say about an export, so a builder that fell out of its own spec would go on
+ * looking used forever. Export one only if a test needs it directly, and say so
+ * on the line above it.
  */
 export type SheetSpec<C extends SheetConfig = SheetConfig> = {
   world: World;

--- a/src/engine/sheets/templates/cards.ts
+++ b/src/engine/sheets/templates/cards.ts
@@ -327,7 +327,7 @@ const cardBox = (config: CardsConfig): Box => {
 /** Nothing on this shelf withholds anything — see `formKeyed`. */
 export const cardsKeyed = (): boolean => false;
 
-export function buildCardsSheet(config: CardsConfig, seed: number): Sheet {
+function buildCardsSheet(config: CardsConfig, seed: number): Sheet {
   const box = cardBox(config);
   const grid = cardGrid(config, box);
   const faces = cardFaces(config, grid.columns * grid.rows);
@@ -386,7 +386,7 @@ export const inchLabel = (mil: Mil): string =>
  * one page of them from another. The catalog pages quote both, and
  * `_templates.test.ts` holds the prose to what the block draws.
  */
-export function describeCards(config: CardsConfig): string {
+function describeCards(config: CardsConfig): string {
   const grid = cardGrid(config, cardBox(config));
   const name = own(TITLE, config.style, TITLE.flashcard);
   if (grid.card.width <= 0) return `${name} — too small to cut on this paper`;

--- a/src/engine/sheets/templates/charts.ts
+++ b/src/engine/sheets/templates/charts.ts
@@ -392,7 +392,7 @@ function headerOf(config: ChartConfig): SheetOptions {
 const chartBox = (config: ChartConfig): Box =>
   sheetBlockBox(headerOf(config), false, { note: "Answer key" });
 
-export function buildChartSheet(config: ChartConfig, seed: number): Sheet {
+function buildChartSheet(config: ChartConfig, seed: number): Sheet {
   const box = chartBox(config);
 
   return {
@@ -444,7 +444,7 @@ function chartBlocks(config: ChartConfig, box: Box): Block[] {
  * One line naming the sheet, in the words a teacher says out loud — with the
  * number that makes it the sheet somebody asked for rather than one like it.
  */
-export function describeChart(config: ChartConfig): string {
+function describeChart(config: ChartConfig): string {
   const box = chartBox(config);
   switch (config.style) {
     case "number-line": {

--- a/src/engine/sheets/templates/forms.ts
+++ b/src/engine/sheets/templates/forms.ts
@@ -453,7 +453,7 @@ function formBlocks(config: FormConfig, box: Box): Block[] {
   }
 }
 
-export function buildFormSheet(config: FormConfig, seed: number): Sheet {
+function buildFormSheet(config: FormConfig, seed: number): Sheet {
   const box = formBox(config, seed);
 
   return {
@@ -474,8 +474,8 @@ export function buildFormSheet(config: FormConfig, seed: number): Sheet {
  * One line naming the sheet, in the words a parent says out loud — with the
  * number that makes it the sheet somebody asked for rather than one like it.
  */
-export function describeForm(config: FormConfig, seed = 0): string {
-  const box = formBox(config, seed);
+function describeForm(config: FormConfig): string {
+  const box = formBox(config, 0);
   const name = own(TITLE, config.style, TITLE["book-report"]);
   switch (config.style) {
     case "reading-log":
@@ -485,9 +485,9 @@ export function describeForm(config: FormConfig, seed = 0): string {
       // `describe` is handed a config and no seed, and a config with no prompt
       // written into it is one whose prompt is a different sentence every time
       // the seed moves — so quoting the seed-zero one would name a sheet nobody
-      // printed.
+      // printed. Where a parent wrote the prompt, the seed decides nothing.
       return config.prompt
-        ? `${name}: “${promptOf(config, seed)}”`
+        ? `${name}: “${promptOf(config, 0)}”`
         : `${name}, one of ${WRITING_PROMPTS.length} drawn from the seed, and a page of lines`;
     default: {
       const fields = formFields(config, box);
@@ -513,5 +513,5 @@ export const FORM_SHEET: SheetSpec<FormConfig> = {
     ...sheet,
     footer: { ...sheet.footer, note: "Answer key" },
   }),
-  describe: (config) => describeForm(config),
+  describe: describeForm,
 };

--- a/src/engine/sheets/templates/nets.ts
+++ b/src/engine/sheets/templates/nets.ts
@@ -270,7 +270,7 @@ const netBox = (config: NetConfig): Box =>
 /** Nothing on this shelf withholds anything — see `formKeyed`. */
 export const netKeyed = (): boolean => false;
 
-export function buildNetSheet(config: NetConfig, seed: number): Sheet {
+function buildNetSheet(config: NetConfig, seed: number): Sheet {
   const box = netBox(config);
   const net =
     config.style === "spinner" ? spinnerNet(config, box) : cubeNet(config, box);
@@ -294,7 +294,7 @@ export function buildNetSheet(config: NetConfig, seed: number): Sheet {
 }
 
 /** One line naming the sheet, and the number that makes it that sheet. */
-export function describeNet(config: NetConfig): string {
+function describeNet(config: NetConfig): string {
   const box = netBox(config);
   if (config.style === "spinner") {
     const net = spinnerNet(config, box);

--- a/src/engine/sheets/templates/paper.ts
+++ b/src/engine/sheets/templates/paper.ts
@@ -18,7 +18,7 @@ import { ruleCapacity } from "../layout";
 import { rulingOf } from "../paper";
 import { SHEET_CREDIT, SHEET_URL, SHEET_WORLD, type SheetSpec } from "../spec";
 
-export function buildPaperSheet(config: PaperConfig, seed: number): Sheet {
+function buildPaperSheet(config: PaperConfig, seed: number): Sheet {
   // Whatever the header and footer leave. Shared with every other family
   // (chrome.ts) rather than counted again here, because the reservation trails
   // sheet.css and a second copy of it would drift silently.
@@ -52,7 +52,7 @@ export function buildPaperSheet(config: PaperConfig, seed: number): Sheet {
  * chooses between are the two a shop's label leaves off: whether the midline is
  * there to write between, and whether a `g` has anywhere to go.
  */
-export function describePaper(config: PaperConfig): string {
+function describePaper(config: PaperConfig): string {
   const ruling = rulingOf(config.rule);
   const paper = `${ruling.label} paper`;
   if (!ruling.handwriting) return paper;

--- a/src/engine/sheets/templates/planner.ts
+++ b/src/engine/sheets/templates/planner.ts
@@ -618,7 +618,7 @@ function plannerBlocks(config: PlannerConfig, box: Box): Block[] {
   ];
 }
 
-export function buildPlannerSheet(config: PlannerConfig, seed: number): Sheet {
+function buildPlannerSheet(config: PlannerConfig, seed: number): Sheet {
   const box = plannerBox(config);
   const verse = config.style === "verse-week" ? verseOf(config) : undefined;
 
@@ -650,7 +650,7 @@ export function buildPlannerSheet(config: PlannerConfig, seed: number): Sheet {
  * so the line describes the paper rather than the request, and says so where
  * the paper could not hold the style at all.
  */
-export function describePlanner(config: PlannerConfig): string {
+function describePlanner(config: PlannerConfig): string {
   const held = plannerFit(config, plannerBox(config));
   const name = own(TITLE, config.style, TITLE.calendar);
   const days = weekDays(config).length;

--- a/src/engine/sheets/words/puzzles.ts
+++ b/src/engine/sheets/words/puzzles.ts
@@ -688,7 +688,7 @@ function headerOf(config: PuzzleConfig): SheetOptions {
 }
 
 /** One line naming what the sheet holds, in the terms it was chosen by. */
-export function describePuzzle(config: PuzzleConfig): string {
+function describePuzzle(config: PuzzleConfig): string {
   const { words } = puzzleWords(config);
   const size = clamp(config.size ?? MIN_GRID, MIN_GRID, MAX_GRID);
   return [
@@ -703,7 +703,7 @@ export function describePuzzle(config: PuzzleConfig): string {
 
 /* ── The sheet ─────────────────────────────────────────────────────────── */
 
-export function buildPuzzleSheet(config: PuzzleConfig, seed: number): Sheet {
+function buildPuzzleSheet(config: PuzzleConfig, seed: number): Sheet {
   const head = headerOf(config);
   const { blocks, outOf } = bodyOf(config, seed);
 

--- a/src/engine/sheets/words/spelling.ts
+++ b/src/engine/sheets/words/spelling.ts
@@ -397,7 +397,7 @@ function headerOf(config: WordsConfig): SheetOptions {
 }
 
 /** One line naming what the sheet holds, in the terms it was chosen by. */
-export function describeWords(config: WordsConfig): string {
+function describeWords(config: WordsConfig): string {
   const words = wordsOf(config);
   return [
     TITLE[config.style] ?? TITLE.copy,
@@ -412,7 +412,7 @@ export function describeWords(config: WordsConfig): string {
 
 /* ── The sheet ─────────────────────────────────────────────────────────── */
 
-export function buildWordsSheet(config: WordsConfig, seed: number): Sheet {
+function buildWordsSheet(config: WordsConfig, seed: number): Sheet {
   const head = headerOf(config);
   const { blocks, outOf } = bodyOf(config, seed);
 

--- a/src/engine/sheets/words/study.ts
+++ b/src/engine/sheets/words/study.ts
@@ -522,7 +522,7 @@ function headerOf(config: WordStudyConfig): SheetOptions {
 }
 
 /** One line naming what the sheet holds, in the terms it was chosen by. */
-export function describeStudy(config: WordStudyConfig): string {
+function describeStudy(config: WordStudyConfig): string {
   const topic = topicOf(config.topic);
   // What the sheet will print rather than what was asked for, and by the same
   // arithmetic the build uses — a line that promised twenty over a page of
@@ -538,7 +538,7 @@ export function describeStudy(config: WordStudyConfig): string {
 
 /* ── The sheet ─────────────────────────────────────────────────────────── */
 
-export function buildStudySheet(config: WordStudyConfig, seed: number): Sheet {
+function buildStudySheet(config: WordStudyConfig, seed: number): Sheet {
   const head = headerOf(config);
   const { blocks, outOf } = bodyOf(config, seed);
 

--- a/src/engine/sheets/writing/handwriting.test.ts
+++ b/src/engine/sheets/writing/handwriting.test.ts
@@ -7,6 +7,7 @@ import {
   glyphEm,
   isCursive,
 } from "../faces";
+import { describeSheet } from "../index";
 import { describeSheetFamily } from "../contract";
 import { ruleCapacity, ruledLines } from "../layout";
 import { RULINGS, inches, rulePitch, toInches, writingSpace } from "../paper";
@@ -29,7 +30,6 @@ import {
   DEFAULT_HAND_RULE,
   HANDWRITING_SHEET,
   MAX_REPEATS,
-  describeHandwriting,
   fontOf,
   handwritingLayout,
   instructionOf,
@@ -601,12 +601,12 @@ describe("joined writing", () => {
   });
 
   it("names itself by the hand it is written in", () => {
-    expect(describeHandwriting(config({ style: "joins", repeats: 3 }))).toBe(
+    expect(describeSheet(config({ style: "joins", repeats: 3 }))).toBe(
       'Joining letters — the common joins — handwriting ⅝" — written 3 times',
     );
-    expect(
-      describeHandwriting(config({ style: "joins", joins: "round" })),
-    ).toContain("joins into a round letter");
+    expect(describeSheet(config({ style: "joins", joins: "round" }))).toContain(
+      "joins into a round letter",
+    );
   });
 });
 
@@ -726,7 +726,7 @@ describe("copywork out of the passage library", () => {
     );
     expect(sheet.header.title).toBe("Copywork — Proverbs 3:5-6");
     expect(
-      describeHandwriting(config({ style: "passage", passage: VERSE })),
+      describeSheet(config({ style: "passage", passage: VERSE })),
     ).toContain("Proverbs 3:5-6");
   });
 
@@ -775,10 +775,10 @@ describe("the sheet", () => {
   });
 
   it("names itself in the terms it was chosen by", () => {
-    expect(describeHandwriting(config())).toBe(
+    expect(describeSheet(config())).toBe(
       'Letter practice — capitals and small letters — handwriting ⅝" — written 3 times',
     );
-    expect(describeHandwriting(config({ style: "numbers", repeats: 4 }))).toBe(
+    expect(describeSheet(config({ style: "numbers", repeats: 4 }))).toBe(
       'Number formation — 0 to 9 — handwriting ⅝" — written 4 times',
     );
   });

--- a/src/engine/sheets/writing/handwriting.ts
+++ b/src/engine/sheets/writing/handwriting.ts
@@ -518,7 +518,7 @@ function headerOf(config: HandwritingConfig): SheetOptions {
 }
 
 /** One line naming what the sheet holds, for the catalog and the record. */
-export function describeHandwriting(config: HandwritingConfig): string {
+function describeHandwriting(config: HandwritingConfig): string {
   const styles = traceStyles(config);
   return [
     titleOf(config),
@@ -530,10 +530,7 @@ export function describeHandwriting(config: HandwritingConfig): string {
 
 /* ── The sheet ─────────────────────────────────────────────────────────── */
 
-export function buildHandwritingSheet(
-  config: HandwritingConfig,
-  seed: number,
-): Sheet {
+function buildHandwritingSheet(config: HandwritingConfig, seed: number): Sheet {
   const head = headerOf(config);
   const credit = sourceOf(config)?.credit;
 

--- a/src/engine/sheets/writing/memory.test.ts
+++ b/src/engine/sheets/writing/memory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { chromeHeight, sheetBlockBox, type FootLine } from "../chrome";
+import { describeSheet } from "../index";
 import { describeSheetFamily } from "../contract";
 import { faceOf } from "../faces";
 import { contentBox } from "../layout";
@@ -11,7 +12,6 @@ import type { Blank, MemoryConfig, SheetOptions } from "../types";
 import {
   MAX_ROUNDS,
   MEMORY_SHEET,
-  describeMemory,
   instructionOf,
   memoryLayout,
   memoryWords,
@@ -192,7 +192,7 @@ describe("the sheet it prints", () => {
     const sheet = MEMORY_SHEET.build(config(), 1);
     expect(sheet.header.title).toBe("Memory work — John 3:16");
     expect(sheet.header.score).toBeUndefined();
-    expect(describeMemory(config())).toBe(
+    expect(describeSheet(config())).toBe(
       "Memory work — John 3:16 — 4 times over",
     );
   });

--- a/src/engine/sheets/writing/memory.ts
+++ b/src/engine/sheets/writing/memory.ts
@@ -243,7 +243,7 @@ function headerOf(config: MemoryConfig): SheetOptions {
 }
 
 /** One line naming what the sheet holds, for the catalog and the record. */
-export function describeMemory(config: MemoryConfig): string {
+function describeMemory(config: MemoryConfig): string {
   const source = copyworkSource(config);
   const words = memoryWords(source.text).length;
   const rounds = clamp(config.rounds, 1, MAX_ROUNDS);
@@ -256,7 +256,7 @@ export function describeMemory(config: MemoryConfig): string {
 
 /* ── The sheet ─────────────────────────────────────────────────────────── */
 
-export function buildMemorySheet(config: MemoryConfig, seed: number): Sheet {
+function buildMemorySheet(config: MemoryConfig, seed: number): Sheet {
   const head = headerOf(config);
   const { credit } = copyworkSource(config);
   const { rounds } = memoryLayout(config, seed);


### PR DESCRIPTION
Closes #216.

(The issue's title is copy-pasted from a sibling story; its body is the one that describes this work.)

## What this does

53 functions that only ever fed their own module's `SHEET` spec object stop being exported — 27 `build*Sheet` builders and 26 `describe*` describers, across every sheet family. `src/engine/sheets/index.ts` is now the only route to a sheet builder, in fact and not only by convention.

Two things were wrong with exporting them. It advertised a second door past the registry, and it blinded `noUnusedLocals`: an export always looks used, so a builder that fell out of its own spec would have gone on looking alive forever. Un-exported, the compiler now notices the day one drifts loose.

The reasoning is written down where the next person will meet it — a paragraph on `SheetSpec` in `src/engine/sheets/spec.ts` saying the functions a family fills the spec in with are its own, and that an export needs a one-line reason on the line above it.

## Two tests that reached in directly

`writing/handwriting.test.ts` and `writing/memory.test.ts` imported `describeHandwriting` and `describeMemory` by name. Both now call `describeSheet` from the registry instead, which is the same assertion made through the front door — and it now also covers the dispatch that gets there. No export was kept for a test's sake, so there are no exemption comments to explain later.

## How "unused" was verified

Not a symbol search. Each of the 53 names was checked against the whole repo — `src/`, `e2e/`, `scripts/`, `docs/` — across `.ts`, `.tsx`, `.astro`, `.mjs`, `.js` and `.md`, which covers test files, Astro components, dynamic `import()` sites and string-keyed registry lookups alike (a bare-word grep catches a name inside a string literal or a property access, not just an import specifier).

Every hit outside a module's own `build:` / `describe:` spec entry was prose: four comments that mention a describer by name to explain a shared behaviour, and the new `SheetSpec` doc block that names `buildArithmeticSheet` as its example. No code path anywhere reaches one of these functions except through `deckSpec`-style registry dispatch in `engine/sheets/index.ts`.

## Bundle closures did not move

Built `develop` and this branch and measured each island's transitive static import closure. Byte-identical on both:

| Island | bytes | chunks |
| --- | --- | --- |
| `/flash-cards` | 389,207 | 11 |
| `/printables` | 203,902 | 4 |
| `/printables/make` | 340,521 | 19 |
| `/spelling/play` | 389,207 | 11 |
| `/typing` | 410,463 | 8 |
| `react-runtime` | 192,242 | 2 |

That is the expected result and worth stating: every function un-exported here is still reachable through its spec object, so nothing became newly tree-shakeable and nothing became newly reachable. The change is to the public surface only.

## Validation

`type-check`, `lint`, `test:unit` (2,810 tests / 118 files), `build`, `format:check`, `section-guard`, `bundle-guard` and the browser smoke test all pass. No behaviour change.
