### PR TITLE
Release: the paper half, on the front page

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -197,6 +197,7 @@ sees a child's request.
 ```bash
 npm run analytics                # sync, count, and print a summary
 npm run analytics -- --days 7    # narrow the table
+npm run analytics -- --by-day    # every breakdown, a column per day
 npm run analytics -- --no-sync   # re-summarise without re-downloading
 npm run analytics -- --no-geoip  # skip the country lookup (offline)
 ```
@@ -235,6 +236,52 @@ One day looks like this:
   "decks":     { "multiply": 1, "words:dolch-4": 1 }
 }
 ```
+
+## Breaking it down by day
+
+The counts have always been per day — the file above is keyed by date, and so
+is every section inside it. What the default summary does is fold the window
+into one total per row, which answers _what is being used_ and cannot answer
+_when_. `--by-day` keeps the days as columns instead, for all eight
+breakdowns:
+
+```
+CAME FROM                              08-14  08-15  08-16   TOTAL
+  (none)                                   —      2    100     102
+  google.com                               —      .     20      20
+  t.co                                     —      1      .       1
+```
+
+`TOTAL` is the same number the default view prints for that row, so the two
+views never disagree — they read the same table in `scripts/analytics-view.mjs`.
+
+**The two marks are not the same fact**, and that difference is most of why
+this view is worth having:
+
+| Cell | Means                                                                 |
+| ---- | --------------------------------------------------------------------- |
+| `.`  | the day was counted and this key was not in it — a real zero          |
+| `—`  | that day's counts have no such field at all, so nothing was looked at |
+
+`—` is the per-day form of the warning further up: a day counted before the
+place lookup shipped has no `countries` key, and a day counted before
+referrers were recorded has no `referrers`. Reading either as zero turns
+"nobody looked" into "nobody came from anywhere", which is the shape of
+mistake this whole pipeline is built to avoid.
+
+Two more things it does rather than doing them quietly. Rows past the tenth
+are counted off (`… and 4 more not shown`), and days that will not fit the
+terminal are dropped from the oldest end with a line saying how many — and the
+totals are then recomputed against the days left, so a row always adds up to
+what is in front of you. Piped to a file there is no terminal to measure, so
+say how wide:
+
+```bash
+npm run analytics -- --by-day --width 200
+```
+
+Redirecting that grid into a file puts city rows on disk, which the caveat
+above is about. Treat the file the way you would treat the terminal.
 
 The long way round, if you want the pieces separately:
 

--- a/scripts/analytics-view.mjs
+++ b/scripts/analytics-view.mjs
@@ -1,0 +1,316 @@
+/**
+ * The eight breakdowns `npm run analytics` prints, and the two ways to read
+ * them.
+ *
+ * The counts arrive already broken down by day: `scripts/rollup-analytics.mjs`
+ * writes `days[date][section][key]` and always has. The only thing that
+ * differs between the two views is what happens to that middle key — the
+ * default folds every day in the window into one total per row, and
+ * `--by-day` keeps the days as columns. Both walk the same `SECTIONS` table,
+ * so a heading, a label or a caveat is written once and cannot come out
+ * saying two different things in the two views.
+ *
+ * Split out of scripts/analytics.mjs so the column arithmetic can be exercised
+ * without a terminal, an S3 sync or a rollup run behind it.
+ */
+
+/** Rows per section. `events` opts out: there are a handful and all matter. */
+const TOP = 10;
+
+/** How wide a row label may get before the middle of it is dropped. */
+const LABEL_MAX = 36;
+
+/**
+ * `BR` → `Brazil`, via `Intl` rather than a table in this repo.
+ *
+ * A two-letter code is exactly as unreadable as the airport codes below it,
+ * which is what prompted the country lookup in the first place — printing
+ * `SG 6` and calling it an improvement would have missed the point. Node has
+ * shipped the region names since v14, so the alternative was carrying 250
+ * country names in a source file and letting them go stale.
+ */
+const REGIONS = new Intl.DisplayNames(["en"], { type: "region" });
+export const countryName = (code) => {
+  if (code === "(unknown)") return "address not in the table";
+  try {
+    return REGIONS.of(code) ?? code;
+  } catch {
+    // `of` throws on anything that isn't a well-formed region code. A code the
+    // table produced but Intl doesn't know is worth printing bare, not worth
+    // taking the summary down for.
+    return code;
+  }
+};
+
+/**
+ * `US / Iowa / Council Bluffs` → `United States / Iowa / Council Bluffs`.
+ *
+ * The rollup stores places qualified by the level above them, because place
+ * names are not unique — Ontario is a Canadian province and a Californian
+ * city, and there are around thirty Springfields. Only the leading country
+ * code is expanded; the rest is already what the source called it.
+ */
+export const placeLabel = (key) => {
+  const cut = key.indexOf(" / ");
+  if (cut === -1) return key;
+  return `${countryName(key.slice(0, cut))}${key.slice(cut)}`;
+};
+
+/**
+ * Every breakdown, in the order they print.
+ *
+ * `title` heads the default view and `short` heads the same section in the
+ * by-day grid, where the heading shares a line with the date columns and a
+ * long one would cost several days of width. The caveats the long headings
+ * carry are repeated in the footer under both views, so nothing is only said
+ * in the version the grid drops.
+ *
+ * `label` receives every key in the section alongside the one being drawn,
+ * because a label can depend on its neighbours: country codes are padded to
+ * the widest present, and `(unknown)` is nine characters against everyone
+ * else's two.
+ *
+ * `compact` is the same row in the grid, where every character spent on a
+ * label is taken off the days that fit beside it. Only the places want one:
+ * spelling `US` out to `United States` on each of ten city rows buys nothing
+ * when the COUNTRY grid three sections up has just named it, and costs about
+ * two days of width.
+ */
+const SECTIONS = [
+  { key: "pages", title: "TOP PAGES", short: "TOP PAGES" },
+  { key: "referrers", title: "CAME FROM", short: "CAME FROM" },
+  {
+    key: "countries",
+    title: "COUNTRY (the visitor's own IP, resolved locally)",
+    short: "COUNTRY",
+    label: (code, all) =>
+      `${code.padEnd(Math.max(...all.map((c) => c.length)))}  ${countryName(code)}`,
+  },
+  {
+    key: "regions",
+    title: "REGION",
+    short: "REGION",
+    label: placeLabel,
+    compact: (key) => key,
+  },
+  {
+    key: "cities",
+    // The count of distinct cities, not just the ten printed, because the
+    // shape of the tail is the thing worth knowing here: a long tail of ones
+    // is what a city breakdown looks like at this traffic, and it is the
+    // reason the caveat at the bottom of this output exists.
+    title: (rows) => `CITY (${rows.length} distinct)`,
+    short: "CITY",
+    label: placeLabel,
+    compact: (key) => key,
+    note: (rows) => {
+      const once = rows.filter((row) => row.total === 1).length;
+      return once
+        ? `${once} of them seen exactly once — see the note below`
+        : null;
+    },
+  },
+  {
+    key: "edges",
+    title: "SERVED FROM (nearest CloudFront edge, not the visitor)",
+    short: "SERVED FROM",
+  },
+  { key: "events", title: "EVENTS", short: "EVENTS", limit: Infinity },
+  { key: "decks", title: "DECKS RACED", short: "DECKS RACED" },
+];
+
+const limitOf = (section) => section.limit ?? TOP;
+const titleOf = (section, rows) =>
+  typeof section.title === "function" ? section.title(rows) : section.title;
+const labelOf = (section, name, names) =>
+  section.label ? section.label(name, names) : name;
+const compactOf = (section, name, names) =>
+  section.compact
+    ? section.compact(name, names)
+    : labelOf(section, name, names);
+
+/**
+ * One section as rows: every key it holds anywhere in `dates`, a cell per day,
+ * and a total across them.
+ *
+ * A cell is `null` only where the day has no such section at all, which is a
+ * different fact from a zero and is why the grid draws the two differently.
+ * Days counted before the place lookup shipped carry no `countries` key and
+ * days counted before referrers were recorded carry no `referrers`; filing
+ * either as zero would read as "nobody came from anywhere that day" rather
+ * than "nobody looked".
+ *
+ * Totals cover the days passed in and nothing wider, so narrowing the window
+ * — or a terminal too narrow to hold it — leaves a table whose rows add up to
+ * what is on screen.
+ */
+export const sectionRows = (days, dates, key) => {
+  // A day that recorded the section contributes a zero to every key it didn't
+  // mention; a day that didn't record it contributes nothing at all.
+  const absent = dates.map((date) => (days[date]?.[key] ? 0 : null));
+  const cells = new Map();
+
+  for (const [at, date] of dates.entries()) {
+    for (const [name, n] of Object.entries(days[date]?.[key] ?? {})) {
+      if (!cells.has(name)) cells.set(name, [...absent]);
+      cells.get(name)[at] = n;
+    }
+  }
+
+  return [...cells]
+    .map(([name, row]) => ({
+      name,
+      cells: row,
+      total: row.reduce((sum, n) => sum + (n ?? 0), 0),
+    }))
+    .sort((a, b) => b.total - a.total || a.name.localeCompare(b.name));
+};
+
+/** The default view: one total per row, over the whole window. */
+export const mergedLines = (days, dates) => {
+  const out = [];
+  for (const section of SECTIONS) {
+    const rows = sectionRows(days, dates, section.key);
+    // Days counted before a field existed have none of it, so a section with
+    // nothing in it stays quiet rather than printing a heading over a window
+    // that predates it. An empty heading and a genuine zero should not look
+    // the same.
+    if (rows.length === 0) continue;
+
+    const names = rows.map((row) => row.name);
+    out.push("", titleOf(section, rows));
+    for (const row of rows.slice(0, limitOf(section))) {
+      out.push(
+        `  ${String(row.total).padStart(6)}  ${labelOf(section, row.name, names)}`,
+      );
+    }
+
+    const note = section.note?.(rows);
+    if (note) out.push(`         ${note}`);
+  }
+  return out;
+};
+
+/**
+ * Drop the middle of an over-long label rather than its end.
+ *
+ * The most specific part of a place key is its last: cutting the tail off
+ * `United States / Washington / Seattle` would take the city with it and
+ * leave a column of rows all reading `United States / Washing…`.
+ */
+export const shorten = (text, max) => {
+  if (text.length <= max) return text;
+  const head = Math.ceil((max - 1) / 2);
+  return `${text.slice(0, head)}…${text.slice(text.length - (max - 1 - head))}`;
+};
+
+const cellText = (n) => (n === null ? "—" : n === 0 ? "." : String(n));
+
+/**
+ * How many day columns fit across `terminal`.
+ *
+ * Each column costs its own width plus the two spaces in front of it. Fixed
+ * either side: two spaces of row indent, the label column, and the total
+ * column behind a wider three-space gap that keeps it from reading as one
+ * more day. One column always "fits" — a terminal too narrow for that is
+ * better overflowing than empty.
+ */
+export const fitDays = (terminal, { label, cell, total }) =>
+  Math.max(1, Math.floor((terminal - 2 - label - total - 3) / (cell + 2)));
+
+/** Rows, labels and column widths for a given set of days. */
+const layout = (days, dates) => {
+  const sections = SECTIONS.map((section) => {
+    const rows = sectionRows(days, dates, section.key);
+    const names = rows.map((row) => row.name);
+    return {
+      section,
+      rows,
+      drawn: rows.slice(0, limitOf(section)).map((row) => ({
+        label: shorten(compactOf(section, row.name, names), LABEL_MAX),
+        cells: row.cells.map(cellText),
+        total: String(row.total),
+      })),
+    };
+  }).filter((entry) => entry.rows.length > 0);
+
+  const drawn = sections.flatMap((entry) => entry.drawn);
+  return {
+    sections,
+    // Shared across every section, so a reader can compare one grid against
+    // the one above it without re-reading the date row each time.
+    label: Math.max(
+      ...sections.map((entry) => entry.section.short.length),
+      ...drawn.map((row) => row.label.length),
+    ),
+    cell: Math.max(
+      5,
+      ...drawn.flatMap((row) => row.cells.map((c) => c.length)),
+    ),
+    total: Math.max(5, ...drawn.map((row) => row.total.length)),
+  };
+};
+
+const LEGEND = [
+  "Down a column is one day; across a row is one key over time.",
+  "  .  none that day",
+  "  —  nothing measured that day: the field is missing from that day's",
+  "     counts, which is not the same as a count of zero",
+];
+
+/**
+ * `--by-day`: the same eight sections with the days kept as columns.
+ *
+ * @param terminal how many characters wide the output may be. Days that don't
+ *   fit are dropped from the oldest end and said so — a table quietly showing
+ *   half the window it was asked for is the failure this pipeline is least
+ *   allowed to have.
+ */
+export const dailyLines = (days, dates, terminal) => {
+  if (dates.length === 0) return [];
+  let plan = layout(days, dates);
+  if (plan.sections.length === 0) return [];
+
+  const shown = dates.slice(-fitDays(terminal, plan));
+  const dropped = dates.length - shown.length;
+  // Re-measured against the days actually on screen, so which rows make the
+  // top ten and what they add up to describe the table rather than a window
+  // wider than it.
+  if (dropped) plan = layout(days, shown);
+
+  const out = [""];
+  if (dropped) {
+    out.push(
+      `This terminal fits ${shown.length} of the window's ${dates.length} days, so the oldest`,
+      `${dropped} are off the table and TOTAL adds up only the columns on it.`,
+      "Widen the terminal, or pass --width to lay one out for a file.",
+      "",
+    );
+  }
+  out.push(...LEGEND);
+
+  for (const { section, rows, drawn } of plan.sections) {
+    out.push(
+      "",
+      [
+        section.short.padEnd(2 + plan.label),
+        ...shown.map((date) => date.slice(5).padStart(plan.cell)),
+      ].join("  ") + `   ${"TOTAL".padStart(plan.total)}`,
+    );
+    for (const row of drawn) {
+      out.push(
+        [
+          `  ${row.label.padEnd(plan.label)}`,
+          ...row.cells.map((cell) => cell.padStart(plan.cell)),
+        ].join("  ") + `   ${row.total.padStart(plan.total)}`,
+      );
+    }
+
+    const hidden = rows.length - drawn.length;
+    if (hidden > 0) out.push(`  … and ${hidden} more not shown`);
+
+    const note = section.note?.(rows);
+    if (note) out.push(`  ${note}`);
+  }
+  return out;
+};

--- a/scripts/analytics-view.test.mjs
+++ b/scripts/analytics-view.test.mjs
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dailyLines,
+  fitDays,
+  mergedLines,
+  sectionRows,
+  shorten,
+} from "./analytics-view.mjs";
+
+/**
+ * The rollup has always counted by day; until `--by-day` the summary threw
+ * that away on the way to the screen. So the cases that matter here are the
+ * ones where a day and a total disagree — a field that only some days
+ * recorded, a window wider than the terminal, and a label too long to print.
+ *
+ * The shape of a day is `scripts/rollup-analytics.mjs`'s output: see `main`
+ * there for which keys are written and which are omitted entirely.
+ */
+
+/** A day before the place lookup or referrers existed — see `loadGeo`. */
+const EARLY = {
+  visitors: 4,
+  pageViews: 9,
+  pages: { "/": 5, "/typing/": 4 },
+  edges: { SEA: 9 },
+  events: { race_start: 2 },
+  decks: {},
+};
+
+const FULL = {
+  visitors: 2,
+  pageViews: 3,
+  pages: { "/": 1, "/flash-cards/": 2 },
+  countries: { US: 2, "(unknown)": 1 },
+  regions: { "US / Washington": 2 },
+  cities: { "US / Washington / Seattle": 1, "US / Iowa / Council Bluffs": 1 },
+  referrers: { "(none)": 2, "t.co": 1 },
+  edges: { SEA: 3 },
+  events: { race_start: 1, "race_end:quit": 1 },
+  decks: { multiply: 1 },
+};
+
+const DAYS = { "2026-08-14": EARLY, "2026-08-15": FULL };
+const DATES = ["2026-08-14", "2026-08-15"];
+
+describe("sectionRows", () => {
+  it("gives every key a cell per day, ordered by total", () => {
+    expect(sectionRows(DAYS, DATES, "pages")).toEqual([
+      { name: "/", cells: [5, 1], total: 6 },
+      { name: "/typing/", cells: [4, 0], total: 4 },
+      { name: "/flash-cards/", cells: [0, 2], total: 2 },
+    ]);
+  });
+
+  /**
+   * The distinction the whole grid turns on. `/typing/` got no views on the
+   * 15th, which the day counted and found none of — a zero. Nothing at all is
+   * known about referrers on the 14th, because that rollup did not record the
+   * field. Both would be `0` if the cells were built by summing.
+   */
+  it("separates a day that counted none from a day that never looked", () => {
+    expect(sectionRows(DAYS, DATES, "referrers")).toEqual([
+      { name: "(none)", cells: [null, 2], total: 2 },
+      { name: "t.co", cells: [null, 1], total: 1 },
+    ]);
+  });
+
+  it("treats an empty section as counted, not as missing", () => {
+    expect(
+      sectionRows(
+        { a: { decks: {} }, b: { decks: { x: 1 } } },
+        ["a", "b"],
+        "decks",
+      ),
+    ).toEqual([{ name: "x", cells: [0, 1], total: 1 }]);
+  });
+
+  it("breaks ties on the name, so a row cannot move when the window does", () => {
+    const rows = sectionRows(
+      { a: { pages: { z: 1 } }, b: { pages: { y: 1 } } },
+      ["a", "b"],
+      "pages",
+    );
+    expect(rows.map((row) => row.name)).toEqual(["y", "z"]);
+  });
+
+  it("has nothing to say about a field no day recorded", () => {
+    expect(sectionRows(DAYS, DATES, "countries")).toHaveLength(2);
+    expect(sectionRows({ a: EARLY }, ["a"], "countries")).toEqual([]);
+  });
+});
+
+describe("mergedLines", () => {
+  it("prints one total per row", () => {
+    expect(mergedLines(DAYS, DATES)).toContain("       6  /");
+  });
+
+  /** An empty heading and a genuine zero must not look the same. */
+  it("stays quiet about a section the window predates", () => {
+    const lines = mergedLines({ a: EARLY }, ["a"]).join("\n");
+    expect(lines).not.toContain("COUNTRY");
+    expect(lines).not.toContain("CAME FROM");
+  });
+
+  it("names countries and counts distinct cities", () => {
+    const lines = mergedLines(DAYS, DATES).join("\n");
+    expect(lines).toContain("US         United States");
+    expect(lines).toContain("(unknown)  address not in the table");
+    expect(lines).toContain("CITY (2 distinct)");
+    expect(lines).toContain("2 of them seen exactly once");
+  });
+});
+
+describe("fitDays", () => {
+  const widths = { label: 25, cell: 5, total: 5 };
+
+  it("fills the space the fixed columns leave", () => {
+    // 2 indent + 25 label + 6 × (5 + 2) + 3 gap + 5 total = 77.
+    expect(fitDays(80, widths)).toBe(6);
+    expect(fitDays(77, widths)).toBe(6);
+    expect(fitDays(76, widths)).toBe(5);
+  });
+
+  /** Overflowing beats printing a table with no days in it. */
+  it("keeps one column however narrow the terminal", () => {
+    expect(fitDays(20, widths)).toBe(1);
+  });
+});
+
+describe("shorten", () => {
+  it("leaves a label that fits alone", () => {
+    expect(shorten("US / Washington", 36)).toBe("US / Washington");
+  });
+
+  /** The city is at the end of a place key, so the end is what must survive. */
+  it("drops the middle, keeping both ends", () => {
+    const cut = shorten("United States / Washington / Seattle", 20);
+    expect(cut).toHaveLength(20);
+    expect(cut.startsWith("United")).toBe(true);
+    expect(cut.endsWith("Seattle")).toBe(true);
+  });
+});
+
+describe("dailyLines", () => {
+  const at = (terminal) => dailyLines(DAYS, DATES, terminal).join("\n");
+
+  it("puts a column under each day and the window's total behind them", () => {
+    expect(at(120)).toMatch(/^TOP PAGES\s+08-14\s+08-15\s+TOTAL$/m);
+    expect(at(120)).toMatch(/^ {2}\/ {2,}5 {2,}1 {2,}6$/m);
+  });
+
+  it("draws a counted zero and an unrecorded field differently", () => {
+    expect(at(120)).toMatch(/^ {2}\/typing\/ {2,}4 {2,}\. {2,}4$/m);
+    expect(at(120)).toMatch(/^ {2}\(none\) {2,}— {2,}2 {2,}2$/m);
+  });
+
+  it("spends no width spelling out a country the COUNTRY grid just named", () => {
+    expect(at(120)).toContain("US / Washington / Seattle");
+    expect(at(120)).not.toContain("United States / Washington / Seattle");
+  });
+
+  /**
+   * A table quietly showing half the window it was asked for is the failure
+   * this pipeline is least allowed to have — see the header of
+   * scripts/rollup-analytics.mjs on the outage that made that the rule.
+   */
+  it("says so when the terminal cannot hold the window", () => {
+    const narrow = dailyLines(DAYS, DATES, 40).join("\n");
+    expect(narrow).toContain("fits 1 of the window's 2 days");
+    expect(narrow).toContain("1 are off the table");
+  });
+
+  it("re-totals against the days on screen, not the window asked for", () => {
+    // `/` is 5 on the 14th and 1 on the 15th; dropping the 14th must leave a
+    // table whose rows add up to what is in front of you.
+    expect(dailyLines(DAYS, DATES, 40).join("\n")).toMatch(
+      /^ {2}\/ {2,}1 {2,}1$/m,
+    );
+  });
+
+  it("says how many rows the top ten left out", () => {
+    const many = {
+      a: {
+        pages: Object.fromEntries(
+          Array.from({ length: 14 }, (_, i) => [`/p${i}`, i + 1]),
+        ),
+      },
+    };
+    expect(dailyLines(many, ["a"], 120).join("\n")).toContain(
+      "… and 4 more not shown",
+    );
+  });
+
+  it("has nothing to draw with no days", () => {
+    expect(dailyLines({}, [], 120)).toEqual([]);
+  });
+});

--- a/scripts/analytics.mjs
+++ b/scripts/analytics.mjs
@@ -25,11 +25,18 @@
  *   npm run analytics                sync, count, summarise
  *   npm run analytics -- --no-sync   re-summarise what's already downloaded
  *   npm run analytics -- --days 7    narrow the table (default 30)
+ *   npm run analytics -- --by-day    every breakdown with a column per day
+ *   npm run analytics -- --width 200 lay the grid out for a file, not a tty
  *   npm run analytics -- --no-geoip  skip the country lookup
  *
  * `--no-geoip` is for working with no network at all. The country table is
  * cached in the temp directory next to the logs, so an ordinary second run
  * downloads nothing and the flag buys nothing — see scripts/geoip.mjs.
+ *
+ * `--width` exists because the by-day grid sizes itself to the terminal and
+ * drops the oldest days that don't fit. Piped into a file there is no terminal
+ * to measure, so without it a redirected run silently lays out for 100
+ * columns — see `dailyLines` in scripts/analytics-view.mjs.
  */
 
 import { execFileSync } from "node:child_process";
@@ -37,6 +44,7 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { dailyLines, mergedLines } from "./analytics-view.mjs";
 import { awsAuthHint, awsIdentityLabel, awsProfileArgs } from "./aws.mjs";
 
 // Temp, deliberately. See the header: nothing this produces is kept, and
@@ -49,9 +57,18 @@ const LOGS = join(tmpdir(), "schoolskills-cflogs");
 
 const argv = process.argv.slice(2);
 const flag = (name) => argv.includes(`--${name}`);
+// Loud about a value it can't use, because both options this parses exist to
+// bound what gets printed: a `--width` that quietly became NaN would disable
+// the fitting whose whole job is to stop the grid overflowing unannounced.
 const option = (name, fallback) => {
   const at = argv.indexOf(`--${name}`);
-  return at === -1 ? fallback : Number(argv[at + 1]);
+  if (at === -1) return fallback;
+  const value = Number(argv[at + 1]);
+  if (Number.isFinite(value) && value > 0) return value;
+  process.stderr.write(
+    `--${name} ${argv[at + 1] ?? ""}: not a positive number, using ${fallback}\n`,
+  );
+  return fallback;
 };
 
 const run = (cmd, args) =>
@@ -102,43 +119,7 @@ function sync() {
 const width = (rows, pick, header) =>
   Math.max(header.length, ...rows.map((row) => String(pick(row)).length));
 
-/**
- * `BR` → `Brazil`, via `Intl` rather than a table in this repo.
- *
- * A two-letter code is exactly as unreadable as the airport codes below it,
- * which is what prompted the country lookup in the first place — printing
- * `SG 6` and calling it an improvement would have missed the point. Node has
- * shipped the region names since v14, so the alternative was carrying 250
- * country names in a source file and letting them go stale.
- */
-const REGIONS = new Intl.DisplayNames(["en"], { type: "region" });
-const countryName = (code) => {
-  if (code === "(unknown)") return "address not in the table";
-  try {
-    return REGIONS.of(code) ?? code;
-  } catch {
-    // `of` throws on anything that isn't a well-formed region code. A code the
-    // table produced but Intl doesn't know is worth printing bare, not worth
-    // taking the summary down for.
-    return code;
-  }
-};
-
-/**
- * `US / Iowa / Council Bluffs` → `United States / Iowa / Council Bluffs`.
- *
- * The rollup stores places qualified by the level above them, because place
- * names are not unique — Ontario is a Canadian province and a Californian
- * city, and there are around thirty Springfields. Only the leading country
- * code is expanded; the rest is already what the source called it.
- */
-const placeLabel = (key) => {
-  const cut = key.indexOf(" / ");
-  if (cut === -1) return key;
-  return `${countryName(key.slice(0, cut))}${key.slice(cut)}`;
-};
-
-function summarise(days, limit) {
+function summarise(days, limit, { byDay, terminal }) {
   const dates = Object.keys(days).sort();
   if (dates.length === 0) {
     console.log(
@@ -197,90 +178,14 @@ function summarise(days, limit) {
     );
   }
 
-  // Pages and decks across the whole window, which is the question the per-day
-  // table can't answer: what is actually being used.
-  const merge = (key) => {
-    const total = {};
-    for (const date of shown)
-      for (const [k, n] of Object.entries(days[date][key] ?? {}))
-        total[k] = (total[k] ?? 0) + n;
-    return Object.entries(total).sort((a, b) => b[1] - a[1]);
-  };
-
-  const pages = merge("pages");
-  if (pages.length) {
-    console.log("\nTOP PAGES");
-    for (const [path, n] of pages.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${path}`);
-  }
-
-  // Days counted before referrers were recorded simply have none of these, so
-  // both blocks stay quiet rather than printing an empty heading over a window
-  // that predates them.
-  const referrers = merge("referrers");
-  if (referrers.length) {
-    console.log("\nCAME FROM");
-    for (const [host, n] of referrers.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${host}`);
-  }
-
-  // Days counted before the place lookup existed have no `countries` key at
-  // all, which is why these stay quiet rather than printing a heading over a
-  // window that predates them. An empty heading and a genuine zero should not
-  // look the same.
-  const countries = merge("countries");
-  if (countries.length) {
-    const codeWidth = Math.max(...countries.map(([code]) => code.length));
-    console.log("\nCOUNTRY (the visitor's own IP, resolved locally)");
-    for (const [code, n] of countries.slice(0, 10))
-      console.log(
-        `  ${String(n).padStart(6)}  ${code.padEnd(codeWidth)}  ${countryName(code)}`,
-      );
-  }
-
-  const regions = merge("regions");
-  if (regions.length) {
-    console.log("\nREGION");
-    for (const [name, n] of regions.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${placeLabel(name)}`);
-  }
-
-  const cities = merge("cities");
-  if (cities.length) {
-    // The count of distinct cities, not just the top ten, because the shape of
-    // the tail is the thing worth knowing here: a long tail of ones is what a
-    // city breakdown looks like at this traffic, and it is the reason the
-    // caveat at the bottom of this output exists.
-    const singletons = cities.filter(([, n]) => n === 1).length;
-    console.log(`\nCITY (${cities.length} distinct)`);
-    for (const [name, n] of cities.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${placeLabel(name)}`);
-    if (singletons)
-      console.log(
-        `         ${singletons} of them seen exactly once — see the note below`,
-      );
-  }
-
-  const edges = merge("edges");
-  if (edges.length) {
-    console.log("\nSERVED FROM (nearest CloudFront edge, not the visitor)");
-    for (const [code, n] of edges.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${code}`);
-  }
-
-  const events = merge("events");
-  if (events.length) {
-    console.log("\nEVENTS");
-    for (const [name, n] of events)
-      console.log(`  ${String(n).padStart(6)}  ${name}`);
-  }
-
-  const decks = merge("decks");
-  if (decks.length) {
-    console.log("\nDECKS RACED");
-    for (const [name, n] of decks.slice(0, 10))
-      console.log(`  ${String(n).padStart(6)}  ${name}`);
-  }
+  // The breakdowns themselves. Which shape they take is the only thing
+  // --by-day changes; the counts behind both are the same per-day totals the
+  // rollup has always written.
+  console.log(
+    (byDay ? dailyLines(days, shown, terminal) : mergedLines(days, shown)).join(
+      "\n",
+    ),
+  );
 
   // Said every time rather than in a doc, because the number most likely to be
   // quoted out of context is the one at the top of a table.
@@ -314,6 +219,10 @@ try {
     summarise(
       JSON.parse(readFileSync(OUT, "utf8")).days ?? {},
       option("days", 30),
+      {
+        byDay: flag("by-day"),
+        terminal: option("width", process.stdout.columns ?? 100),
+      },
     );
   }
 } catch (error) {

--- a/src/components/site/SiteHeader.astro
+++ b/src/components/site/SiteHeader.astro
@@ -8,8 +8,12 @@
  * colour code the map teaches — a dot per world, in that world's own colour,
  * so "the green one" means the same thing here as it does there.
  *
- * The flag's pennant takes `--accent`, which is whatever world the page is
- * standing in. Walking from the jungle to the glacier recolours it.
+ * The mark is `/favicon.svg` — the same file the tab icon points at, so what
+ * is on the page and what is in the tab cannot drift apart. Linked rather
+ * than inlined: it is 35 kB of traced curves, which is one request the
+ * browser has already made for the tab, and would otherwise be 35 kB of HTML
+ * on every page. That file is also the small-size art, with the book's page
+ * rules and lettering dropped, which is the right art at 32px.
  */
 import { WORLDS, type World } from "@/engine/worlds";
 
@@ -26,20 +30,13 @@ const { world } = Astro.props;
 <header class="mast">
   <div class="mast__in">
     <a class="mast__mark" href="/">
-      <svg
-        class="mast__flag"
-        width="22"
-        height="24"
-        viewBox="0 0 22 24"
-        aria-hidden="true"
-      >
-        <path
-          d="M4.2 2.5v19"
-          stroke="currentColor"
-          stroke-width="2.4"
-          stroke-linecap="round"></path>
-        <path class="mast__pennant" d="M5.4 3.6 19 8.2 5.4 12.8z"></path>
-      </svg>
+      <img
+        class="mast__logo"
+        src="/favicon.svg"
+        width="32"
+        height="32"
+        alt=""
+      />
       <span class="mast__name">School Skills</span>
     </a>
 

--- a/src/components/site/WorldMap.astro
+++ b/src/components/site/WorldMap.astro
@@ -50,8 +50,9 @@ const BADGES: Partial<Record<World, string>> = {
     Three are games, one subject each and one thing to get good at. Start
     anywhere, stop anywhere, and switch mid-week &mdash; nothing has to be
     finished before anything else opens, and the same player carries their
-    records between all three. The fourth is The Print Shop, which makes paper
-    rather than points, and is a stop for you rather than for them.
+    records between all three. The fourth is The Print Shop, and it is the one
+    that is yours rather than theirs: worksheets for maths, handwriting, phonics
+    and more, printed from the browser with the answer key behind them.
   </p>
 
   {

--- a/src/engine/worlds.ts
+++ b/src/engine/worlds.ts
@@ -149,7 +149,7 @@ export const WORLDS: WorldInfo[] = [
     subject: "Worksheets to print",
     tagline: "For the grown-up. Pick a sheet, tune it, print it.",
     blurb:
-      "Times tables, handwriting rules, spelling lists and Scripture copywork, as paper you can hand over. Sheets print straight from the browser with an answer key — no download, no account, and nothing about your child in the file.",
+      "Times tables, handwriting rules, spelling lists and Scripture copywork, as paper you can hand over. Sheets print straight from the browser with an answer key, or save as a PDF — no account, and nothing about your child in the file.",
     icon: "🖨️",
     href: "/printables",
     island: "/printables/make",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -24,6 +24,17 @@ interface Props {
   image?: string;
   /** Structured data for this page, serialised into a JSON-LD script tag. */
   jsonLd?: Record<string, unknown>;
+  /**
+   * The trail to this page, root first, as `BreadcrumbList` structured data.
+   *
+   * Given rather than derived from the path, because the path does not know
+   * what its segments are called: `/printables/bible/psalm-23-copywork/a4` is
+   * three words and a stock, and only the route that built it knows those are
+   * "The Print Shop", "Bible" and a sheet with a name. A page that says nothing
+   * emits nothing, which is the right default — a breadcrumb on a page with no
+   * hierarchy above it is a claim about a structure that isn't there.
+   */
+  breadcrumb?: Array<{ name: string; href: string }>;
   /** Which world this page is in. Drives every colour on it. */
   world?: World;
   /**
@@ -51,12 +62,65 @@ const {
   description,
   image = "/og-default.png",
   jsonLd,
+  breadcrumb,
   world = "grid",
   noindex = false,
 } = Astro.props;
 
 const canonical = new URL(Astro.url.pathname, Astro.site).href;
 const ogImage = new URL(image, Astro.site).href;
+
+/**
+ * The publisher, stamped onto every page's structured data.
+ *
+ * Google reads a site's logo off an Organization node, and the claim it is
+ * making — this mark belongs to this domain — is about the site rather than
+ * about any one page. So it is attached here instead of being written into the
+ * thirty route files that carry `jsonLd`, which would drift apart the first
+ * time one of them was edited alone. `publisher` is valid on every `@type`
+ * this site emits: WebSite, CollectionPage, AboutPage and LearningResource are
+ * all CreativeWorks.
+ *
+ * The PNG rather than favicon.svg, because Google's logo guidance takes a
+ * raster. It is the same mark, from the same traced curves — see
+ * scripts/generate-icons.mjs.
+ *
+ * A page that states its own publisher keeps it, so a future page that is not
+ * ours to claim can say so.
+ */
+/**
+ * The trail as schema.org sees it: a list, one-indexed, each item an absolute
+ * URL. Its own script rather than a field on `jsonLd`, because a
+ * `BreadcrumbList` is an `ItemList` and not a `CreativeWork` — the publisher
+ * below would be invalid on it, and Google reads sibling blocks fine.
+ */
+const crumbs = breadcrumb?.length
+  ? {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: breadcrumb.map((step, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        name: step.name,
+        item: new URL(step.href, Astro.site).href,
+      })),
+    }
+  : undefined;
+
+const structured = jsonLd && {
+  ...jsonLd,
+  publisher: jsonLd.publisher ?? {
+    "@type": "Organization",
+    name: "School Skills",
+    url: new URL("/", Astro.site).href,
+    logo: {
+      "@type": "ImageObject",
+      url: new URL("/icon-512.png", Astro.site).href,
+      width: 512,
+      height: 512,
+    },
+  },
+};
 ---
 
 <!doctype html>
@@ -120,11 +184,20 @@ const ogImage = new URL(image, Astro.site).href;
     </script>
 
     {
-      jsonLd && (
+      structured && (
         <script
           type="application/ld+json"
           is:inline
-          set:html={JSON.stringify(jsonLd)}
+          set:html={JSON.stringify(structured)}
+        />
+      )
+    }
+    {
+      crumbs && (
+        <script
+          type="application/ld+json"
+          is:inline
+          set:html={JSON.stringify(crumbs)}
         />
       )
     }

--- a/src/layouts/Content.astro
+++ b/src/layouts/Content.astro
@@ -20,6 +20,8 @@ interface Props {
   description: string;
   image?: string;
   jsonLd?: Record<string, unknown>;
+  /** The trail to this page — see `Base.astro`. */
+  breadcrumb?: Array<{ name: string; href: string }>;
   /** Which world this page is in. Drives every colour on it. */
   world: World;
   /**
@@ -35,7 +37,8 @@ interface Props {
   noindex?: boolean;
 }
 
-const { title, description, image, jsonLd, world, noindex } = Astro.props;
+const { title, description, image, jsonLd, breadcrumb, world, noindex } =
+  Astro.props;
 
 // Line world and Empty world have no scenery, so their pages tighten the
 // measure and drop the display type a size. See content.css.
@@ -47,6 +50,7 @@ const pause = world === "line" || world === "empty";
   description={description}
   image={image}
   jsonLd={jsonLd}
+  breadcrumb={breadcrumb}
   world={world}
   noindex={noindex}
 >

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,6 +10,11 @@ import Content from "@/layouts/Content.astro";
  * It renders in Empty world, which is one horizon line and no ground. The joke
  * is that it's also the literal truth, and a dead end is a better place to be
  * charming than a privacy policy is.
+ *
+ * `noindex` because this file is reachable at /404 as well as being served for
+ * every wrong address. CloudFront answers a mistyped URL with a real 404 status
+ * (sst.config.ts), which is the signal that matters — but nothing stops a
+ * crawler asking for /404 itself and getting a 200 with a page on it.
  */
 ---
 
@@ -17,6 +22,7 @@ import Content from "@/layouts/Content.astro";
   title="Page not found — School Skills"
   description="That page doesn't exist. Head back to the map."
   world="empty"
+  noindex
 >
   <div class="void">
     <p class="hero__eyebrow">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,11 @@
 import Content from "@/layouts/Content.astro";
 import AdSlot from "@/components/site/AdSlot.astro";
 import WorldMap from "@/components/site/WorldMap.astro";
+import { SheetView } from "@/components/sheet/Sheet";
+import { buildSheet } from "@/engine/sheets";
 import { passage, passageText } from "@/engine/sheets/passages";
+import { MATHS_SEED, MATHS_SHEETS } from "./printables/_maths";
+import { ALL_SHEETS, SHELVES } from "./printables/_shelves";
 
 /**
  * The overworld.
@@ -16,14 +20,25 @@ import { passage, passageText } from "@/engine/sheets/passages";
  * So the page is the map first and the argument second: colour, worlds and one
  * obvious way in above the fold, then the honest prose underneath it. The
  * "what it isn't" block is deliberately the same size as the "what it is" one,
- * because the limits are half the pitch here. This is a supplement — three
- * narrow skills drilled properly — and a parent who discovers that in week
- * three instead of minute one has been sold something.
+ * because the limits are half the pitch here. This is a supplement — practice
+ * of things somebody else taught — and a parent who discovers that in week
+ * three instead of minute one has been sold something. Which limit says so has
+ * moved: the games really are three narrow skills, but the paper is wide
+ * enough that "not a whole subject" stopped being the true one, and what is
+ * still true of both halves is that nothing here teaches.
+ *
+ * **Every landmark on this page carries `.no-print`, so the overworld prints
+ * nothing.** `@page { margin: 0 }` in print.css is global and cannot be scoped,
+ * so any section without the class prints edge to edge — and once the paper
+ * band below put a real sheet on this page, the rule that keeps that from
+ * happening (§20, held by `Sheet.test.tsx`) started applying here. Printing a
+ * screen was never the use for this one, and the alternative reading — the
+ * overworld printing the worksheet it happens to be showing — hands a parent
+ * paper they did not choose.
  */
-const title =
-  "School Skills — free homeschool practice games for times tables, spelling and typing";
+const title = "Free printable worksheets and practice games | School Skills";
 const description =
-  "Three free practice games for homeschool and after-school: times tables, sight words and touch typing. No account, no tracking, no personalised ads. A supplement to your lessons, not a curriculum.";
+  "Worksheets to print for maths, handwriting, phonics and spelling, plus three practice games for times tables, sight words and touch typing. Free, with no account and nothing uploaded.";
 
 /**
  * The one verse on this page, and the band it sits in is why it is allowed to
@@ -49,6 +64,28 @@ const description =
  * release's own and the credit line travels with them.
  */
 const verse = passage("the-plans-of-the-diligent");
+
+/**
+ * The sheet the paper band shows, read out of the maths catalog rather than
+ * configured here.
+ *
+ * A config written on this page would be a second place a sheet is described,
+ * and it would drift from the page it links to. Taking the catalog's own entry
+ * and its own seed means the paper on the home page is the paper at
+ * `/printables/multiplication-worksheets`, problem for problem.
+ *
+ * Multiplication because it is the sheet a parent recognises without reading
+ * it: a grid of times-table facts is legible as a worksheet at a glance, which
+ * a phonics or handwriting sheet shrunk to a third of its size is not.
+ */
+const PEEK = "multiplication-worksheets";
+const peekEntry = MATHS_SHEETS.find((sheet) => sheet.slug === PEEK);
+if (!peekEntry) {
+  throw new Error(
+    `The home page shows ${PEEK}, which is no longer in the maths catalog. Point it at a sheet that exists.`,
+  );
+}
+const peek = buildSheet(peekEntry.config, MATHS_SEED);
 ---
 
 <Content
@@ -68,16 +105,17 @@ const verse = passage("the-plans-of-the-diligent");
     isAccessibleForFree: true,
   }}
 >
-  <header class="hero wrap">
+  <header class="hero wrap no-print">
     <p class="hero__eyebrow">
       <span class="hero__world">The map</span>
-      Free &middot; no account &middot; works offline
+      No account &middot; nothing uploaded &middot; works offline
     </p>
-    <h1 class="hero__title">Ten minutes of drill they&rsquo;ll ask for</h1>
+    <h1 class="hero__title">Free practice games and printable worksheets</h1>
     <p class="hero__lead">
-      Times tables, sight words and touch typing, as three small games. Made for
-      homeschool and after-school practice at home &mdash; free, with no account
-      and nothing about your child ever leaving the device it&rsquo;s on.
+      Three small games &mdash; times tables, sight words and touch typing
+      &mdash; and a print shop of worksheets for maths, handwriting, phonics and
+      more. No account, nothing to install, and nothing about your child ever
+      leaves the device it&rsquo;s on.
     </p>
     {
       /*
@@ -122,13 +160,91 @@ const verse = passage("the-plans-of-the-diligent");
       keyboard user's next Tab carries on from the hero button they just left,
       several screens above where the page now is. */
   }
-  <section class="band band--tight wrap" id="worlds" tabindex="-1">
+  <section class="band band--tight wrap no-print" id="worlds" tabindex="-1">
     <WorldMap />
   </section>
 
-  <div class="wrap"><AdSlot name="article" /></div>
-  <section class="band band--inset" id="limits" tabindex="-1">
-    <div class="wrap">
+  {
+    /*
+     * The paper half, which the rest of this page would otherwise leave as one
+     * clause under the map.
+     *
+     * The sheet below is the renderer, not a picture of it. `SheetView` with no
+     * `client:*` is HTML at build time, so the band costs this page no
+     * JavaScript and what a parent sees here is what the catalog prints.
+     *
+     * `data-world="paper"` rather than a set of one-off colours: world blocks
+     * are scoped to the attribute, so the band is painted out of The Print
+     * Shop's own tokens, down to a `--go` that is the colour of paper.
+     *
+     * The sheet is an illustration, not paper: a page that prints a sheet is a
+     * page that IS that sheet (docs/printables.md §8), and the overworld is not
+     * one. See the note on printing at the top of this file.
+     */
+  }
+  <section
+    class="band paper no-print"
+    data-world="paper"
+    aria-labelledby="paper-head"
+  >
+    <div class="wrap paper__in no-print">
+      <div class="paper__say">
+        <h2 class="h2" id="paper-head">The other half of this site is paper</h2>
+        <p class="h2__sub">
+          {ALL_SHEETS.length} worksheets, free and with no account. Every one is an
+          ordinary web page, so you can read it on screen, print it, or pick{
+            " "
+          }
+          <em>Save as PDF</em> and keep the file &mdash; on a phone as easily as a
+          laptop. Each comes with its answer key on the page behind it.
+        </p>
+
+        {
+          /* One chip per shelf, off the same registry the catalog builds
+            itself from, so a shelf added there turns up here. `role="list"`
+            restores what base.css strips, as the map does. */
+        }
+        <ul class="paper__shelves" role="list">
+          {
+            SHELVES.map((shelf) => (
+              <li>
+                <a href={shelf.href}>{shelf.label}</a>
+              </li>
+            ))
+          }
+        </ul>
+
+        <p class="aside">
+          <strong>And when a sheet is nearly right, change it.</strong> The bench
+          sets what is on it, the paper, the type size and how many problems fit,
+          and redraws the page as you go. The settings live in the address bar, so
+          a sheet you tuned can be bookmarked, or passed to someone else as an ordinary
+          link.
+        </p>
+
+        <div class="hero__actions">
+          <a class="cta" href="/printables">Browse the worksheets</a>
+          <a class="cta cta--quiet" href="/printables/make">Build your own</a>
+        </div>
+      </div>
+
+      {
+        /*
+         * Decorative here, and only here. The band's point is carried by the
+         * heading, the shelves and the two links; a screen reader made to walk
+         * thirty multiplication problems to reach them would be worse off for
+         * the illustration, and the sheet's own page reads it properly.
+         */
+      }
+      <div class="paper__peek" aria-hidden="true">
+        <SheetView sheet={peek} />
+      </div>
+    </div>
+  </section>
+
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+  <section class="band band--inset no-print" id="limits" tabindex="-1">
+    <div class="wrap no-print">
       <h2 class="h2">What this is, and what it isn&rsquo;t</h2>
       <p class="h2__sub">
         Worth knowing before you build a morning around it. This is one piece of
@@ -201,10 +317,12 @@ const verse = passage("the-plans-of-the-diligent");
               >
             </li>
             <li>
-              <span class="truth__what">Not a whole subject</span>
+              <span class="truth__what">Not a teacher</span>
               <span class="truth__why"
-                >Three narrow skills, on purpose. Reading comprehension, writing
-                and maths reasoning aren&rsquo;t here and aren&rsquo;t planned.</span
+                >The games are three narrow skills on purpose. The paper goes
+                wider &mdash; grammar, phonics, word problems, book reports
+                &mdash; but none of it teaches: a sheet is practice, or a frame
+                for work you set, and nothing on it explains anything.</span
               >
             </li>
           </ul>
@@ -213,8 +331,8 @@ const verse = passage("the-plans-of-the-diligent");
     </div>
   </section>
 
-  <div class="wrap"><AdSlot name="article" /></div>
-  <section class="band wrap">
+  <div class="wrap no-print"><AdSlot name="article" /></div>
+  <section class="band wrap no-print">
     <h2 class="h2">Where it fits in a day</h2>
     <p class="h2__sub">
       Short and frequent beats long and rare, which is convenient &mdash; ten
@@ -265,8 +383,8 @@ const verse = passage("the-plans-of-the-diligent");
     }
   </section>
 
-  <section class="band band--inset">
-    <div class="wrap">
+  <section class="band band--inset no-print">
+    <div class="wrap no-print">
       <h2 class="h2">What they see, and what you don&rsquo;t</h2>
       <p class="h2__sub">
         There is no parent account because there is no account at all. This is
@@ -304,8 +422,8 @@ const verse = passage("the-plans-of-the-diligent");
     </div>
   </section>
 
-  <section class="band" id="for-parents" tabindex="-1">
-    <div class="wrap">
+  <section class="band no-print" id="for-parents" tabindex="-1">
+    <div class="wrap no-print">
       <h2 class="h2">For parents</h2>
       <div class="prose">
         <p>

--- a/src/pages/printables/[...slug].astro
+++ b/src/pages/printables/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "./_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { buildSheet } from "@/engine/sheets";
@@ -53,7 +54,7 @@ const other = STOCKS.find((candidate) => candidate.id !== stock.id)!;
 
 const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
 const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page on ${stock.label}, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app/printables/${pathFor(sheet, stock)}`;
 
 const siblings = shelf();
@@ -63,6 +64,7 @@ const siblings = shelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("paper", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/[topic].astro
+++ b/src/pages/printables/[topic].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "./_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -58,7 +59,7 @@ const printed = buildSheet(sheet.config, MATHS_SEED);
 const key = answerKey(sheet.config, MATHS_SEED);
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const strands = mathsShelf();
@@ -69,6 +70,7 @@ const strand = strands.find((group) => group.id === sheet.strand)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("math", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/_phonics.ts
+++ b/src/pages/printables/_phonics.ts
@@ -191,14 +191,27 @@ export const PHONICS_SHEETS: PhonicsSheet[] = [
     // would be in at three if the digraph were ever ticked here.
     config: phonics("blending", LETTERS, 20, 2, { maxSounds: 3 }),
   },
+  /*
+   * Named for onset and rime rather than for word families, though a word
+   * family is what it prints.
+   *
+   * The spelling shelf has a word-family sheet too, and it is the one a parent
+   * searching that phrase should land on: fourteen fixed families, chosen for
+   * being the commonest. This one draws its endings from the spellings a child
+   * has actually been taught, so it is the same idea arriving through the
+   * phonics progression — a genuinely different sheet, and one that was
+   * competing with its neighbour for a query only one of them can win. The
+   * slug stays as it is: the URL is live and there is nowhere on a static site
+   * to redirect it from.
+   */
   {
     slug: "word-family-worksheets",
-    name: "Word families",
-    short: "Word families",
-    heading: "Word family worksheets",
-    keyword: "Free printable word family worksheets",
+    name: "Onset and rime",
+    short: "Onset and rime",
+    heading: "Onset and rime worksheets",
+    keyword: "Free printable onset and rime worksheets",
     summary:
-      "Twenty spelling sums — a beginning added to an ending, with the word they make written on the line, and the key on the page behind.",
+      "Twenty spelling sums — a beginning added to an ending, with the word they make written on the line, and the key on the page behind. The endings come from the spellings you have ticked.",
     lead: "A beginning, a plus sign and an ending, with a line for the word. Changing one sound at the front of a word a child can already read is the cheapest reading practice there is, and it is where a first reader gets their first hundred words.",
     notes: [
       "The endings on this page are not chosen from a list — they are the endings the words a child can read happen to share, which is why a family only appears when there are at least two words behind it. A sheet with one word in a family is not teaching a pattern, it is teaching a word, and there is a better sheet for that.",

--- a/src/pages/printables/_shelves.ts
+++ b/src/pages/printables/_shelves.ts
@@ -243,6 +243,33 @@ export const SHELVES: Shelf[] = [
 ];
 
 /** The shelves with a hub of their own — the subject nav, in order. */
+/**
+ * The trail to a page under The Print Shop, as `Base.astro`'s `breadcrumb`
+ * wants it: root first, the page itself last.
+ *
+ * Read out of `SHELVES`, so a shelf renamed or moved there is renamed in every
+ * breadcrumb beneath it rather than in twenty route files. `hub` is what
+ * decides whether the shelf is a step at all — paper's "hub" is the front door
+ * itself, and a trail that listed it twice would be describing a level that
+ * isn't there.
+ *
+ * Sub-groups are left out on purpose. A breadcrumb step is somewhere you can
+ * go, and a group ("Parts of speech") is a heading on a hub rather than a
+ * route.
+ */
+export const trailTo = (
+  id: ShelfId | null,
+  ...tail: Array<{ name: string; href: string }>
+): Array<{ name: string; href: string }> => {
+  const shelf = id ? SHELVES.find((entry) => entry.id === id) : undefined;
+  return [
+    { name: "Home", href: "/" },
+    { name: "The Print Shop", href: "/printables" },
+    ...(shelf?.hub ? [{ name: shelf.label, href: shelf.href }] : []),
+    ...tail,
+  ];
+};
+
 export const HUBS: Shelf[] = SHELVES.filter((shelf) => shelf.hub);
 
 export const ALL_SHEETS: ShelfSheet[] = SHELVES.flatMap(

--- a/src/pages/printables/bible/[...slug].astro
+++ b/src/pages/printables/bible/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -66,7 +67,7 @@ const credit = creditFor(sheet);
 
 const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
 const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page on ${stock.label}, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${hrefFor(sheet, stock)}`;
 
 const groups = bibleShelf();
@@ -77,6 +78,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("bible", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/bible/index.astro
+++ b/src/pages/printables/bible/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SCRIPTURE_CREDIT } from "@/engine/sheets/passages";
 import { BIBLE_SHEETS, STOCKS, bibleShelf, hrefFor } from "../_bible";
@@ -21,7 +22,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable Bible copywork, handwriting and memory verse worksheets | School Skills";
 const description =
-  "Printable Scripture practice: verses to trace, copywork at every ruling, and memory sheets with progressive blanks and the full verse on the answer key. Public-domain text, free, no account, and nothing to download.";
+  "Printable Scripture practice: verses to trace, copywork at every ruling, and memory sheets with progressive blanks and the full verse on the answer key. Public-domain text, free, no account, print or save as PDF.";
 
 const groups = bibleShelf();
 const letter = STOCKS[0];
@@ -31,6 +32,7 @@ const letter = STOCKS[0];
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("bible")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/charts/[slug].astro
+++ b/src/pages/printables/charts/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -54,7 +55,7 @@ const printed = buildSheet(sheet.config, CHART_SEED);
 const key = keyed(sheet) ? answerKey(sheet.config, CHART_SEED) : null;
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = chartShelf();
@@ -65,6 +66,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("charts", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/charts/index.astro
+++ b/src/pages/printables/charts/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { CHART_SHEETS, chartShelf, pathFor } from "../_charts";
 import HubLinks from "../_HubLinks.astro";
@@ -22,7 +23,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable maths charts, number lines and grids | School Skills";
 const description =
-  "Printable reference sheets: hundred charts blank and filled, number lines with the interval you choose, first-quadrant and four-quadrant coordinate grids, and place-value charts down to thousandths. Real inches, drawn as ink so they print — free, no account, no download.";
+  "Printable reference sheets: hundred charts blank and filled, number lines with the interval you choose, first-quadrant and four-quadrant coordinate grids, and place-value charts down to thousandths. Real inches, drawn as ink so they print — free, no account, print or save as PDF.";
 
 const groups = chartShelf();
 ---
@@ -31,6 +32,7 @@ const groups = chartShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("charts")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/cursive/[...slug].astro
+++ b/src/pages/printables/cursive/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { buildSheet } from "@/engine/sheets";
@@ -51,7 +52,7 @@ const other = STOCKS.find((candidate) => candidate.id !== stock.id)!;
 
 const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
 const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page on ${stock.label}, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${hrefFor(sheet, stock)}`;
 
 const groups = cursiveShelf();
@@ -62,6 +63,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("cursive", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/cursive/index.astro
+++ b/src/pages/printables/cursive/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { JOIN_FAMILIES } from "@/engine/sheets/writing/joins";
 import {
@@ -26,7 +27,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable cursive worksheets — letters, joins and copywork | School Skills";
 const description =
-  "Printable cursive practice: the alphabet in capitals and small letters, all six families of join, whole words, sentences and copywork. Three cursive models to choose from. Free, no account, and nothing to download.";
+  "Printable cursive practice: the alphabet in capitals and small letters, all six families of join, whole words, sentences and copywork. Three cursive models to choose from. Free, no account, print or save as PDF.";
 
 const groups = cursiveShelf();
 const letter = STOCKS[0];
@@ -40,6 +41,7 @@ const joins = CURSIVE_SHEETS.find((sheet) => sheet.config.style === "joins")!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("cursive")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/grade/[grade].astro
+++ b/src/pages/printables/grade/[grade].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import HubLinks from "../_HubLinks.astro";
 import {
@@ -64,7 +65,7 @@ const description = `${grade.heading} for ages ${younger} and ${older}: ${shelve
   .map((shelf) => shelf.label)
   .join(
     ", ",
-  )}. Every one prints straight from the page — free, no account, and nothing to download.`;
+  )}. Every one prints straight from the page — free, no account, print or save as PDF.`;
 const url = `https://schoolskills.app${gradeHref(grade)}`;
 ---
 
@@ -72,6 +73,11 @@ const url = `https://schoolskills.app${gradeHref(grade)}`;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo(
+    null,
+    { name: "By school year", href: "/printables/grade" },
+    { name: grade.label, href: url },
+  )}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/grade/index.astro
+++ b/src/pages/printables/grade/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import HubLinks from "../_HubLinks.astro";
 import { GRADES, gradeHref, sheetsForGrade } from "../_grades";
@@ -25,13 +26,17 @@ const years = GRADES.map((grade) => ({
 
 const title = "Printable worksheets by grade, Pre-K to 8th | School Skills";
 const description =
-  "Ten pages, one per school year: what a child that age can print, drawn from every shelf in the Print Shop at once. Free, no account, and nothing to download — and the ages come off each sheet rather than off a standard.";
+  "Ten pages, one per school year: what a child that age can print, drawn from every shelf in the Print Shop at once. Free, no account, print or save as PDF — and the ages come off each sheet rather than off a standard.";
 ---
 
 <Content
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo(null, {
+    name: "By school year",
+    href: "/printables/grade",
+  })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/grammar/[slug].astro
+++ b/src/pages/printables/grammar/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -51,7 +52,7 @@ const printed = buildSheet(sheet.config, GRAMMAR_SEED);
 const key = answerKey(sheet.config, GRAMMAR_SEED);
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = grammarShelf();
@@ -62,6 +63,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("grammar", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/grammar/index.astro
+++ b/src/pages/printables/grammar/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { GRAMMAR_SHEETS, grammarShelf, pathFor } from "../_grammar";
 import HubLinks from "../_HubLinks.astro";
@@ -20,7 +21,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable grammar worksheets — parts of speech, sentences and punctuation | School Skills";
 const description =
-  "Printable grammar practice: parts of speech, subject and predicate, statements and questions and commands, end punctuation and capital letters. Every sheet prints its answer key on the page behind — free, no account, no download.";
+  "Printable grammar practice: parts of speech, subject and predicate, statements and questions and commands, end punctuation and capital letters. Every sheet prints its answer key on the page behind — free, no account, print or save as PDF.";
 
 const groups = grammarShelf();
 ---
@@ -29,6 +30,7 @@ const groups = grammarShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("grammar")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/handwriting/[...slug].astro
+++ b/src/pages/printables/handwriting/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { buildSheet } from "@/engine/sheets";
@@ -59,7 +60,7 @@ const other = STOCKS.find((candidate) => candidate.id !== stock.id)!;
 
 const heading = a4 ? `${sheet.heading}, for A4` : sheet.heading;
 const title = `${sheet.keyword}${a4 ? ", A4" : ""} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page on ${stock.label} — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page on ${stock.label}, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${hrefFor(sheet, stock)}`;
 
 const groups = handwritingShelf();
@@ -70,6 +71,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("handwriting", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/handwriting/index.astro
+++ b/src/pages/printables/handwriting/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import {
   HANDWRITING_SHEETS,
@@ -23,7 +24,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable handwriting worksheets — trace, copy, write | School Skills";
 const description =
-  "Printable handwriting practice: letter tracing in upper and lower case, number formation 0–9, sight words, sentences and copywork. Every sheet traces first, then copies, then leaves an empty line. Free, no account, and nothing to download.";
+  "Printable handwriting practice: letter tracing in upper and lower case, number formation 0–9, sight words, sentences and copywork. Every sheet traces first, then copies, then leaves an empty line. Free, no account, print or save as PDF.";
 
 const groups = handwritingShelf();
 const letter = STOCKS[0];
@@ -33,6 +34,7 @@ const letter = STOCKS[0];
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("handwriting")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/index.astro
+++ b/src/pages/printables/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "./_shelves";
 import { BIBLE_SHEETS, bibleShelf, hrefFor as bibleHref } from "./_bible";
 import { STOCKS, pathFor, shelf } from "./_catalog";
 import { CHART_SHEETS, chartShelf, pathFor as chartPath } from "./_charts";
@@ -61,7 +62,7 @@ import "@/styles/search.css";
  */
 const title = "Free printable worksheets — The Print Shop | School Skills";
 const description =
-  "Practice sheets you can print at home, free and without an account. Every sheet is an ordinary web page, so printing it needs no download, no reader and no sign-up — and nothing about your child goes into the file.";
+  "Practice sheets you can print at home, free and without an account. Every sheet is an ordinary web page: read it on screen, print it, or save it as a PDF to keep — and nothing about your child goes into the file.";
 
 /** Listed on the default stock; each sheet page carries the link to its twin. */
 const letter = STOCKS[0];
@@ -81,6 +82,7 @@ const paperwork = templateShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo(null)}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -360,7 +362,7 @@ const paperwork = templateShelf();
     <h2 class="h2">A worksheet here is a web page</h2>
     <div class="prose">
       <p>
-        Not a PDF, not a picture of a worksheet, and nothing to download. A
+        Not a PDF you have to fetch first, and not a picture of a worksheet. A
         sheet is real text and real lines laid out in real inches, so printing
         one is <em>File &rarr; Print</em> on the page you are already looking at.
         If you want to keep a copy, choose <em>Save as PDF</em> in the print dialog

--- a/src/pages/printables/math.astro
+++ b/src/pages/printables/math.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "./_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { MATHS_SHEETS, mathsShelf, pathFor } from "./_maths";
 import HubLinks from "./_HubLinks.astro";
@@ -22,7 +23,7 @@ import HubLinks from "./_HubLinks.astro";
 const title =
   "Free printable math worksheets, with answer keys | School Skills";
 const description =
-  "Printable maths worksheets with the answer key on the second page: addition, times tables, long division, fractions, decimals, money, time, area, integers and word problems. Free, no account, and nothing to download.";
+  "Printable maths worksheets with the answer key on the second page: addition, times tables, long division, fractions, decimals, money, time, area, integers and word problems. Free, no account, print or save as PDF.";
 
 const strands = mathsShelf();
 ---
@@ -31,6 +32,7 @@ const strands = mathsShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("math")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -133,7 +135,7 @@ const strands = mathsShelf();
     <div class="wrap">
       <h2 class="h2">A worksheet here is a web page</h2>
       <p class="h2__sub">
-        Not a PDF, not a picture of a worksheet, and nothing to download.
+        Not a PDF you have to fetch first, and not a picture of a worksheet.
       </p>
       <div class="prose">
         <p>

--- a/src/pages/printables/phonics/[slug].astro
+++ b/src/pages/printables/phonics/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -51,7 +52,7 @@ const printed = buildSheet(sheet.config, PHONICS_SEED);
 const key = keyed(sheet) ? answerKey(sheet.config, PHONICS_SEED) : null;
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = phonicsShelf();
@@ -62,6 +63,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("phonics", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/phonics/index.astro
+++ b/src/pages/printables/phonics/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { PHONICS_SHEETS, pathFor, phonicsShelf } from "../_phonics";
 import HubLinks from "../_HubLinks.astro";
@@ -20,7 +21,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable phonics worksheets — built from the sounds you have taught | School Skills";
 const description =
-  "Printable phonics practice: sound cards, a sounds-we-know wall chart, CVC blending lines, word families, sound-to-word matching, dictation and decodable sentences. Every sheet is built from the spellings you tick, so nothing on it is a sound your child has not met — free, no account, no download.";
+  "Printable phonics practice: sound cards, a sounds-we-know wall chart, CVC blending lines, word families, sound-to-word matching, dictation and decodable sentences. Every sheet is built from the spellings you tick, so nothing on it is a sound your child has not met — free, no account, print or save as PDF.";
 
 const groups = phonicsShelf();
 ---
@@ -29,6 +30,7 @@ const groups = phonicsShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("phonics")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/spelling/[slug].astro
+++ b/src/pages/printables/spelling/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -52,7 +53,7 @@ const printed = buildSheet(sheet.config, SPELLING_SEED);
 const key = keyed(sheet) ? answerKey(sheet.config, SPELLING_SEED) : null;
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = spellingShelf();
@@ -71,6 +72,7 @@ const study = sheet.config.kind === "word-study";
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("spelling", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/spelling/index.astro
+++ b/src/pages/printables/spelling/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SPELLING_SHEETS, pathFor, spellingShelf } from "../_spelling";
 import HubLinks from "../_HubLinks.astro";
@@ -28,6 +29,7 @@ const groups = spellingShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("spelling")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/pages/printables/templates/[slug].astro
+++ b/src/pages/printables/templates/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { SheetView } from "@/components/sheet/Sheet";
 import { answerKey, buildSheet } from "@/engine/sheets";
@@ -55,7 +56,7 @@ const printed = buildSheet(sheet.config, TEMPLATE_SEED);
 const key = keyed(sheet) ? answerKey(sheet.config, TEMPLATE_SEED) : null;
 
 const title = `${sheet.keyword} | School Skills`;
-const description = `${sheet.summary} Printed straight from this page — free, no account, and no download.`;
+const description = `${sheet.summary} Print it straight from this page, or save it as a PDF — free, and no account.`;
 const url = `https://schoolskills.app${pathFor(sheet)}`;
 
 const groups = templateShelf();
@@ -66,6 +67,7 @@ const group = groups.find((entry) => entry.id === sheet.group)!;
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("templates", { name: sheet.name, href: url })}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "LearningResource",

--- a/src/pages/printables/templates/index.astro
+++ b/src/pages/printables/templates/index.astro
@@ -1,5 +1,6 @@
 ---
 import Content from "@/layouts/Content.astro";
+import { trailTo } from "../_shelves";
 import AdSlot from "@/components/site/AdSlot.astro";
 import { TEMPLATE_SHEETS, pathFor, templateShelf } from "../_templates";
 import HubLinks from "../_HubLinks.astro";
@@ -26,7 +27,7 @@ import HubLinks from "../_HubLinks.astro";
 const title =
   "Free printable forms, planners, charts and templates | School Skills";
 const description =
-  "Printable blank templates: reading logs and book report forms, lab report and scientific method sheets, blank calendars, weekly planners, chore and behaviour charts, blank flashcards, name tags, bookmarks, award certificates, and dice and spinner nets. Real inches and cut lines on every boundary — free, no account, no download.";
+  "Printable blank templates: reading logs and book report forms, lab report and scientific method sheets, blank calendars, weekly planners, chore and behaviour charts, blank flashcards, name tags, bookmarks, award certificates, and dice and spinner nets. Real inches and cut lines on every boundary — free, no account, print or save as PDF.";
 
 const groups = templateShelf();
 ---
@@ -35,6 +36,7 @@ const groups = templateShelf();
   title={title}
   description={description}
   world="paper"
+  breadcrumb={trailTo("templates")}
   jsonLd={{
     "@context": "https://schema.org",
     "@type": "CollectionPage",

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3,12 +3,12 @@
    game there is one exit door in the top bar and nothing else — a nav bar over
    a race is a nav bar in a child's way.
 
-   It reads as a HUD rather than a website header: a flag, a dot per world
+   It reads as a HUD rather than a website header: the mark, a dot per world
    colour-coded to match the map, and one button that plays. The header renders
    one link per entry in the world registry, so the row grows with it rather
-   than with anything written down here. The flag's pennant takes
-   the current world's accent, so walking from the jungle to the glacier
-   recolours the thing you navigate by. That is the only ornament in here. */
+   than with anything written down here. The dots are the only colour that
+   moves; the mark is the same in every world, because a logo that changed
+   colour as you walked would stop reading as the way home. */
 
 .skip {
   position: absolute;
@@ -54,14 +54,11 @@
   color: var(--chalk);
 }
 
-.mast__flag {
+/* The plate is drawn with its own corner radius, so nothing here shapes it.
+   `flex: none` is what stops a narrow phone squashing it to make room for the
+   name beside it. */
+.mast__logo {
   flex: none;
-  overflow: visible;
-}
-
-/* The pennant is the world you're standing in. */
-.mast__pennant {
-  fill: var(--accent);
 }
 
 .mast__name {

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -601,6 +601,77 @@
   color: var(--chalk);
 }
 
+/* ── The paper half ─────────────────────────────────────────
+   The home page's Print Shop band. Its section carries `data-world="paper"`,
+   so everything below reads The Print Shop's own tokens and the change of
+   subject arrives as a change of ground — the same trick the map plays to
+   render four worlds at once.                                              */
+
+.paper__in {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(21rem, 100%), 1fr));
+  gap: var(--gap-5);
+  align-items: center;
+}
+
+.paper__shelves {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-1);
+  margin-top: var(--gap-3);
+}
+
+.paper__shelves a {
+  display: inline-block;
+  padding: 0.35em 0.8em;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  font-size: var(--step--1);
+  font-weight: 700;
+  color: var(--chalk-soft);
+  white-space: nowrap;
+  transition:
+    color 0.14s ease,
+    border-color 0.14s ease,
+    background-color 0.14s ease;
+}
+
+.paper__shelves a:hover {
+  color: var(--chalk);
+  border-color: color-mix(in oklab, var(--accent) 55%, transparent);
+  background: rgb(255 255 255 / 5%);
+}
+
+/* A whole sheet, shown small.
+
+   `transform` rather than a smaller width, because every length inside a sheet
+   is a real inch (sheet.css) — narrowing the box would reflow the paper into a
+   layout it never prints as, which is exactly the lie this band exists to
+   avoid. Scaling leaves the geometry alone and shrinks the picture of it.
+
+   A transform costs no layout, so the frame has to be given the scaled size
+   itself or the text beside it would sit on top of a sheet the box knows
+   nothing about. */
+.paper__peek {
+  --peek: 0.46;
+  width: calc(8.5in * var(--peek));
+  height: calc(11in * var(--peek));
+  margin-inline: auto;
+}
+
+.paper__peek .sheet {
+  transform: scale(var(--peek));
+  transform-origin: top left;
+}
+
+/* 8.5 inches at 0.46 is 375px, which is wider than the phone it has to sit on
+   once the wrap has taken its padding. */
+@media (width <= 34rem) {
+  .paper__peek {
+    --peek: 0.34;
+  }
+}
+
 /* ── The pause menu: privacy, terms, 404 ────────────────────────────────
    Line world and Empty world have no scenery, so the page carries itself on
    measure and rhythm alone. Nothing to add here beyond a narrower column and


### PR DESCRIPTION
Two changes since the last release.

**[#239](https://github.com/jordanmbush/schoolskills/pull/239) — Show the paper half on the front page, and let search find it**
The home page sold three games while 179 of the 200 built pages are printables. The hero now names both halves and a band after the map shows a real worksheet, rendered at build time with no JavaScript. The masthead's yellow pennant becomes the actual logo. Around thirty places claiming "no download" — true but misleading, since you can keep a sheet — now say what you can do instead. Plus `BreadcrumbList` on 178 pages, an `Organization` node with the logo, `noindex` on `/404`, and a duplicate title pair resolved.

One behaviour change worth knowing: **the overworld now prints nothing** rather than a mangled margin-less article, because putting a real sheet on the home page brought it under the print-isolation rule (§20).

**[#238](https://github.com/jordanmbush/schoolskills/pull/238) — Let every breakdown be read a day at a time**

---

Merge commit, not squash — squashing diverges `develop` and `main` permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)