### PR TITLE
Never show half the word you are typing

### DIFF
--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -1821,24 +1821,30 @@ try {
   await tabletCtx.close();
 
   /**
-   * The word a child is on, measured against the box it is drawn in.
+   * The passage under a cursor: what it shows, and what it is allowed to move.
    *
-   * The passage is a window of twenty words that has to wrap, and whether it
-   * wraps is decided by where the space between two words lives: a browser
+   * Two things a child depends on, and only a browser can be asked about
+   * either. `Passage.test.tsx` pins the markup both are built on.
+   *
+   * **The word being typed is on screen, whole.** Whether the passage wraps at
+   * all comes down to where the space between two words lives: a browser
    * breaks a line at a space and will not break inside an element that calls
-   * its own content one unbreakable run. Get that wrong and the twenty words
-   * lay out as a single line three times the width of the column, `overflow:
-   * hidden` takes the end off it, and the live word — six committed words in,
-   * so already near the right edge — is cut in half. A child who cannot see
-   * the word cannot type it, and the only way out is quitting the run.
+   * its own content one unbreakable run. Get that wrong and the words lay out
+   * as a single line several times the width of the column, `overflow: hidden`
+   * takes the end off it, and the live word — a few committed words in, so
+   * already near the right edge — is cut in half. A child who cannot see the
+   * word cannot type it, and the only way out is quitting the run.
    *
-   * Only a browser can be asked. `Passage.test.tsx` pins the markup that makes
-   * the break possible; this is the check that the letters are actually on
-   * screen, and it is the reason both exist.
+   * **Nothing moves sideways.** The cursor runs left to right and the block
+   * scrolls up a whole line at a time, and that is the whole of the motion a
+   * child should ever see here. A word that shifts left as another is
+   * committed — a sliding window reflowing, or a highlight that costs width —
+   * takes away the one thing an eye reading ahead relies on, which is knowing
+   * where the cursor will be next.
    */
-  log("\n14. The word you are on is never cut off by the edge of the track");
+  log("\n14. The passage moves only where a passage should");
 
-  /** Type a free-play passage, watching the live word from every side. */
+  /** Type a free-play passage, watching every word in it for movement. */
   const walkPassage = async (width, height, words) => {
     const ctx = await browser.newContext({ viewport: { width, height } });
     const p = await ctx.newPage();
@@ -1867,46 +1873,76 @@ try {
     await p.waitForSelector(".countdown", { timeout: 9000 });
     await p.waitForSelector(".countdown", { state: "detached", timeout: 9000 });
 
-    let out = -Infinity;
-    let word = "";
-    let sideways = 0;
-    for (let i = 0; i < words; i++) {
-      const seen = await p.evaluate(() => {
-        const box = document.querySelector(".typing .passage");
+    /**
+     * Where every word is, and where the live one is against its frame.
+     *
+     * Positions are measured against the frame rather than the viewport, so
+     * that a scroll of the frame reads as the words moving and a scroll of the
+     * page reads as nothing — which is the right way round for what is being
+     * asked here.
+     */
+    const readPassage = () =>
+      p.evaluate(() => {
+        const frame = document.querySelector(".passage__text");
         const live = document.querySelector(".passage__word.is-live");
-        if (!box || !live) return null;
-        const b = box.getBoundingClientRect();
-        // Every side, and every rectangle the word is drawn in: a word too
-        // long for the column breaks across two lines, and both halves have
-        // to be on screen for it to be readable.
+        if (!frame || !live) return null;
+        const f = frame.getBoundingClientRect();
+        const at = [...frame.children].map((w) => {
+          const r = w.getBoundingClientRect();
+          return [r.left - f.left, r.top - f.top];
+        });
+        // Every side, and every rectangle the live word is drawn in: a word
+        // too long for the column breaks across two lines, and both halves
+        // have to be on screen for it to be readable.
         const past = (r) =>
           Math.max(
-            r.right - b.right,
-            b.left - r.left,
-            r.bottom - b.bottom,
-            b.top - r.top,
+            r.right - f.right,
+            f.left - r.left,
+            r.bottom - f.bottom,
+            f.top - r.top,
           );
         return {
           word: live.textContent.trim(),
+          at,
           past: Math.round(Math.max(...[...live.getClientRects()].map(past))),
-          // The mechanism rather than the symptom, and the reading that does
-          // not depend on which words this seed dealt: a passage that wraps
-          // has nothing to scroll sideways to.
-          sideways: box.scrollWidth - box.clientWidth,
+          // A passage that wraps has nothing to scroll sideways to. This is
+          // the mechanism rather than the symptom, and unlike the reading
+          // above it does not depend on which words this seed dealt.
+          sideways: frame.scrollWidth - frame.clientWidth,
         };
       });
-      if (!seen) break;
-      if (seen.past > out) {
-        out = seen.past;
-        word = seen.word;
-      }
-      sideways = Math.max(sideways, seen.sideways);
-      await p.keyboard.type(seen.word, { delay: 5 });
+
+    let out = -Infinity;
+    let word = "";
+    let sideways = 0;
+    /** The furthest any word slid left or right after it was first drawn. */
+    let slid = 0;
+    /** Every distance the block moved by, so they can be shown to be lines. */
+    const steps = [];
+    let before = await readPassage();
+    for (let i = 0; i < words && before; i++) {
+      await p.keyboard.type(before.word, { delay: 5 });
       await p.keyboard.press("Space");
       await p.waitForTimeout(40);
+      const now = await readPassage();
+      if (!now) break;
+      if (now.past > out) {
+        out = now.past;
+        word = now.word;
+      }
+      sideways = Math.max(sideways, now.sideways);
+      for (let n = 0; n < Math.min(before.at.length, now.at.length); n++) {
+        slid = Math.max(slid, Math.abs(now.at[n][0] - before.at[n][0]));
+        const up = before.at[n][1] - now.at[n][1];
+        // A pixel of slack: a live word is drawn a letter to a span, and a row
+        // of separately-rounded letters is not always the exact width of the
+        // same word as one run of text.
+        if (Math.abs(up) > 1) steps.push(up);
+      }
+      before = now;
     }
     await ctx.close();
-    return { out, word, sideways };
+    return { out, word, sideways, slid, steps };
   };
 
   // A laptop and the narrowest phone the site is built for. The narrow one is
@@ -1923,6 +1959,34 @@ try {
     `1280px: ${laptop.out}px past the edge on "${laptop.word}", ` +
       `${laptop.sideways}px of sideways overflow; ` +
       `320px: ${phone.out}px on "${phone.word}", ${phone.sideways}px`,
+  );
+
+  /**
+   * Every move the block made, as the one distance it should be.
+   *
+   * The walk covers several lines at both sizes, so this is not a claim about
+   * one move: a two-line jump, a half-line drift and a scroll back down would
+   * each be a second distance, and a scroll that never happened leaves none at
+   * all. Compared unrounded and to within a pixel, because a line at the
+   * smallest text size is 33.6px and lands on either side of 34.
+   */
+  const oneLine = (walk) => {
+    if (walk.steps.length === 0) return "never moved";
+    const lo = Math.min(...walk.steps);
+    const hi = Math.max(...walk.steps);
+    return lo > 0 && hi - lo <= 1
+      ? null
+      : `${lo.toFixed(1)}–${hi.toFixed(1)}px`;
+  };
+  const laptopLines = oneLine(laptop);
+  const phoneLines = oneLine(phone);
+  check(
+    "and it moves only upwards, a line at a time, with no word sliding sideways",
+    laptop.slid <= 1 && phone.slid <= 1 && !laptopLines && !phoneLines,
+    `1280px: worst sideways slide ${laptop.slid.toFixed(1)}px, ` +
+      `${laptop.steps.length} moves up${laptopLines ? ` of ${laptopLines}` : " of one line"}; ` +
+      `320px: ${phone.slid.toFixed(1)}px, ${phone.steps.length} moves` +
+      `${phoneLines ? ` of ${phoneLines}` : " of one line"}`,
   );
 
   log(

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -1820,6 +1820,111 @@ try {
   );
   await tabletCtx.close();
 
+  /**
+   * The word a child is on, measured against the box it is drawn in.
+   *
+   * The passage is a window of twenty words that has to wrap, and whether it
+   * wraps is decided by where the space between two words lives: a browser
+   * breaks a line at a space and will not break inside an element that calls
+   * its own content one unbreakable run. Get that wrong and the twenty words
+   * lay out as a single line three times the width of the column, `overflow:
+   * hidden` takes the end off it, and the live word — six committed words in,
+   * so already near the right edge — is cut in half. A child who cannot see
+   * the word cannot type it, and the only way out is quitting the run.
+   *
+   * Only a browser can be asked. `Passage.test.tsx` pins the markup that makes
+   * the break possible; this is the check that the letters are actually on
+   * screen, and it is the reason both exist.
+   */
+  log("\n14. The word you are on is never cut off by the edge of the track");
+
+  /** Type a free-play passage, watching the live word from every side. */
+  const walkPassage = async (width, height, words) => {
+    const ctx = await browser.newContext({ viewport: { width, height } });
+    const p = await ctx.newPage();
+    p.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
+    await p.goto(`${BASE}/typing`, { waitUntil: "networkidle" });
+    await p
+      .getByRole("button", { name: /add a player/i })
+      .first()
+      .click();
+    await p.waitForSelector(".modal__panel", { timeout: 8000 });
+    await p.locator(".modal__panel input").first().fill("Track");
+    await p.getByRole("button", { name: /^add player$/i }).click();
+    await p.waitForSelector(".modal__panel", {
+      state: "detached",
+      timeout: 8000,
+    });
+    await p.getByText("Track", { exact: false }).first().click();
+    // The longest free-play run there is. What decides how close to the right
+    // edge the live word starts is the width of the six words behind it, and
+    // the window is only full once six have been committed — so a walk that
+    // ended early would be measuring the easy end of the passage.
+    await p.getByRole("button", { name: /^80$/ }).click();
+    await p.getByRole("button", { name: /start race/i }).click();
+    // The 3·2·1 is on screen before the run is live and a key pressed at it is
+    // thrown away, so wait for it to arrive and then to leave.
+    await p.waitForSelector(".countdown", { timeout: 9000 });
+    await p.waitForSelector(".countdown", { state: "detached", timeout: 9000 });
+
+    let out = -Infinity;
+    let word = "";
+    let sideways = 0;
+    for (let i = 0; i < words; i++) {
+      const seen = await p.evaluate(() => {
+        const box = document.querySelector(".typing .passage");
+        const live = document.querySelector(".passage__word.is-live");
+        if (!box || !live) return null;
+        const b = box.getBoundingClientRect();
+        // Every side, and every rectangle the word is drawn in: a word too
+        // long for the column breaks across two lines, and both halves have
+        // to be on screen for it to be readable.
+        const past = (r) =>
+          Math.max(
+            r.right - b.right,
+            b.left - r.left,
+            r.bottom - b.bottom,
+            b.top - r.top,
+          );
+        return {
+          word: live.textContent.trim(),
+          past: Math.round(Math.max(...[...live.getClientRects()].map(past))),
+          // The mechanism rather than the symptom, and the reading that does
+          // not depend on which words this seed dealt: a passage that wraps
+          // has nothing to scroll sideways to.
+          sideways: box.scrollWidth - box.clientWidth,
+        };
+      });
+      if (!seen) break;
+      if (seen.past > out) {
+        out = seen.past;
+        word = seen.word;
+      }
+      sideways = Math.max(sideways, seen.sideways);
+      await p.keyboard.type(seen.word, { delay: 5 });
+      await p.keyboard.press("Space");
+      await p.waitForTimeout(40);
+    }
+    await ctx.close();
+    return { out, word, sideways };
+  };
+
+  // A laptop and the narrowest phone the site is built for. The narrow one is
+  // not the harder case here — a short column wraps sooner — but it is where a
+  // word is most likely to be wider than the room it has.
+  const laptop = await walkPassage(1280, 1000, 26);
+  const phone = await walkPassage(320, 640, 26);
+  check(
+    "the live word stays inside the passage, and the passage never runs off sideways",
+    laptop.out <= 0 &&
+      phone.out <= 0 &&
+      laptop.sideways === 0 &&
+      phone.sideways === 0,
+    `1280px: ${laptop.out}px past the edge on "${laptop.word}", ` +
+      `${laptop.sideways}px of sideways overflow; ` +
+      `320px: ${phone.out}px on "${phone.word}", ${phone.sideways}px`,
+  );
+
   log(
     `\nconsole errors: ${errors.length ? errors.slice(0, 5).join(" | ") : "none"}`,
   );

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -1862,10 +1862,11 @@ try {
       timeout: 8000,
     });
     await p.getByText("Track", { exact: false }).first().click();
-    // The longest free-play run there is. What decides how close to the right
-    // edge the live word starts is the width of the six words behind it, and
-    // the window is only full once six have been committed — so a walk that
-    // ended early would be measuring the easy end of the passage.
+    // The longest free-play run there is. The block only moves once the cursor
+    // has run out of lines below it, so a walk that never filled the frame
+    // would be watching a passage that had no reason to move yet — and the
+    // widest viewport here fits the most words to a line, so it is the one
+    // that decides how many words buy a scroll.
     await p.getByRole("button", { name: /^80$/ }).click();
     await p.getByRole("button", { name: /start race/i }).click();
     // The 3·2·1 is on screen before the run is live and a key pressed at it is
@@ -1901,9 +1902,21 @@ try {
             r.bottom - f.bottom,
             f.top - r.top,
           );
+        // Which row of the frame the cursor is drawn on, 0 being the top
+        // one. The line's height comes off the last word sitting higher than
+        // the live one, which is the reading `Passage` scrolls by.
+        const n = [...frame.children].indexOf(live);
+        let step = 0;
+        for (let i = n - 1; i >= 0; i--) {
+          if (at[i][1] < at[n][1] - 1) {
+            step = at[n][1] - at[i][1];
+            break;
+          }
+        }
         return {
           word: live.textContent.trim(),
           at,
+          row: step ? Math.round(at[n][1] / step) : 0,
           past: Math.round(Math.max(...[...live.getClientRects()].map(past))),
           // A passage that wraps has nothing to scroll sideways to. This is
           // the mechanism rather than the symptom, and unlike the reading
@@ -1919,13 +1932,22 @@ try {
     let slid = 0;
     /** Every distance the block moved by, so they can be shown to be lines. */
     const steps = [];
+    /** Words actually measured, so a walk that measured none cannot pass. */
+    let read = 0;
+    /** The row the cursor sat on, once the block had started moving. */
+    const heldRows = [];
     let before = await readPassage();
     for (let i = 0; i < words && before; i++) {
       await p.keyboard.type(before.word, { delay: 5 });
       await p.keyboard.press("Space");
       await p.waitForTimeout(40);
       const now = await readPassage();
-      if (!now) break;
+      // A live word with no client rects reads as `-Infinity`, which is a
+      // reading of nothing that every comparison below would wave through as
+      // comfortably inside the frame. Only a real number counts as a word
+      // measured, and the count is what the checks are held to.
+      if (!now || !Number.isFinite(now.past)) break;
+      read++;
       if (now.past > out) {
         out = now.past;
         word = now.word;
@@ -1939,10 +1961,15 @@ try {
         // same word as one run of text.
         if (Math.abs(up) > 1) steps.push(up);
       }
+      // Only once the block has moved does the row mean anything. Before that
+      // the passage is barely longer than its frame, so a scroll asked for is
+      // a scroll the browser clamps away, and the cursor sits low whether it
+      // is being held there or not — which flatters exactly the bug below.
+      if (steps.length > 0) heldRows.push(now.row);
       before = now;
     }
     await ctx.close();
-    return { out, word, sideways, slid, steps };
+    return { out, word, sideways, slid, steps, read, words, heldRows };
   };
 
   // A laptop and the narrowest phone the site is built for. The narrow one is
@@ -1952,13 +1979,16 @@ try {
   const phone = await walkPassage(320, 640, 26);
   check(
     "the live word stays inside the passage, and the passage never runs off sideways",
-    laptop.out <= 0 &&
+    laptop.read === laptop.words &&
+      phone.read === phone.words &&
+      laptop.out <= 0 &&
       phone.out <= 0 &&
       laptop.sideways === 0 &&
       phone.sideways === 0,
-    `1280px: ${laptop.out}px past the edge on "${laptop.word}", ` +
-      `${laptop.sideways}px of sideways overflow; ` +
-      `320px: ${phone.out}px on "${phone.word}", ${phone.sideways}px`,
+    `1280px: ${laptop.out}px past the edge on "${laptop.word}" over ` +
+      `${laptop.read}/${laptop.words} words, ${laptop.sideways}px of sideways ` +
+      `overflow; 320px: ${phone.out}px on "${phone.word}" over ` +
+      `${phone.read}/${phone.words} words, ${phone.sideways}px`,
   );
 
   /**
@@ -1987,6 +2017,35 @@ try {
       `${laptop.steps.length} moves up${laptopLines ? ` of ${laptopLines}` : " of one line"}; ` +
       `320px: ${phone.slid.toFixed(1)}px, ${phone.steps.length} moves` +
       `${phoneLines ? ` of ${phoneLines}` : " of one line"}`,
+  );
+
+  /**
+   * The row the cursor keeps while the block scrolls under it.
+   *
+   * A three-line frame is worth having because the cursor sits on the middle
+   * line of it: a line already typed above, a line still to come below. That
+   * only holds if three lines are counted as three, and between roughly 525px
+   * and 750px of width the passage is sized by the `3.2vw` term of its clamp,
+   * where a line is a fraction of a pixel rounded up — so three of them come
+   * to marginally more than the frame cut to hold them. Counted without
+   * forgiveness that reads as two lines: the cursor is pinned to the top row
+   * and the block scrolls under every word.
+   *
+   * Neither check above can see it: the block still moves upwards, a line at a
+   * time, just always. The row is what gives it away, taken from the readings
+   * after the block first moved and at its lowest — one 640px walk inside the
+   * band, and the two widths the other checks already use.
+   */
+  const heldRow = (walk) =>
+    walk.heldRows.length ? Math.min(...walk.heldRows) : 0;
+  const band = await walkPassage(640, 800, 26);
+  check(
+    "and the cursor keeps a row below the first while the block moves under it",
+    heldRow(laptop) >= 1 && heldRow(phone) >= 1 && heldRow(band) >= 1,
+    `rows kept while scrolling — 1280px: ${heldRow(laptop)} over ` +
+      `${laptop.heldRows.length} readings, 320px: ${heldRow(phone)} over ` +
+      `${phone.heldRows.length}, 640px: ${heldRow(band)} over ` +
+      `${band.heldRows.length}`,
   );
 
   log(

--- a/src/games/typing/Passage.test.tsx
+++ b/src/games/typing/Passage.test.tsx
@@ -6,19 +6,24 @@ import type { Card, CardResult } from "@/engine/types";
 import { Passage } from "./Passage";
 
 /**
- * The passage, and the one thing about its markup that is not cosmetic.
+ * The passage, and the two things about its markup that are not cosmetic.
  *
- * A browser breaks a line at a space, and it will not break inside an element
- * that says its content is one unbreakable run. So where the space between two
- * words is rendered decides whether the passage wraps at all: keep it inside a
- * word span and there is no break to take, the twenty-word window lays out as
- * one line several times the width of the column, and `overflow: hidden` takes
- * the end off it — including the word the child is on. That is a dead end for a
- * five-year-old, who cannot type what they cannot see, so it is pinned here.
+ * **Where the space between two words goes.** A browser breaks a line at a
+ * space, and it will not break inside an element that says its content is one
+ * unbreakable run. Keep the space inside a word span and there is no break to
+ * take: the passage lays out as one line several times the width of the
+ * column, and `overflow: hidden` takes the end off it — including the word the
+ * child is on. That is a dead end for a five-year-old, who cannot type what
+ * they cannot see.
+ *
+ * **Which word the passage starts at.** Always the first, so a word laid out
+ * once keeps its place. A window that slid to follow the cursor would reflow
+ * the whole block a word to the left on every commit, walking a word up to the
+ * line above while the cursor dropped to the start of the line below.
  *
  * What this file cannot check is the layout itself — there is no browser in
  * this suite. Section 14 of `e2e/smoke.mjs` measures the live word against the
- * box it is drawn in, in a real one.
+ * frame it is drawn in, and watches for a word that moves, in a real one.
  */
 
 const card = (answer: string): Card => ({
@@ -82,6 +87,25 @@ describe("Passage", () => {
     expect(live).toContain('class="passage__ch is-hit">s</span>');
     expect(live).toContain('class="passage__ch is-hit">n</span>');
     expect(live).toContain('class="passage__ch">h</span>');
+  });
+
+  it("draws from the first word however far in the cursor is", () => {
+    // The cursor is twenty words in and the passage still starts at word
+    // zero, so nothing already on screen has to move. A window that slid six
+    // words behind the cursor would start at "w14" instead.
+    const long = Array.from({ length: 60 }, (_, n) => card(`w${n}`));
+    const deep = renderToStaticMarkup(
+      <Passage
+        deck={long}
+        results={long.slice(0, 20).map((c) => typed(c.answer))}
+        entry=""
+      />,
+    );
+    const drawn = readsAs(deep).split(" ");
+    expect(drawn[0]).toBe("w0");
+    // And it stops a bounded way past the cursor rather than drawing the rest
+    // of a hundred-word lesson: twenty typed, fourteen to read ahead on.
+    expect(drawn.at(-1)).toBe("w33");
   });
 
   it("shows what was typed past the end of a word", () => {

--- a/src/games/typing/Passage.test.tsx
+++ b/src/games/typing/Passage.test.tsx
@@ -1,0 +1,94 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { Card, CardResult } from "@/engine/types";
+
+import { Passage } from "./Passage";
+
+/**
+ * The passage, and the one thing about its markup that is not cosmetic.
+ *
+ * A browser breaks a line at a space, and it will not break inside an element
+ * that says its content is one unbreakable run. So where the space between two
+ * words is rendered decides whether the passage wraps at all: keep it inside a
+ * word span and there is no break to take, the twenty-word window lays out as
+ * one line several times the width of the column, and `overflow: hidden` takes
+ * the end off it — including the word the child is on. That is a dead end for a
+ * five-year-old, who cannot type what they cannot see, so it is pinned here.
+ *
+ * What this file cannot check is the layout itself — there is no browser in
+ * this suite. Section 14 of `e2e/smoke.mjs` measures the live word against the
+ * box it is drawn in, in a real one.
+ */
+
+const card = (answer: string): Card => ({
+  prompt: answer,
+  answer,
+  factId: answer,
+});
+
+const typed = (answer: string, ok = true): CardResult => ({
+  prompt: answer,
+  answer,
+  given: ok ? answer : `${answer}x`,
+  ok,
+  ms: 900,
+  factId: answer,
+});
+
+const deck = ["think", "searched", "sunshine", "painter"].map(card);
+
+/** The passage with two words behind the cursor, one live and one ahead. */
+const html = renderToStaticMarkup(
+  <Passage
+    deck={deck}
+    results={[typed("think"), typed("searched", false)]}
+    entry="sun"
+  />,
+);
+
+/** What the paragraph reads as, with every tag taken out. */
+const readsAs = (markup: string) =>
+  markup
+    .replace(/<[^>]+>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+describe("Passage", () => {
+  it("keeps the space between two words out of either word", () => {
+    // The space that follows a word is what the line breaks at, so it may not
+    // belong to the word. `is-live` included: the live word is the one that
+    // must never be cut in half.
+    expect(html).not.toMatch(/\s<\/span>/);
+    expect(html).toMatch(/<\/span> <span class="passage__word/);
+  });
+
+  it("still reads as words with spaces between them", () => {
+    // The other half of the rule: a break opportunity that was deleted rather
+    // than moved would pass the check above and run every word together.
+    expect(readsAs(html)).toBe("think searched sunshine painter");
+  });
+
+  it("marks each word as read back, live, or still ahead", () => {
+    expect(html).toContain('class="passage__word is-done">think</span>');
+    expect(html).toContain('class="passage__word is-wrong">searched</span>');
+    expect(html).toContain('class="passage__word is-live" aria-current="true"');
+    expect(html).toContain('class="passage__word">painter</span>');
+  });
+
+  it("colours the live word by what has been typed of it, and no further", () => {
+    // Three letters typed of "sunshine": s-u-n hit, and the rest plain.
+    const live = html.slice(html.indexOf("is-live"));
+    expect(live).toContain('class="passage__ch is-hit">s</span>');
+    expect(live).toContain('class="passage__ch is-hit">n</span>');
+    expect(live).toContain('class="passage__ch">h</span>');
+  });
+
+  it("shows what was typed past the end of a word", () => {
+    // Or a doubled letter looks like nothing happened.
+    const over = renderToStaticMarkup(
+      <Passage deck={deck} results={[]} entry="thinkk" />,
+    );
+    expect(over).toContain('class="passage__ch is-miss">k</span>');
+  });
+});

--- a/src/games/typing/Passage.tsx
+++ b/src/games/typing/Passage.tsx
@@ -6,6 +6,23 @@ import type { Card, CardResult } from "@/engine/types";
 const AHEAD = 14;
 
 /**
+ * The fraction of a line that counting lines forgives.
+ *
+ * Chromium rounds a line box up to the next sixty-fourth of a pixel, so three
+ * lines come to marginally more than a frame cut to hold three: at 640px wide
+ * the frame is 122.88 and a line 40.96875, and three lines are 122.90625. The
+ * division lands at 2.9992 and floors to two — a whole line lost, which takes
+ * away the row the cursor holds and scrolls the block under every word.
+ *
+ * It happens wherever the text size is a fraction of a pixel, which is the
+ * whole `3.2vw` middle of the clamp `.passage__text` is sized by: roughly
+ * 525px to 750px of width, so portrait tablets and phones held sideways. The
+ * shortfall is arithmetic and never a real line, so counting forgives a
+ * fiftieth of one.
+ */
+const SNAP = 0.02;
+
+/**
  * The passage, with the current word live under the cursor.
  *
  * Per-character colouring on the current word only. Doing it on the whole
@@ -119,11 +136,14 @@ export function Passage({
     // The three lines the frame is cut to, unless a short screen has squeezed
     // the row below them — `.passage` is what gives when the board wants the
     // height, so what is really on screen is whichever of the two is smaller.
+    // Counted with `SNAP`, or three lines in a three-line frame count as two.
     const showing = Math.floor(
       Math.min(
         text.getBoundingClientRect().height,
         box.getBoundingClientRect().height,
-      ) / step,
+      ) /
+        step +
+        SNAP,
     );
     // The row the cursor may reach before the block starts moving: the last
     // one that still has a line under it. A screen squeezed to a single line

--- a/src/games/typing/Passage.tsx
+++ b/src/games/typing/Passage.tsx
@@ -1,9 +1,8 @@
-import { Fragment } from "react";
+import { Fragment, useLayoutEffect, useRef } from "react";
 
 import type { Card, CardResult } from "@/engine/types";
 
-/** Words either side of the current one. Enough to read ahead, not a wall. */
-const BEHIND = 6;
+/** How far past the cursor to draw. Enough to read ahead, not a wall. */
 const AHEAD = 14;
 
 /**
@@ -13,9 +12,18 @@ const AHEAD = 14;
  * passage would turn a page of text into a page of red and green, and the one
  * place a typist is looking is the word they're on.
  *
- * A window rather than the whole passage: a fifty-word run would otherwise
- * reflow every time a word committed, and the line you're reading would move
- * under you.
+ * **The words never move sideways.** The passage is drawn from its first word
+ * every time and only ever grows at the end, so a word laid out once keeps the
+ * position it was given: committing a word repaints it and moves nothing. A
+ * window that slid — dropping a word off the front to add one at the back —
+ * reflows the whole block a word to the left each time, which walks a word up
+ * to the end of the line above while the cursor drops back to the start of the
+ * line below. The eye then has nowhere to expect the cursor, which is the one
+ * thing a child reading ahead depends on.
+ *
+ * So the cursor runs left to right along a line and down the lines, the way
+ * typing does, and the only thing that ever moves is the block itself — up by
+ * whole lines, and not until the cursor has run out of lines below it.
  */
 export function Passage({
   deck,
@@ -31,14 +39,103 @@ export function Passage({
   credit?: string;
 }) {
   const at = results.length;
-  const from = Math.max(0, at - BEHIND);
-  const visible = deck.slice(from, at + AHEAD);
+  const visible = deck.slice(0, at + AHEAD);
+
+  const boxRef = useRef<HTMLElement>(null);
+  const textRef = useRef<HTMLParagraphElement>(null);
+
+  /**
+   * Scroll the block by whole lines, but only once the cursor has run out of
+   * room below.
+   *
+   * The cursor walks down the lines it can see and the passage stays put; the
+   * scroll starts when the line being typed on would otherwise be the last one
+   * showing, and from then on it is one line per line — always leaving a line
+   * still to come underneath. Waiting until it is needed is what makes the
+   * movement mean something: the block moves because there is more passage,
+   * not because a word was finished.
+   *
+   * Written straight to `scrollTop` rather than held as state, because the
+   * answer is a reading of the layout and putting it through a render would
+   * only ask for the same layout twice.
+   *
+   * Every number here is measured, because where the lines break is the
+   * browser's answer and not ours — it moves with the width, the text size and
+   * the length of the words. It is also what keeps a word too long for the
+   * column honest: that word wraps onto a second line of its own, and this
+   * counts it like any other line.
+   *
+   * No dependency list: a resize or a turned tablet re-wraps the passage
+   * without a single prop changing, and the run's own ticker re-renders this
+   * screen often enough for that to be all the redraw it needs. A render that
+   * moves nothing costs a handful of reads and a scroll position set to what
+   * it already was.
+   */
+  useLayoutEffect(() => {
+    const box = boxRef.current;
+    const text = textRef.current;
+    if (!box || !text) return;
+    // Element children are the words: the spaces between them are text nodes,
+    // so word `n` of the passage is child `n`.
+    const words = text.children;
+    const live = words[at] as HTMLElement | undefined;
+    const first = words[0] as HTMLElement | undefined;
+    if (!live || !first) return;
+
+    // The last word of the line above — the first one going back that sits
+    // higher, so never more than a line's worth of words to look at.
+    let above: HTMLElement | null = null;
+    for (let i = at - 1; i >= 0; i--) {
+      const word = words[i] as HTMLElement;
+      if (word.offsetTop < live.offsetTop) {
+        above = word;
+        break;
+      }
+    }
+    // Nothing above means the first line, which is never scrolled off.
+    if (!above) {
+      text.scrollTop = 0;
+      return;
+    }
+
+    /**
+     * A line's height, read off two real lines — and read off `rect`, which
+     * keeps its fraction.
+     *
+     * `offsetTop` and `clientHeight` are whole pixels, and a line here is
+     * rarely one: at the smallest text size it is 33.6, so three of them fill
+     * a frame the browser reports as 101 and the division comes out at two
+     * lines rather than three. That one lost line is the difference between
+     * the cursor holding a row and the passage scrolling under every word.
+     */
+    const step =
+      live.getBoundingClientRect().top - above.getBoundingClientRect().top;
+    if (step <= 0) {
+      text.scrollTop = 0;
+      return;
+    }
+
+    const line = Math.round((live.offsetTop - first.offsetTop) / step);
+    // The three lines the frame is cut to, unless a short screen has squeezed
+    // the row below them — `.passage` is what gives when the board wants the
+    // height, so what is really on screen is whichever of the two is smaller.
+    const showing = Math.floor(
+      Math.min(
+        text.getBoundingClientRect().height,
+        box.getBoundingClientRect().height,
+      ) / step,
+    );
+    // The row the cursor may reach before the block starts moving: the last
+    // one that still has a line under it. A screen squeezed to a single line
+    // has no such row, and `max` hands that case the only row there is.
+    const held = Math.max(0, showing - 2);
+    text.scrollTop = Math.max(0, line - held) * step;
+  });
 
   return (
-    <section className="passage" aria-label="Passage to type">
-      <p className="passage__text">
-        {visible.map((card, offset) => {
-          const i = from + offset;
+    <section ref={boxRef} className="passage" aria-label="Passage to type">
+      <p ref={textRef} className="passage__text">
+        {visible.map((card, i) => {
           const mark = i < at ? (results[i].ok ? " is-done" : " is-wrong") : "";
           return (
             <Fragment key={i}>
@@ -65,9 +162,9 @@ export function Passage({
 /**
  * The word under the cursor, a character at a time.
  *
- * Split out from the window above because it is the one word with state: every
- * other word is either read back or read ahead, and this one is being compared
- * to what the hands are doing letter by letter.
+ * Split out from the passage above because it is the one word with state:
+ * every other word is either read back or read ahead, and this one is being
+ * compared to what the hands are doing letter by letter.
  */
 function LiveWord({ answer, entry }: { answer: string; entry: string }) {
   return (

--- a/src/games/typing/Passage.tsx
+++ b/src/games/typing/Passage.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from "react";
+
 import type { Card, CardResult } from "@/engine/types";
 
 /** Words either side of the current one. Enough to read ahead, not a wall. */
@@ -37,53 +39,56 @@ export function Passage({
       <p className="passage__text">
         {visible.map((card, offset) => {
           const i = from + offset;
-          if (i < at) {
-            const done = results[i];
-            return (
-              <span
-                key={i}
-                className={`passage__word${done.ok ? " is-done" : " is-wrong"}`}
-              >
-                {card.answer}{" "}
-              </span>
-            );
-          }
-          if (i > at) {
-            return (
-              <span key={i} className="passage__word">
-                {card.answer}{" "}
-              </span>
-            );
-          }
+          const mark = i < at ? (results[i].ok ? " is-done" : " is-wrong") : "";
           return (
-            <span key={i} className="passage__word is-live" aria-current="true">
-              {card.answer.split("").map((letter, n) => {
-                const typed = entry[n];
-                const state =
-                  typed === undefined
-                    ? ""
-                    : typed === letter
-                      ? " is-hit"
-                      : " is-miss";
-                return (
-                  <span key={n} className={`passage__ch${state}`}>
-                    {letter}
-                  </span>
-                );
-              })}
-              {/* Anything typed past the end of the word is wrong but has to
-                  be visible, or a doubled letter looks like nothing
-                  happened. */}
-              {entry.length > card.answer.length && (
-                <span className="passage__ch is-miss">
-                  {entry.slice(card.answer.length)}
-                </span>
-              )}{" "}
-            </span>
+            <Fragment key={i}>
+              {i === at ? (
+                <LiveWord answer={card.answer} entry={entry} />
+              ) : (
+                <span className={`passage__word${mark}`}>{card.answer}</span>
+              )}
+              {/* The space between two words, and the only place a line is
+                  allowed to break. It belongs BETWEEN the spans, not inside
+                  one: a word span is a unit the line may not break inside, so
+                  a space kept in there is a break the browser will not take —
+                  and the whole passage lays out as one unbreakable line that
+                  runs off the right edge, taking the live word with it. */}{" "}
+            </Fragment>
           );
         })}
       </p>
       {credit && <p className="passage__credit">{credit}</p>}
     </section>
+  );
+}
+
+/**
+ * The word under the cursor, a character at a time.
+ *
+ * Split out from the window above because it is the one word with state: every
+ * other word is either read back or read ahead, and this one is being compared
+ * to what the hands are doing letter by letter.
+ */
+function LiveWord({ answer, entry }: { answer: string; entry: string }) {
+  return (
+    <span className="passage__word is-live" aria-current="true">
+      {answer.split("").map((letter, n) => {
+        const typed = entry[n];
+        const state =
+          typed === undefined ? "" : typed === letter ? " is-hit" : " is-miss";
+        return (
+          <span key={n} className={`passage__ch${state}`}>
+            {letter}
+          </span>
+        );
+      })}
+      {/* Anything typed past the end of the word is wrong but has to be
+          visible, or a doubled letter looks like nothing happened. */}
+      {entry.length > answer.length && (
+        <span className="passage__ch is-miss">
+          {entry.slice(answer.length)}
+        </span>
+      )}
+    </span>
   );
 }

--- a/src/styles/game/lesson.css
+++ b/src/styles/game/lesson.css
@@ -176,9 +176,11 @@
      short screen with the board on would grow the page instead of the row:
      the line you type on, and then the board, would slide under the fold.
 
-     Clipping is the right end to lose. `Passage` is already a window on the
-     deck — six words behind, fourteen ahead — so what goes is more read-ahead,
-     and the live word sits near the top of it either way. */
+     Clipping is the right end to lose, and it is also what the passage is
+     read through: `Passage` lifts the block by whole lines so the line being
+     typed on is the second one showing, which puts the lines already typed
+     above the top edge and the read-ahead below the bottom one. Both are
+     clipped here. The line the cursor is on never is. */
   min-height: 0;
   overflow: hidden;
 }
@@ -193,6 +195,31 @@
   letter-spacing: 0.01em;
   color: var(--chalk-soft);
   text-align: left;
+
+  /* Room either side for the highlight on a word that starts or ends a line.
+     Every word carries a quarter-em of padding it does not pay for in width
+     (see `.passage__word`), so the line breaks where the letters say it should
+     and the highlight of the last word on a line hangs a quarter-em past them.
+     Overflow is clipped at the padding edge, so a quarter-em of padding here
+     is exactly the room that hang needs. */
+  padding-inline: 0.25em;
+
+  /* Exactly three lines — one read back, the one being typed on, and one to
+     read ahead on — which `Passage` scrolls a whole line at a time. Six em is
+     three of them because a line box here is the 2 of `line-height` and `em`
+     on this rule is this element's own size.
+
+     A height rather than a maximum, and a height rather than a word count:
+     the passage holds the same three lines from the first word to the last,
+     so nothing under it is nudged as the block fills up, and a run that drew
+     every word typed so far would otherwise grow this row a line at a time
+     and push the keyboard off the bottom of a laptop.
+
+     `hidden` still scrolls when it is asked to in script, which is the whole
+     arrangement: no scrollbar, nothing a child can drag, and a view that
+     moves only when the cursor has run out of room. */
+  height: 6em;
+  overflow: hidden;
 }
 
 /* A word breaks only where it has to.
@@ -212,6 +239,16 @@
    cannot read. */
 .passage__word {
   overflow-wrap: anywhere;
+
+  /* Room for the live word's highlight, kept on EVERY word so that lighting
+     one costs no width. The highlight is drawn inside the flow, so a padding
+     only the live word carried would push every word after it along by half
+     an em and pull them back a word later — the passage twitching sideways
+     once per word, under the eye that is trying to read ahead on it. The
+     margin takes the same half em straight back off, so the gap between two
+     words is the space between them and nothing else. */
+  padding: 0.1em 0.25em;
+  margin-inline: -0.25em;
 }
 
 .passage__word.is-done {
@@ -224,11 +261,11 @@
   text-underline-offset: 0.28em;
 }
 
+/* Nothing here may change the word's size — see the padding above. */
 .passage__word.is-live {
   color: var(--chalk);
   background: color-mix(in oklab, var(--accent) 16%, transparent);
   border-radius: 6px;
-  padding: 0.1em 0.25em;
   box-shadow: inset 0 -2px 0 var(--accent);
 }
 

--- a/src/styles/game/lesson.css
+++ b/src/styles/game/lesson.css
@@ -169,19 +169,33 @@
   margin-inline: auto;
   width: 100%;
 
+  /* One line of the passage, named once because the frame below is three of
+     them and the floor here is one: `.passage__text` sets `line-height: 2`,
+     so a line is twice the size the text is set at. */
+  --passage-size: clamp(1.05rem, 3.2vw, 1.5rem);
+  --passage-line: calc(2 * var(--passage-size));
+
   /* The passage is the row of the race grid that gives — `.race` makes it
      `minmax(0, 1fr)` while every other row is `auto`, and the keyboard below
-     the input is one of those. But a grid item still refuses to be shorter
-     than its own content unless it is told it may, so without these two a
-     short screen with the board on would grow the page instead of the row:
-     the line you type on, and then the board, would slide under the fold.
+     the input is one of those. What makes it give is `contain: size`: `.race`
+     is a `min-height`, so a row asking for the height of its own content is
+     handed it and the page grows instead of the row — the line you type on,
+     and then the board, sliding under the fold, which is the one thing that
+     `min-height` is there to prevent (§7). Size containment answers that
+     question without reading the passage: the row takes what the grid has
+     left over, and the frame inside it is cut to fit rather than the other
+     way round.
 
-     Clipping is the right end to lose, and it is also what the passage is
-     read through: `Passage` lifts the block by whole lines so the line being
-     typed on is the second one showing, which puts the lines already typed
-     above the top edge and the read-ahead below the bottom one. Both are
-     clipped here. The line the cursor is on never is. */
-  min-height: 0;
+     A floor of one line, because a screen with nothing left over would give
+     a contained row nothing at all, and the line being typed on is the one
+     thing a child cannot do without. `Passage` counts the lines the frame
+     really has, so a squeezed frame reads a line at a time rather than
+     showing half of one.
+
+     `overflow` clips what hangs below the frame — the credit line, on a row
+     too short to hold both. The frame does its own clipping. */
+  contain: size;
+  min-height: var(--passage-line);
   overflow: hidden;
 }
 
@@ -190,7 +204,7 @@
    needs to be at speed. */
 .passage__text {
   font-family: var(--font-mono);
-  font-size: clamp(1.05rem, 3.2vw, 1.5rem);
+  font-size: var(--passage-size);
   line-height: 2;
   letter-spacing: 0.01em;
   color: var(--chalk-soft);
@@ -204,21 +218,27 @@
      is exactly the room that hang needs. */
   padding-inline: 0.25em;
 
-  /* Exactly three lines — one read back, the one being typed on, and one to
-     read ahead on — which `Passage` scrolls a whole line at a time. Six em is
-     three of them because a line box here is the 2 of `line-height` and `em`
-     on this rule is this element's own size.
+  /* Three lines — one read back, the one being typed on, and one to read
+     ahead on — or the whole row where a short screen has left less than
+     three, which is the `100%` half of the minimum. Both halves are settled
+     before the first word and neither moves again during a run, so the
+     passage holds the same lines from the first word to the last: nothing
+     under it is nudged as the block fills up, where a run that simply drew
+     every word typed so far would grow this row a line at a time and push
+     the keyboard off the bottom of a laptop.
 
-     A height rather than a maximum, and a height rather than a word count:
-     the passage holds the same three lines from the first word to the last,
-     so nothing under it is nudged as the block fills up, and a run that drew
-     every word typed so far would otherwise grow this row a line at a time
-     and push the keyboard off the bottom of a laptop.
+     A height and not a maximum: a maximum would let the frame grow with the
+     passage — a line at a time as the words arrive — and take the credit
+     line under it along for the ride. The `100%` resolves because `.passage`
+     is size-contained above and so has a height of its own to be a
+     percentage of; `Passage` reads this frame back rather than assuming
+     three lines, and holds the cursor on the last row with a line still
+     under it.
 
      `hidden` still scrolls when it is asked to in script, which is the whole
      arrangement: no scrollbar, nothing a child can drag, and a view that
      moves only when the cursor has run out of room. */
-  height: 6em;
+  height: min(calc(3 * var(--passage-line)), 100%);
   overflow: hidden;
 }
 

--- a/src/styles/game/lesson.css
+++ b/src/styles/game/lesson.css
@@ -195,8 +195,23 @@
   text-align: left;
 }
 
+/* A word breaks only where it has to.
+
+   `anywhere` is a last resort and not the usual case: a browser reaches for it
+   only when a word has no ordinary break to fall back on, so a word that would
+   fit a line of its own still travels down to the next line whole. What it
+   covers is the word wider than the column — a long one at a large text size,
+   or a parent-authored drill — which has no next line to travel to.
+
+   `white-space: nowrap` is what it replaces, and the trap. It keeps a
+   hyphenated word in one piece, which is presumably why it was reached for,
+   but it also forbids that last resort: the word overflows instead, and the
+   `overflow: hidden` above takes the end off it. So the trade is a hyphenated
+   word that may now split at its hyphen, against a word a child can only half
+   see — and half a word is a dead end, because they cannot type what they
+   cannot read. */
 .passage__word {
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .passage__word.is-done {


### PR DESCRIPTION
The focused word could be clipped by the right edge of the passage, leaving a child unable to see the letter to type next — a hard block, with quitting the run as the only way out.

## Root cause

Not the window size and not the container width. `Passage.tsx` rendered the space between words **inside** each word's span (`{card.answer}{" "}`), and `.passage__word` carried `white-space: nowrap`. Every break opportunity in the passage therefore sat inside an element that forbids breaking, so the browser had nowhere to wrap: twenty words laid out as a single line — 1789px inside a 672px column on a laptop, 1272px inside 296px on a phone — and the row's `overflow: hidden` took the end off it. The live word sits after the committed words, so it went over the edge as soon as those grew wide enough.

Verified twice: in the app (`scrollWidth 1863 / clientWidth 672`, one line box high) and in an isolated Chromium probe confirming adjacent `nowrap` spans carrying their own trailing space yield zero break opportunities.

## The three commits are one fix

- **`97ddc4a`** — space rendered *between* spans; `.passage__word` trades `nowrap` for `overflow-wrap: anywhere`, so an ordinary word still wraps whole and a word wider than the column breaks instead of being clipped.
- **`39eaa1f`** — once the passage genuinely wraps, the old sliding window (6 behind / 14 ahead) re-flowed the whole block on every commit: a word moving **624px sideways**, jumping a line up and back down mid-run. Now the passage is start-anchored and only grows at the end, every word carries the highlight's padding back as a negative margin so lighting one costs no width, and the text is a three-line frame scrolled a whole line at a time.
- **`4cd5dbd`** — review findings.

**These do not separate.** `develop`'s small passage row was a symptom of the bug: one unwrapped line. The wrap fix alone costs 207px of page scroll at 740×360; the frame is what returns it to 65.

## Review findings, all measured

Five must-fix issues, all in `39eaa1f`:

1. **Three lines counted as two.** Chromium snaps the line step up to the next 1/64px, so three steps marginally exceed a `6em` frame (at 640px: `3 × 34.25 = 102.75` vs a frame of `102.7188` → ratio 2.9990 → floors to 2). Across the whole `clamp(1.05rem, 3.2vw, 1.5rem)` band — portrait tablets, phones in landscape — the cursor was pinned to the top row with no read-back line. Fixed with a sub-pixel tolerance; new e2e case at 640px fails without it.
2. **The frame pushed the page into scroll**, which `docs/typing.md` §7 (line 401) names as the outcome the layout exists to prevent — *"a race that scrolls under a thumb mid-word"*. `max-height` does not fix this; the row is clamped with `contain: size` instead.

| viewport | develop | before fix | after fix |
| --- | --- | --- | --- |
| 1280×1000 @200% | 0 | 123 | **0** |
| 1280×600 | 0 | 77 | **0** |
| 740×360 | 65 | 160 | **65** |
| 844×390 | 41 | 137 | **41** |
| 320×640 @200% | 281 | 415 | **281** |

3. **An e2e check could pass having measured nothing** (`-Infinity` initial value; a renamed selector printed a pass). It now requires every reading and reports the count.
4, 5. Two comments contradicting the code they sit on, rewritten.

## Regression cover

`src/games/typing/Passage.test.tsx` for the markup invariants and section 14 of `e2e/smoke.mjs` for real browser geometry. **Each was seen to fail before its fix and to name the problem when it did** — the unit test printed the bug in one line (`<span class="passage__word is-done">think </span>`, the space inside the word); the e2e check reported 27px of overflow at 1280px and 182px at 320px, and 624px of sideways slide, all 0 after.

## Known trade-offs

- Over-typing a word still widens it and nudges the rest of that line — feedback for the child's own keystroke rather than an unexplained shift. Documented in `LiveWord`.
- A hyphenated word may split at its hyphen: the cost of `overflow-wrap: anywhere`, which is what saves a word too wide for the column. Documented in `.passage__word`.

Gate green: type-check, lint, 2,816 unit tests, build with the per-island bundle budget, format:check, section-guard, smoke.
