### PR TITLE
Let every breakdown be read a day at a time

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -197,6 +197,7 @@ sees a child's request.
 ```bash
 npm run analytics                # sync, count, and print a summary
 npm run analytics -- --days 7    # narrow the table
+npm run analytics -- --by-day    # every breakdown, a column per day
 npm run analytics -- --no-sync   # re-summarise without re-downloading
 npm run analytics -- --no-geoip  # skip the country lookup (offline)
 ```
@@ -235,6 +236,52 @@ One day looks like this:
   "decks":     { "multiply": 1, "words:dolch-4": 1 }
 }
 ```
+
+## Breaking it down by day
+
+The counts have always been per day — the file above is keyed by date, and so
+is every section inside it. What the default summary does is fold the window
+into one total per row, which answers _what is being used_ and cannot answer
+_when_. `--by-day` keeps the days as columns instead, for all eight
+breakdowns:
+
+```
+CAME FROM                              08-14  08-15  08-16   TOTAL
+  (none)                                   —      2    100     102
+  google.com                               —      .     20      20
+  t.co                                     —      1      .       1
+```
+
+`TOTAL` is the same number the default view prints for that row, so the two
+views never disagree — they read the same table in `scripts/analytics-view.mjs`.
+
+**The two marks are not the same fact**, and that difference is most of why
+this view is worth having:
+
+| Cell | Means                                                                 |
+| ---- | --------------------------------------------------------------------- |
+| `.`  | the day was counted and this key was not in it — a real zero          |
+| `—`  | that day's counts have no such field at all, so nothing was looked at |
+
+`—` is the per-day form of the warning further up: a day counted before the
+place lookup shipped has no `countries` key, and a day counted before
+referrers were recorded has no `referrers`. Reading either as zero turns
+"nobody looked" into "nobody came from anywhere", which is the shape of
+mistake this whole pipeline is built to avoid.
+
+Two more things it does rather than doing them quietly. Rows past the tenth
+are counted off (`… and 4 more not shown`), and days that will not fit the
+terminal are dropped from the oldest end with a line saying how many — and the
+totals are then recomputed against the days left, so a row always adds up to
+what is in front of you. Piped to a file there is no terminal to measure, so
+say how wide:
+
+```bash
+npm run analytics -- --by-day --width 200
+```
+
+Redirecting that grid into a file puts city rows on disk, which the caveat
+above is about. Treat the file the way you would treat the terminal.
 
 The long way round, if you want the pieces separately:
 

--- a/scripts/analytics-view.mjs
+++ b/scripts/analytics-view.mjs
@@ -1,0 +1,316 @@
+/**
+ * The eight breakdowns `npm run analytics` prints, and the two ways to read
+ * them.
+ *
+ * The counts arrive already broken down by day: `scripts/rollup-analytics.mjs`
+ * writes `days[date][section][key]` and always has. The only thing that
+ * differs between the two views is what happens to that middle key — the
+ * default folds every day in the window into one total per row, and
+ * `--by-day` keeps the days as columns. Both walk the same `SECTIONS` table,
+ * so a heading, a label or a caveat is written once and cannot come out
+ * saying two different things in the two views.
+ *
+ * Split out of scripts/analytics.mjs so the column arithmetic can be exercised
+ * without a terminal, an S3 sync or a rollup run behind it.
+ */
+
+/** Rows per section. `events` opts out: there are a handful and all matter. */
+const TOP = 10;
+
+/** How wide a row label may get before the middle of it is dropped. */
+const LABEL_MAX = 36;
+
+/**
+ * `BR` → `Brazil`, via `Intl` rather than a table in this repo.
+ *
+ * A two-letter code is exactly as unreadable as the airport codes below it,
+ * which is what prompted the country lookup in the first place — printing
+ * `SG 6` and calling it an improvement would have missed the point. Node has
+ * shipped the region names since v14, so the alternative was carrying 250
+ * country names in a source file and letting them go stale.
+ */
+const REGIONS = new Intl.DisplayNames(["en"], { type: "region" });
+export const countryName = (code) => {
+  if (code === "(unknown)") return "address not in the table";
+  try {
+    return REGIONS.of(code) ?? code;
+  } catch {
+    // `of` throws on anything that isn't a well-formed region code. A code the
+    // table produced but Intl doesn't know is worth printing bare, not worth
+    // taking the summary down for.
+    return code;
+  }
+};
+
+/**
+ * `US / Iowa / Council Bluffs` → `United States / Iowa / Council Bluffs`.
+ *
+ * The rollup stores places qualified by the level above them, because place
+ * names are not unique — Ontario is a Canadian province and a Californian
+ * city, and there are around thirty Springfields. Only the leading country
+ * code is expanded; the rest is already what the source called it.
+ */
+export const placeLabel = (key) => {
+  const cut = key.indexOf(" / ");
+  if (cut === -1) return key;
+  return `${countryName(key.slice(0, cut))}${key.slice(cut)}`;
+};
+
+/**
+ * Every breakdown, in the order they print.
+ *
+ * `title` heads the default view and `short` heads the same section in the
+ * by-day grid, where the heading shares a line with the date columns and a
+ * long one would cost several days of width. The caveats the long headings
+ * carry are repeated in the footer under both views, so nothing is only said
+ * in the version the grid drops.
+ *
+ * `label` receives every key in the section alongside the one being drawn,
+ * because a label can depend on its neighbours: country codes are padded to
+ * the widest present, and `(unknown)` is nine characters against everyone
+ * else's two.
+ *
+ * `compact` is the same row in the grid, where every character spent on a
+ * label is taken off the days that fit beside it. Only the places want one:
+ * spelling `US` out to `United States` on each of ten city rows buys nothing
+ * when the COUNTRY grid three sections up has just named it, and costs about
+ * two days of width.
+ */
+const SECTIONS = [
+  { key: "pages", title: "TOP PAGES", short: "TOP PAGES" },
+  { key: "referrers", title: "CAME FROM", short: "CAME FROM" },
+  {
+    key: "countries",
+    title: "COUNTRY (the visitor's own IP, resolved locally)",
+    short: "COUNTRY",
+    label: (code, all) =>
+      `${code.padEnd(Math.max(...all.map((c) => c.length)))}  ${countryName(code)}`,
+  },
+  {
+    key: "regions",
+    title: "REGION",
+    short: "REGION",
+    label: placeLabel,
+    compact: (key) => key,
+  },
+  {
+    key: "cities",
+    // The count of distinct cities, not just the ten printed, because the
+    // shape of the tail is the thing worth knowing here: a long tail of ones
+    // is what a city breakdown looks like at this traffic, and it is the
+    // reason the caveat at the bottom of this output exists.
+    title: (rows) => `CITY (${rows.length} distinct)`,
+    short: "CITY",
+    label: placeLabel,
+    compact: (key) => key,
+    note: (rows) => {
+      const once = rows.filter((row) => row.total === 1).length;
+      return once
+        ? `${once} of them seen exactly once — see the note below`
+        : null;
+    },
+  },
+  {
+    key: "edges",
+    title: "SERVED FROM (nearest CloudFront edge, not the visitor)",
+    short: "SERVED FROM",
+  },
+  { key: "events", title: "EVENTS", short: "EVENTS", limit: Infinity },
+  { key: "decks", title: "DECKS RACED", short: "DECKS RACED" },
+];
+
+const limitOf = (section) => section.limit ?? TOP;
+const titleOf = (section, rows) =>
+  typeof section.title === "function" ? section.title(rows) : section.title;
+const labelOf = (section, name, names) =>
+  section.label ? section.label(name, names) : name;
+const compactOf = (section, name, names) =>
+  section.compact
+    ? section.compact(name, names)
+    : labelOf(section, name, names);
+
+/**
+ * One section as rows: every key it holds anywhere in `dates`, a cell per day,
+ * and a total across them.
+ *
+ * A cell is `null` only where the day has no such section at all, which is a
+ * different fact from a zero and is why the grid draws the two differently.
+ * Days counted before the place lookup shipped carry no `countries` key and
+ * days counted before referrers were recorded carry no `referrers`; filing
+ * either as zero would read as "nobody came from anywhere that day" rather
+ * than "nobody looked".
+ *
+ * Totals cover the days passed in and nothing wider, so narrowing the window
+ * — or a terminal too narrow to hold it — leaves a table whose rows add up to
+ * what is on screen.
+ */
+export const sectionRows = (days, dates, key) => {
+  // A day that recorded the section contributes a zero to every key it didn't
+  // mention; a day that didn't record it contributes nothing at all.
+  const absent = dates.map((date) => (days[date]?.[key] ? 0 : null));
+  const cells = new Map();
+
+  for (const [at, date] of dates.entries()) {
+    for (const [name, n] of Object.entries(days[date]?.[key] ?? {})) {
+      if (!cells.has(name)) cells.set(name, [...absent]);
+      cells.get(name)[at] = n;
+    }
+  }
+
+  return [...cells]
+    .map(([name, row]) => ({
+      name,
+      cells: row,
+      total: row.reduce((sum, n) => sum + (n ?? 0), 0),
+    }))
+    .sort((a, b) => b.total - a.total || a.name.localeCompare(b.name));
+};
+
+/** The default view: one total per row, over the whole window. */
+export const mergedLines = (days, dates) => {
+  const out = [];
+  for (const section of SECTIONS) {
+    const rows = sectionRows(days, dates, section.key);
+    // Days counted before a field existed have none of it, so a section with
+    // nothing in it stays quiet rather than printing a heading over a window
+    // that predates it. An empty heading and a genuine zero should not look
+    // the same.
+    if (rows.length === 0) continue;
+
+    const names = rows.map((row) => row.name);
+    out.push("", titleOf(section, rows));
+    for (const row of rows.slice(0, limitOf(section))) {
+      out.push(
+        `  ${String(row.total).padStart(6)}  ${labelOf(section, row.name, names)}`,
+      );
+    }
+
+    const note = section.note?.(rows);
+    if (note) out.push(`         ${note}`);
+  }
+  return out;
+};
+
+/**
+ * Drop the middle of an over-long label rather than its end.
+ *
+ * The most specific part of a place key is its last: cutting the tail off
+ * `United States / Washington / Seattle` would take the city with it and
+ * leave a column of rows all reading `United States / Washing…`.
+ */
+export const shorten = (text, max) => {
+  if (text.length <= max) return text;
+  const head = Math.ceil((max - 1) / 2);
+  return `${text.slice(0, head)}…${text.slice(text.length - (max - 1 - head))}`;
+};
+
+const cellText = (n) => (n === null ? "—" : n === 0 ? "." : String(n));
+
+/**
+ * How many day columns fit across `terminal`.
+ *
+ * Each column costs its own width plus the two spaces in front of it. Fixed
+ * either side: two spaces of row indent, the label column, and the total
+ * column behind a wider three-space gap that keeps it from reading as one
+ * more day. One column always "fits" — a terminal too narrow for that is
+ * better overflowing than empty.
+ */
+export const fitDays = (terminal, { label, cell, total }) =>
+  Math.max(1, Math.floor((terminal - 2 - label - total - 3) / (cell + 2)));
+
+/** Rows, labels and column widths for a given set of days. */
+const layout = (days, dates) => {
+  const sections = SECTIONS.map((section) => {
+    const rows = sectionRows(days, dates, section.key);
+    const names = rows.map((row) => row.name);
+    return {
+      section,
+      rows,
+      drawn: rows.slice(0, limitOf(section)).map((row) => ({
+        label: shorten(compactOf(section, row.name, names), LABEL_MAX),
+        cells: row.cells.map(cellText),
+        total: String(row.total),
+      })),
+    };
+  }).filter((entry) => entry.rows.length > 0);
+
+  const drawn = sections.flatMap((entry) => entry.drawn);
+  return {
+    sections,
+    // Shared across every section, so a reader can compare one grid against
+    // the one above it without re-reading the date row each time.
+    label: Math.max(
+      ...sections.map((entry) => entry.section.short.length),
+      ...drawn.map((row) => row.label.length),
+    ),
+    cell: Math.max(
+      5,
+      ...drawn.flatMap((row) => row.cells.map((c) => c.length)),
+    ),
+    total: Math.max(5, ...drawn.map((row) => row.total.length)),
+  };
+};
+
+const LEGEND = [
+  "Down a column is one day; across a row is one key over time.",
+  "  .  none that day",
+  "  —  nothing measured that day: the field is missing from that day's",
+  "     counts, which is not the same as a count of zero",
+];
+
+/**
+ * `--by-day`: the same eight sections with the days kept as columns.
+ *
+ * @param terminal how many characters wide the output may be. Days that don't
+ *   fit are dropped from the oldest end and said so — a table quietly showing
+ *   half the window it was asked for is the failure this pipeline is least
+ *   allowed to have.
+ */
+export const dailyLines = (days, dates, terminal) => {
+  if (dates.length === 0) return [];
+  let plan = layout(days, dates);
+  if (plan.sections.length === 0) return [];
+
+  const shown = dates.slice(-fitDays(terminal, plan));
+  const dropped = dates.length - shown.length;
+  // Re-measured against the days actually on screen, so which rows make the
+  // top ten and what they add up to describe the table rather than a window
+  // wider than it.
+  if (dropped) plan = layout(days, shown);
+
+  const out = [""];
+  if (dropped) {
+    out.push(
+      `This terminal fits ${shown.length} of the window's ${dates.length} days, so the oldest`,
+      `${dropped} are off the table and TOTAL adds up only the columns on it.`,
+      "Widen the terminal, or pass --width to lay one out for a file.",
+      "",
+    );
+  }
+  out.push(...LEGEND);
+
+  for (const { section, rows, drawn } of plan.sections) {
+    out.push(
+      "",
+      [
+        section.short.padEnd(2 + plan.label),
+        ...shown.map((date) => date.slice(5).padStart(plan.cell)),
+      ].join("  ") + `   ${"TOTAL".padStart(plan.total)}`,
+    );
+    for (const row of drawn) {
+      out.push(
+        [
+          `  ${row.label.padEnd(plan.label)}`,
+          ...row.cells.map((cell) => cell.padStart(plan.cell)),
+        ].join("  ") + `   ${row.total.padStart(plan.total)}`,
+      );
+    }
+
+    const hidden = rows.length - drawn.length;
+    if (hidden > 0) out.push(`  … and ${hidden} more not shown`);
+
+    const note = section.note?.(rows);
+    if (note) out.push(`  ${note}`);
+  }
+  return out;
+};

--- a/scripts/analytics-view.test.mjs
+++ b/scripts/analytics-view.test.mjs
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dailyLines,
+  fitDays,
+  mergedLines,
+  sectionRows,
+  shorten,
+} from "./analytics-view.mjs";
+
+/**
+ * The rollup has always counted by day; until `--by-day` the summary threw
+ * that away on the way to the screen. So the cases that matter here are the
+ * ones where a day and a total disagree — a field that only some days
+ * recorded, a window wider than the terminal, and a label too long to print.
+ *
+ * The shape of a day is `scripts/rollup-analytics.mjs`'s output: see `main`
+ * there for which keys are written and which are omitted entirely.
+ */
+
+/** A day before the place lookup or referrers existed — see `loadGeo`. */
+const EARLY = {
+  visitors: 4,
+  pageViews: 9,
+  pages: { "/": 5, "/typing/": 4 },
+  edges: { SEA: 9 },
+  events: { race_start: 2 },
+  decks: {},
+};
+
+const FULL = {
+  visitors: 2,
+  pageViews: 3,
+  pages: { "/": 1, "/flash-cards/": 2 },
+  countries: { US: 2, "(unknown)": 1 },
+  regions: { "US / Washington": 2 },
+  cities: { "US / Washington / Seattle": 1, "US / Iowa / Council Bluffs": 1 },
+  referrers: { "(none)": 2, "t.co": 1 },
+  edges: { SEA: 3 },
+  events: { race_start: 1, "race_end:quit": 1 },
+  decks: { multiply: 1 },
+};
+
+const DAYS = { "2026-08-14": EARLY, "2026-08-15": FULL };
+const DATES = ["2026-08-14", "2026-08-15"];
+
+describe("sectionRows", () => {
+  it("gives every key a cell per day, ordered by total", () => {
+    expect(sectionRows(DAYS, DATES, "pages")).toEqual([
+      { name: "/", cells: [5, 1], total: 6 },
+      { name: "/typing/", cells: [4, 0], total: 4 },
+      { name: "/flash-cards/", cells: [0, 2], total: 2 },
+    ]);
+  });
+
+  /**
+   * The distinction the whole grid turns on. `/typing/` got no views on the
+   * 15th, which the day counted and found none of — a zero. Nothing at all is
+   * known about referrers on the 14th, because that rollup did not record the
+   * field. Both would be `0` if the cells were built by summing.
+   */
+  it("separates a day that counted none from a day that never looked", () => {
+    expect(sectionRows(DAYS, DATES, "referrers")).toEqual([
+      { name: "(none)", cells: [null, 2], total: 2 },
+      { name: "t.co", cells: [null, 1], total: 1 },
+    ]);
+  });
+
+  it("treats an empty section as counted, not as missing", () => {
+    expect(
+      sectionRows(
+        { a: { decks: {} }, b: { decks: { x: 1 } } },
+        ["a", "b"],
+        "decks",
+      ),
+    ).toEqual([{ name: "x", cells: [0, 1], total: 1 }]);
+  });
+
+  it("breaks ties on the name, so a row cannot move when the window does", () => {
+    const rows = sectionRows(
+      { a: { pages: { z: 1 } }, b: { pages: { y: 1 } } },
+      ["a", "b"],
+      "pages",
+    );
+    expect(rows.map((row) => row.name)).toEqual(["y", "z"]);
+  });
+
+  it("has nothing to say about a field no day recorded", () => {
+    expect(sectionRows(DAYS, DATES, "countries")).toHaveLength(2);
+    expect(sectionRows({ a: EARLY }, ["a"], "countries")).toEqual([]);
+  });
+});
+
+describe("mergedLines", () => {
+  it("prints one total per row", () => {
+    expect(mergedLines(DAYS, DATES)).toContain("       6  /");
+  });
+
+  /** An empty heading and a genuine zero must not look the same. */
+  it("stays quiet about a section the window predates", () => {
+    const lines = mergedLines({ a: EARLY }, ["a"]).join("\n");
+    expect(lines).not.toContain("COUNTRY");
+    expect(lines).not.toContain("CAME FROM");
+  });
+
+  it("names countries and counts distinct cities", () => {
+    const lines = mergedLines(DAYS, DATES).join("\n");
+    expect(lines).toContain("US         United States");
+    expect(lines).toContain("(unknown)  address not in the table");
+    expect(lines).toContain("CITY (2 distinct)");
+    expect(lines).toContain("2 of them seen exactly once");
+  });
+});
+
+describe("fitDays", () => {
+  const widths = { label: 25, cell: 5, total: 5 };
+
+  it("fills the space the fixed columns leave", () => {
+    // 2 indent + 25 label + 6 × (5 + 2) + 3 gap + 5 total = 77.
+    expect(fitDays(80, widths)).toBe(6);
+    expect(fitDays(77, widths)).toBe(6);
+    expect(fitDays(76, widths)).toBe(5);
+  });
+
+  /** Overflowing beats printing a table with no days in it. */
+  it("keeps one column however narrow the terminal", () => {
+    expect(fitDays(20, widths)).toBe(1);
+  });
+});
+
+describe("shorten", () => {
+  it("leaves a label that fits alone", () => {
+    expect(shorten("US / Washington", 36)).toBe("US / Washington");
+  });
+
+  /** The city is at the end of a place key, so the end is what must survive. */
+  it("drops the middle, keeping both ends", () => {
+    const cut = shorten("United States / Washington / Seattle", 20);
+    expect(cut).toHaveLength(20);
+    expect(cut.startsWith("United")).toBe(true);
+    expect(cut.endsWith("Seattle")).toBe(true);
+  });
+});
+
+describe("dailyLines", () => {
+  const at = (terminal) => dailyLines(DAYS, DATES, terminal).join("\n");
+
+  it("puts a column under each day and the window's total behind them", () => {
+    expect(at(120)).toMatch(/^TOP PAGES\s+08-14\s+08-15\s+TOTAL$/m);
+    expect(at(120)).toMatch(/^ {2}\/ {2,}5 {2,}1 {2,}6$/m);
+  });
+
+  it("draws a counted zero and an unrecorded field differently", () => {
+    expect(at(120)).toMatch(/^ {2}\/typing\/ {2,}4 {2,}\. {2,}4$/m);
+    expect(at(120)).toMatch(/^ {2}\(none\) {2,}— {2,}2 {2,}2$/m);
+  });
+
+  it("spends no width spelling out a country the COUNTRY grid just named", () => {
+    expect(at(120)).toContain("US / Washington / Seattle");
+    expect(at(120)).not.toContain("United States / Washington / Seattle");
+  });
+
+  /**
+   * A table quietly showing half the window it was asked for is the failure
+   * this pipeline is least allowed to have — see the header of
+   * scripts/rollup-analytics.mjs on the outage that made that the rule.
+   */
+  it("says so when the terminal cannot hold the window", () => {
+    const narrow = dailyLines(DAYS, DATES, 40).join("\n");
+    expect(narrow).toContain("fits 1 of the window's 2 days");
+    expect(narrow).toContain("1 are off the table");
+  });
+
+  it("re-totals against the days on screen, not the window asked for", () => {
+    // `/` is 5 on the 14th and 1 on the 15th; dropping the 14th must leave a
+    // table whose rows add up to what is in front of you.
+    expect(dailyLines(DAYS, DATES, 40).join("\n")).toMatch(
+      /^ {2}\/ {2,}1 {2,}1$/m,
+    );
+  });
+
+  it("says how many rows the top ten left out", () => {
+    const many = {
+      a: {
+        pages: Object.fromEntries(
+          Array.from({ length: 14 }, (_, i) => [`/p${i}`, i + 1]),
+        ),
+      },
+    };
+    expect(dailyLines(many, ["a"], 120).join("\n")).toContain(
+      "… and 4 more not shown",
+    );
+  });
+
+  it("has nothing to draw with no days", () => {
+    expect(dailyLines({}, [], 120)).toEqual([]);
+  });
+});

--- a/scripts/analytics.mjs
+++ b/scripts/analytics.mjs
@@ -25,11 +25,18 @@
  *   npm run analytics                sync, count, summarise
  *   npm run analytics -- --no-sync   re-summarise what's already downloaded
  *   npm run analytics -- --days 7    narrow the table (default 30)
+ *   npm run analytics -- --by-day    every breakdown with a column per day
+ *   npm run analytics -- --width 200 lay the grid out for a file, not a tty
  *   npm run analytics -- --no-geoip  skip the country lookup
  *
  * `--no-geoip` is for working with no network at all. The country table is
  * cached in the temp directory next to the logs, so an ordinary second run
  * downloads nothing and the flag buys nothing — see scripts/geoip.mjs.
+ *
+ * `--width` exists because the by-day grid sizes itself to the terminal and
+ * drops the oldest days that don't fit. Piped into a file there is no terminal
+ * to measure, so without it a redirected run silently lays out for 100
+ * columns — see `dailyLines` in scripts/analytics-view.mjs.
  */
 
 import { execFileSync } from "node:child_process";
@@ -37,6 +44,7 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { dailyLines, mergedLines } from "./analytics-view.mjs";
 import { awsAuthHint, awsIdentityLabel, awsProfileArgs } from "./aws.mjs";
 
 // Temp, deliberately. See the header: nothing this produces is kept, and
@@ -49,9 +57,18 @@ const LOGS = join(tmpdir(), "schoolskills-cflogs");
 
 const argv = process.argv.slice(2);
 const flag = (name) => argv.includes(`--${name}`);
+// Loud about a value it can't use, because both options this parses exist to
+// bound what gets printed: a `--width` that quietly became NaN would disable
+// the fitting whose whole job is to stop the grid overflowing unannounced.
 const option = (name, fallback) => {
   const at = argv.indexOf(`--${name}`);
-  return at === -1 ? fallback : Number(argv[at + 1]);
+  if (at === -1) return fallback;
+  const value = Number(argv[at + 1]);
+  if (Number.isFinite(value) && value > 0) return value;
+  process.stderr.write(
+    `--${name} ${argv[at + 1] ?? ""}: not a positive number, using ${fallback}\n`,
+  );
+  return fallback;
 };
 
 const run = (cmd, args) =>
@@ -102,43 +119,7 @@ function sync() {
 const width = (rows, pick, header) =>
   Math.max(header.length, ...rows.map((row) => String(pick(row)).length));
 
-/**
- * `BR` → `Brazil`, via `Intl` rather than a table in this repo.
- *
- * A two-letter code is exactly as unreadable as the airport codes below it,
- * which is what prompted the country lookup in the first place — printing
- * `SG 6` and calling it an improvement would have missed the point. Node has
- * shipped the region names since v14, so the alternative was carrying 250
- * country names in a source file and letting them go stale.
- */
-const REGIONS = new Intl.DisplayNames(["en"], { type: "region" });
-const countryName = (code) => {
-  if (code === "(unknown)") return "address not in the table";
-  try {
-    return REGIONS.of(code) ?? code;
-  } catch {
-    // `of` throws on anything that isn't a well-formed region code. A code the
-    // table produced but Intl doesn't know is worth printing bare, not worth
-    // taking the summary down for.
-    return code;
-  }
-};
-
-/**
- * `US / Iowa / Council Bluffs` → `United States / Iowa / Council Bluffs`.
- *
- * The rollup stores places qualified by the level above them, because place
- * names are not unique — Ontario is a Canadian province and a Californian
- * city, and there are around thirty Springfields. Only the leading country
- * code is expanded; the rest is already what the source called it.
- */
-const placeLabel = (key) => {
-  const cut = key.indexOf(" / ");
-  if (cut === -1) return key;
-  return `${countryName(key.slice(0, cut))}${key.slice(cut)}`;
-};
-
-function summarise(days, limit) {
+function summarise(days, limit, { byDay, terminal }) {
   const dates = Object.keys(days).sort();
   if (dates.length === 0) {
     console.log(
@@ -197,90 +178,14 @@ function summarise(days, limit) {
     );
   }
 
-  // Pages and decks across the whole window, which is the question the per-day
-  // table can't answer: what is actually being used.
-  const merge = (key) => {
-    const total = {};
-    for (const date of shown)
-      for (const [k, n] of Object.entries(days[date][key] ?? {}))
-        total[k] = (total[k] ?? 0) + n;
-    return Object.entries(total).sort((a, b) => b[1] - a[1]);
-  };
-
-  const pages = merge("pages");
-  if (pages.length) {
-    console.log("\nTOP PAGES");
-    for (const [path, n] of pages.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${path}`);
-  }
-
-  // Days counted before referrers were recorded simply have none of these, so
-  // both blocks stay quiet rather than printing an empty heading over a window
-  // that predates them.
-  const referrers = merge("referrers");
-  if (referrers.length) {
-    console.log("\nCAME FROM");
-    for (const [host, n] of referrers.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${host}`);
-  }
-
-  // Days counted before the place lookup existed have no `countries` key at
-  // all, which is why these stay quiet rather than printing a heading over a
-  // window that predates them. An empty heading and a genuine zero should not
-  // look the same.
-  const countries = merge("countries");
-  if (countries.length) {
-    const codeWidth = Math.max(...countries.map(([code]) => code.length));
-    console.log("\nCOUNTRY (the visitor's own IP, resolved locally)");
-    for (const [code, n] of countries.slice(0, 10))
-      console.log(
-        `  ${String(n).padStart(6)}  ${code.padEnd(codeWidth)}  ${countryName(code)}`,
-      );
-  }
-
-  const regions = merge("regions");
-  if (regions.length) {
-    console.log("\nREGION");
-    for (const [name, n] of regions.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${placeLabel(name)}`);
-  }
-
-  const cities = merge("cities");
-  if (cities.length) {
-    // The count of distinct cities, not just the top ten, because the shape of
-    // the tail is the thing worth knowing here: a long tail of ones is what a
-    // city breakdown looks like at this traffic, and it is the reason the
-    // caveat at the bottom of this output exists.
-    const singletons = cities.filter(([, n]) => n === 1).length;
-    console.log(`\nCITY (${cities.length} distinct)`);
-    for (const [name, n] of cities.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${placeLabel(name)}`);
-    if (singletons)
-      console.log(
-        `         ${singletons} of them seen exactly once — see the note below`,
-      );
-  }
-
-  const edges = merge("edges");
-  if (edges.length) {
-    console.log("\nSERVED FROM (nearest CloudFront edge, not the visitor)");
-    for (const [code, n] of edges.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${code}`);
-  }
-
-  const events = merge("events");
-  if (events.length) {
-    console.log("\nEVENTS");
-    for (const [name, n] of events)
-      console.log(`  ${String(n).padStart(6)}  ${name}`);
-  }
-
-  const decks = merge("decks");
-  if (decks.length) {
-    console.log("\nDECKS RACED");
-    for (const [name, n] of decks.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${name}`);
-  }
+  // The breakdowns themselves. Which shape they take is the only thing
+  // --by-day changes; the counts behind both are the same per-day totals the
+  // rollup has always written.
+  console.log(
+    (byDay ? dailyLines(days, shown, terminal) : mergedLines(days, shown)).join(
+      "\n",
+    ),
+  );
 
   // Said every time rather than in a doc, because the number most likely to be
   // quoted out of context is the one at the top of a table.
@@ -314,6 +219,10 @@ try {
     summarise(
       JSON.parse(readFileSync(OUT, "utf8")).days ?? {},
       option("days", 30),
+      {
+        byDay: flag("by-day"),
+        terminal: option("width", process.stdout.columns ?? 100),
+      },
     );
   }
 } catch (error) {


### PR DESCRIPTION
## What

`npm run analytics -- --by-day` prints all eight breakdowns — pages, referrers, countries, regions, cities, edges, events, decks — with a column per day instead of one total per row. The default output is unchanged.

```
CAME FROM                              08-18  08-19  08-20  08-21   TOTAL
  (none)                                   —      2    100     134     236
  google.com                               —      .     20      11      31
```

## Why this was a viewer change, not a pipeline one

The counts were already per day. `rollup-analytics.mjs` writes `days[date][section][key]` and always has. What threw the days away was `merge()` in `summarise()`, which summed each section across the window on the way to the screen — so the summary could answer *what is being used* and never *when*.

## Three things worth a look in review

**`.` and `—` are different facts.** `.` is a day that was counted and had none of that key. `—` is a day whose counts have no such field at all — the place lookup hadn't shipped, or referrers weren't yet recorded. Building the cells by summing would have flattened both to `0`, turning "nobody looked" into "nobody came from anywhere", which is the misreading `docs/analytics.md` spends three paragraphs warning about. Most of the new tests cover this.

**Nothing is capped quietly.** The grid fits itself to the terminal, drops the oldest days that don't fit, says how many, and re-totals against the days left — so a row adds up to what's on screen rather than to a window the reader can't see. Rows past the tenth are counted off too (`… and 219 more not shown`).

**`--width`** is for a piped run, which has no terminal to measure and would otherwise lay out for 100 columns unannounced. Adding it turned up the same hole in `--days`, where a value parsing to `NaN` silently widened the window; both now fall back and say so on stderr.

## Structure

The eight sections move to `scripts/analytics-view.mjs` as one table both views walk, so a heading, a label or a caveat is written once and can't come out saying two different things in the two views. That also puts the column arithmetic somewhere testable without a terminal, an S3 sync or a rollup run behind it.

## Verification

- Snapshotted the default view before touching anything and diffed after — **identical except one tie-break**: two rows both at 1 were previously ordered by which day the key first appeared, so they could swap places just because the window moved. They now sort alphabetically.
- Against live logs, every `TOTAL` matches the merged view across all six comparable sections.
- Layout checked at 60/70/80/120/200 columns; no grid line overflows.
- `lint`, `type-check`, `build` and all 2835 unit tests pass. 19 new tests.

## Note

`docs/analytics.md` gains a **Breaking it down by day** section. It flags that redirecting the grid to a file puts city rows on disk, which the existing "read it, don't publish it" caveat is about — the file deserves the same treatment as the terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hK7wRrFGc6Yqs2fT9rP5T