### PR TITLE
Show the paper half on the front page, and let search find it

### DIFF
--- a/src/components/site/SiteHeader.astro
+++ b/src/components/site/SiteHeader.astro
@@ -8,8 +8,12 @@
  * colour code the map teaches — a dot per world, in that world's own colour,
  * so "the green one" means the same thing here as it does there.
  *
- * The flag's pennant takes `--accent`, which is whatever world the page is
- * standing in. Walking from the jungle to the glacier recolours it.
+ * The mark is `/favicon.svg` — the same file the tab icon points at, so what
+ * is on the page and what is in the tab cannot drift apart. Linked rather
+ * than inlined: it is 35 kB of traced curves, which is one request the
+ * browser has already made for the tab, and would otherwise be 35 kB of HTML
+ * on every page. That file is also the small-size art, with the book's page
+ * rules and lettering dropped, which is the right art at 32px.
  */
 import { WORLDS, type World } from "@/engine/worlds";
 
@@ -26,20 +30,13 @@ const { world } = Astro.props;
 <header class="mast">
   <div class="mast__in">
     <a class="mast__mark" href="/">
-      <svg
-        class="mast__flag"
-        width="22"
-        height="24"
-        viewBox="0 0 22 24"
-        aria-hidden="true"
-      >
-        <path
-          d="M4.2 2.5v19"
-          stroke="currentColor"
-          stroke-width="2.4"
-          stroke-linecap="round"></path>
-        <path class="mast__pennant" d="M5.4 3.6 19 8.2 5.4 12.8z"></path>
-      </svg>
+      <img
+        class="mast__logo"
+        src="/favicon.svg"
+        width="32"
+        height="32"
+        alt=""
+      />
       <span class="mast__name">School Skills</span>
     </a>
 

--- a/src/components/site/WorldMap.astro
+++ b/src/components/site/WorldMap.astro
@@ -50,8 +50,9 @@ const BADGES: Partial<Record<World, string>> = {
     Three are games, one subject each and one thing to get good at. Start
     anywhere, stop anywhere, and switch mid-week &mdash; nothing has to be
     finished before anything else opens, and the same player carries their
-    records between all three. The fourth is The Print Shop, which makes paper
-    rather than points, and is a stop for you rather than for them.
+    records between all three. The fourth is The Print Shop, and it is the one
+    that is yours rather than theirs: worksheets for maths, handwriting, phonics
+    and more, printed from the browser with the answer key behind them.
   </p>
 
   {

--- a/src/engine/worlds.ts
+++ b/src/engine/worlds.ts
@@ -149,7 +149,7 @@ export const WORLDS: WorldInfo[] = [
     subject: "Worksheets to print",
     tagline: "For the grown-up. Pick a sheet, tune it, print it.",
     blurb:
-      "Times tables, handwriting rules, spelling lists and Scripture copywork, as paper you can hand over. Sheets print straight from the browser with an answer key — no download, no account, and nothing about your child in the file.",
+      "Times tables, handwriting rules, spelling lists and Scripture copywork, as paper you can hand over. Sheets print straight from the browser with an answer key, or save as a PDF — no account, and nothing about your child in the file.",
     icon: "🖨️",
     href: "/printables",
     island: "/printables/make",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -24,6 +24,17 @@ interface Props {
   image?: string;
   /** Structured data for this page, serialised into a JSON-LD script tag. */
   jsonLd?: Record<string, unknown>;
+  /**
+   * The trail to this page, root first, as `BreadcrumbList` structured data.
+   *
+   * Given rather than derived from the path, because the path does not know
+   * what its segments are called: `/printables/bible/psalm-23-copywork/a4` is
+   * three words and a stock, and only the route that built it knows those are
+   * "The Print Shop", "Bible" and a sheet with a name. A page that says nothing
+   * emits nothing, which is the right default — a breadcrumb on a page with no
+   * hierarchy above it is a claim about a structure that isn't there.
+   */
+  breadcrumb?: Array<{ name: string; href: string }>;
   /** Which world this page is in. Drives every colour on it. */
   world?: World;
   /**
@@ -51,12 +62,65 @@ const {
   description,
   image = "/og-default.png",
   jsonLd,
+  breadcrumb,
   world = "grid",
   noindex = false,
 } = Astro.props;
 
 const canonical = new URL(Astro.url.pathname, Astro.site).href;
 const ogImage = new URL(image, Astro.site).href;
+
+/**
+ * The publisher, stamped onto every page's structured data.
+ *
+ * Google reads a site's logo off an Organization node, and the claim it is
+ * making — this mark belongs to this domain — is about the site rather than
+ * about any one page. So it is attached here instead of being written into the
+ * thirty route files that carry `jsonLd`, which would drift apart the first
+ * time one of them was edited alone. `publisher` is valid on every `@type`
+ * this site emits: WebSite, CollectionPage, AboutPage and LearningResource are
+ * all CreativeWorks.
+ *
+ * The PNG rather than favicon.svg, because Google's logo guidance takes a
+ * raster. It is the same mark, from the same traced curves — see
+ * scripts/generate-icons.mjs.
+ *
+ * A page that states its own publisher keeps it, so a future page that is not
+ * ours to claim can say so.
+ */
+/**
+ * The trail as schema.org sees it: a list, one-indexed, each item an absolute
+ * URL. Its own script rather than a field on `jsonLd`, because a
+ * `BreadcrumbList` is an `ItemList` and not a `CreativeWork` — the publisher
+ * below would be invalid on it, and Google reads sibling blocks fine.
+ */
+const crumbs = breadcrumb?.length
+  ? {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: breadcrumb.map((step, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        name: step.name,
+        item: new URL(step.href, Astro.site).href,
+      })),
+    }
+  : undefined;
+
+const structured = jsonLd && {
+  ...jsonLd,
+  publisher: jsonLd.publisher ?? {
+    "@type": "Organization",
+    name: "School Skills",
+    url: new URL("/", Astro.site).href,
+    logo: {
+      "@type": "ImageObject",
+      url: new URL("/icon-512.png", Astro.site).href,
+      width: 512,
+      height: 512,
+    },
+  },
+};
 ---
 
 <!doctype html>
@@ -120,11 +184,20 @@ const ogImage = new URL(image, Astro.site).href;
     </script>
 
     {
-      jsonLd && (
+      structured && (
         <script
           type="application/ld+json"
           is:inline
-          set:html={JSON.stringify(jsonLd)}
+          set:html={JSON.stringify(structured)}
+        />
+      )
+    }
+    {
+      crumbs && (
+        <script
+          type="application/ld+json"
+          is:inline
+          set:html={JSON.stringify(crumbs)}
         />
       )
     }

--- a/src/layouts/Content.astro
+++ b/src/layouts/Content.astro
@@ -20,6 +20,8 @@ interface Props {
   description: string;
   image?: string;
   jsonLd?: Record<string, unknown>;
+  /** The trail to this page — see `Base.astro`. */
+  breadcrumb?: Array<{ name: string; href: string }>;
   /** Which world this page is in. Drives every colour on it. */
   world: World;
   /**
@@ -35,7 +37,8 @@ interface Props {
   noindex?: boolean;
 }
 
-const { title, description, image, jsonLd, world, noindex } = Astro.props;
+const { title, description, image, jsonLd, breadcrumb, world, noindex } =
+  Astro.props;
 
 // Line world and Empty world have no scenery, so their pages tighten the
 // measure and drop the display type a size. See content.css.
@@ -47,6 +50,7 @@ const pause = world === "line" || world === "empty";
   description={description}
   image={image}
   jsonLd={jsonLd}
+  breadcrumb={breadcrumb}
   world={world}
   noindex={noindex}
 >

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,6 +10,11 @@ import Content from "@/layouts/Content.astro";
  * It renders in Empty world, which is one horizon line and no ground. The joke
  * is that it's also the literal truth, and a dead end is a better place to be
  * charming than a privacy policy is.
+ *
+ * `noindex` because this file is reachable at /404 as well as being served for
+ * every wrong address. CloudFront answers a mistyped URL with a real 404 status
+ * (sst.config.ts), which is the signal that matters — but nothing stops a
+ * crawler asking for /404 itself and getting a 200 with a page on it.
  */
 ---
 
@@ -17,6 +22,7 @@ import Content from "@/layouts/Content.astro";
   title="Page not found — School Skills"
   description="That page doesn't exist. Head back to the map."
   world="empty"
+  noindex
 >
   <div class="void">
     <p class="hero__eyebrow">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,11 @@
 import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import WorldMap from "@/components/site/WorldMap.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { buildSheet } from "@/engine/sheets";
 import { passage, passageText } from "@/engine/sheets/passages";
+import { MATHS_SEED, MATHS_SHEETS } from "./printables/_maths";
+import { ALL_SHEETS, SHELVES } from "./printables/_shelves";
 
 /**
  * The overworld.
@@ -16,14 +20,25 @@ import { passage, passageText } from "@/engine/sheets/passages";
  * So the page is the map first and the argument second: colour, worlds and one
  * obvious way in above the fold, then the honest prose underneath it. The
  * "what it isn't" block is deliberately the same size as the "what it is" one,
- * because the limits are half the pitch here. This is a supplement — three
- * narrow skills drilled properly — and a parent who discovers that in week
- * three instead of minute one has been sold something.
+ * because the limits are half the pitch here. This is a supplement — practice
+ * of things somebody else taught — and a parent who discovers that in week
+ * three instead of minute one has been sold something. Which limit says so has
+ * moved: the games really are three narrow skills, but the paper is wide
+ * enough that "not a whole subject" stopped being the true one, and what is
+ * still true of both halves is that nothing here teaches.
+ *
+ * **Every landmark on this page carries `.no-print`, so the overworld prints
+ * nothing.** `@page { margin: 0 }` in print.css is global and cannot be scoped,
+ * so any section without the class prints edge to edge — and once the paper
+ * band below put a real sheet on this page, the rule that keeps that from
+ * happening (§20, held by `Sheet.test.tsx`) started applying here. Printing a
+ * screen was never the use for this one, and the alternative reading — the
+ * overworld printing the worksheet it happens to be showing — hands a parent
+ * paper they did not choose.
  */
-const title =
-  "School Skills — free homeschool practice games for times tables, spelling and typing";
+const title = "Free printable worksheets and practice games | School Skills";
 const description =
-  "Three free practice games for homeschool and after-school: times tables, sight words and touch typing. No account, no tracking, no personalised ads. A supplement to your lessons, not a curriculum.";
+  "Worksheets to print for maths, handwriting, phonics and spelling, plus three practice games for times tables, sight words and touch typing. Free, with no account and nothing uploaded.";
 
 /**
  * The one verse on this page, and the band it sits in is why it is allowed to
@@ -49,6 +64,28 @@ const description =
  * release's own and the credit line travels with them.
  */
 const verse = passage("the-plans-of-the-diligent");
+
+/**
+ * The sheet the paper band shows, read out of the maths catalog rather than
+ * configured here.
+ *
+ * A config written on this page would be a second place a sheet is described,
+ * and it would drift from the page it links to. Taking the catalog's own entry
+ * and its own seed means the paper on the home page is the paper at
+ * `/printables/multiplication-worksheets`, problem for problem.
+ *
+ * Multiplication because it is the sheet a parent recognises without reading
+ * it: a grid of times-table facts is legible as a worksheet at a glance, which
+ * a phonics or handwriting sheet shrunk to a third of its size is not.
+ */
+const PEEK = "multiplication-worksheets";
+const peekEntry = MATHS_SHEETS.find((sheet) => sheet.slug === PEEK);
+if (!peekEntry) {
+  throw new Error(
+    `The home page shows ${PEEK}, which is no longer in the maths catalog. Point it at a sheet that exists.`,
+  );
+}
+const peek = buildSheet(peekEntry.config, MATHS_SEED);
 ---
 
 <Content
@@ -68,16 +105,17 @@ const verse = passage("the-plans-of-the-diligent");
     isAccessibleForFree: true,
   }}
 >
-  <header class="hero wrap">
+  <header class="hero wrap no-print">
     <p class="hero__eyebrow">
       <span class="hero__world">The map</span>
-      Free &middot; no account &middot; works offline
+      No account &middot; nothing uploaded &middot; works offline
     </p>
-    <h1 class="hero__title">Ten minutes of drill they&rsquo;ll ask for</h1>
+    <h1 class="hero__title">Free practice games and printable worksheets</h1>
     <p class="hero__lead">
-      Times tables, sight words and touch typing, as three small games. Made for
-      homeschool and after-school practice at home &mdash; free, with no account
-      and nothing about your child ever leaving the device it&rsquo;s on.
+      Three small games &mdash; times tables, sight words and touch typing
+      &mdash; and a print shop of worksheets for maths, handwriting, phonics and
+      more. No account, nothing to install, and nothing about your child ever
+      leaves the device it&rsquo;s on.
     </p>
     {
       /*
@@ -122,13 +160,91 @@ const verse = passage("the-plans-of-the-diligent");
       keyboard user's next Tab carries on from the hero button they just left,
       several screens above where the page now is. */
   }
-  <section class="band band--tight wrap" id="worlds" tabindex="-1">
+  <section class="band band--tight wrap no-print" id="worlds" tabindex="-1">
     <WorldMap />
   </section>
 
-  <div class="wrap"><AdSlot name="article" /></div>
-  <section class="band band--inset" id="limits" tabindex="-1">
-    <div class="wrap">
+  {
+    /*
+     * The paper half, which the rest of this page would otherwise leave as one
+     * clause under the map.
+     *
+     * The sheet below is the renderer, not a picture of it. `SheetView` with no
+     * `client:*` is HTML at build time, so the band costs this page no
+     * JavaScript and what a parent sees here is what the catalog prints.
+     *
+     * `data-world="paper"` rather than a set of one-off colours: world blocks
+     * are scoped to the attribute, so the band is painted out of The Print
+     * Shop's own tokens, down to a `--go` that is the colour of paper.
+     *
+     * The sheet is an illustration, not paper: a page that prints a sheet is a
+     * page that IS that sheet (docs/printables.md §8), and the overworld is not
+     * one. See the note on printing at the top of this file.
+     */
+  }
+  <section
+    class="band paper no-print"
+    data-world="paper"
+    aria-labelledby="paper-head"
+  >
+    <div class="wrap paper__in no-print">
+      <div class="paper__say">
+        <h2 class="h2" id="paper-head">The other half of this site is paper</h2>
+        <p class="h2__sub">
+          {ALL_SHEETS.length} worksheets, free and with no account. Every one is an
+          ordinary web page, so you can read it on screen, print it, or pick{
+            " "
+          }
+          <em>Save as PDF</em> and keep the file &mdash; on a phone as easily as a
+          laptop. Each comes with its answer key on the page behind it.
+        </p>
+
+        {
+          /* One chip per shelf, off the same registry the catalog builds
+            itself from, so a shelf added there turns up here. `role="list"`
+            restores what base.css strips, as the map does. */
+        }
+        <ul class="paper__shelves" role="list">
+          {
+            SHELVES.map((shelf) => (
+              <li>
+                <a href={shelf.href}>{shelf.label}</a>
+              </li>
+            ))
+          }
+        </ul>
+
+        <p class="aside">
+          <strong>And when a sheet is nearly right, change it.</strong> The bench
+          sets what is on it, the paper, the type size and how many problems fit,
+          and redraws the page as you go. The settings live in the address bar, so
+          a sheet you tuned can be bookmarked, or passed to someone else as an ordinary
+          link.
+        </p>
+
+        <div class="hero__actions">
+          <a class="cta" href="/printables">Browse the worksheets</a>
+          <a class="cta cta--quiet" href="/printables/make">Build your own</a>
+        </div>
+      </div>
+
+      {
+        /*
+         * Decorative here, and only here. The band's point is carried by the
+         * heading, the shelves and the two links; a screen reader made to walk
+         * thirty multiplication problems to reach them would be worse off for
+         * the illustration, and the sheet's own page reads it properly.
+         */
+      }
+      <div class="paper__peek" aria-hidden="true">
+        <SheetView sheet={peek} />
+      </div>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+  <section class="band band--inset no-print" id="limits" tabindex="-1">
+    <div class="wrap no-print">
       <h2 class="h2">What this is, and what it isn&rsquo;t</h2>
       <p class="h2__sub">
         Worth knowing before you build a morning around it. This is one piece of
@@ -201,10 +317,12 @@ const verse = passage("the-plans-of-the-diligent");
               >
             </li>
             <li>
-              <span class="truth__what">Not a whole subject</span>
+              <span class="truth__what">Not a teacher</span>
               <span class="truth__why"
-                >Three narrow skills, on purpose. Reading comprehension, writing
-                and maths reasoning aren&rsquo;t here and aren&rsquo;t planned.</span
+                >The games are three narrow skills on purpose. The paper goes
+                wider &mdash; grammar, phonics, word problems, book reports
+                &mdash; but none of it teaches: a sheet is practice, or a frame
+                for work you set, and nothing on it explains anything.</span
               >
             </li>
           </ul>
@@ -213,8 +331,8 @@ const verse = passage("the-plans-of-the-diligent");
     </div>
   </section>
 
-  <div class="wrap"><AdSlot name="article" /></div>
-  <section class="band wrap">
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+  <section class="band wrap no-print">
     <h2 class="h2">Where it fits in a day</h2>
     <p class="h2__sub">
       Short and frequent beats long and rare, which is convenient &mdash; ten
@@ -265,8 +383,8 @@ const verse = passage("the-plans-of-the-diligent");
     }
   </section>
 
-  <section class="band band--inset">
-    <div class="wrap">
+  <section class="band band--inset no-print">
+    <div class="wrap no-print">
       <h2 class="h2">What they see, and what you don&rsquo;t</h2>
       <p class="h2__sub">
         There is no parent account because there is no account at all. This is
@@ -304,8 +422,8 @@ const verse = passage("the-plans-of-the-diligent");
     </div>
   </section>
 
-  <section class="band" id="for-parents" tabindex="-1">
-    <div class="wrap">
+  <section class="band no-print" id="for-parents" tabindex="-1">
+    <div class="wrap no-print">
       <h2 class="h2">For parents</h2>
       <div class="prose">
         <p>

--- a/src/pages/printables/[...slug].astro
+++ b/src/pages/printables/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "./_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { buildSheet } from "@/engine/sheets";
@@ -53,7 +54,7 @@ const other = STOCKS.find((candidate) => candidate.id !== stock.id)!;
 
 const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
 const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page on ${stock.label}, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app/printables/${pathFor(sheet, stock)}`;
 
 const siblings = shelf();
@@ -63,6 +64,7 @@ const siblings = shelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("paper", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/[topic].astro
+++ b/src/pages/printables/[topic].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "./_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -58,7 +59,7 @@ const printed = buildSheet(sheet.config, MATHS_SEED);
 const key = answerKey(sheet.config, MATHS_SEED);
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const strands = mathsShelf();
@@ -69,6 +70,7 @@ const strand = strands.find((group) => group.id === sheet.strand)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("math", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/_phonics.ts
+++ b/src/pages/printables/_phonics.ts
@@ -191,14 +191,27 @@ export const PHONICS_SHEETS: PhonicsSheet[] = [
     // would be in at three if the digraph were ever ticked here.
     config: phonics("blending", LETTERS, 20, 2, { maxSounds: 3 }),
   },
+  /*
+   * Named for onset and rime rather than for word families, though a word
+   * family is what it prints.
+   *
+   * The spelling shelf has a word-family sheet too, and it is the one a parent
+   * searching that phrase should land on: fourteen fixed families, chosen for
+   * being the commonest. This one draws its endings from the spellings a child
+   * has actually been taught, so it is the same idea arriving through the
+   * phonics progression — a genuinely different sheet, and one that was
+   * competing with its neighbour for a query only one of them can win. The
+   * slug stays as it is: the URL is live and there is nowhere on a static site
+   * to redirect it from.
+   */
   {
     slug: "word-family-worksheets",
-    name: "Word families",
-    short: "Word families",
-    heading: "Word family worksheets",
-    keyword: "Free printable word family worksheets",
+    name: "Onset and rime",
+    short: "Onset and rime",
+    heading: "Onset and rime worksheets",
+    keyword: "Free printable onset and rime worksheets",
     summary:
-      "Twenty spelling sums — a beginning added to an ending, with the word they make written on the line, and the key on the page behind.",
+      "Twenty spelling sums — a beginning added to an ending, with the word they make written on the line, and the key on the page behind. The endings come from the spellings you have ticked.",
     lead: "A beginning, a plus sign and an ending, with a line for the word. Changing one sound at the front of a word a child can already read is the cheapest reading practice there is, and it is where a first reader gets their first hundred words.",
     notes: [
       "The endings on this page are not chosen from a list — they are the endings the words a child can read happen to share, which is why a family only appears when there are at least two words behind it. A sheet with one word in a family is not teaching a pattern, it is teaching a word, and there is a better sheet for that.",

--- a/src/pages/printables/_shelves.ts
+++ b/src/pages/printables/_shelves.ts
@@ -243,6 +243,33 @@ export const SHELVES: Shelf[] = [
 ];
 
 /** The shelves with a hub of their own — the subject nav, in order. */
+/**
+ * The trail to a page under The Print Shop, as `Base.astro`'s `breadcrumb`
+ * wants it: root first, the page itself last.
+ *
+ * Read out of `SHELVES`, so a shelf renamed or moved there is renamed in every
+ * breadcrumb beneath it rather than in twenty route files. `hub` is what
+ * decides whether the shelf is a step at all — paper's "hub" is the front door
+ * itself, and a trail that listed it twice would be describing a level that
+ * isn't there.
+ *
+ * Sub-groups are left out on purpose. A breadcrumb step is somewhere you can
+ * go, and a group ("Parts of speech") is a heading on a hub rather than a
+ * route.
+ */
+export const trailTo = (
+  id: ShelfId | null,
+  ...tail: Array<{ name: string; href: string }>
+): Array<{ name: string; href: string }> => {
+  const shelf = id ? SHELVES.find((entry) => entry.id === id) : undefined;
+  return [
+    { name: "Home", href: "/" },
+    { name: "The Print Shop", href: "/printables" },
+    ...(shelf?.hub ? [{ name: shelf.label, href: shelf.href }] : []),
+    ...tail,
+  ];
+};
+
 export const HUBS: Shelf[] = SHELVES.filter((shelf) => shelf.hub);
 
 export const ALL_SHEETS: ShelfSheet[] = SHELVES.flatMap(

--- a/src/pages/printables/bible/[...slug].astro
+++ b/src/pages/printables/bible/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -66,7 +67,7 @@ const credit = creditFor(sheet);
 
 const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
 const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page on ${stock.label}, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${hrefFor(sheet, stock)}`;
 
 const groups = bibleShelf();
@@ -77,6 +78,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("bible", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/bible/index.astro
+++ b/src/pages/printables/bible/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SCRIPTURE_CREDIT } from "@/engine/sheets/passages";
 import { BIBLE_SHEETS, STOCKS, bibleShelf, hrefFor } from "../_bible";
@@ -21,7 +22,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable Bible copywork, handwriting and memory verse worksheets | School Skills";
 const description =
-  "Printable Scripture practice: verses to trace, copywork at every ruling, and memory sheets with progressive blanks and the full verse on the answer key. Public-domain text, free, no account, and nothing to download.";
+  "Printable Scripture practice: verses to trace, copywork at every ruling, and memory sheets with progressive blanks and the full verse on the answer key. Public-domain text, free, no account, print or save as PDF.";
 
 const groups = bibleShelf();
 const letter = STOCKS[0];
@@ -31,6 +32,7 @@ const letter = STOCKS[0];
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("bible")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/charts/[slug].astro
+++ b/src/pages/printables/charts/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -54,7 +55,7 @@ const printed = buildSheet(sheet.config, CHART_SEED);
 const key = keyed(sheet) ? answerKey(sheet.config, CHART_SEED) : null;
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = chartShelf();
@@ -65,6 +66,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("charts", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/charts/index.astro
+++ b/src/pages/printables/charts/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { CHART_SHEETS, chartShelf, pathFor } from "../_charts";
 import HubLinks from "../_HubLinks.astro";
@@ -22,7 +23,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable maths charts, number lines and grids | School Skills";
 const description =
-  "Printable reference sheets: hundred charts blank and filled, number lines with the interval you choose, first-quadrant and four-quadrant coordinate grids, and place-value charts down to thousandths. Real inches, drawn as ink so they print — free, no account, no download.";
+  "Printable reference sheets: hundred charts blank and filled, number lines with the interval you choose, first-quadrant and four-quadrant coordinate grids, and place-value charts down to thousandths. Real inches, drawn as ink so they print — free, no account, print or save as PDF.";
 
 const groups = chartShelf();
 ---
@@ -31,6 +32,7 @@ const groups = chartShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("charts")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/cursive/[...slug].astro
+++ b/src/pages/printables/cursive/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { buildSheet } from "@/engine/sheets";
@@ -51,7 +52,7 @@ const other = STOCKS.find((candidate) => candidate.id !== stock.id)!;
 
 const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
 const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page on ${stock.label}, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${hrefFor(sheet, stock)}`;
 
 const groups = cursiveShelf();
@@ -62,6 +63,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("cursive", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/cursive/index.astro
+++ b/src/pages/printables/cursive/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { JOIN_FAMILIES } from "@/engine/sheets/writing/joins";
 import {
@@ -26,7 +27,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable cursive worksheets — letters, joins and copywork | School Skills";
 const description =
-  "Printable cursive practice: the alphabet in capitals and small letters, all six families of join, whole words, sentences and copywork. Three cursive models to choose from. Free, no account, and nothing to download.";
+  "Printable cursive practice: the alphabet in capitals and small letters, all six families of join, whole words, sentences and copywork. Three cursive models to choose from. Free, no account, print or save as PDF.";
 
 const groups = cursiveShelf();
 const letter = STOCKS[0];
@@ -40,6 +41,7 @@ const joins = CURSIVE_SHEETS.find((sheet) => sheet.config.style === "joins")!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("cursive")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/grade/[grade].astro
+++ b/src/pages/printables/grade/[grade].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import HubLinks from "../_HubLinks.astro";
 import {
@@ -64,7 +65,7 @@ const description = `${grade.heading} for ages ${younger} and ${older}: ${shelve
   .map((shelf) => shelf.label)
   .join(
     ", ",
-  )}. Every one prints straight from the page — free, no account, and nothing to download.`;
+  )}. Every one prints straight from the page — free, no account, print or save as PDF.`;
 const url = `https://schoolskills.app${gradeHref(grade)}`;
 ---
 
@@ -72,6 +73,11 @@ const url = `https://schoolskills.app${gradeHref(grade)}`;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo(
+    null,
+    { name: "By school year", href: "/printables/grade" },
+    { name: grade.label, href: url },
+  )}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/grade/index.astro
+++ b/src/pages/printables/grade/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import HubLinks from "../_HubLinks.astro";
 import { GRADES, gradeHref, sheetsForGrade } from "../_grades";
@@ -25,13 +26,17 @@ const years = GRADES.map((grade) => ({
 
 const title = "Printable worksheets by grade, Pre-K to 8th | School Skills";
 const description =
-  "Ten pages, one per school year: what a child that age can print, drawn from every shelf in the Print Shop at once. Free, no account, and nothing to download — and the ages come off each sheet rather than off a standard.";
+  "Ten pages, one per school year: what a child that age can print, drawn from every shelf in the Print Shop at once. Free, no account, print or save as PDF — and the ages come off each sheet rather than off a standard.";
 ---
 
 <Content
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo(null, {
+    name: "By school year",
+    href: "/printables/grade",
+  })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/grammar/[slug].astro
+++ b/src/pages/printables/grammar/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -51,7 +52,7 @@ const printed = buildSheet(sheet.config, GRAMMAR_SEED);
 const key = answerKey(sheet.config, GRAMMAR_SEED);
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = grammarShelf();
@@ -62,6 +63,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("grammar", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/grammar/index.astro
+++ b/src/pages/printables/grammar/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { GRAMMAR_SHEETS, grammarShelf, pathFor } from "../_grammar";
 import HubLinks from "../_HubLinks.astro";
@@ -20,7 +21,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable grammar worksheets — parts of speech, sentences and punctuation | School Skills";
 const description =
-  "Printable grammar practice: parts of speech, subject and predicate, statements and questions and commands, end punctuation and capital letters. Every sheet prints its answer key on the page behind — free, no account, no download.";
+  "Printable grammar practice: parts of speech, subject and predicate, statements and questions and commands, end punctuation and capital letters. Every sheet prints its answer key on the page behind — free, no account, print or save as PDF.";
 
 const groups = grammarShelf();
 ---
@@ -29,6 +30,7 @@ const groups = grammarShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("grammar")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/handwriting/[...slug].astro
+++ b/src/pages/printables/handwriting/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { buildSheet } from "@/engine/sheets";
@@ -59,7 +60,7 @@ const other = STOCKS.find((candidate) => candidate.id !== stock.id)!;
 
 const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
 const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page on ${stock.label}, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${hrefFor(sheet, stock)}`;
 
 const groups = handwritingShelf();
@@ -70,6 +71,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("handwriting", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/handwriting/index.astro
+++ b/src/pages/printables/handwriting/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import {
   HANDWRITING_SHEETS,
@@ -23,7 +24,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable handwriting worksheets — trace, copy, write | School Skills";
 const description =
-  "Printable handwriting practice: letter tracing in upper and lower case, number formation 0–9, sight words, sentences and copywork. Every sheet traces first, then copies, then leaves an empty line. Free, no account, and nothing to download.";
+  "Printable handwriting practice: letter tracing in upper and lower case, number formation 0–9, sight words, sentences and copywork. Every sheet traces first, then copies, then leaves an empty line. Free, no account, print or save as PDF.";
 
 const groups = handwritingShelf();
 const letter = STOCKS[0];
@@ -33,6 +34,7 @@ const letter = STOCKS[0];
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("handwriting")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "./_shelves";
 import { BIBLE_SHEETS, bibleShelf, hrefFor as bibleHref } from "./_bible";
 import { STOCKS, pathFor, shelf } from "./_catalog";
 import { CHART_SHEETS, chartShelf, pathFor as chartPath } from "./_charts";
@@ -61,7 +62,7 @@ import "@/styles/search.css";
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
-  "Practice sheets you can print at home, free and without an account. Every sheet is an ordinary web page, so printing it needs no download, no reader and no sign-up — and nothing about your child goes into the file.";
+  "Practice sheets you can print at home, free and without an account. Every sheet is an ordinary web page: read it on screen, print it, or save it as a PDF to keep — and nothing about your child goes into the file.";
 
 /** Listed on the default stock; each sheet page carries the link to its twin. */
 const letter = STOCKS[0];
@@ -81,6 +82,7 @@ const paperwork = templateShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo(null)}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -360,7 +362,7 @@ const paperwork = templateShelf();
     <h2 class="h2">A worksheet here is a web page</h2>
     <div class="prose">
       <p>
-        Not a PDF, not a picture of a worksheet, and nothing to download. A
+        Not a PDF you have to fetch first, and not a picture of a worksheet. A
         sheet is real text and real lines laid out in real inches, so printing
         one is <em>File &rarr; Print</em> on the page you are already looking at.
         If you want to keep a copy, choose <em>Save as PDF</em> in the print dialog

--- a/src/pages/printables/math.astro
+++ b/src/pages/printables/math.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "./_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { MATHS_SHEETS, mathsShelf, pathFor } from "./_maths";
 import HubLinks from "./_HubLinks.astro";
@@ -22,7 +23,7 @@ import HubLinks from "./_HubLinks.astro";
 const title =
   "Free printable math worksheets, with answer keys | School Skills";
 const description =
-  "Printable maths worksheets with the answer key on the second page: addition, times tables, long division, fractions, decimals, money, time, area, integers and word problems. Free, no account, and nothing to download.";
+  "Printable maths worksheets with the answer key on the second page: addition, times tables, long division, fractions, decimals, money, time, area, integers and word problems. Free, no account, print or save as PDF.";
 
 const strands = mathsShelf();
 ---
@@ -31,6 +32,7 @@ const strands = mathsShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("math")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -133,7 +135,7 @@ const strands = mathsShelf();
     <div class="wrap">
       <h2 class="h2">A worksheet here is a web page</h2>
       <p class="h2__sub">
-        Not a PDF, not a picture of a worksheet, and nothing to download.
+        Not a PDF you have to fetch first, and not a picture of a worksheet.
       </p>
       <div class="prose">
         <p>

--- a/src/pages/printables/phonics/[slug].astro
+++ b/src/pages/printables/phonics/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -51,7 +52,7 @@ const printed = buildSheet(sheet.config, PHONICS_SEED);
 const key = keyed(sheet) ? answerKey(sheet.config, PHONICS_SEED) : null;
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = phonicsShelf();
@@ -62,6 +63,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("phonics", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/phonics/index.astro
+++ b/src/pages/printables/phonics/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { PHONICS_SHEETS, pathFor, phonicsShelf } from "../_phonics";
 import HubLinks from "../_HubLinks.astro";
@@ -20,7 +21,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable phonics worksheets — built from the sounds you have taught | School Skills";
 const description =
-  "Printable phonics practice: sound cards, a sounds-we-know wall chart, CVC blending lines, word families, sound-to-word matching, dictation and decodable sentences. Every sheet is built from the spellings you tick, so nothing on it is a sound your child has not met — free, no account, no download.";
+  "Printable phonics practice: sound cards, a sounds-we-know wall chart, CVC blending lines, word families, sound-to-word matching, dictation and decodable sentences. Every sheet is built from the spellings you tick, so nothing on it is a sound your child has not met — free, no account, print or save as PDF.";
 
 const groups = phonicsShelf();
 ---
@@ -29,6 +30,7 @@ const groups = phonicsShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("phonics")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/spelling/[slug].astro
+++ b/src/pages/printables/spelling/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -52,7 +53,7 @@ const printed = buildSheet(sheet.config, SPELLING_SEED);
 const key = keyed(sheet) ? answerKey(sheet.config, SPELLING_SEED) : null;
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = spellingShelf();
@@ -71,6 +72,7 @@ const study = sheet.config.kind === "word-study";
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("spelling", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/spelling/index.astro
+++ b/src/pages/printables/spelling/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SPELLING_SHEETS, pathFor, spellingShelf } from "../_spelling";
 import HubLinks from "../_HubLinks.astro";
@@ -28,6 +29,7 @@ const groups = spellingShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("spelling")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/templates/[slug].astro
+++ b/src/pages/printables/templates/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -55,7 +56,7 @@ const printed = buildSheet(sheet.config, TEMPLATE_SEED);
 const key = keyed(sheet) ? answerKey(sheet.config, TEMPLATE_SEED) : null;
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = templateShelf();
@@ -66,6 +67,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("templates", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/templates/index.astro
+++ b/src/pages/printables/templates/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { TEMPLATE_SHEETS, pathFor, templateShelf } from "../_templates";
 import HubLinks from "../_HubLinks.astro";
@@ -26,7 +27,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable forms, planners, charts and templates | School Skills";
 const description =
-  "Printable blank templates: reading logs and book report forms, lab report and scientific method sheets, blank calendars, weekly planners, chore and behaviour charts, blank flashcards, name tags, bookmarks, award certificates, and dice and spinner nets. Real inches and cut lines on every boundary — free, no account, no download.";
+  "Printable blank templates: reading logs and book report forms, lab report and scientific method sheets, blank calendars, weekly planners, chore and behaviour charts, blank flashcards, name tags, bookmarks, award certificates, and dice and spinner nets. Real inches and cut lines on every boundary — free, no account, print or save as PDF.";
 
 const groups = templateShelf();
 ---
@@ -35,6 +36,7 @@ const groups = templateShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("templates")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3,12 +3,12 @@
    game there is one exit door in the top bar and nothing else — a nav bar over
    a race is a nav bar in a child's way.
 
-   It reads as a HUD rather than a website header: a flag, a dot per world
+   It reads as a HUD rather than a website header: the mark, a dot per world
    colour-coded to match the map, and one button that plays. The header renders
    one link per entry in the world registry, so the row grows with it rather
-   than with anything written down here. The flag's pennant takes
-   the current world's accent, so walking from the jungle to the glacier
-   recolours the thing you navigate by. That is the only ornament in here. */
+   than with anything written down here. The dots are the only colour that
+   moves; the mark is the same in every world, because a logo that changed
+   colour as you walked would stop reading as the way home. */
 
 .skip {
   position: absolute;
@@ -54,14 +54,11 @@
   color: var(--chalk);
 }
 
-.mast__flag {
+/* The plate is drawn with its own corner radius, so nothing here shapes it.
+   `flex: none` is what stops a narrow phone squashing it to make room for the
+   name beside it. */
+.mast__logo {
   flex: none;
-  overflow: visible;
-}
-
-/* The pennant is the world you're standing in. */
-.mast__pennant {
-  fill: var(--accent);
 }
 
 .mast__name {

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -601,6 +601,77 @@
   color: var(--chalk);
 }
 
+/* ── The paper half ─────────────────────────────────────────
+   The home page's Print Shop band. Its section carries `data-world="paper"`,
+   so everything below reads The Print Shop's own tokens and the change of
+   subject arrives as a change of ground — the same trick the map plays to
+   render four worlds at once.                                              */
+
+.paper__in {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(21rem, 100%), 1fr));
+  gap: var(--gap-5);
+  align-items: center;
+}
+
+.paper__shelves {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-1);
+  margin-top: var(--gap-3);
+}
+
+.paper__shelves a {
+  display: inline-block;
+  padding: 0.35em 0.8em;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  font-size: var(--step--1);
+  font-weight: 700;
+  color: var(--chalk-soft);
+  white-space: nowrap;
+  transition:
+    color 0.14s ease,
+    border-color 0.14s ease,
+    background-color 0.14s ease;
+}
+
+.paper__shelves a:hover {
+  color: var(--chalk);
+  border-color: color-mix(in oklab, var(--accent) 55%, transparent);
+  background: rgb(255 255 255 / 5%);
+}
+
+/* A whole sheet, shown small.
+
+   `transform` rather than a smaller width, because every length inside a sheet
+   is a real inch (sheet.css) — narrowing the box would reflow the paper into a
+   layout it never prints as, which is exactly the lie this band exists to
+   avoid. Scaling leaves the geometry alone and shrinks the picture of it.
+
+   A transform costs no layout, so the frame has to be given the scaled size
+   itself or the text beside it would sit on top of a sheet the box knows
+   nothing about. */
+.paper__peek {
+  --peek: 0.46;
+  width: calc(8.5in * var(--peek));
+  height: calc(11in * var(--peek));
+  margin-inline: auto;
+}
+
+.paper__peek .sheet {
+  transform: scale(var(--peek));
+  transform-origin: top left;
+}
+
+/* 8.5 inches at 0.46 is 375px, which is wider than the phone it has to sit on
+   once the wrap has taken its padding. */
+@media (width <= 34rem) {
+  .paper__peek {
+    --peek: 0.34;
+  }
+}
+
 /* ── The pause menu: privacy, terms, 404 ────────────────────────────────
    Line world and Empty world have no scenery, so the page carries itself on
    measure and rhythm alone. Nothing to add here beyond a narrower column and


### PR DESCRIPTION
The home page sold three games. **179 of the 200 pages this build emits are printables** — 27 sheet families across 10 shelves — and The Print Shop got one clause under the map. The `<title>` and meta description did not contain the word "worksheet" at all.

## The front page

The hero now names both halves, and a band after the map shows **a real worksheet**. `SheetView` with no `client:*` is HTML at build time, so it costs the page no JavaScript and what a parent sees is what the catalog prints. The band is painted `data-world="paper"`, so the change of subject arrives as a change of ground — down to a `--go` that is the colour of paper.

The masthead's yellow pennant is replaced by the actual logo. Both it and the tab icon are now `/favicon.svg`, linked rather than inlined: the traced art is 35 kB, which is a request the browser has already made for the tab and would otherwise be 35 kB of HTML on every page. 32px was picked against 28, 36 and 40 rendered in the real header.

## Saying true things

`no download, no reader, nothing to install` was true and misleading — you *can* keep a sheet, and most parents will want to. Around thirty places said some version of it. Two contradicted themselves outright: `/printables` said "nothing to download" and then, two sentences later, "choose *Save as PDF* and your browser writes one for you."

The `hero__note` chips are deliberately left alone; as a compact chip it reads as "nothing stands between you and the sheet", which is true.

Two claims in "What it isn't" had also stopped being true. It said reading comprehension, writing and maths reasoning were absent — the catalog has word problems, book reports, story maps and paragraph frames. The limit still true of both halves is that **nothing here teaches**.

## SEO

From an audit of the built output. The fundamentals were already sound: 200/200 titles, descriptions, self-referencing canonicals, `lang`, viewport, full `og:*`; every indexable page in the sitemap; **zero orphan pages and zero broken internal links**. Four gaps:

| | before | after |
| --- | --- | --- |
| `BreadcrumbList` | 0 pages | 178 |
| `Organization` + logo | none | all 200 |
| `/404` indexable | yes | `noindex` |
| Duplicate titles | 1 pair | none |

Breadcrumbs are declared by each route rather than derived from the path — the 38 A4 twins and the grade hubs are not in the sheet registry, and stripping `/a4` off a URL would be exactly the implicit coupling this codebase avoids. `trailTo()` reads `SHELVES`, so a shelf renamed there is renamed in every trail beneath it.

The duplicate pair were two genuinely different sheets sharing a title, an h1 and a keyword. The phonics one is now named for **onset and rime**, which is what its own `teaches` field already said. Its slug stays — the URL is live and a static site has nowhere to redirect it from.

## Deliberately not done

**Titles over ~60 characters (61 of 200).** Nothing gets under 60 without deleting keywords, and 60 is a *display* limit — Google reads the whole tag as a ranking signal. Cutting "parts of speech" from the grammar hub trades ranking signal for cosmetics. The keyword is front-loaded on all of them, so the visible part of the snippet is the part that matters.

## Note on printing

Every landmark on the home page now carries `.no-print`, so **the overworld prints nothing**. `@page { margin: 0 }` is global and cannot be scoped, so a section without the class prints edge to edge — and putting a sheet on this page brought it under the rule (§20) that prevents that. It previously printed a mangled margin-less article. The alternative reading, the overworld printing a worksheet nobody chose, is worse.

## Validation

`type-check`, `lint`, `build` (200 pages; sitemap, search-index and bundle guards all pass) and `test:unit` (2835 passed) green at each commit. Screenshotted at 1280px and 390px — no sideways scroll, primary CTA above the fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)